### PR TITLE
Move tokio dep to dev-dependencies

### DIFF
--- a/ot/mpz-ot/Cargo.toml
+++ b/ot/mpz-ot/Cargo.toml
@@ -25,14 +25,14 @@ rand_core.workspace = true
 rand_chacha.workspace = true
 p256 = { workspace = true, optional = true }
 thiserror.workspace = true
+rayon = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+criterion = { workspace = true, features = ["async_tokio"] }
 tokio = { workspace = true, features = [
     "net",
     "macros",
     "rt",
     "rt-multi-thread",
 ] }
-rayon = { workspace = true }
-
-[dev-dependencies]
-rstest = { workspace = true }
-criterion = { workspace = true, features = ["async_tokio"] }


### PR DESCRIPTION
This PR moves `tokio` dependency in `mpz-ot` to the dev dependencies.