### PR TITLE
Rewrite KOS15

### DIFF
--- a/ot/mpz-ot-core/Cargo.toml
+++ b/ot/mpz-ot-core/Cargo.toml
@@ -8,7 +8,7 @@ name = "mpz_ot_core"
 
 [features]
 default = ["rayon"]
-rayon = ["dep:rayon", "itybity/rayon"]
+rayon = ["dep:rayon", "itybity/rayon", "blake3/rayon"]
 
 [dependencies]
 mpz-core.workspace = true

--- a/ot/mpz-ot-core/benches/ot.rs
+++ b/ot/mpz-ot-core/benches/ot.rs
@@ -59,7 +59,7 @@ fn kos(c: &mut Criterion) {
                 let receiver_setup = receiver.extend(choices.len() + 256).unwrap();
                 sender.extend(msgs.len() + 256, receiver_setup).unwrap();
 
-                let receiver_check = receiver.check(chi_seed);
+                let receiver_check = receiver.check(chi_seed).unwrap();
                 sender.check(chi_seed, receiver_check).unwrap();
 
                 let mut receiver_keys = receiver.keys(choices.len()).unwrap();

--- a/ot/mpz-ot-core/benches/ot.rs
+++ b/ot/mpz-ot-core/benches/ot.rs
@@ -1,7 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use itybity::{IntoBitIterator, ToBits};
 use mpz_core::Block;
-use mpz_ot_core::chou_orlandi;
-use rand::{RngCore, SeedableRng};
+use mpz_ot_core::{chou_orlandi, kos};
+use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 
 fn chou_orlandi(c: &mut Criterion) {
@@ -27,10 +28,60 @@ fn chou_orlandi(c: &mut Criterion) {
     }
 }
 
+fn kos(c: &mut Criterion) {
+    let mut group = c.benchmark_group("kos");
+    for n in [1024, 262144] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            let msgs = vec![[Block::ONES; 2]; n];
+            let mut rng = ChaCha12Rng::from_entropy();
+            let mut choices = vec![0u8; n / 8];
+            rng.fill_bytes(&mut choices);
+            let choices = choices.into_lsb0_vec();
+            let delta = Block::random(&mut rng);
+            let chi_seed = Block::random(&mut rng);
+
+            let receiver_seeds: [[Block; 2]; 128] = std::array::from_fn(|_| [rng.gen(), rng.gen()]);
+            let sender_seeds: [Block; 128] = delta
+                .iter_lsb0()
+                .zip(receiver_seeds)
+                .map(|(b, seeds)| if b { seeds[1] } else { seeds[0] })
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap();
+
+            b.iter(|| {
+                let sender = kos::Sender::new(kos::SenderConfig::default());
+                let receiver = kos::Receiver::new(kos::ReceiverConfig::default());
+
+                let mut sender = sender.base_setup(delta, sender_seeds);
+                let mut receiver = receiver.base_setup(receiver_seeds);
+
+                let receiver_setup = receiver.extend(choices.len() + 256);
+                sender.extend(msgs.len() + 256, receiver_setup).unwrap();
+
+                let receiver_check = receiver.check(chi_seed);
+                sender.check(chi_seed, receiver_check).unwrap();
+
+                let derandomize = receiver.derandomize(&choices);
+                let payload = sender.send(&msgs, derandomize).unwrap();
+                let received = receiver.receive(payload).unwrap();
+
+                black_box(received)
+            })
+        });
+    }
+}
+
 criterion_group! {
     name = chou_orlandi_benches;
     config = Criterion::default().sample_size(50);
     targets = chou_orlandi
 }
 
-criterion_main!(chou_orlandi_benches);
+criterion_group! {
+    name = kos_benches;
+    config = Criterion::default().sample_size(50);
+    targets = kos
+}
+
+criterion_main!(chou_orlandi_benches, kos_benches);

--- a/ot/mpz-ot-core/benches/ot.rs
+++ b/ot/mpz-ot-core/benches/ot.rs
@@ -53,8 +53,8 @@ fn kos(c: &mut Criterion) {
                 let sender = kos::Sender::new(kos::SenderConfig::default());
                 let receiver = kos::Receiver::new(kos::ReceiverConfig::default());
 
-                let mut sender = sender.base_setup(delta, sender_seeds);
-                let mut receiver = receiver.base_setup(receiver_seeds);
+                let mut sender = sender.setup(delta, sender_seeds);
+                let mut receiver = receiver.setup(receiver_seeds);
 
                 let receiver_setup = receiver.extend(choices.len() + 256);
                 sender.extend(msgs.len() + 256, receiver_setup).unwrap();

--- a/ot/mpz-ot-core/src/kos/config.rs
+++ b/ot/mpz-ot-core/src/kos/config.rs
@@ -1,0 +1,85 @@
+use derive_builder::Builder;
+
+/// KOS15 sender configuration.
+#[derive(Debug, Default, Clone, Builder)]
+pub struct SenderConfig {
+    /// Whether the Sender should commit to the messages.
+    #[builder(setter(custom), default = "false")]
+    sender_commit: bool,
+    /// Whether the Receiver should commit to their choices.
+    #[builder(setter(custom), default = "false")]
+    receiver_commit: bool,
+}
+
+impl SenderConfigBuilder {
+    /// Sets the Sender to commit to the messages.
+    pub fn sender_commit(&mut self) -> &mut Self {
+        self.sender_commit = Some(true);
+        self
+    }
+
+    /// Sets the Receiver to commit to their choices.
+    pub fn receiver_commit(&mut self) -> &mut Self {
+        self.receiver_commit = Some(true);
+        self
+    }
+}
+
+impl SenderConfig {
+    /// Creates a new builder for SenderConfig.
+    pub fn builder() -> SenderConfigBuilder {
+        SenderConfigBuilder::default()
+    }
+
+    /// Whether the Sender should commit to the messages.
+    pub fn sender_commit(&self) -> bool {
+        self.sender_commit
+    }
+
+    /// Whether the Receiver should commit to their choices.
+    pub fn receiver_commit(&self) -> bool {
+        self.receiver_commit
+    }
+}
+
+/// KOS15 receiver configuration.
+#[derive(Debug, Default, Clone, Builder)]
+pub struct ReceiverConfig {
+    /// Whether the Sender should commit to the messages.
+    #[builder(setter(custom), default = "false")]
+    sender_commit: bool,
+    /// Whether the Receiver should commit to their choices.
+    #[builder(setter(custom), default = "false")]
+    receiver_commit: bool,
+}
+
+impl ReceiverConfigBuilder {
+    /// Sets the Sender to commit to the messages.
+    pub fn sender_commit(&mut self) -> &mut Self {
+        self.sender_commit = Some(true);
+        self
+    }
+
+    /// Sets the Receiver to commit to their choices.
+    pub fn receiver_commit(&mut self) -> &mut Self {
+        self.receiver_commit = Some(true);
+        self
+    }
+}
+
+impl ReceiverConfig {
+    /// Creates a new builder for ReceiverConfig.
+    pub fn builder() -> ReceiverConfigBuilder {
+        ReceiverConfigBuilder::default()
+    }
+
+    /// Whether the Sender should commit to the messages.
+    pub fn sender_commit(&self) -> bool {
+        self.sender_commit
+    }
+
+    /// Whether the Receiver should commit to their choices.
+    pub fn receiver_commit(&self) -> bool {
+        self.receiver_commit
+    }
+}

--- a/ot/mpz-ot-core/src/kos/config.rs
+++ b/ot/mpz-ot-core/src/kos/config.rs
@@ -6,21 +6,12 @@ pub struct SenderConfig {
     /// Whether the Sender should commit to the messages.
     #[builder(setter(custom), default = "false")]
     sender_commit: bool,
-    /// Whether the Receiver should commit to their choices.
-    #[builder(setter(custom), default = "false")]
-    receiver_commit: bool,
 }
 
 impl SenderConfigBuilder {
     /// Sets the Sender to commit to the messages.
     pub fn sender_commit(&mut self) -> &mut Self {
         self.sender_commit = Some(true);
-        self
-    }
-
-    /// Sets the Receiver to commit to their choices.
-    pub fn receiver_commit(&mut self) -> &mut Self {
-        self.receiver_commit = Some(true);
         self
     }
 }
@@ -35,11 +26,6 @@ impl SenderConfig {
     pub fn sender_commit(&self) -> bool {
         self.sender_commit
     }
-
-    /// Whether the Receiver should commit to their choices.
-    pub fn receiver_commit(&self) -> bool {
-        self.receiver_commit
-    }
 }
 
 /// KOS15 receiver configuration.
@@ -48,21 +34,12 @@ pub struct ReceiverConfig {
     /// Whether the Sender should commit to the messages.
     #[builder(setter(custom), default = "false")]
     sender_commit: bool,
-    /// Whether the Receiver should commit to their choices.
-    #[builder(setter(custom), default = "false")]
-    receiver_commit: bool,
 }
 
 impl ReceiverConfigBuilder {
     /// Sets the Sender to commit to the messages.
     pub fn sender_commit(&mut self) -> &mut Self {
         self.sender_commit = Some(true);
-        self
-    }
-
-    /// Sets the Receiver to commit to their choices.
-    pub fn receiver_commit(&mut self) -> &mut Self {
-        self.receiver_commit = Some(true);
         self
     }
 }
@@ -76,10 +53,5 @@ impl ReceiverConfig {
     /// Whether the Sender should commit to the messages.
     pub fn sender_commit(&self) -> bool {
         self.sender_commit
-    }
-
-    /// Whether the Receiver should commit to their choices.
-    pub fn receiver_commit(&self) -> bool {
-        self.receiver_commit
     }
 }

--- a/ot/mpz-ot-core/src/kos/config.rs
+++ b/ot/mpz-ot-core/src/kos/config.rs
@@ -3,13 +3,13 @@ use derive_builder::Builder;
 /// KOS15 sender configuration.
 #[derive(Debug, Default, Clone, Builder)]
 pub struct SenderConfig {
-    /// Whether the Sender should commit to the messages.
+    /// Enables committed sender functionality.
     #[builder(setter(custom), default = "false")]
     sender_commit: bool,
 }
 
 impl SenderConfigBuilder {
-    /// Sets the Sender to commit to the messages.
+    /// Enables committed sender functionality.
     pub fn sender_commit(&mut self) -> &mut Self {
         self.sender_commit = Some(true);
         self
@@ -22,7 +22,7 @@ impl SenderConfig {
         SenderConfigBuilder::default()
     }
 
-    /// Whether the Sender should commit to the messages.
+    /// Enables committed sender functionality.
     pub fn sender_commit(&self) -> bool {
         self.sender_commit
     }
@@ -31,13 +31,13 @@ impl SenderConfig {
 /// KOS15 receiver configuration.
 #[derive(Debug, Default, Clone, Builder)]
 pub struct ReceiverConfig {
-    /// Whether the Sender should commit to the messages.
+    /// Enables committed sender functionality.
     #[builder(setter(custom), default = "false")]
     sender_commit: bool,
 }
 
 impl ReceiverConfigBuilder {
-    /// Sets the Sender to commit to the messages.
+    /// Enables committed sender functionality.
     pub fn sender_commit(&mut self) -> &mut Self {
         self.sender_commit = Some(true);
         self
@@ -50,7 +50,7 @@ impl ReceiverConfig {
         ReceiverConfigBuilder::default()
     }
 
-    /// Whether the Sender should commit to the messages.
+    /// Enables committed sender functionality.
     pub fn sender_commit(&self) -> bool {
         self.sender_commit
     }

--- a/ot/mpz-ot-core/src/kos/error.rs
+++ b/ot/mpz-ot-core/src/kos/error.rs
@@ -1,0 +1,39 @@
+/// Errors that can occur when using the KOS15 sender.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum SenderError {
+    #[error("invalid state: expected {0}")]
+    InvalidState(String),
+    #[error("count mismatch: receiver expected {0}, got {1}")]
+    CountMismatch(usize, usize),
+    #[error("consistency check failed")]
+    ConsistencyCheckFailed,
+    #[error("not enough OTs are setup: expected {0}, actual {1}")]
+    InsufficientSetup(usize, usize),
+}
+
+/// Errors that can occur when using the KOS15 receiver.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ReceiverError {
+    #[error("invalid state: expected {0}")]
+    InvalidState(String),
+    #[error("count mismatch: receiver expected {0} but sender sent {1}")]
+    CountMismatch(usize, usize),
+    #[error("invalid payload")]
+    InvalidPayload,
+    #[error(transparent)]
+    ReceiverVerifyError(#[from] ReceiverVerifyError),
+}
+
+/// Errors that can occur during verification of the sender's messages.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ReceiverVerifyError {
+    #[error("tape was not recorded")]
+    TapeNotRecorded,
+    #[error("invalid payload index")]
+    InvalidPayloadIndex,
+    #[error("payload inconsistent")]
+    InconsistentPayload,
+}

--- a/ot/mpz-ot-core/src/kos/error.rs
+++ b/ot/mpz-ot-core/src/kos/error.rs
@@ -4,8 +4,10 @@
 pub enum SenderError {
     #[error("invalid state: expected {0}")]
     InvalidState(String),
-    #[error("count mismatch: receiver expected {0}, got {1}")]
+    #[error("count mismatch: expected {0}, got {1}")]
     CountMismatch(usize, usize),
+    #[error("id mismatch: expected {0}, got {1}")]
+    IdMismatch(u32, u32),
     #[error("invalid extend")]
     InvalidExtend,
     #[error("consistency check failed")]
@@ -20,8 +22,12 @@ pub enum SenderError {
 pub enum ReceiverError {
     #[error("invalid state: expected {0}")]
     InvalidState(String),
-    #[error("count mismatch: receiver expected {0} but sender sent {1}")]
+    #[error("count mismatch: expected {0}, got {1}")]
     CountMismatch(usize, usize),
+    #[error("id mismatch: expected {0}, got {1}")]
+    IdMismatch(u32, u32),
+    #[error("not enough OTs are setup: expected {0}, actual {1}")]
+    InsufficientSetup(usize, usize),
     #[error("invalid payload")]
     InvalidPayload,
     #[error(transparent)]
@@ -34,8 +40,8 @@ pub enum ReceiverError {
 pub enum ReceiverVerifyError {
     #[error("tape was not recorded")]
     TapeNotRecorded,
-    #[error("invalid payload index")]
-    InvalidPayloadIndex,
+    #[error("invalid transfer id: {0}")]
+    InvalidTransferId(u32),
     #[error("payload inconsistent")]
     InconsistentPayload,
 }

--- a/ot/mpz-ot-core/src/kos/error.rs
+++ b/ot/mpz-ot-core/src/kos/error.rs
@@ -6,6 +6,8 @@ pub enum SenderError {
     InvalidState(String),
     #[error("count mismatch: receiver expected {0}, got {1}")]
     CountMismatch(usize, usize),
+    #[error("invalid extend")]
+    InvalidExtend,
     #[error("consistency check failed")]
     ConsistencyCheckFailed,
     #[error("not enough OTs are setup: expected {0}, actual {1}")]

--- a/ot/mpz-ot-core/src/kos/mod.rs
+++ b/ot/mpz-ot-core/src/kos/mod.rs
@@ -107,7 +107,7 @@ mod tests {
         let receiver_setup = receiver.extend(choices.len() + 256).unwrap();
         sender.extend(data.len() + 256, receiver_setup).unwrap();
 
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         sender.check(chi_seed, receiver_check).unwrap();
 
         let mut receiver_keys = receiver.keys(choices.len()).unwrap();
@@ -145,7 +145,7 @@ mod tests {
         let receiver_setup = receiver.extend(256).unwrap();
         sender.extend(256, receiver_setup).unwrap();
 
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         sender.check(chi_seed, receiver_check).unwrap();
 
         let mut receiver_keys = receiver.keys(choices.len()).unwrap();
@@ -177,13 +177,35 @@ mod tests {
         sender.extend(256, receiver_setup).unwrap();
 
         // Perform check
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         sender.check(chi_seed, receiver_check).unwrap();
 
         // Extending more should fail
         let receiver_setup = receiver.extend(256).unwrap_err();
 
         assert!(matches!(receiver_setup, ReceiverError::InvalidState(_)));
+    }
+
+    #[rstest]
+    fn test_kos_extension_insufficient_setup(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::default());
+
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
+
+        let receiver_setup = receiver.extend(64).unwrap();
+        sender.extend(64, receiver_setup).unwrap();
+
+        // Perform check
+        let err = receiver.check(chi_seed).unwrap_err();
+
+        assert!(matches!(err, ReceiverError::InsufficientSetup(_, _)));
     }
 
     #[rstest]
@@ -206,7 +228,7 @@ mod tests {
 
         sender.extend(512, receiver_setup).unwrap();
 
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         let err = sender.check(chi_seed, receiver_check).unwrap_err();
 
         assert!(matches!(err, SenderError::ConsistencyCheckFailed));
@@ -231,7 +253,7 @@ mod tests {
         let receiver_setup = receiver.extend(choices.len() + 256).unwrap();
         sender.extend(data.len() + 256, receiver_setup).unwrap();
 
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         sender.check(chi_seed, receiver_check).unwrap();
 
         let mut receiver_keys = receiver.keys(choices.len()).unwrap();
@@ -267,7 +289,7 @@ mod tests {
         let receiver_setup = receiver.extend(choices.len() + 256).unwrap();
         sender.extend(data.len() + 256, receiver_setup).unwrap();
 
-        let receiver_check = receiver.check(chi_seed);
+        let receiver_check = receiver.check(chi_seed).unwrap();
         sender.check(chi_seed, receiver_check).unwrap();
 
         let mut receiver_keys = receiver.keys(choices.len()).unwrap();

--- a/ot/mpz-ot-core/src/kos/mod.rs
+++ b/ot/mpz-ot-core/src/kos/mod.rs
@@ -101,8 +101,8 @@ mod tests {
         let sender = Sender::new(SenderConfig::default());
         let receiver = Receiver::new(ReceiverConfig::default());
 
-        let mut sender = sender.base_setup(delta, sender_seeds);
-        let mut receiver = receiver.base_setup(receiver_seeds);
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
 
         let receiver_setup = receiver.extend(choices.len() + 256);
         sender.extend(data.len() + 256, receiver_setup).unwrap();
@@ -130,8 +130,8 @@ mod tests {
         let sender = Sender::new(SenderConfig::default());
         let receiver = Receiver::new(ReceiverConfig::default());
 
-        let mut sender = sender.base_setup(delta, sender_seeds);
-        let mut receiver = receiver.base_setup(receiver_seeds);
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
 
         let receiver_setup = receiver.extend(choices.len() + 256);
         sender.extend(data.len() + 256, receiver_setup).unwrap();
@@ -169,8 +169,8 @@ mod tests {
         let sender = Sender::new(SenderConfig::default());
         let receiver = Receiver::new(ReceiverConfig::default());
 
-        let mut sender = sender.base_setup(delta, sender_seeds);
-        let mut receiver = receiver.base_setup(receiver_seeds);
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
 
         let mut receiver_setup = receiver.extend(choices.len() + 256);
 
@@ -198,8 +198,8 @@ mod tests {
         let sender = Sender::new(SenderConfig::default());
         let receiver = Receiver::new(ReceiverConfig::builder().sender_commit().build().unwrap());
 
-        let mut sender = sender.base_setup(delta, sender_seeds);
-        let mut receiver = receiver.base_setup(receiver_seeds);
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
 
         let receiver_setup = receiver.extend(choices.len() + 256);
         sender.extend(data.len() + 256, receiver_setup).unwrap();
@@ -229,8 +229,8 @@ mod tests {
         let sender = Sender::new(SenderConfig::default());
         let receiver = Receiver::new(ReceiverConfig::builder().sender_commit().build().unwrap());
 
-        let mut sender = sender.base_setup(delta, sender_seeds);
-        let mut receiver = receiver.base_setup(receiver_seeds);
+        let mut sender = sender.setup(delta, sender_seeds);
+        let mut receiver = receiver.setup(receiver_seeds);
 
         let receiver_setup = receiver.extend(choices.len() + 256);
         sender.extend(data.len() + 256, receiver_setup).unwrap();

--- a/ot/mpz-ot-core/src/kos/mod.rs
+++ b/ot/mpz-ot-core/src/kos/mod.rs
@@ -1,0 +1,256 @@
+//! An implementation of the [`KOS15`](https://eprint.iacr.org/2015/546.pdf) oblivious transfer extension protocol.
+
+mod config;
+mod error;
+pub mod msgs;
+mod receiver;
+mod sender;
+
+pub use config::{
+    ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
+    SenderConfigBuilder, SenderConfigBuilderError,
+};
+pub use error::{ReceiverError, ReceiverVerifyError, SenderError};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+pub use receiver::{state as receiver_state, Receiver};
+pub use sender::{state as sender_state, Keys, Sender};
+
+/// Computational security parameter
+pub const CSP: usize = 128;
+/// Statistical security parameter
+pub const SSP: usize = 128;
+/// Rng to use for secret sharing the IKNP matrix.
+pub(crate) type Rng = ChaCha20Rng;
+/// Rng seed type
+pub(crate) type RngSeed = <Rng as SeedableRng>::Seed;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use itybity::ToBits;
+    use rstest::*;
+
+    use mpz_core::Block;
+
+    use rand::Rng;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
+
+    #[fixture]
+    fn choices() -> Vec<bool> {
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
+        (0..128).map(|_| rng.gen()).collect()
+    }
+
+    #[fixture]
+    fn data() -> Vec<[Block; 2]> {
+        let mut rng = ChaCha12Rng::seed_from_u64(1);
+        (0..128)
+            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .collect()
+    }
+
+    #[fixture]
+    fn delta() -> Block {
+        let mut rng = ChaCha12Rng::seed_from_u64(2);
+        rng.gen::<[u8; 16]>().into()
+    }
+
+    #[fixture]
+    fn receiver_seeds() -> [[Block; 2]; CSP] {
+        let mut rng = ChaCha12Rng::seed_from_u64(3);
+        std::array::from_fn(|_| [rng.gen(), rng.gen()])
+    }
+
+    #[fixture]
+    fn sender_seeds(delta: Block, receiver_seeds: [[Block; 2]; CSP]) -> [Block; CSP] {
+        delta
+            .iter_lsb0()
+            .zip(receiver_seeds)
+            .map(|(b, seeds)| if b { seeds[1] } else { seeds[0] })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
+    }
+
+    #[fixture]
+    fn chi_seed() -> Block {
+        let mut rng = ChaCha12Rng::seed_from_u64(4);
+        rng.gen::<[u8; 16]>().into()
+    }
+
+    #[fixture]
+    fn expected(data: Vec<[Block; 2]>, choices: Vec<bool>) -> Vec<Block> {
+        data.iter()
+            .zip(choices.iter())
+            .map(|([a, b], choice)| if *choice { *b } else { *a })
+            .collect()
+    }
+
+    #[rstest]
+    fn test_kos_extension(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+        choices: Vec<bool>,
+        data: Vec<[Block; 2]>,
+        expected: Vec<Block>,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::default());
+
+        let mut sender = sender.base_setup(delta, sender_seeds);
+        let mut receiver = receiver.base_setup(receiver_seeds);
+
+        let receiver_setup = receiver.extend(choices.len() + 256);
+        sender.extend(data.len() + 256, receiver_setup).unwrap();
+
+        let receiver_check = receiver.check(chi_seed);
+        sender.check(chi_seed, receiver_check).unwrap();
+
+        let derandomize = receiver.derandomize(&choices);
+        let payload = sender.send(&data, derandomize).unwrap();
+        let received = receiver.receive(payload).unwrap();
+
+        assert_eq!(received, expected);
+    }
+
+    #[rstest]
+    fn test_kos_extension_multiple_extends(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+        mut choices: Vec<bool>,
+        mut data: Vec<[Block; 2]>,
+        mut expected: Vec<Block>,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::default());
+
+        let mut sender = sender.base_setup(delta, sender_seeds);
+        let mut receiver = receiver.base_setup(receiver_seeds);
+
+        let receiver_setup = receiver.extend(choices.len() + 256);
+        sender.extend(data.len() + 256, receiver_setup).unwrap();
+
+        let more_choices = choices[..7].to_vec();
+        let more_data = data[..7].to_vec();
+        let more_expected = expected[..7].to_vec();
+
+        let receiver_setup = receiver.extend(7);
+        sender.extend(7, receiver_setup).unwrap();
+
+        let receiver_check = receiver.check(chi_seed);
+        sender.check(chi_seed, receiver_check).unwrap();
+
+        choices.extend(more_choices);
+        data.extend(more_data);
+        expected.extend(more_expected);
+
+        let derandomize = receiver.derandomize(&choices);
+        let payload = sender.send(&data, derandomize).unwrap();
+        let received = receiver.receive(payload).unwrap();
+
+        assert_eq!(received, expected);
+    }
+
+    #[rstest]
+    fn test_kos_extension_bad_consistency_check(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+        choices: Vec<bool>,
+        data: Vec<[Block; 2]>,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::default());
+
+        let mut sender = sender.base_setup(delta, sender_seeds);
+        let mut receiver = receiver.base_setup(receiver_seeds);
+
+        let mut receiver_setup = receiver.extend(choices.len() + 256);
+
+        // Flip a bit in the receiver's extension message (breaking the mono-chrome choice vector)
+        *receiver_setup.us.first_mut().unwrap() ^= 1;
+
+        sender.extend(data.len() + 256, receiver_setup).unwrap();
+
+        let receiver_check = receiver.check(chi_seed);
+        let err = sender.check(chi_seed, receiver_check).unwrap_err();
+
+        assert!(matches!(err, SenderError::ConsistencyCheckFailed));
+    }
+
+    #[rstest]
+    fn test_kos_extension_verify_messages(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+        choices: Vec<bool>,
+        data: Vec<[Block; 2]>,
+        expected: Vec<Block>,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::builder().sender_commit().build().unwrap());
+
+        let mut sender = sender.base_setup(delta, sender_seeds);
+        let mut receiver = receiver.base_setup(receiver_seeds);
+
+        let receiver_setup = receiver.extend(choices.len() + 256);
+        sender.extend(data.len() + 256, receiver_setup).unwrap();
+
+        let receiver_check = receiver.check(chi_seed);
+        sender.check(chi_seed, receiver_check).unwrap();
+
+        let derandomize = receiver.derandomize(&choices);
+        let payload = sender.send(&data, derandomize).unwrap();
+        let received = receiver.receive(payload).unwrap();
+
+        assert_eq!(received, expected);
+
+        receiver.verify(0, delta, &data).unwrap();
+    }
+
+    #[rstest]
+    fn test_kos_extension_verify_messages_fail(
+        delta: Block,
+        sender_seeds: [Block; CSP],
+        receiver_seeds: [[Block; 2]; CSP],
+        chi_seed: Block,
+        choices: Vec<bool>,
+        mut data: Vec<[Block; 2]>,
+        expected: Vec<Block>,
+    ) {
+        let sender = Sender::new(SenderConfig::default());
+        let receiver = Receiver::new(ReceiverConfig::builder().sender_commit().build().unwrap());
+
+        let mut sender = sender.base_setup(delta, sender_seeds);
+        let mut receiver = receiver.base_setup(receiver_seeds);
+
+        let receiver_setup = receiver.extend(choices.len() + 256);
+        sender.extend(data.len() + 256, receiver_setup).unwrap();
+
+        let receiver_check = receiver.check(chi_seed);
+        sender.check(chi_seed, receiver_check).unwrap();
+
+        let derandomize = receiver.derandomize(&choices);
+        let payload = sender.send(&data, derandomize).unwrap();
+        let received = receiver.receive(payload).unwrap();
+
+        assert_eq!(received, expected);
+
+        data[0][0] = Block::default();
+
+        let err = receiver.verify(0, delta, &data).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ReceiverError::ReceiverVerifyError(ReceiverVerifyError::InconsistentPayload)
+        ));
+    }
+}

--- a/ot/mpz-ot-core/src/kos/mod.rs
+++ b/ot/mpz-ot-core/src/kos/mod.rs
@@ -13,7 +13,7 @@ pub use config::{
 pub use error::{ReceiverError, ReceiverVerifyError, SenderError};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
-pub use receiver::{state as receiver_state, Receiver, ReceiverKeys};
+pub use receiver::{state as receiver_state, PayloadRecord, Receiver, ReceiverKeys};
 pub use sender::{state as sender_state, Sender, SenderKeys};
 
 /// Computational security parameter
@@ -267,7 +267,11 @@ mod tests {
 
         assert_eq!(received, expected);
 
-        receiver.verify(0, delta, &data).unwrap();
+        receiver
+            .remove_record(0)
+            .unwrap()
+            .verify(delta, &data)
+            .unwrap();
     }
 
     #[rstest]
@@ -305,7 +309,11 @@ mod tests {
 
         data[0][0] = Block::default();
 
-        let err = receiver.verify(0, delta, &data).unwrap_err();
+        let err = receiver
+            .remove_record(0)
+            .unwrap()
+            .verify(delta, &data)
+            .unwrap_err();
 
         assert!(matches!(
             err,

--- a/ot/mpz-ot-core/src/kos/msgs.rs
+++ b/ot/mpz-ot-core/src/kos/msgs.rs
@@ -47,6 +47,8 @@ pub struct Check {
 /// Sender payload message.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SenderPayload {
+    /// Transfer ID
+    pub id: u32,
     /// Sender's ciphertexts
     pub ciphertexts: Vec<Block>,
 }

--- a/ot/mpz-ot-core/src/kos/msgs.rs
+++ b/ot/mpz-ot-core/src/kos/msgs.rs
@@ -31,11 +31,11 @@ pub enum Message<BaseMsg> {
 pub struct Extend {
     /// The number of OTs to set up.
     pub count: usize,
-    /// The receiver's setup vectors.
+    /// The receiver's extension vectors.
     pub us: Vec<u8>,
 }
 
-/// Consistency check sent by the receiver.
+/// Values for the correlation check sent by the receiver.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct Check {

--- a/ot/mpz-ot-core/src/kos/msgs.rs
+++ b/ot/mpz-ot-core/src/kos/msgs.rs
@@ -1,0 +1,52 @@
+//! Messages for the KOS15 protocol.
+
+use enum_try_as_inner::EnumTryAsInner;
+use mpz_core::{
+    cointoss::msgs::{
+        ReceiverPayload as CointossReceiverPayload, SenderCommitment,
+        SenderPayload as CointossSenderPayload,
+    },
+    Block,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::msgs::Derandomize;
+
+/// A KOS15 protocol message.
+#[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum Message<BaseMsg> {
+    BaseMsg(BaseMsg),
+    Extend(Extend),
+    Check(Check),
+    Derandomize(Derandomize),
+    SenderPayload(SenderPayload),
+    CointossCommit(SenderCommitment),
+    CointossReceiverPayload(CointossReceiverPayload),
+    CointossSenderPayload(CointossSenderPayload),
+}
+
+/// Extension message sent by the receiver.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Extend {
+    /// The number of OTs to set up.
+    pub count: usize,
+    /// The receiver's setup vectors.
+    pub us: Vec<u8>,
+}
+
+/// Consistency check sent by the receiver.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct Check {
+    pub x: Block,
+    pub t0: Block,
+    pub t1: Block,
+}
+
+/// Sender payload message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SenderPayload {
+    /// Sender's ciphertexts
+    pub ciphertexts: Vec<Block>,
+}

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -306,7 +306,7 @@ impl Receiver<state::Extension> {
                 .map(|(setup_choice, new_choice)| setup_choice ^ new_choice),
         );
 
-        self.state.choices.copy_from_slice(choices);
+        self.state.choices[..choices.len()].copy_from_slice(choices);
 
         Derandomize { flip }
     }

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -43,6 +43,16 @@ pub struct Receiver<T: state::State = state::Initialized> {
     tape: Option<Tape>,
 }
 
+impl<T> Receiver<T>
+where
+    T: state::State,
+{
+    /// Returns the Receiver's configuration
+    pub fn config(&self) -> &ReceiverConfig {
+        &self.config
+    }
+}
+
 impl Receiver {
     /// Creates a new Sender
     ///

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -228,7 +228,15 @@ impl Receiver<state::Extension> {
     /// # Arguments
     ///
     /// * `chi_seed` - The seed used to generate the consistency check weights.
-    pub fn check(&mut self, chi_seed: Block) -> Check {
+    pub fn check(&mut self, chi_seed: Block) -> Result<Check, ReceiverError> {
+        // Make sure we have enough sacrifical OTs to perform the consistency check.
+        if self.state.unchecked_ts.len() < CSP + SSP {
+            return Err(ReceiverError::InsufficientSetup(
+                CSP + SSP,
+                self.state.unchecked_ts.len(),
+            ));
+        }
+
         let mut seed = RngSeed::default();
         seed.iter_mut()
             .zip(chi_seed.to_bytes().into_iter().cycle())
@@ -313,7 +321,7 @@ impl Receiver<state::Extension> {
         // Disable any further extensions.
         self.state.extended = true;
 
-        Check { x, t0, t1 }
+        Ok(Check { x, t0, t1 })
     }
 
     /// Returns receiver's keys for the given number of OTs.

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -1,0 +1,486 @@
+use std::collections::HashMap;
+
+use crate::{
+    kos::{
+        error::ReceiverVerifyError,
+        msgs::{Check, Extend, SenderPayload},
+        ReceiverConfig, ReceiverError, Rng, RngSeed, CSP, SSP,
+    },
+    msgs::Derandomize,
+};
+
+use itybity::{FromBitIterator, ToBits};
+use mpz_core::{aes::FIXED_KEY_AES, Block};
+
+use blake3::Hasher;
+use rand::{thread_rng, Rng as _, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use rand_core::RngCore;
+use utils::bits::ToBitsIter;
+
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
+#[derive(Debug, Default)]
+struct PayloadRecord {
+    counter: usize,
+    choices: Vec<u8>,
+    ts: Vec<Block>,
+    keys: Vec<Block>,
+    ciphertext_digest: [u8; 32],
+}
+
+#[derive(Debug, Default)]
+struct Tape {
+    records: HashMap<usize, PayloadRecord>,
+}
+
+/// KOS15 receiver.
+#[derive(Debug, Default)]
+pub struct Receiver<T: state::State = state::Initialized> {
+    config: ReceiverConfig,
+    state: T,
+    /// Protocol tape
+    tape: Option<Tape>,
+}
+
+impl Receiver {
+    /// Creates a new Sender
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The Sender's configuration
+    pub fn new(config: ReceiverConfig) -> Self {
+        let tape = if config.sender_commit() {
+            Some(Tape::default())
+        } else {
+            None
+        };
+
+        Receiver {
+            config,
+            state: state::Initialized::default(),
+            tape,
+        }
+    }
+
+    /// Complete the base setup phase of the protocol.
+    ///
+    /// # Arguments
+    ///
+    /// * `seeds` - The receiver's rng seeds
+    pub fn base_setup(self, seeds: [[Block; 2]; CSP]) -> Receiver<state::Extension> {
+        let rngs = seeds
+            .iter()
+            .map(|seeds| {
+                seeds.map(|seed| {
+                    let mut seed_ = RngSeed::default();
+                    seed_
+                        .iter_mut()
+                        .zip(seed.to_bytes().into_iter().cycle())
+                        .for_each(|(s, c)| *s = c);
+                    Rng::from_seed(seed_)
+                })
+            })
+            .collect();
+
+        Receiver {
+            config: self.config,
+            state: state::Extension {
+                rngs,
+                ts: Vec::default(),
+                keys: Vec::default(),
+                choices: Vec::default(),
+                key_counter: 0,
+                ot_counter: 0,
+                payload_counter: 0,
+                unchecked_ts: Vec::default(),
+                unchecked_choices: Vec::default(),
+            },
+            tape: self.tape,
+        }
+    }
+}
+
+impl Receiver<state::Extension> {
+    /// Returns the number of payloads that have been received.
+    pub fn payload_count(&self) -> usize {
+        self.state.payload_counter
+    }
+
+    /// The number of remaining OTs which can be consumed.
+    pub fn remaining(&self) -> usize {
+        self.state.keys.len()
+    }
+
+    /// Perform the IKNP OT extension.
+    ///
+    /// # Sacrificial OTs
+    ///
+    /// Performing the consistency check sacrifices 256 OTs for the consistency check, so be sure to
+    /// extend enough OTs to compensate for this.
+    ///
+    /// # Streaming
+    ///
+    /// Extension can be performed in a streaming fashion by calling this method multiple times, sending
+    /// the `Extend` messages to the sender in-between calls.
+    ///
+    /// The freshly extended OTs are not available until after the consistency check has been
+    /// performed. See [`Receiver::check`].
+    ///
+    /// # Arguments
+    ///
+    /// * `choices` - The receiver's choices
+    pub fn extend(&mut self, count: usize) -> Extend {
+        // Round up the OTs to extend to the nearest multiple of 64 (matrix transpose optimization).
+        let count = (count + 63) & !63;
+
+        const NROWS: usize = CSP;
+        let row_width = count / 8;
+
+        let mut rng = thread_rng();
+        let choices = (0..row_width)
+            .flat_map(|_| rng.gen::<u8>().into_lsb0_iter())
+            .collect::<Vec<_>>();
+
+        let choice_vector = Vec::<u8>::from_lsb0_iter(choices.iter().copied());
+
+        let mut ts = vec![0u8; NROWS * row_width];
+        let mut us = vec![0u8; NROWS * row_width];
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let iter = self.state.rngs
+                    .par_iter_mut()
+                    .zip(ts.par_chunks_exact_mut(row_width))
+                    .zip(us.par_chunks_exact_mut(row_width));
+            } else {
+                let iter = self.state.rngs
+                    .iter_mut()
+                    .zip(ts.chunks_exact_mut(row_width))
+                    .zip(uss.chunks_exact_mut(row_width));
+            }
+        }
+
+        iter.for_each(|((rngs, t), u)| {
+            // Figure 3, step 2.
+            rngs[0].fill_bytes(t);
+            rngs[1].fill_bytes(u);
+
+            // Figure 3, step 3.
+            // Computing `u = t_0 + t_1 + x`.
+            u.iter_mut()
+                .zip(t)
+                .zip(&choice_vector)
+                .for_each(|((u, t), r)| {
+                    *u ^= *t ^ r;
+                });
+        });
+
+        matrix_transpose::transpose_bits(&mut ts, NROWS).expect("matrix is rectangular");
+
+        self.state.unchecked_ts.extend(
+            ts.chunks_exact(NROWS / 8)
+                .map(|t| Block::try_from(t).unwrap()),
+        );
+        self.state.unchecked_choices.extend(choices);
+
+        Extend { count, us }
+    }
+
+    /// Checks the consistency of the receiver's choice vectors for all outstanding OTs.
+    ///
+    /// See section 3.1 of the paper for more details.
+    ///
+    /// # Sacrificial OTs
+    ///
+    /// Performing this check sacrifices 256 OTs for the consistency check, so be sure to
+    /// extend enough OTs to compensate for this.
+    ///
+    /// # ⚠️ Warning ⚠️
+    ///
+    /// The provided seed must be unbiased! It should be generated using a secure
+    /// coin-toss protocol **after** the receiver has sent their setup message, ie
+    /// after they have already committed to their choice vectors.
+    ///
+    /// # Arguments
+    ///
+    /// * `chi_seed` - The seed used to generate the consistency check weights.
+    pub fn check(&mut self, chi_seed: Block) -> Check {
+        let mut seed = RngSeed::default();
+        seed.iter_mut()
+            .zip(chi_seed.to_bytes().into_iter().cycle())
+            .for_each(|(s, c)| *s = c);
+
+        let mut rng = Rng::from_seed(seed);
+
+        let mut unchecked_ts = std::mem::take(&mut self.state.unchecked_ts);
+        let mut unchecked_choices = std::mem::take(&mut self.state.unchecked_choices);
+
+        // Figure 7, "Check correlation", point 1.
+        // Sample random weights for the consistency check.
+        let chis = (0..unchecked_ts.len())
+            .map(|_| Block::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        // Figure 7, "Check correlation", point 2.
+        // Compute the random linear combinations.
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let (x, t0, t1) = unchecked_choices.par_iter()
+                    .zip(&unchecked_ts)
+                    .zip(chis)
+                    .map(|((c, t), chi)| {
+                        let x = if *c { chi } else { Block::ZERO };
+                        let (t0, t1) = t.clmul(chi);
+                        (x, t0, t1)
+                    })
+                    .reduce(
+                        || (Block::ZERO, Block::ZERO, Block::ZERO),
+                        |(_x, _t0, _t1), (x, t0, t1)| {
+                            (_x ^ x, _t0 ^ t0, _t1 ^ t1)
+                        },
+                    );
+            } else {
+                use itybity::ToBits;
+
+                let (x, t0, t1) = unchecked_choices.iter()
+                    .zip(&unchecked_ts)
+                    .zip(chis)
+                    .map(|((c, t), chi)| {
+                        let x = if *c { chi } else { Block::ZERO };
+                        let (t0, t1) = t.clmul(chi);
+                        (x, t0, t1)
+                    })
+                    .reduce(|(_x, _t0, _t1), (x, t0, t1)| {
+                        (_x ^ x, _t0 ^ t0, _t1 ^ t1)
+                    }).unwrap();
+            }
+        }
+
+        // Strip off the rows sacrificed for the consistency check.
+        let nrows = unchecked_ts.len() - (CSP + SSP);
+        unchecked_ts.truncate(nrows);
+        unchecked_choices.truncate(nrows);
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let iter = unchecked_ts.par_iter().enumerate();
+            } else {
+                let iter = unchecked_ts.iter().enumerate();
+            }
+        }
+
+        let cipher = &(*FIXED_KEY_AES);
+        let keys = iter
+            .map(|(j, t)| {
+                let j = Block::from(((self.state.key_counter + j) as u128).to_be_bytes());
+                cipher.tccr(j, *t)
+            })
+            .collect::<Vec<_>>();
+
+        self.state.key_counter += keys.len();
+
+        // Add to existing keys.
+        self.state.keys.extend(keys);
+        self.state.choices.extend(unchecked_choices);
+
+        // If we're recording, we track `ts` too
+        if self.tape.is_some() {
+            self.state.ts.extend(unchecked_ts);
+        }
+
+        Check { x, t0, t1 }
+    }
+
+    /// Derandomize the receiver's choices from the setup phase.
+    ///
+    /// # Arguments
+    ///
+    /// * `choices` - The receiver's corrected choices.
+    pub fn derandomize(&mut self, choices: &[bool]) -> Derandomize {
+        let flip = Vec::<u8>::from_lsb0_iter(
+            self.state
+                .choices
+                .iter()
+                .zip(choices)
+                .map(|(setup_choice, new_choice)| setup_choice ^ new_choice),
+        );
+
+        self.state.choices.copy_from_slice(choices);
+
+        Derandomize { flip }
+    }
+
+    /// Obliviously receive the sender's messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - The sender's payload
+    pub fn receive(&mut self, payload: SenderPayload) -> Result<Vec<Block>, ReceiverError> {
+        let SenderPayload { ciphertexts } = payload;
+
+        if ciphertexts.len() % 2 != 0 {
+            return Err(ReceiverError::InvalidPayload);
+        }
+
+        let count = ciphertexts.len() / 2;
+
+        if count > self.state.keys.len() {
+            return Err(ReceiverError::CountMismatch(self.state.keys.len(), count));
+        }
+
+        let keys = Vec::from_iter(self.state.keys.drain(..count));
+        let choices = Vec::from_iter(self.state.choices.drain(..count));
+
+        if let Some(tape) = &mut self.tape {
+            let ts = Vec::from_iter(self.state.ts.drain(..count));
+
+            let mut hasher = Hasher::default();
+            ciphertexts.iter().for_each(|ct| {
+                hasher.update(&ct.to_bytes());
+            });
+
+            tape.records.insert(
+                self.state.payload_counter,
+                PayloadRecord {
+                    counter: self.state.ot_counter,
+                    choices: Vec::from_lsb0_iter(choices.iter().copied()),
+                    ts,
+                    keys: keys.clone(),
+                    ciphertext_digest: hasher.finalize().into(),
+                },
+            );
+        }
+
+        let plaintexts = keys
+            .into_iter()
+            .zip(choices)
+            .zip(ciphertexts.chunks(2))
+            .map(|((key, c), ct)| if c { key ^ ct[1] } else { key ^ ct[0] })
+            .collect();
+
+        self.state.ot_counter += count;
+        self.state.payload_counter += 1;
+
+        Ok(plaintexts)
+    }
+
+    /// Checks the purported messages against the receiver's protocol tape, using the sender's
+    /// base choices `delta`.
+    ///
+    /// # ⚠️ Warning ⚠️
+    ///
+    /// The authenticity of `delta` must be established outside the context of this function. This
+    /// can be achieved using verifiable OT for the base choices.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The index of the payload.
+    /// * `delta` - The sender's base choices.
+    /// * `purported_msgs` - The purported messages sent by the sender.
+    pub fn verify(
+        &self,
+        index: usize,
+        delta: Block,
+        purported_msgs: &[[Block; 2]],
+    ) -> Result<(), ReceiverError> {
+        let Some(tape) = &self.tape else {
+            return Err(ReceiverVerifyError::TapeNotRecorded)?;
+        };
+
+        let Some(record) = tape.records.get(&index) else {
+            return Err(ReceiverVerifyError::InvalidPayloadIndex)?;
+        };
+
+        let PayloadRecord {
+            counter,
+            choices,
+            ts,
+            keys,
+            ciphertext_digest,
+        } = record;
+
+        // Here we compute the complementary key to the one used earlier in the protocol.
+        //
+        // From this, we encrypt the purported messages and check that the ciphertext digests match.
+        let cipher = &(*FIXED_KEY_AES);
+        let mut hasher = Hasher::default();
+        for (j, (((c, t), key), msgs)) in choices
+            .iter_lsb0()
+            .zip(ts)
+            .zip(keys)
+            .zip(purported_msgs)
+            .enumerate()
+        {
+            let j = Block::new(((counter + j) as u128).to_be_bytes());
+            let key_ = cipher.tccr(j, *t ^ delta);
+
+            let (ct0, ct1) = if c {
+                (msgs[0] ^ key_, msgs[1] ^ *key)
+            } else {
+                (msgs[0] ^ *key, msgs[1] ^ key_)
+            };
+
+            hasher.update(&ct0.to_bytes());
+            hasher.update(&ct1.to_bytes());
+        }
+
+        let digest: [u8; 32] = hasher.finalize().into();
+
+        if *ciphertext_digest != digest {
+            return Err(ReceiverVerifyError::InconsistentPayload)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// The receiver's state.
+pub mod state {
+    use super::*;
+
+    mod sealed {
+        pub trait Sealed {}
+
+        impl Sealed for super::Initialized {}
+        impl Sealed for super::Extension {}
+    }
+
+    /// The receiver's state.
+    pub trait State: sealed::Sealed {}
+
+    /// The receiver's initial state.
+    #[derive(Default)]
+    pub struct Initialized {}
+
+    impl State for Initialized {}
+
+    opaque_debug::implement!(Initialized);
+
+    /// The receiver's state after base setup
+    pub struct Extension {
+        /// Receiver's rngs
+        pub(super) rngs: Vec<[ChaCha20Rng; 2]>,
+        /// Receiver's ts
+        pub(super) ts: Vec<Block>,
+        /// Receiver's keys
+        pub(super) keys: Vec<Block>,
+        /// Receiver's random choices
+        pub(super) choices: Vec<bool>,
+        /// Keys computed so far
+        pub(super) key_counter: usize,
+        /// OTs received so far
+        pub(super) ot_counter: usize,
+        /// Payloads received so far
+        pub(super) payload_counter: usize,
+
+        /// Receiver's unchecked ts
+        pub(super) unchecked_ts: Vec<Block>,
+        /// Receiver's unchecked choices
+        pub(super) unchecked_choices: Vec<bool>,
+    }
+
+    impl State for Extension {}
+
+    opaque_debug::implement!(Extension);
+}

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -48,11 +48,11 @@ where
 }
 
 impl Receiver {
-    /// Creates a new Sender
+    /// Creates a new Receiver
     ///
     /// # Arguments
     ///
-    /// * `config` - The Sender's configuration
+    /// * `config` - The Receiver's configuration
     pub fn new(config: ReceiverConfig) -> Self {
         let tape = if config.sender_commit() {
             Some(Default::default())
@@ -77,6 +77,7 @@ impl Receiver {
             .iter()
             .map(|seeds| {
                 seeds.map(|seed| {
+                    // Stretch the Block-sized seed to a 32-byte seed.
                     let mut seed_ = RngSeed::default();
                     seed_
                         .iter_mut()
@@ -382,7 +383,8 @@ pub struct ReceiverKeys {
     index: usize,
     /// Decryption keys
     keys: Vec<Block>,
-    /// Choices
+    /// The Receiver's choices. If derandomization is performed, these are the overwritten
+    /// with the derandomized choices.
     choices: Vec<bool>,
 
     /// Receiver `ts`

--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -9,14 +9,13 @@ use crate::{
     msgs::Derandomize,
 };
 
-use itybity::{FromBitIterator, ToBits};
+use itybity::{FromBitIterator, IntoBits, ToBits};
 use mpz_core::{aes::FIXED_KEY_AES, Block};
 
 use blake3::Hasher;
 use rand::{thread_rng, Rng as _, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
-use utils::bits::ToBitsIter;
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -140,7 +139,7 @@ impl Receiver<state::Extension> {
 
         let mut rng = thread_rng();
         let choices = (0..row_width)
-            .flat_map(|_| rng.gen::<u8>().into_lsb0_iter())
+            .flat_map(|_| rng.gen::<u8>().into_iter_lsb0())
             .collect::<Vec<_>>();
 
         let choice_vector = Vec::<u8>::from_lsb0_iter(choices.iter().copied());
@@ -157,7 +156,7 @@ impl Receiver<state::Extension> {
                 let iter = self.state.rngs
                     .iter_mut()
                     .zip(ts.chunks_exact_mut(row_width))
-                    .zip(uss.chunks_exact_mut(row_width));
+                    .zip(us.chunks_exact_mut(row_width));
             }
         }
 
@@ -241,8 +240,6 @@ impl Receiver<state::Extension> {
                         },
                     );
             } else {
-                use itybity::ToBits;
-
                 let (x, t0, t1) = unchecked_choices.iter()
                     .zip(&unchecked_ts)
                     .zip(chis)

--- a/ot/mpz-ot-core/src/kos/sender.rs
+++ b/ot/mpz-ot-core/src/kos/sender.rs
@@ -172,7 +172,7 @@ impl Sender<state::Extension> {
         }
 
         if us.len() != NROWS * row_width {
-            panic!();
+            return Err(SenderError::InvalidExtend);
         }
 
         let mut qs = vec![0u8; NROWS * row_width];

--- a/ot/mpz-ot-core/src/kos/sender.rs
+++ b/ot/mpz-ot-core/src/kos/sender.rs
@@ -199,6 +199,14 @@ impl Sender<state::Extension> {
     /// * `chi_seed` - The seed used to generate the consistency check weights.
     /// * `receiver_check` - The receiver's consistency check message.
     pub fn check(&mut self, chi_seed: Block, receiver_check: Check) -> Result<(), SenderError> {
+        // Make sure we have enough sacrifical OTs to perform the consistency check.
+        if self.state.unchecked_qs.len() < CSP + SSP {
+            return Err(SenderError::InsufficientSetup(
+                CSP + SSP,
+                self.state.unchecked_qs.len(),
+            ));
+        }
+
         let mut seed = RngSeed::default();
         seed.iter_mut()
             .zip(chi_seed.to_bytes().into_iter().cycle())

--- a/ot/mpz-ot-core/src/kos/sender.rs
+++ b/ot/mpz-ot-core/src/kos/sender.rs
@@ -83,6 +83,16 @@ impl Keys {
     }
 }
 
+impl<T> Sender<T>
+where
+    T: state::State,
+{
+    /// Returns the Sender's configuration
+    pub fn config(&self) -> &SenderConfig {
+        &self.config
+    }
+}
+
 impl Sender {
     /// Creates a new Sender
     ///

--- a/ot/mpz-ot-core/src/kos/sender.rs
+++ b/ot/mpz-ot-core/src/kos/sender.rs
@@ -1,0 +1,383 @@
+use crate::{
+    kos::{
+        msgs::{Check, Extend, SenderPayload},
+        Rng, RngSeed, SenderConfig, SenderError, CSP, SSP,
+    },
+    msgs::Derandomize,
+};
+
+use itybity::IntoBitIterator;
+use mpz_core::{aes::FIXED_KEY_AES, Block};
+
+use rand::{Rng as _, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use rand_core::RngCore;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "rayon")] {
+        use itybity::ToParallelBits;
+        use rayon::prelude::*;
+    } else {
+        use itybity::ToBits;
+    }
+}
+
+/// KOS15 sender.
+#[derive(Debug, Default)]
+pub struct Sender<T: state::State = state::Initialized> {
+    config: SenderConfig,
+    state: T,
+}
+
+/// Returned by the `Sender::keys` method, used in cases where the sender
+/// wishes to reserve a set of keys for use later, while still being able to process
+/// other payloads.
+///
+/// A set of keys which can be used to encrypt a payload.
+pub struct Keys {
+    keys: Vec<[Block; 2]>,
+}
+
+impl Keys {
+    /// Encrypts the provided messages using the keys, performing Beaver derandomization.
+    ///
+    /// # Arguments
+    ///
+    /// * `msgs` - The messages to encrypt
+    /// * `derandomize` - The receiver's derandomized choices.
+    pub fn send(
+        self,
+        msgs: &[[Block; 2]],
+        derandomize: Derandomize,
+    ) -> Result<SenderPayload, SenderError> {
+        let Derandomize { flip } = derandomize;
+
+        let flip = flip.into_lsb0_vec();
+
+        if msgs.len() > flip.len() {
+            return Err(SenderError::CountMismatch(flip.len(), msgs.len()));
+        }
+
+        if msgs.len() > self.keys.len() {
+            return Err(SenderError::InsufficientSetup(msgs.len(), self.keys.len()));
+        }
+
+        // Encrypt the chosen messages using the generated keys from ROT.
+        let ciphertexts = self
+            .keys
+            .into_iter()
+            .zip(msgs)
+            .zip(flip)
+            .flat_map(|(([k0, k1], [m0, m1]), flip)| {
+                // Use Beaver derandomization to correct the receiver's choices
+                // from the extension phase.
+                if flip {
+                    [k1 ^ *m0, k0 ^ *m1]
+                } else {
+                    [k0 ^ *m0, k1 ^ *m1]
+                }
+            })
+            .collect();
+
+        Ok(SenderPayload { ciphertexts })
+    }
+}
+
+impl Sender {
+    /// Creates a new Sender
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The Sender's configuration
+    pub fn new(config: SenderConfig) -> Self {
+        Sender {
+            config,
+            state: state::Initialized::default(),
+        }
+    }
+
+    /// Complete the base setup phase of the protocol.
+    ///
+    /// # Arguments
+    ///
+    /// * `delta` - The sender's base OT choices
+    /// * `seeds` - The receiver's rng seeds received via base OT
+    pub fn base_setup(self, delta: Block, seeds: [Block; CSP]) -> Sender<state::Extension> {
+        let rngs = seeds
+            .iter()
+            .map(|seed| {
+                let mut seed_ = RngSeed::default();
+                seed_
+                    .iter_mut()
+                    .zip(seed.to_bytes().into_iter().cycle())
+                    .for_each(|(s, c)| *s = c);
+                Rng::from_seed(seed_)
+            })
+            .collect();
+
+        Sender {
+            config: self.config,
+            state: state::Extension {
+                delta,
+                rngs,
+                keys: Vec::default(),
+                counter: 0,
+                unchecked_qs: Vec::default(),
+                unchecked_keys: Vec::default(),
+            },
+        }
+    }
+}
+
+impl Sender<state::Extension> {
+    /// The number of remaining OTs which can be consumed.
+    pub fn remaining(&self) -> usize {
+        self.state.keys.len()
+    }
+
+    /// Perform the IKNP OT extension.
+    ///
+    /// # Sacrificial OTs
+    ///
+    /// Performing the consistency check sacrifices 256 OTs, so be sure to extend enough to
+    /// compensate for this.
+    ///
+    /// # Streaming
+    ///
+    /// Extension can be performed in a streaming fashion by processing an extension in batches via
+    /// multiple calls to this method.
+    ///
+    /// The freshly extended OTs are not available until after the consistency check has been
+    /// performed. See [`Sender::check`].
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of additional OTs to extend
+    /// * `extend` - The receiver's setup message
+    pub fn extend(&mut self, count: usize, extend: Extend) -> Result<(), SenderError> {
+        // Round up the OTs to extend to the nearest multiple of 64 (matrix transpose optimization).
+        let count = (count + 63) & !63;
+
+        const NROWS: usize = CSP;
+        let row_width = count / 8;
+
+        let Extend {
+            us,
+            count: receiver_count,
+        } = extend;
+
+        // Make sure the number of OTs to extend matches the receiver's setup message.
+        if receiver_count != count {
+            return Err(SenderError::CountMismatch(receiver_count, count));
+        }
+
+        if us.len() != NROWS * row_width {
+            panic!();
+        }
+
+        let mut qs = vec![0u8; NROWS * row_width];
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let iter = self.state.delta
+                    .par_iter_lsb0()
+                    .zip(self.state.rngs.par_iter_mut())
+                    .zip(qs.par_chunks_exact_mut(row_width))
+                    .zip(us.par_chunks_exact(row_width));
+            } else {
+                let iter = self.state.delta
+                    .iter_lsb0()
+                    .zip(self.state.rngs.iter_mut())
+                    .zip(qs.chunks_exact_mut(row_width))
+                    .zip(us.chunks_exact(row_width));
+            }
+        }
+
+        let zero = vec![0u8; row_width];
+        iter.for_each(|(((b, rng), q), u)| {
+            rng.fill_bytes(q);
+            // If `b` is true, xor `u` into `q`, otherwise xor 0 into `q` (constant time).
+            let u = if b { u } else { &zero };
+            q.iter_mut().zip(u).for_each(|(q, u)| *q ^= u);
+        });
+
+        matrix_transpose::transpose_bits(&mut qs, NROWS).expect("matrix is rectangular");
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let iter = qs.par_chunks_exact(NROWS / 8).enumerate();
+            } else {
+                let iter = qs.chunks_exact(NROWS / 8).enumerate();
+            }
+        }
+
+        let cipher = &(*FIXED_KEY_AES);
+        let (qs, keys): (Vec<_>, Vec<_>) = iter
+            .map(|(j, q)| {
+                let q: Block = q.try_into().unwrap();
+                let j = Block::new(((self.state.counter + j) as u128).to_be_bytes());
+
+                let k0 = cipher.tccr(j, q);
+                let k1 = cipher.tccr(j, q ^ self.state.delta);
+
+                (q, [k0, k1])
+            })
+            .unzip();
+
+        self.state.counter += count;
+
+        self.state.unchecked_qs.extend(qs);
+        self.state.unchecked_keys.extend(keys);
+
+        Ok(())
+    }
+
+    /// Checks the consistency of the receiver's choice vectors for all outstanding OTs.
+    ///
+    /// See section 3.1 of the paper for more details.
+    ///
+    /// # Sacrificial OTs
+    ///
+    /// Performing this check sacrifices 256 OTs for the consistency check, so be sure to
+    /// extend enough OTs to compensate for this.
+    ///
+    /// # ⚠️ Warning ⚠️
+    ///
+    /// The provided seed must be unbiased! It should be generated using a secure
+    /// coin-toss protocol **after** the receiver has sent their extension message, ie
+    /// after they have already committed to their choice vectors.
+    ///
+    /// # Arguments
+    ///
+    /// * `chi_seed` - The seed used to generate the consistency check weights.
+    /// * `receiver_check` - The receiver's consistency check message.
+    pub fn check(&mut self, chi_seed: Block, receiver_check: Check) -> Result<(), SenderError> {
+        let mut seed = RngSeed::default();
+        seed.iter_mut()
+            .zip(chi_seed.to_bytes().into_iter().cycle())
+            .for_each(|(s, c)| *s = c);
+
+        let mut rng = Rng::from_seed(seed);
+
+        let unchecked_qs = std::mem::take(&mut self.state.unchecked_qs);
+        let mut unchecked_keys = std::mem::take(&mut self.state.unchecked_keys);
+
+        // Figure 7, "Check correlation", point 1.
+        // Sample random weights for the consistency check.
+        let chis = (0..unchecked_qs.len())
+            .map(|_| rng.gen())
+            .collect::<Vec<_>>();
+
+        // Figure 7, "Check correlation", point 3.
+        // Compute the random linear combinations.
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rayon")] {
+                let check = unchecked_qs.into_par_iter()
+                    .zip(chis)
+                    .map(|(q, chi)| q.clmul(chi))
+                    .reduce(
+                        || (Block::ZERO, Block::ZERO),
+                        |(_a, _b), (a, b)| (a ^ _a, b ^ _b),
+                    );
+            } else {
+                let check = unchecked_qs.into_iter()
+                    .zip(chis)
+                    .map(|(q, chi)| q.clmul(chi))
+                    .reduce(
+                        |(_a, _b), (a, b)| (a ^ _a, b ^ _b),
+                    ).unwrap();
+            }
+        }
+
+        let Check { x, t0, t1 } = receiver_check;
+        let tmp = x.clmul(self.state.delta);
+        let check = (check.0 ^ tmp.0, check.1 ^ tmp.1);
+
+        // Call the police!
+        if check != (t0, t1) {
+            return Err(SenderError::ConsistencyCheckFailed);
+        }
+
+        // Strip off the rows sacrificed for the consistency check.
+        let nrows = unchecked_keys.len() - (CSP + SSP);
+        unchecked_keys.truncate(nrows);
+
+        // Add to existing qs.
+        self.state.keys.extend(unchecked_keys);
+
+        Ok(())
+    }
+
+    /// Reserves a set of keys which can be used to encrypt a payload later.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of keys to reserve.
+    pub fn keys(&mut self, count: usize) -> Result<Keys, SenderError> {
+        if count > self.state.keys.len() {
+            return Err(SenderError::InsufficientSetup(count, self.state.keys.len()));
+        }
+
+        Ok(Keys {
+            keys: self.state.keys.drain(..count).collect(),
+        })
+    }
+
+    /// Obliviously transfers the provided messages to the receiver, applying Beaver
+    /// derandomization to correct the receiver's choices made during extension.
+    ///
+    /// # Arguments
+    ///
+    /// * `msgs` - The messages to obliviously transfer
+    /// * `derandomize` - The receiver's derandomization choices
+    pub fn send(
+        &mut self,
+        msgs: &[[Block; 2]],
+        derandomize: Derandomize,
+    ) -> Result<SenderPayload, SenderError> {
+        self.keys(msgs.len())?.send(msgs, derandomize)
+    }
+}
+
+/// The sender's state.
+pub mod state {
+    use super::*;
+
+    mod sealed {
+        pub trait Sealed {}
+
+        impl Sealed for super::Initialized {}
+        impl Sealed for super::Extension {}
+    }
+
+    /// The sender's state.
+    pub trait State: sealed::Sealed {}
+
+    /// The sender's initial state.
+    #[derive(Default)]
+    pub struct Initialized {}
+
+    impl State for Initialized {}
+
+    opaque_debug::implement!(Initialized);
+
+    /// The sender's state after base setup
+    pub struct Extension {
+        /// Sender's base OT choices
+        pub(super) delta: Block,
+        /// Receiver's rngs seeded from base OT
+        pub(super) rngs: Vec<ChaCha20Rng>,
+        /// Sender's keys
+        pub(super) keys: Vec<[Block; 2]>,
+        /// Number of OTs sent so far
+        pub(super) counter: usize,
+
+        /// Sender's unchecked qs
+        pub(super) unchecked_qs: Vec<Block>,
+        /// Sender's unchecked keys
+        pub(super) unchecked_keys: Vec<[Block; 2]>,
+    }
+
+    impl State for Extension {}
+
+    opaque_debug::implement!(Extension);
+}

--- a/ot/mpz-ot-core/src/lib.rs
+++ b/ot/mpz-ot-core/src/lib.rs
@@ -1,8 +1,19 @@
 //! Low-level crate containing core functionalities for oblivious transfer protocols.
+//!
+//! This crate is not intended to be used directly. Instead, use the higher-level APIs provided by
+//! the `mpz-ot` crate.
+//!
+//! # ⚠️ Warning ⚠️
+//!
+//! Some implementations make assumptions about invariants which may not be checked if using these
+//! low-level APIs naively. Failing to uphold these invariants may result in security vulnerabilities.
+//!
+//! USE AT YOUR OWN RISK.
 
 #![deny(missing_docs, unreachable_pub, unused_must_use)]
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
 
 pub mod chou_orlandi;
+pub mod kos;
 pub mod msgs;

--- a/ot/mpz-ot-core/src/msgs.rs
+++ b/ot/mpz-ot-core/src/msgs.rs
@@ -5,7 +5,63 @@ use serde::{Deserialize, Serialize};
 /// A message sent by the receiver which a sender can use to perform
 /// Beaver derandomization.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "UncheckedDerandomize")]
 pub struct Derandomize {
+    /// Transfer ID
+    pub id: u32,
+    /// The number of choices to derandomize.
+    pub count: u32,
     /// Correction bits
     pub flip: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UncheckedDerandomize {
+    id: u32,
+    count: u32,
+    flip: Vec<u8>,
+}
+
+impl TryFrom<UncheckedDerandomize> for Derandomize {
+    type Error = std::io::Error;
+
+    fn try_from(value: UncheckedDerandomize) -> Result<Self, Self::Error> {
+        // Divide by 8, rounding up
+        let expected_len = (value.count as usize + 7) / 8;
+
+        if value.flip.len() != expected_len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "flip length does not match count",
+            ));
+        }
+
+        Ok(Derandomize {
+            id: value.id,
+            count: value.count,
+            flip: value.flip,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unchecked_derandomize() {
+        assert!(Derandomize::try_from(UncheckedDerandomize {
+            id: 0,
+            count: 0,
+            flip: vec![],
+        })
+        .is_ok());
+
+        assert!(Derandomize::try_from(UncheckedDerandomize {
+            id: 0,
+            count: 9,
+            flip: vec![0],
+        })
+        .is_err());
+    }
 }

--- a/ot/mpz-ot/Cargo.toml
+++ b/ot/mpz-ot/Cargo.toml
@@ -36,6 +36,7 @@ rayon = { workspace = true }
 itybity.workspace = true
 enum-try-as-inner = { tag = "0.1.0", git = "https://github.com/sinui0/enum-try-as-inner" }
 opaque-debug.workspace = true
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/ot/mpz-ot/src/kos/error.rs
+++ b/ot/mpz-ot/src/kos/error.rs
@@ -1,0 +1,71 @@
+use mpz_ot_core::kos::msgs::Message;
+
+use crate::OTError;
+
+/// A KOS sender error.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum SenderError {
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    CoreError(#[from] mpz_ot_core::kos::SenderError),
+    #[error(transparent)]
+    BaseOTError(#[from] crate::OTError),
+    #[error(transparent)]
+    CointossError(#[from] mpz_core::cointoss::CointossError),
+    #[error("invalid state: expected {0}")]
+    StateError(String),
+}
+
+impl From<SenderError> for OTError {
+    fn from(err: SenderError) -> Self {
+        match err {
+            SenderError::IOError(e) => e.into(),
+            e => OTError::SenderError(Box::new(e)),
+        }
+    }
+}
+
+impl<BaseMsg> From<enum_try_as_inner::Error<Message<BaseMsg>>> for SenderError {
+    fn from(value: enum_try_as_inner::Error<Message<BaseMsg>>) -> Self {
+        SenderError::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}
+
+/// A KOS receiver error.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ReceiverError {
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    CoreError(#[from] mpz_ot_core::kos::ReceiverError),
+    #[error(transparent)]
+    BaseOTError(#[from] crate::OTError),
+    #[error(transparent)]
+    CointossError(#[from] mpz_core::cointoss::CointossError),
+    #[error("invalid state: expected {0}")]
+    StateError(String),
+}
+
+impl From<ReceiverError> for OTError {
+    fn from(err: ReceiverError) -> Self {
+        match err {
+            ReceiverError::IOError(e) => e.into(),
+            e => OTError::ReceiverError(Box::new(e)),
+        }
+    }
+}
+
+impl<BaseMsg> From<enum_try_as_inner::Error<Message<BaseMsg>>> for ReceiverError {
+    fn from(value: enum_try_as_inner::Error<Message<BaseMsg>>) -> Self {
+        ReceiverError::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}

--- a/ot/mpz-ot/src/kos/error.rs
+++ b/ot/mpz-ot/src/kos/error.rs
@@ -16,6 +16,8 @@ pub enum SenderError {
     CointossError(#[from] mpz_core::cointoss::CointossError),
     #[error("invalid state: expected {0}")]
     StateError(String),
+    #[error("configuration error: {0}")]
+    ConfigError(String),
 }
 
 impl From<SenderError> for OTError {
@@ -50,6 +52,10 @@ pub enum ReceiverError {
     CointossError(#[from] mpz_core::cointoss::CointossError),
     #[error("invalid state: expected {0}")]
     StateError(String),
+    #[error("configuration error: {0}")]
+    ConfigError(String),
+    #[error(transparent)]
+    VerifyError(#[from] ReceiverVerifyError),
 }
 
 impl From<ReceiverError> for OTError {
@@ -68,4 +74,11 @@ impl<BaseMsg> From<enum_try_as_inner::Error<Message<BaseMsg>>> for ReceiverError
             value.to_string(),
         ))
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ReceiverVerifyError {
+    #[error("delta value is not inconsistent")]
+    InconsistentDelta,
 }

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -10,8 +10,8 @@ pub use receiver::Receiver;
 pub use sender::Sender;
 
 pub use mpz_ot_core::kos::{
-    msgs, Keys, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
-    SenderConfigBuilder, SenderConfigBuilderError,
+    msgs, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
+    SenderConfigBuilder, SenderConfigBuilderError, SenderKeys,
 };
 use utils_aio::{sink::IoSink, stream::IoStream};
 

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -1,0 +1,191 @@
+//! An implementation of the [`KOS15`](https://eprint.iacr.org/2015/546.pdf) oblivious transfer extension protocol.
+
+mod error;
+mod receiver;
+mod sender;
+
+pub use error::{ReceiverError, SenderError};
+use futures_util::{SinkExt, StreamExt};
+pub use receiver::Receiver;
+pub use sender::Sender;
+
+pub use mpz_ot_core::kos::{
+    msgs, Keys, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
+    SenderConfigBuilder, SenderConfigBuilderError,
+};
+use utils_aio::{sink::IoSink, stream::IoStream};
+
+/// Converts a sink of KOS messages into a sink of base OT messages.
+pub(crate) fn into_base_sink<'a, Si: IoSink<msgs::Message<T>> + Send + Unpin, T: Send + 'a>(
+    sink: &'a mut Si,
+) -> impl IoSink<T> + Send + Unpin + 'a {
+    Box::pin(SinkExt::with(sink, |msg| async move {
+        Ok(msgs::Message::BaseMsg(msg))
+    }))
+}
+
+/// Converts a stream of KOS messages into a stream of base OT messages.
+pub(crate) fn into_base_stream<'a, St: IoStream<msgs::Message<T>> + Send + Unpin, T: Send + 'a>(
+    stream: &'a mut St,
+) -> impl IoStream<T> + Send + Unpin + 'a {
+    StreamExt::map(stream, |msg| match msg {
+        Ok(msg) => match msg.into_base_msg() {
+            Ok(msg) => Ok(msg),
+            Err(err) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                err.to_string(),
+            )),
+        },
+        Err(err) => Err(err),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use rstest::*;
+
+    use itybity::ToBits;
+    use mpz_core::Block;
+    use mpz_ot_core::kos::msgs::Message;
+    use rand::Rng;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
+    use utils_aio::{duplex::MpscDuplex, sink::IoSink, stream::IoStream};
+
+    use crate::{
+        mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
+        OTReceiver, OTSender, RevealMessages, VerifyMessages,
+    };
+
+    #[fixture]
+    fn choices() -> Vec<bool> {
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
+        (0..128).map(|_| rng.gen()).collect()
+    }
+
+    #[fixture]
+    fn data() -> Vec<[Block; 2]> {
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
+        (0..128)
+            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .collect()
+    }
+
+    fn choose<T>(
+        data: impl Iterator<Item = [T; 2]>,
+        choices: impl Iterator<Item = bool>,
+    ) -> impl Iterator<Item = T> {
+        data.zip(choices)
+            .map(|([zero, one], choice)| if choice { one } else { zero })
+    }
+
+    async fn setup<
+        Si: IoSink<Message<()>> + Send + Unpin,
+        St: IoStream<Message<()>> + Send + Unpin,
+    >(
+        sender_config: SenderConfig,
+        receiver_config: ReceiverConfig,
+        sender_sink: &mut Si,
+        sender_stream: &mut St,
+        receiver_sink: &mut Si,
+        receiver_stream: &mut St,
+        count: usize,
+    ) -> (Sender<MockOTReceiver<Block>>, Receiver<MockOTSender<Block>>) {
+        let (base_sender, base_receiver) = mock_ot_pair();
+
+        let mut sender = Sender::new(sender_config, base_receiver);
+        let mut receiver = Receiver::new(receiver_config, base_sender);
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.setup_with_delta(sender_sink, sender_stream, Block::ONES),
+            receiver.setup(receiver_sink, receiver_stream)
+        );
+
+        sender_res.unwrap();
+        receiver_res.unwrap();
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.extend(sender_sink, sender_stream, count),
+            receiver.extend(receiver_sink, receiver_stream, count)
+        );
+
+        sender_res.unwrap();
+        receiver_res.unwrap();
+
+        (sender, receiver)
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_kos(data: Vec<[Block; 2]>, choices: Vec<bool>) {
+        let (sender_channel, receiver_channel) = MpscDuplex::new();
+
+        let (mut sender_sink, mut sender_stream) = sender_channel.split();
+        let (mut receiver_sink, mut receiver_stream) = receiver_channel.split();
+
+        let (mut sender, mut receiver) = setup(
+            SenderConfig::default(),
+            ReceiverConfig::default(),
+            &mut sender_sink,
+            &mut sender_stream,
+            &mut receiver_sink,
+            &mut receiver_stream,
+            data.len(),
+        )
+        .await;
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.send(&mut sender_sink, &mut sender_stream, &data),
+            receiver.receive(&mut receiver_sink, &mut receiver_stream, &choices)
+        );
+
+        sender_res.unwrap();
+        let received = receiver_res.unwrap();
+
+        let expected = choose(data.iter().copied(), choices.iter_lsb0()).collect::<Vec<_>>();
+
+        assert_eq!(received, expected);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_kos_committed_sender(data: Vec<[Block; 2]>, choices: Vec<bool>) {
+        let (sender_channel, receiver_channel) = MpscDuplex::new();
+
+        let (mut sender_sink, mut sender_stream) = sender_channel.split();
+        let (mut receiver_sink, mut receiver_stream) = receiver_channel.split();
+
+        let (mut sender, mut receiver) = setup(
+            SenderConfig::builder().sender_commit().build().unwrap(),
+            ReceiverConfig::builder().sender_commit().build().unwrap(),
+            &mut sender_sink,
+            &mut sender_stream,
+            &mut receiver_sink,
+            &mut receiver_stream,
+            data.len(),
+        )
+        .await;
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.send(&mut sender_sink, &mut sender_stream, &data),
+            receiver.receive(&mut receiver_sink, &mut receiver_stream, &choices)
+        );
+
+        sender_res.unwrap();
+        let received = receiver_res.unwrap();
+
+        let expected = choose(data.iter().copied(), choices.iter_lsb0()).collect::<Vec<_>>();
+
+        assert_eq!(received, expected);
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.reveal(&mut sender_sink, &mut sender_stream),
+            receiver.verify(&mut receiver_sink, &mut receiver_stream, 0, &data)
+        );
+
+        sender_res.unwrap();
+        receiver_res.unwrap();
+    }
+}

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -56,7 +56,7 @@ mod tests {
 
     use crate::{
         mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
-        OTReceiver, OTSender, RevealMessages, VerifyMessages,
+        CommittedOTSender, OTReceiver, OTSender, VerifiableOTReceiver,
     };
 
     #[fixture]

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -10,8 +10,8 @@ pub use receiver::Receiver;
 pub use sender::Sender;
 
 pub use mpz_ot_core::kos::{
-    msgs, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
-    SenderConfigBuilder, SenderConfigBuilderError, SenderKeys,
+    msgs, PayloadRecord, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError,
+    ReceiverKeys, SenderConfig, SenderConfigBuilder, SenderConfigBuilderError, SenderKeys,
 };
 use utils_aio::{sink::IoSink, stream::IoStream};
 

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -4,7 +4,7 @@ mod error;
 mod receiver;
 mod sender;
 
-pub use error::{ReceiverError, SenderError};
+pub use error::{ReceiverError, ReceiverVerifyError, SenderError};
 use futures_util::{SinkExt, StreamExt};
 pub use receiver::Receiver;
 pub use sender::Sender;
@@ -99,7 +99,7 @@ mod tests {
         let mut receiver = Receiver::new(receiver_config, base_sender);
 
         let (sender_res, receiver_res) = tokio::join!(
-            sender.setup_with_delta(sender_sink, sender_stream, Block::ONES),
+            sender.setup(sender_sink, sender_stream),
             receiver.setup(receiver_sink, receiver_stream)
         );
 

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -1,0 +1,260 @@
+use async_trait::async_trait;
+use futures::SinkExt;
+use itybity::{BitIterable, FromBitIterator, IntoBitIterator};
+use mpz_core::{cointoss, Block, ProtocolMessage};
+use mpz_ot_core::kos::{
+    msgs::Message, receiver_state as state, Receiver as ReceiverCore, ReceiverConfig, CSP, SSP,
+};
+
+use enum_try_as_inner::EnumTryAsInner;
+use rand::{thread_rng, Rng};
+use utils_aio::{
+    non_blocking_backend::{Backend, NonBlockingBackend},
+    sink::IoSink,
+    stream::{ExpectStreamExt, IoStream},
+};
+
+use crate::{OTError, OTReceiver, OTSender, VerifyChoices, VerifyMessages};
+
+use super::{into_base_sink, into_base_stream, ReceiverError};
+
+#[derive(Debug, EnumTryAsInner)]
+enum State {
+    Initialized(Box<ReceiverCore<state::Initialized>>),
+    Extension(Box<ReceiverCore<state::Extension>>),
+    Error,
+}
+
+impl From<enum_try_as_inner::Error<State>> for ReceiverError {
+    fn from(value: enum_try_as_inner::Error<State>) -> Self {
+        ReceiverError::StateError(value.to_string())
+    }
+}
+
+/// KOS receiver.
+#[derive(Debug)]
+pub struct Receiver<BaseOT> {
+    state: State,
+    base: BaseOT,
+
+    /// The verified delta value used by the sender, if revealed.
+    delta: Option<Block>,
+}
+
+impl<BaseOT> Receiver<BaseOT>
+where
+    BaseOT: OTSender<[Block; 2]> + Send,
+{
+    /// Creates a new receiver.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The receiver's configuration
+    pub fn new(config: ReceiverConfig, base: BaseOT) -> Self {
+        Self {
+            state: State::Initialized(Box::new(ReceiverCore::new(config))),
+            base,
+            delta: None,
+        }
+    }
+
+    /// The number of remaining OTs which can be consumed.
+    pub fn remaining(&self) -> Result<usize, ReceiverError> {
+        Ok(self.state.as_extension()?.remaining())
+    }
+
+    /// Performs the base OT setup.
+    ///
+    /// # Arguments
+    ///
+    /// * `sink` - The sink to send messages to the base OT receiver
+    /// * `stream` - The stream to receive messages from the base OT receiver
+    pub async fn setup<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+    ) -> Result<(), ReceiverError> {
+        let ext_receiver = self.state.replace(State::Error).into_initialized()?;
+
+        let mut rng = thread_rng();
+        let seeds: [[Block; 2]; CSP] = std::array::from_fn(|_| [rng.gen(), rng.gen()]);
+
+        // Send seeds to sender
+        self.base
+            .send(
+                &mut into_base_sink(sink),
+                &mut into_base_stream(stream),
+                &seeds,
+            )
+            .await?;
+
+        let ext_receiver = ext_receiver.base_setup(seeds);
+
+        self.state = State::Extension(Box::new(ext_receiver));
+
+        Ok(())
+    }
+
+    /// Performs OT extension.
+    ///
+    /// # Arguments
+    ///
+    /// * `sink` - The sink to send messages to the sender
+    /// * `stream` - The stream to receive messages from the sender
+    /// * `count` - The number of OTs to extend
+    pub async fn extend<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        count: usize,
+    ) -> Result<(), ReceiverError> {
+        let mut ext_receiver = self.state.replace(State::Error).into_extension()?;
+
+        // Extend the OTs, adding padding for the consistency check.
+        let (mut ext_receiver, extend) = Backend::spawn(move || {
+            let extend = ext_receiver.extend(count + CSP + SSP);
+
+            (ext_receiver, extend)
+        })
+        .await;
+
+        // Commit to cointoss seed
+        let seed: Block = thread_rng().gen();
+        let (cointoss_sender, cointoss_commitment) = cointoss::Sender::new(vec![seed]).send();
+
+        // Send the extend message and cointoss commitment
+        sink.feed(Message::Extend(extend)).await?;
+        sink.feed(Message::CointossCommit(cointoss_commitment))
+            .await?;
+        sink.flush().await?;
+
+        // Receive cointoss
+        let cointoss_payload = stream
+            .expect_next()
+            .await?
+            .into_cointoss_receiver_payload()?;
+
+        // Open commitment
+        let (mut seeds, payload) = cointoss_sender.finalize(cointoss_payload)?;
+        let chi_seed = seeds.pop().expect("seed is present");
+
+        // Compute consistency check
+        let (ext_receiver, check) = Backend::spawn(move || {
+            let check = ext_receiver.check(chi_seed);
+
+            (ext_receiver, check)
+        })
+        .await;
+
+        // Send consistency check
+        sink.feed(Message::CointossSenderPayload(payload)).await?;
+        sink.feed(Message::Check(check)).await?;
+        sink.flush().await?;
+
+        self.state = State::Extension(ext_receiver);
+
+        Ok(())
+    }
+}
+
+impl<BaseOT> ProtocolMessage for Receiver<BaseOT>
+where
+    BaseOT: ProtocolMessage,
+{
+    type Msg = Message<BaseOT::Msg>;
+}
+
+#[async_trait]
+impl<BaseOT, T> OTReceiver<T, Block> for Receiver<BaseOT>
+where
+    BaseOT: ProtocolMessage + Send,
+    T: BitIterable + Send + Sync + 'static,
+{
+    async fn receive<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        choices: &[T],
+    ) -> Result<Vec<Block>, OTError> {
+        let mut receiver = self
+            .state
+            .replace(State::Error)
+            .into_extension()
+            .map_err(ReceiverError::from)?;
+
+        let choices = choices.into_lsb0_vec();
+        let derandomize = receiver.derandomize(&choices);
+
+        // Send derandomize message
+        sink.send(Message::Derandomize(derandomize)).await?;
+
+        // Receive payload
+        let payload = stream
+            .expect_next()
+            .await?
+            .into_sender_payload()
+            .map_err(ReceiverError::from)?;
+
+        let (receiver, received) = Backend::spawn(move || {
+            receiver
+                .receive(payload)
+                .map(|received| (receiver, received))
+                .map_err(ReceiverError::from)
+        })
+        .await?;
+
+        self.state = State::Extension(receiver);
+
+        Ok(received)
+    }
+}
+
+#[async_trait]
+impl<BaseOT> VerifyMessages<[Block; 2]> for Receiver<BaseOT>
+where
+    BaseOT: VerifyChoices<Vec<bool>> + ProtocolMessage + Send,
+{
+    async fn verify<
+        Si: IoSink<Self::Msg> + Send + Unpin,
+        St: IoStream<Self::Msg> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        index: usize,
+        msgs: &[[Block; 2]],
+    ) -> Result<(), OTError> {
+        let receiver = self.state.as_extension().map_err(ReceiverError::from)?;
+
+        let delta = if let Some(delta) = self.delta {
+            delta
+        } else {
+            // Receive delta by verifying the sender's base OT choices.
+            let choices = self
+                .base
+                .verify_choices(&mut into_base_sink(sink), &mut into_base_stream(stream))
+                .await?;
+
+            let delta = <[u8; 16]>::from_lsb0_iter(choices).into();
+
+            self.delta = Some(delta);
+
+            delta
+        };
+
+        receiver
+            .verify(index, delta, msgs)
+            .map_err(ReceiverError::from)?;
+
+        Ok(())
+    }
+}

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -105,7 +105,7 @@ where
             )
             .await?;
 
-        let ext_receiver = ext_receiver.base_setup(seeds);
+        let ext_receiver = ext_receiver.setup(seeds);
 
         self.state = State::Extension(Box::new(ext_receiver));
 

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -283,8 +283,13 @@ where
             actual_delta
         };
 
-        receiver
-            .verify(id as u32, delta, msgs)
+        let record = receiver
+            .remove_record(id as u32)
+            .map_err(ReceiverError::from)?;
+
+        let msgs = msgs.to_vec();
+        Backend::spawn(move || record.verify(delta, &msgs))
+            .await
             .map_err(ReceiverError::from)?;
 
         Ok(())

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -168,6 +168,8 @@ where
         })
         .await;
 
+        let check = check?;
+
         // Send consistency check
         sink.feed(Message::CointossSenderPayload(payload)).await?;
         sink.feed(Message::Check(check)).await?;

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -170,7 +170,7 @@ where
 
         let check = check?;
 
-        // Send consistency check
+        // Send cointoss decommitment and correlation check value.
         sink.feed(Message::CointossSenderPayload(payload)).await?;
         sink.feed(Message::Check(check)).await?;
         sink.flush().await?;

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -151,7 +151,7 @@ where
 
         let seeds: [Block; CSP] = seeds.try_into().expect("seeds should be CSP length");
 
-        let ext_sender = ext_sender.base_setup(delta, seeds);
+        let ext_sender = ext_sender.setup(delta, seeds);
 
         self.state = State::Extension(ext_sender);
 

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -255,7 +255,11 @@ where
             .into_derandomize()
             .map_err(SenderError::from)?;
 
-        let payload = sender.send(msgs, derandomize).map_err(SenderError::from)?;
+        let mut sender_keys = sender.keys(msgs.len()).map_err(SenderError::from)?;
+        sender_keys
+            .derandomize(derandomize)
+            .map_err(SenderError::from)?;
+        let payload = sender_keys.encrypt(msgs).map_err(SenderError::from)?;
 
         sink.send(Message::SenderPayload(payload))
             .await

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -1,4 +1,6 @@
-use crate::{kos::SenderError, OTError, OTReceiver, OTSender, RevealChoices, RevealMessages};
+use crate::{
+    kos::SenderError, CommittedOTReceiver, CommittedOTSender, OTError, OTReceiver, OTSender,
+};
 
 use async_trait::async_trait;
 use futures_util::SinkExt;
@@ -205,9 +207,9 @@ where
 }
 
 #[async_trait]
-impl<BaseOT> RevealMessages for Sender<BaseOT>
+impl<BaseOT> CommittedOTSender<[Block; 2]> for Sender<BaseOT>
 where
-    BaseOT: RevealChoices + ProtocolMessage + Send,
+    BaseOT: CommittedOTReceiver<bool, Block> + ProtocolMessage + Send,
 {
     async fn reveal<
         Si: IoSink<Self::Msg> + Send + Unpin,

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -1,0 +1,236 @@
+use crate::{kos::SenderError, OTError, OTReceiver, OTSender, RevealChoices, RevealMessages};
+
+use async_trait::async_trait;
+use futures_util::SinkExt;
+use itybity::IntoBits;
+use mpz_core::{cointoss, Block, ProtocolMessage};
+use mpz_ot_core::kos::{
+    msgs::Message, sender_state as state, Sender as SenderCore, SenderConfig, CSP, SSP,
+};
+use rand::{thread_rng, Rng};
+use utils_aio::{
+    non_blocking_backend::{Backend, NonBlockingBackend},
+    sink::IoSink,
+    stream::{ExpectStreamExt, IoStream},
+};
+
+use enum_try_as_inner::EnumTryAsInner;
+
+use super::{into_base_sink, into_base_stream};
+
+#[derive(Debug, EnumTryAsInner)]
+enum State {
+    Initialized(SenderCore<state::Initialized>),
+    Extension(SenderCore<state::Extension>),
+    Complete,
+    Error,
+}
+
+impl From<enum_try_as_inner::Error<State>> for SenderError {
+    fn from(value: enum_try_as_inner::Error<State>) -> Self {
+        SenderError::StateError(value.to_string())
+    }
+}
+
+/// KOS sender.
+#[derive(Debug)]
+pub struct Sender<BaseOT> {
+    state: State,
+    base: BaseOT,
+}
+
+impl<BaseOT> Sender<BaseOT>
+where
+    BaseOT: OTReceiver<bool, Block> + Send,
+{
+    /// Creates a new Sender
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The Sender's configuration
+    pub fn new(config: SenderConfig, base: BaseOT) -> Self {
+        Self {
+            state: State::Initialized(SenderCore::new(config)),
+            base,
+        }
+    }
+
+    /// The number of remaining OTs which can be consumed.
+    pub fn remaining(&self) -> Result<usize, SenderError> {
+        Ok(self.state.as_extension()?.remaining())
+    }
+
+    /// Performs the base OT setup with the provided delta.
+    ///
+    /// # Arguments
+    ///
+    /// * `sink` - The sink to send messages to the base OT sender
+    /// * `stream` - The stream to receive messages from the base OT sender
+    /// * `delta` - The delta value to use for the base OT setup.
+    pub async fn setup_with_delta<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        delta: Block,
+    ) -> Result<(), SenderError> {
+        let ext_sender = self.state.replace(State::Error).into_initialized()?;
+
+        let choices = delta.into_lsb0_vec();
+        let seeds = self
+            .base
+            .receive(
+                &mut into_base_sink(sink),
+                &mut into_base_stream(stream),
+                &choices,
+            )
+            .await?;
+
+        let seeds: [Block; CSP] = seeds.try_into().expect("seeds should be CSP length");
+
+        let ext_sender = ext_sender.base_setup(delta, seeds);
+
+        self.state = State::Extension(ext_sender);
+
+        Ok(())
+    }
+
+    /// Performs OT extension.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - The channel to communicate with the receiver.
+    /// * `count` - The number of OTs to extend.
+    pub async fn extend<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        count: usize,
+    ) -> Result<(), SenderError> {
+        let mut ext_sender = self.state.replace(State::Error).into_extension()?;
+
+        // Receive extend message from the receiver.
+        let extend = stream
+            .expect_next()
+            .await?
+            .into_extend()
+            .map_err(SenderError::from)?;
+
+        // Receive cointoss commitments from the receiver.
+        let commitment = stream.expect_next().await?.into_cointoss_commit()?;
+
+        // Extend the OTs, adding padding for the consistency check.
+        let mut ext_sender = Backend::spawn(move || {
+            ext_sender
+                .extend(count + CSP + SSP, extend)
+                .map(|_| ext_sender)
+        })
+        .await?;
+
+        // Execute cointoss protocol for consistency check.
+        let seed: Block = thread_rng().gen();
+        let cointoss_receiver = cointoss::Receiver::new(vec![seed]);
+
+        let (cointoss_receiver, cointoss_payload) = cointoss_receiver.reveal(commitment)?;
+
+        // Send cointoss payload to the receiver.
+        sink.send(Message::CointossReceiverPayload(cointoss_payload))
+            .await?;
+
+        // Receive cointoss sender payload from the receiver.
+        let cointoss_sender_payload = stream.expect_next().await?.into_cointoss_sender_payload()?;
+
+        // Receive consistency check from the receiver.
+        let receiver_check = stream.expect_next().await?.into_check()?;
+
+        // Derive chi seed for the consistency check.
+        let chi_seed = cointoss_receiver.finalize(cointoss_sender_payload)?[0];
+
+        // Check consistency of extension.
+        let ext_sender = Backend::spawn(move || {
+            ext_sender
+                .check(chi_seed, receiver_check)
+                .map(|_| ext_sender)
+        })
+        .await?;
+
+        self.state = State::Extension(ext_sender);
+
+        Ok(())
+    }
+}
+
+impl<BaseOT> ProtocolMessage for Sender<BaseOT>
+where
+    BaseOT: ProtocolMessage,
+{
+    type Msg = Message<BaseOT::Msg>;
+}
+
+#[async_trait]
+impl<BaseOT> OTSender<[Block; 2]> for Sender<BaseOT>
+where
+    BaseOT: ProtocolMessage + Send,
+{
+    async fn send<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+        msgs: &[[Block; 2]],
+    ) -> Result<(), OTError> {
+        let sender = self.state.as_extension_mut().map_err(SenderError::from)?;
+
+        let derandomize = stream
+            .expect_next()
+            .await?
+            .into_derandomize()
+            .map_err(SenderError::from)?;
+
+        let payload = sender.send(msgs, derandomize).map_err(SenderError::from)?;
+
+        sink.send(Message::SenderPayload(payload))
+            .await
+            .map_err(SenderError::from)?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<BaseOT> RevealMessages for Sender<BaseOT>
+where
+    BaseOT: RevealChoices + ProtocolMessage + Send,
+{
+    async fn reveal<
+        Si: IoSink<Self::Msg> + Send + Unpin,
+        St: IoStream<Self::Msg> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+    ) -> Result<(), OTError> {
+        let _ = self
+            .state
+            .replace(State::Error)
+            .into_extension()
+            .map_err(SenderError::from)?;
+
+        // Reveal base OT choices to the receiver.
+        self.base
+            .reveal_choices(&mut into_base_sink(sink), &mut into_base_stream(stream))
+            .await?;
+
+        // This sender is no longer usable, so mark it as complete.
+        self.state = State::Complete;
+
+        Ok(())
+    }
+}

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::all)]
 
 pub mod chou_orlandi;
+pub mod kos;
 #[cfg(feature = "mock")]
 pub mod mock;
 

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -160,13 +160,13 @@ where
     ///
     /// * `sink` - The IO sink to the sender.
     /// * `stream` - The IO stream from the sender.
-    /// * `index` - The index of the messages to verify.
+    /// * `id` - The transfer id of the messages to verify.
     /// * `msgs` - The purported messages sent by the sender.
     async fn verify<Si: IoSink<Self::Msg> + Send + Unpin, St: IoStream<Self::Msg> + Send + Unpin>(
         &mut self,
         sink: &mut Si,
         stream: &mut St,
-        index: usize,
+        id: usize,
         msgs: &[V],
     ) -> Result<(), OTError>;
 }


### PR DESCRIPTION
This PR reimplements KOS15, fixing some security and performance issues. There might be a couple odds and ends that still need to be buttoned up, but I wanted to open this now and start getting feedback sooner.

# Changes
1. Incorporates changes from #36 #28 
2. Decouples CO15 from KOS, making it generic over the base OT instead.
3. Fixes the consistency check, performing the cointoss _after_ the receiver has committed to their extension payload.
4. Fixes the committed sender functionality, where the replay protocol uses the committed receiver functionality from the base OT to open and enforce the authenticity of the `delta` used by the sender in the setup.
5. Implemented incremental extension, where both parties can re-extend their base OTs multiple times (performing a consistency check for every extension).
6. Added toggle-able parallelism using rayon.
7. Support the "split" functionality without actually splitting the internal state into multiple instances. This preserves support for parallelism/concurrency in the actor implementation (coming in another PR).