### PR TITLE
KOS Actor

### DIFF
--- a/ot/mpz-ot-core/src/kos/mod.rs
+++ b/ot/mpz-ot-core/src/kos/mod.rs
@@ -311,11 +311,9 @@ mod tests {
 
         assert_eq!(received, expected);
 
-        receiver
-            .remove_record(0)
-            .unwrap()
-            .verify(delta, &data)
-            .unwrap();
+        let receiver = receiver.start_verification(delta).unwrap();
+
+        receiver.remove_record(0).unwrap().verify(&data).unwrap();
     }
 
     #[rstest]
@@ -353,10 +351,12 @@ mod tests {
 
         data[0][0] = Block::default();
 
+        let receiver = receiver.start_verification(delta).unwrap();
+
         let err = receiver
             .remove_record(0)
             .unwrap()
-            .verify(delta, &data)
+            .verify(&data)
             .unwrap_err();
 
         assert!(matches!(

--- a/ot/mpz-ot/Cargo.toml
+++ b/ot/mpz-ot/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 name = "mpz_ot"
 
 [features]
-default = ["mock", "rayon"]
+default = ["mock", "rayon", "actor"]
 rayon = ["mpz-ot-core/rayon"]
+actor = ["dep:serde"]
 mock = []
 
 [dependencies]

--- a/ot/mpz-ot/src/actor/kos/error.rs
+++ b/ot/mpz-ot/src/actor/kos/error.rs
@@ -1,0 +1,122 @@
+use crate::{
+    actor::kos::msgs::Message,
+    kos::{ReceiverError, SenderError},
+};
+
+/// Errors that can occur in the KOS Sender Actor.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub enum SenderActorError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    SenderError(#[from] SenderError),
+    #[error("actor channel error: {0}")]
+    Channel(String),
+}
+
+impl From<mpz_ot_core::kos::SenderError> for SenderActorError {
+    fn from(err: mpz_ot_core::kos::SenderError) -> Self {
+        SenderActorError::SenderError(err.into())
+    }
+}
+
+impl From<enum_try_as_inner::Error<crate::kos::SenderState>> for SenderActorError {
+    fn from(value: enum_try_as_inner::Error<crate::kos::SenderState>) -> Self {
+        SenderError::StateError(value.to_string()).into()
+    }
+}
+
+impl From<futures::channel::oneshot::Canceled> for SenderActorError {
+    fn from(err: futures::channel::oneshot::Canceled) -> Self {
+        SenderActorError::Channel(err.to_string())
+    }
+}
+
+impl<T> From<futures::channel::mpsc::TrySendError<T>> for SenderActorError {
+    fn from(err: futures::channel::mpsc::TrySendError<T>) -> Self {
+        SenderActorError::Channel(err.to_string())
+    }
+}
+
+impl<T> From<enum_try_as_inner::Error<Message<T>>> for SenderActorError {
+    fn from(value: enum_try_as_inner::Error<Message<T>>) -> Self {
+        SenderActorError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}
+
+impl<T> From<futures::channel::mpsc::TrySendError<T>> for SenderError {
+    fn from(err: futures::channel::mpsc::TrySendError<T>) -> Self {
+        SenderError::Other(format!("actor channel error: {}", err))
+    }
+}
+
+impl From<futures::channel::oneshot::Canceled> for SenderError {
+    fn from(err: futures::channel::oneshot::Canceled) -> Self {
+        SenderError::Other(format!("actor channel canceled: {}", err))
+    }
+}
+
+/// Errors that can occur in the KOS Receiver Actor.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub enum ReceiverActorError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    ReceiverError(#[from] ReceiverError),
+    #[error("received unexpected transfer id: {0}")]
+    UnexpectedTransferId(String),
+    #[error("actor channel error: {0}")]
+    Channel(String),
+}
+
+impl From<mpz_ot_core::kos::ReceiverError> for ReceiverActorError {
+    fn from(err: mpz_ot_core::kos::ReceiverError) -> Self {
+        ReceiverActorError::ReceiverError(err.into())
+    }
+}
+
+impl From<enum_try_as_inner::Error<crate::kos::ReceiverState>> for ReceiverActorError {
+    fn from(value: enum_try_as_inner::Error<crate::kos::ReceiverState>) -> Self {
+        ReceiverError::StateError(value.to_string()).into()
+    }
+}
+
+impl From<futures::channel::oneshot::Canceled> for ReceiverActorError {
+    fn from(err: futures::channel::oneshot::Canceled) -> Self {
+        ReceiverActorError::Channel(err.to_string())
+    }
+}
+
+impl<T> From<futures::channel::mpsc::TrySendError<T>> for ReceiverActorError {
+    fn from(err: futures::channel::mpsc::TrySendError<T>) -> Self {
+        ReceiverActorError::Channel(err.to_string())
+    }
+}
+
+impl<T> From<enum_try_as_inner::Error<Message<T>>> for ReceiverActorError {
+    fn from(value: enum_try_as_inner::Error<Message<T>>) -> Self {
+        ReceiverActorError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}
+
+impl<T> From<futures::channel::mpsc::TrySendError<T>> for ReceiverError {
+    fn from(err: futures::channel::mpsc::TrySendError<T>) -> Self {
+        ReceiverError::Other(format!("actor channel error: {}", err))
+    }
+}
+
+impl From<futures::channel::oneshot::Canceled> for ReceiverError {
+    fn from(err: futures::channel::oneshot::Canceled) -> Self {
+        ReceiverError::Other(format!("actor channel canceled: {}", err))
+    }
+}

--- a/ot/mpz-ot/src/actor/kos/error.rs
+++ b/ot/mpz-ot/src/actor/kos/error.rs
@@ -14,11 +14,22 @@ pub enum SenderActorError {
     SenderError(#[from] SenderError),
     #[error("actor channel error: {0}")]
     Channel(String),
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<mpz_ot_core::kos::SenderError> for SenderActorError {
     fn from(err: mpz_ot_core::kos::SenderError) -> Self {
         SenderActorError::SenderError(err.into())
+    }
+}
+
+impl From<crate::OTError> for SenderActorError {
+    fn from(err: crate::OTError) -> Self {
+        match err {
+            crate::OTError::IOError(err) => err.into(),
+            err => SenderActorError::Other(err.to_string()),
+        }
     }
 }
 
@@ -74,11 +85,22 @@ pub enum ReceiverActorError {
     UnexpectedTransferId(String),
     #[error("actor channel error: {0}")]
     Channel(String),
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<mpz_ot_core::kos::ReceiverError> for ReceiverActorError {
     fn from(err: mpz_ot_core::kos::ReceiverError) -> Self {
         ReceiverActorError::ReceiverError(err.into())
+    }
+}
+
+impl From<crate::OTError> for ReceiverActorError {
+    fn from(err: crate::OTError) -> Self {
+        match err {
+            crate::OTError::IOError(err) => err.into(),
+            err => ReceiverActorError::Other(err.to_string()),
+        }
     }
 }
 

--- a/ot/mpz-ot/src/actor/kos/mod.rs
+++ b/ot/mpz-ot/src/actor/kos/mod.rs
@@ -76,7 +76,7 @@ mod tests {
     use mpz_ot_core::kos::{ReceiverConfig, SenderConfig};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha12Rng;
-    use utils_aio::duplex::MpscDuplex;
+    use utils_aio::duplex::MemoryDuplex;
 
     #[fixture]
     fn choices() -> Vec<bool> {
@@ -108,16 +108,16 @@ mod tests {
     ) -> (
         SenderActor<
             MockOTReceiver<Block>,
-            SplitSink<MpscDuplex<Message<()>>, Message<()>>,
-            SplitStream<MpscDuplex<Message<()>>>,
+            SplitSink<MemoryDuplex<Message<()>>, Message<()>>,
+            SplitStream<MemoryDuplex<Message<()>>>,
         >,
         ReceiverActor<
             MockOTSender<Block>,
-            SplitSink<MpscDuplex<Message<()>>, Message<()>>,
-            SplitStream<MpscDuplex<Message<()>>>,
+            SplitSink<MemoryDuplex<Message<()>>, Message<()>>,
+            SplitStream<MemoryDuplex<Message<()>>>,
         >,
     ) {
-        let (sender_channel, receiver_channel) = MpscDuplex::new();
+        let (sender_channel, receiver_channel) = MemoryDuplex::new();
 
         let (sender_sink, sender_stream) = sender_channel.split();
         let (receiver_sink, receiver_stream) = receiver_channel.split();

--- a/ot/mpz-ot/src/actor/kos/mod.rs
+++ b/ot/mpz-ot/src/actor/kos/mod.rs
@@ -1,0 +1,221 @@
+mod error;
+pub mod msgs;
+mod receiver;
+mod sender;
+
+use futures::{SinkExt, StreamExt};
+use utils_aio::{sink::IoSink, stream::IoStream};
+
+use crate::kos::{msgs::Message as KosMessage, ReceiverError, SenderError};
+
+pub use error::{ReceiverActorError, SenderActorError};
+pub use receiver::{ReceiverActor, SharedReceiver};
+pub use sender::{SenderActor, SharedSender};
+
+/// Converts a sink of KOS actor messages into a sink of KOS messages.
+pub(crate) fn into_kos_sink<'a, Si: IoSink<msgs::Message<T>> + Send + Unpin, T: Send + 'a>(
+    sink: &'a mut Si,
+) -> impl IoSink<KosMessage<T>> + Send + Unpin + 'a {
+    Box::pin(SinkExt::with(sink, |msg| async move {
+        Ok(msgs::Message::Protocol(msg))
+    }))
+}
+
+/// Converts a stream of KOS actor messages into a stream of KOS messages.
+pub(crate) fn into_kos_stream<'a, St: IoStream<msgs::Message<T>> + Send + Unpin, T: Send + 'a>(
+    stream: &'a mut St,
+) -> impl IoStream<KosMessage<T>> + Send + Unpin + 'a {
+    StreamExt::map(stream, |msg| match msg {
+        Ok(msg) => match msg.into_protocol() {
+            Ok(msg) => Ok(msg),
+            Err(err) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                err.to_string(),
+            )),
+        },
+        Err(err) => Err(err),
+    })
+}
+
+impl<T> From<enum_try_as_inner::Error<msgs::Message<T>>> for SenderError {
+    fn from(value: enum_try_as_inner::Error<msgs::Message<T>>) -> Self {
+        SenderError::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}
+
+impl<T> From<enum_try_as_inner::Error<msgs::Message<T>>> for ReceiverError {
+    fn from(value: enum_try_as_inner::Error<msgs::Message<T>>) -> Self {
+        ReceiverError::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            value.to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        kos::{Receiver, Sender},
+        mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
+        OTReceiverShared, OTSenderShared, VerifiableOTReceiverShared,
+    };
+
+    use msgs::Message;
+
+    use super::*;
+    use futures::{
+        stream::{SplitSink, SplitStream},
+        StreamExt,
+    };
+    use rstest::*;
+
+    use mpz_core::Block;
+    use mpz_ot_core::kos::{ReceiverConfig, SenderConfig};
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha12Rng;
+    use utils_aio::duplex::MpscDuplex;
+
+    #[fixture]
+    fn choices() -> Vec<bool> {
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
+        (0..128).map(|_| rng.gen()).collect()
+    }
+
+    #[fixture]
+    fn data() -> Vec<[Block; 2]> {
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
+        (0..128)
+            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .collect()
+    }
+
+    fn choose<T>(
+        data: impl IntoIterator<Item = [T; 2]>,
+        choices: impl IntoIterator<Item = bool>,
+    ) -> impl Iterator<Item = T> {
+        data.into_iter()
+            .zip(choices)
+            .map(|([zero, one], choice)| if choice { one } else { zero })
+    }
+
+    async fn setup(
+        sender_config: SenderConfig,
+        receiver_config: ReceiverConfig,
+        count: usize,
+    ) -> (
+        SenderActor<
+            MockOTReceiver<Block>,
+            SplitSink<MpscDuplex<Message<()>>, Message<()>>,
+            SplitStream<MpscDuplex<Message<()>>>,
+        >,
+        ReceiverActor<
+            MockOTSender<Block>,
+            SplitSink<MpscDuplex<Message<()>>, Message<()>>,
+            SplitStream<MpscDuplex<Message<()>>>,
+        >,
+    ) {
+        let (sender_channel, receiver_channel) = MpscDuplex::new();
+
+        let (sender_sink, sender_stream) = sender_channel.split();
+        let (receiver_sink, receiver_stream) = receiver_channel.split();
+
+        let (base_sender, base_receiver) = mock_ot_pair();
+
+        let sender = Sender::new(sender_config, base_receiver);
+        let receiver = Receiver::new(receiver_config, base_sender);
+
+        let mut sender = SenderActor::new(sender, sender_sink, sender_stream);
+        let mut receiver = ReceiverActor::new(receiver, receiver_sink, receiver_stream);
+
+        let (sender_res, receiver_res) = tokio::join!(sender.setup(count), receiver.setup(count));
+
+        sender_res.unwrap();
+        receiver_res.unwrap();
+
+        (sender, receiver)
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_kos_actor(data: Vec<[Block; 2]>, choices: Vec<bool>) {
+        let (mut sender_actor, mut receiver_actor) = setup(
+            SenderConfig::default(),
+            ReceiverConfig::default(),
+            data.len(),
+        )
+        .await;
+
+        let sender = sender_actor.sender();
+        let receiver = receiver_actor.receiver();
+
+        tokio::spawn(async move {
+            sender_actor.run().await.unwrap();
+            sender_actor
+        });
+
+        tokio::spawn(async move {
+            receiver_actor.run().await.unwrap();
+            receiver_actor
+        });
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.send("test", &data),
+            receiver.receive("test", &choices)
+        );
+
+        sender_res.unwrap();
+        let received_data: Vec<Block> = receiver_res.unwrap();
+
+        let expected_data = choose(data, choices).collect::<Vec<_>>();
+
+        assert_eq!(received_data, expected_data);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_kos_actor_verifiable_receiver(data: Vec<[Block; 2]>, choices: Vec<bool>) {
+        let (mut sender_actor, mut receiver_actor) = setup(
+            SenderConfig::builder().sender_commit().build().unwrap(),
+            ReceiverConfig::builder().sender_commit().build().unwrap(),
+            data.len(),
+        )
+        .await;
+
+        let sender = sender_actor.sender();
+        let receiver = receiver_actor.receiver();
+
+        let sender_task = tokio::spawn(async move {
+            sender_actor.run().await.unwrap();
+            sender_actor
+        });
+
+        tokio::spawn(async move {
+            receiver_actor.run().await.unwrap();
+            receiver_actor
+        });
+
+        let (sender_res, receiver_res) = tokio::join!(
+            sender.send("test", &data),
+            receiver.receive("test", &choices)
+        );
+
+        sender_res.unwrap();
+
+        let received_data: Vec<Block> = receiver_res.unwrap();
+
+        let expected_data = choose(data.clone(), choices).collect::<Vec<_>>();
+
+        assert_eq!(received_data, expected_data);
+
+        sender.shutdown().await.unwrap();
+
+        let mut sender_actor = sender_task.await.unwrap();
+
+        sender_actor.reveal().await.unwrap();
+
+        receiver.verify("test", &data).await.unwrap();
+    }
+}

--- a/ot/mpz-ot/src/actor/kos/msgs.rs
+++ b/ot/mpz-ot/src/actor/kos/msgs.rs
@@ -1,0 +1,50 @@
+//! Message types for the KOS actors.
+
+use enum_try_as_inner::EnumTryAsInner;
+use serde::{Deserialize, Serialize};
+
+use mpz_ot_core::{
+    kos::msgs::{Message as KosMessage, SenderPayload},
+    msgs::Derandomize,
+};
+
+/// KOS actor message
+#[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum Message<BaseOT> {
+    ActorMessage(ActorMessage),
+    Protocol(KosMessage<BaseOT>),
+}
+
+impl<T> From<ActorMessage> for Message<T> {
+    fn from(value: ActorMessage) -> Self {
+        Message::ActorMessage(value)
+    }
+}
+
+/// KOS actor message
+#[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum ActorMessage {
+    TransferRequest(TransferRequest),
+    TransferPayload(TransferPayload),
+    Reveal,
+}
+
+/// A message indicating that a transfer with the provided id is expected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferRequest {
+    /// The id of the transfer.
+    pub id: String,
+    /// Beaver-derandomization.
+    pub derandomize: Derandomize,
+}
+
+/// A message containing a payload for a transfer with the provided id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferPayload {
+    /// The id of the transfer.
+    pub id: String,
+    /// The payload.
+    pub payload: SenderPayload,
+}

--- a/ot/mpz-ot/src/actor/kos/receiver.rs
+++ b/ot/mpz-ot/src/actor/kos/receiver.rs
@@ -1,0 +1,346 @@
+use std::collections::{HashMap, VecDeque};
+
+use async_trait::async_trait;
+use futures::{
+    channel::{mpsc, oneshot},
+    stream::Fuse,
+    SinkExt, StreamExt,
+};
+use utils_aio::{
+    non_blocking_backend::{Backend, NonBlockingBackend},
+    sink::IoSink,
+    stream::IoStream,
+};
+
+use crate::{
+    kos::{Receiver, ReceiverError, ReceiverKeys},
+    OTError, OTReceiverShared, VerifiableOTReceiverShared, VerifiableOTSender,
+};
+use mpz_core::{Block, ProtocolMessage};
+use mpz_ot_core::kos::{msgs::SenderPayload, PayloadRecord};
+
+use crate::actor::kos::{
+    into_kos_sink, into_kos_stream,
+    msgs::{ActorMessage, Message, TransferPayload, TransferRequest},
+    ReceiverActorError,
+};
+
+enum Command {
+    Receive {
+        id: String,
+        choices: Vec<bool>,
+        caller_response: oneshot::Sender<Result<(ReceiverKeys, SenderPayload), ReceiverError>>,
+    },
+    Verify(Verify),
+    Shutdown(Shutdown),
+}
+
+struct Verify {
+    id: String,
+    caller_response: oneshot::Sender<Result<PayloadRecord, ReceiverError>>,
+}
+
+struct PendingTransfer {
+    keys: ReceiverKeys,
+    caller_response: oneshot::Sender<Result<(ReceiverKeys, SenderPayload), ReceiverError>>,
+}
+
+opaque_debug::implement!(PendingTransfer);
+
+struct Shutdown {
+    caller_response: oneshot::Sender<Result<(), ReceiverActorError>>,
+}
+
+#[derive(Default)]
+struct State {
+    ids: HashMap<String, u32>,
+
+    pending_transfers: HashMap<String, PendingTransfer>,
+    pending_verify: VecDeque<Verify>,
+}
+
+/// KOS receiver actor.
+pub struct ReceiverActor<BaseOT, Si, St> {
+    sink: Si,
+    stream: Fuse<St>,
+
+    receiver: Receiver<BaseOT>,
+
+    state: State,
+
+    command_sender: mpsc::UnboundedSender<Command>,
+    commands: mpsc::UnboundedReceiver<Command>,
+}
+
+impl<BaseOT, Si, St> ReceiverActor<BaseOT, Si, St>
+where
+    // TODO: Support non-verifiable base OT.
+    BaseOT: VerifiableOTSender<bool, [Block; 2]> + ProtocolMessage + Send,
+    Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+    St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+{
+    /// Create a new receiver actor.
+    pub fn new(receiver: Receiver<BaseOT>, sink: Si, stream: St) -> Self {
+        let (command_sender, commands) = mpsc::unbounded();
+
+        Self {
+            receiver,
+            sink,
+            stream: stream.fuse(),
+            state: Default::default(),
+            command_sender,
+            commands,
+        }
+    }
+
+    /// Sets up the receiver with the given number of OTs.
+    pub async fn setup(&mut self, count: usize) -> Result<(), ReceiverActorError> {
+        let mut sink = into_kos_sink(&mut self.sink);
+        let mut stream = into_kos_stream(&mut self.stream);
+
+        self.receiver.setup(&mut sink, &mut stream).await?;
+        self.receiver.extend(&mut sink, &mut stream, count).await?;
+
+        Ok(())
+    }
+
+    /// Returns a `SharedReceiver` which implements `Clone`.
+    pub fn receiver(&self) -> SharedReceiver {
+        SharedReceiver {
+            sender: self.command_sender.clone(),
+        }
+    }
+
+    /// Run the receiver actor.
+    pub async fn run(&mut self) -> Result<(), ReceiverActorError> {
+        loop {
+            futures::select! {
+                msg = self.stream.select_next_some() => self.handle_msg(msg?).await?,
+                cmd = self.commands.select_next_some() => {
+                    if let Command::Shutdown(Shutdown { caller_response }) = cmd {
+                        _ = caller_response.send(Ok(()));
+                        return Ok(());
+                    }
+
+                    self.handle_cmd(cmd).await?
+                },
+            }
+        }
+    }
+
+    async fn start_transfer(
+        &mut self,
+        id: &str,
+        choices: &[bool],
+    ) -> Result<ReceiverKeys, ReceiverError> {
+        let mut keys = self
+            .receiver
+            .state_mut()
+            .as_extension_mut()?
+            .keys(choices.len())?;
+
+        let derandomize = keys.derandomize(choices)?;
+
+        self.sink
+            .send(
+                ActorMessage::TransferRequest(TransferRequest {
+                    id: id.to_string(),
+                    derandomize,
+                })
+                .into(),
+            )
+            .await?;
+
+        Ok(keys)
+    }
+
+    async fn start_verification(&mut self) -> Result<(), ReceiverError> {
+        self.receiver
+            .verify_delta(
+                &mut into_kos_sink(&mut self.sink),
+                &mut into_kos_stream(&mut self.stream),
+            )
+            .await?;
+
+        // Process backlog of pending verifications.
+        let backlog = std::mem::take(&mut self.state.pending_verify);
+        for verify in backlog {
+            self.handle_verify(verify)
+        }
+
+        Ok(())
+    }
+
+    fn handle_verify(&mut self, verify: Verify) {
+        // If we're ready to start verifying we do so, otherwise, we buffer
+        // the verification for later.
+        if self.receiver.state().is_verify() {
+            let Verify {
+                id,
+                caller_response,
+            } = verify;
+
+            if let Some(id) = self.state.ids.get(&id) {
+                // Send payload record to the caller.
+                _ = caller_response.send(
+                    self.receiver
+                        .state_mut()
+                        .as_verify_mut()
+                        .map_err(ReceiverError::from)
+                        .and_then(|receiver| {
+                            receiver.remove_record(*id).map_err(ReceiverError::from)
+                        }),
+                );
+            } else {
+                _ = caller_response.send(Err(ReceiverError::Other(format!(
+                    "transfer id not found: {id}"
+                ))));
+            }
+        } else {
+            self.state.pending_verify.push_back(verify)
+        }
+    }
+
+    async fn handle_cmd(&mut self, cmd: Command) -> Result<(), ReceiverError> {
+        match cmd {
+            Command::Receive {
+                id,
+                choices,
+                caller_response,
+            } => {
+                let keys = match self.start_transfer(&id, &choices).await {
+                    Ok(keys) => keys,
+                    Err(e) => {
+                        _ = caller_response.send(Err(e));
+                        return Ok(());
+                    }
+                };
+
+                self.state.ids.insert(id.clone(), keys.id());
+                self.state.pending_transfers.insert(
+                    id,
+                    PendingTransfer {
+                        keys,
+                        caller_response,
+                    },
+                );
+            }
+            Command::Verify(verify) => self.handle_verify(verify),
+            Command::Shutdown(_) => unreachable!("shutdown should be handled already"),
+        }
+
+        Ok(())
+    }
+
+    async fn handle_msg(&mut self, msg: Message<BaseOT::Msg>) -> Result<(), ReceiverActorError> {
+        let msg = msg.into_actor_message()?;
+
+        match msg {
+            ActorMessage::TransferPayload(TransferPayload { id, payload }) => {
+                let PendingTransfer {
+                    keys,
+                    caller_response,
+                } = self
+                    .state
+                    .pending_transfers
+                    .remove(&id)
+                    .ok_or_else(|| ReceiverActorError::UnexpectedTransferId(id))?;
+
+                _ = caller_response.send(Ok((keys, payload)));
+            }
+            ActorMessage::Reveal => {
+                self.start_verification().await?;
+            }
+            msg => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unexpected msg: {:?}", msg),
+                ))?
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// KOS receiver actor control.
+#[derive(Debug, Clone)]
+pub struct SharedReceiver {
+    sender: mpsc::UnboundedSender<Command>,
+}
+
+impl SharedReceiver {
+    /// Shuts down the receiver actor.
+    pub async fn shutdown(&self) -> Result<(), ReceiverActorError> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender.unbounded_send(Command::Shutdown(Shutdown {
+            caller_response: sender,
+        }))?;
+
+        receiver.await?
+    }
+}
+
+#[async_trait]
+impl OTReceiverShared<bool, Block> for SharedReceiver {
+    async fn receive(&self, id: &str, choices: &[bool]) -> Result<Vec<Block>, OTError> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .unbounded_send(Command::Receive {
+                id: id.to_string(),
+                choices: choices.to_vec(),
+                caller_response: sender,
+            })
+            .map_err(ReceiverError::from)?;
+
+        let (keys, payload) = receiver.await.map_err(ReceiverError::from)??;
+
+        Backend::spawn(move || keys.decrypt_blocks(payload))
+            .await
+            .map_err(OTError::from)
+    }
+}
+
+#[async_trait]
+impl<const N: usize> OTReceiverShared<bool, [u8; N]> for SharedReceiver {
+    async fn receive(&self, id: &str, choices: &[bool]) -> Result<Vec<[u8; N]>, OTError> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .unbounded_send(Command::Receive {
+                id: id.to_string(),
+                choices: choices.to_vec(),
+                caller_response: sender,
+            })
+            .map_err(ReceiverError::from)?;
+
+        let (keys, payload) = receiver.await.map_err(ReceiverError::from)??;
+
+        Backend::spawn(move || keys.decrypt_bytes(payload))
+            .await
+            .map_err(OTError::from)
+    }
+}
+
+#[async_trait]
+impl VerifiableOTReceiverShared<bool, Block, [Block; 2]> for SharedReceiver {
+    async fn verify(&self, id: &str, msgs: &[[Block; 2]]) -> Result<(), OTError> {
+        let (sender, receiver) = oneshot::channel();
+
+        self.sender
+            .unbounded_send(Command::Verify(Verify {
+                id: id.to_string(),
+                caller_response: sender,
+            }))
+            .map_err(ReceiverError::from)?;
+
+        let record = receiver.await.map_err(ReceiverError::from)??;
+
+        let msgs = msgs.to_vec();
+        Backend::spawn(move || record.verify(&msgs))
+            .await
+            .map_err(OTError::from)
+    }
+}

--- a/ot/mpz-ot/src/actor/kos/receiver.rs
+++ b/ot/mpz-ot/src/actor/kos/receiver.rs
@@ -216,6 +216,13 @@ where
                     }
                 };
 
+                if self.state.ids.contains_key(&id) {
+                    _ = caller_response.send(Err(ReceiverError::Other(format!(
+                        "duplicate transfer id: {id}"
+                    ))));
+                    return Ok(());
+                }
+
                 self.state.ids.insert(id.clone(), keys.id());
                 self.state.pending_transfers.insert(
                     id,

--- a/ot/mpz-ot/src/actor/kos/receiver.rs
+++ b/ot/mpz-ot/src/actor/kos/receiver.rs
@@ -14,7 +14,7 @@ use utils_aio::{
 
 use crate::{
     kos::{Receiver, ReceiverError, ReceiverKeys},
-    OTError, OTReceiverShared, VerifiableOTReceiverShared, VerifiableOTSender,
+    OTError, OTReceiverShared, OTSetup, VerifiableOTReceiverShared, VerifiableOTSender,
 };
 use mpz_core::{Block, ProtocolMessage};
 use mpz_ot_core::kos::{msgs::SenderPayload, PayloadRecord};
@@ -75,7 +75,7 @@ pub struct ReceiverActor<BaseOT, Si, St> {
 impl<BaseOT, Si, St> ReceiverActor<BaseOT, Si, St>
 where
     // TODO: Support non-verifiable base OT.
-    BaseOT: VerifiableOTSender<bool, [Block; 2]> + ProtocolMessage + Send,
+    BaseOT: OTSetup + VerifiableOTSender<bool, [Block; 2]> + ProtocolMessage + Send,
     Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
     St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
 {

--- a/ot/mpz-ot/src/actor/kos/sender.rs
+++ b/ot/mpz-ot/src/actor/kos/sender.rs
@@ -17,7 +17,7 @@ use crate::{
         msgs::{ActorMessage, Message, TransferPayload, TransferRequest},
     },
     kos::{Sender, SenderError, SenderKeys},
-    CommittedOTReceiver, OTError, OTReceiver, OTSenderShared,
+    CommittedOTReceiver, CommittedOTSenderShared, OTError, OTReceiver, OTSenderShared,
 };
 
 use super::SenderActorError;
@@ -314,5 +314,17 @@ impl<const N: usize> OTSenderShared<[[u8; N]; 2]> for SharedSender {
             .await
             .map_err(SenderError::from)?
             .map_err(OTError::from)
+    }
+}
+
+#[async_trait]
+impl<T> CommittedOTSenderShared<T> for SharedSender
+where
+    SharedSender: OTSenderShared<T>,
+{
+    async fn reveal(&self) -> Result<(), OTError> {
+        // this is no-op, as the reveal is performed using the actor struct after
+        // shutdown.
+        Ok(())
     }
 }

--- a/ot/mpz-ot/src/actor/kos/sender.rs
+++ b/ot/mpz-ot/src/actor/kos/sender.rs
@@ -17,7 +17,7 @@ use crate::{
         msgs::{ActorMessage, Message, TransferPayload, TransferRequest},
     },
     kos::{Sender, SenderError, SenderKeys},
-    CommittedOTReceiver, CommittedOTSenderShared, OTError, OTReceiver, OTSenderShared,
+    CommittedOTReceiver, CommittedOTSenderShared, OTError, OTReceiver, OTSenderShared, OTSetup,
 };
 
 use super::SenderActorError;
@@ -66,7 +66,7 @@ pub struct SenderActor<BaseOT, Si, St> {
 
 impl<BaseOT, Si, St> SenderActor<BaseOT, Si, St>
 where
-    BaseOT: OTReceiver<bool, Block> + ProtocolMessage + Send,
+    BaseOT: OTSetup + OTReceiver<bool, Block> + ProtocolMessage + Send,
     Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
     St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
 {

--- a/ot/mpz-ot/src/actor/kos/sender.rs
+++ b/ot/mpz-ot/src/actor/kos/sender.rs
@@ -1,0 +1,318 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use futures::channel::{mpsc, oneshot};
+use futures_util::{stream::Fuse, SinkExt, StreamExt};
+use mpz_core::{Block, ProtocolMessage};
+use mpz_ot_core::kos::msgs::SenderPayload;
+use utils_aio::{
+    non_blocking_backend::{Backend, NonBlockingBackend},
+    sink::IoSink,
+    stream::IoStream,
+};
+
+use crate::{
+    actor::kos::{
+        into_kos_sink, into_kos_stream,
+        msgs::{ActorMessage, Message, TransferPayload, TransferRequest},
+    },
+    kos::{Sender, SenderError, SenderKeys},
+    CommittedOTReceiver, OTError, OTReceiver, OTSenderShared,
+};
+
+use super::SenderActorError;
+
+enum Command {
+    GetKeys(GetKeys),
+    SendPayload(PendingPayload),
+    Shutdown(Shutdown),
+}
+
+struct GetKeys {
+    id: String,
+    caller_response: oneshot::Sender<Result<SenderKeys, SenderError>>,
+}
+
+struct PendingPayload {
+    id: String,
+    payload: SenderPayload,
+    caller_response: oneshot::Sender<Result<(), SenderError>>,
+}
+
+struct Shutdown {
+    caller_response: oneshot::Sender<Result<(), SenderActorError>>,
+}
+
+#[derive(Default)]
+struct State {
+    pending_keys: HashMap<String, Result<SenderKeys, SenderError>>,
+    pending_callers: HashMap<String, oneshot::Sender<Result<SenderKeys, SenderError>>>,
+}
+
+opaque_debug::implement!(State);
+
+/// KOS sender actor.
+pub struct SenderActor<BaseOT, Si, St> {
+    sink: Si,
+    stream: Fuse<St>,
+
+    sender: Sender<BaseOT>,
+
+    state: State,
+
+    command_sender: mpsc::UnboundedSender<Command>,
+    commands: mpsc::UnboundedReceiver<Command>,
+}
+
+impl<BaseOT, Si, St> SenderActor<BaseOT, Si, St>
+where
+    BaseOT: OTReceiver<bool, Block> + ProtocolMessage + Send,
+    Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+    St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+{
+    /// Creates a new sender actor.
+    pub fn new(sender: Sender<BaseOT>, sink: Si, stream: St) -> Self {
+        let (buffer_sender, buffer_receiver) = mpsc::unbounded();
+        Self {
+            sink,
+            stream: stream.fuse(),
+            sender,
+            state: Default::default(),
+            command_sender: buffer_sender,
+            commands: buffer_receiver,
+        }
+    }
+
+    /// Sets up the sender with the given number of OTs.
+    pub async fn setup(&mut self, count: usize) -> Result<(), SenderActorError> {
+        let mut sink = into_kos_sink(&mut self.sink);
+        let mut stream = into_kos_stream(&mut self.stream);
+
+        self.sender.setup(&mut sink, &mut stream).await?;
+        self.sender.extend(&mut sink, &mut stream, count).await?;
+
+        Ok(())
+    }
+
+    /// Sets up the sender with the given number of OTs.
+    pub async fn setup_with_delta(
+        &mut self,
+        delta: Block,
+        count: usize,
+    ) -> Result<(), SenderActorError> {
+        let mut sink = into_kos_sink(&mut self.sink);
+        let mut stream = into_kos_stream(&mut self.stream);
+
+        self.sender
+            .setup_with_delta(&mut sink, &mut stream, delta)
+            .await?;
+        self.sender.extend(&mut sink, &mut stream, count).await?;
+
+        Ok(())
+    }
+
+    /// Returns a `SharedSender` which implements `Clone`.
+    pub fn sender(&self) -> SharedSender {
+        SharedSender {
+            command_sender: self.command_sender.clone(),
+        }
+    }
+
+    /// Runs the sender actor.
+    pub async fn run(&mut self) -> Result<(), SenderActorError> {
+        loop {
+            futures::select! {
+                // Processes a message received from the Receiver.
+                msg = self.stream.select_next_some() => {
+                    self.handle_msg(msg?.into_actor_message()?)?;
+                }
+                // Processes a command
+                cmd = self.commands.select_next_some() => {
+                    if let Command::Shutdown(Shutdown { caller_response }) = cmd {
+                        _ = caller_response.send(Ok(()));
+                        return Ok(());
+                    }
+
+                    self.handle_cmd(cmd).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_cmd(&mut self, cmd: Command) {
+        match cmd {
+            Command::GetKeys(GetKeys {
+                id,
+                caller_response,
+            }) => {
+                if let Some(keys) = self.state.pending_keys.remove(&id) {
+                    _ = caller_response.send(keys);
+                } else {
+                    self.state.pending_callers.insert(id, caller_response);
+                }
+            }
+            Command::SendPayload(PendingPayload {
+                id,
+                payload,
+                caller_response,
+            }) => {
+                let res = self
+                    .sink
+                    .send(ActorMessage::TransferPayload(TransferPayload { id, payload }).into())
+                    .await;
+
+                _ = caller_response.send(res.map_err(SenderError::from));
+            }
+            Command::Shutdown(_) => unreachable!("shutdown should be handled already"),
+        }
+    }
+
+    fn handle_msg(&mut self, msg: ActorMessage) -> Result<(), SenderActorError> {
+        match msg {
+            ActorMessage::TransferRequest(TransferRequest { id, derandomize }) => {
+                println!("receiver req: {:?}", id);
+
+                // Reserve the keys for the transfer.
+                let keys = self
+                    .sender
+                    .state_mut()
+                    .as_extension_mut()
+                    .map_err(SenderError::from)
+                    .and_then(|sender| {
+                        sender
+                            .keys(derandomize.count as usize)
+                            .map_err(SenderError::from)
+                    });
+
+                // Derandomization is cheap, we just do it here.
+                let keys = keys
+                    .and_then(|mut keys| {
+                        keys.derandomize(derandomize)?;
+                        Ok(keys)
+                    })
+                    .map_err(SenderError::from);
+
+                // If there is a pending caller, send the keys to it, otherwise
+                // we buffer it.
+                if let Some(pending_caller) = self.state.pending_callers.remove(&id) {
+                    _ = pending_caller.send(keys);
+                } else {
+                    self.state.pending_keys.insert(id, keys);
+                }
+            }
+            msg => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unexpected msg: {:?}", msg),
+                ))?
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<BaseOT, Si, St> SenderActor<BaseOT, Si, St>
+where
+    BaseOT: CommittedOTReceiver<bool, Block> + ProtocolMessage + Send,
+    Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+    St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+{
+    /// Reveals all messages sent to the receiver.
+    ///
+    /// # Warning
+    ///
+    /// Obviously, you should be sure you want to do this before calling this function!
+    pub async fn reveal(&mut self) -> Result<(), SenderActorError> {
+        self.sink.send(ActorMessage::Reveal.into()).await?;
+
+        self.sender
+            .reveal(
+                &mut into_kos_sink(&mut self.sink),
+                &mut into_kos_stream(&mut self.stream),
+            )
+            .await
+            .map_err(SenderActorError::from)
+    }
+}
+
+/// KOS Shared Sender
+#[derive(Clone)]
+pub struct SharedSender {
+    command_sender: mpsc::UnboundedSender<Command>,
+}
+
+opaque_debug::implement!(SharedSender);
+
+impl SharedSender {
+    /// Shuts down the sender actor.
+    pub async fn shutdown(&self) -> Result<(), SenderActorError> {
+        let (caller_response, receiver) = oneshot::channel();
+        self.command_sender
+            .unbounded_send(Command::Shutdown(Shutdown { caller_response }))?;
+
+        receiver.await?
+    }
+}
+
+#[async_trait]
+impl OTSenderShared<[Block; 2]> for SharedSender {
+    async fn send(&self, id: &str, msgs: &[[Block; 2]]) -> Result<(), OTError> {
+        let (caller_response, receiver) = oneshot::channel();
+        self.command_sender
+            .unbounded_send(Command::GetKeys(GetKeys {
+                id: id.to_string(),
+                caller_response,
+            }))
+            .map_err(SenderError::from)?;
+
+        let keys = receiver.await.map_err(SenderError::from)??;
+        let msgs = msgs.to_vec();
+        let payload = Backend::spawn(move || keys.encrypt_blocks(&msgs)).await?;
+
+        let (caller_response, receiver) = oneshot::channel();
+        self.command_sender
+            .unbounded_send(Command::SendPayload(PendingPayload {
+                id: id.to_string(),
+                payload,
+                caller_response,
+            }))
+            .map_err(SenderError::from)?;
+
+        receiver
+            .await
+            .map_err(SenderError::from)?
+            .map_err(OTError::from)
+    }
+}
+
+#[async_trait]
+impl<const N: usize> OTSenderShared<[[u8; N]; 2]> for SharedSender {
+    async fn send(&self, id: &str, msgs: &[[[u8; N]; 2]]) -> Result<(), OTError> {
+        let (caller_response, receiver) = oneshot::channel();
+        self.command_sender
+            .unbounded_send(Command::GetKeys(GetKeys {
+                id: id.to_string(),
+                caller_response,
+            }))
+            .map_err(SenderError::from)?;
+
+        let keys = receiver.await.map_err(SenderError::from)??;
+        let msgs = msgs.to_vec();
+        let payload = Backend::spawn(move || keys.encrypt_bytes(&msgs)).await?;
+
+        let (caller_response, receiver) = oneshot::channel();
+        self.command_sender
+            .unbounded_send(Command::SendPayload(PendingPayload {
+                id: id.to_string(),
+                payload,
+                caller_response,
+            }))
+            .map_err(SenderError::from)?;
+
+        receiver
+            .await
+            .map_err(SenderError::from)?
+            .map_err(OTError::from)
+    }
+}

--- a/ot/mpz-ot/src/actor/mod.rs
+++ b/ot/mpz-ot/src/actor/mod.rs
@@ -1,0 +1,4 @@
+//! Actor implementations of oblivious transfer protocols.
+
+/// KOS actor implementations.
+pub mod kos;

--- a/ot/mpz-ot/src/kos/error.rs
+++ b/ot/mpz-ot/src/kos/error.rs
@@ -18,6 +18,8 @@ pub enum SenderError {
     StateError(String),
     #[error("configuration error: {0}")]
     ConfigError(String),
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<SenderError> for OTError {
@@ -26,6 +28,12 @@ impl From<SenderError> for OTError {
             SenderError::IOError(e) => e.into(),
             e => OTError::SenderError(Box::new(e)),
         }
+    }
+}
+
+impl From<mpz_ot_core::kos::SenderError> for OTError {
+    fn from(err: mpz_ot_core::kos::SenderError) -> Self {
+        SenderError::from(err).into()
     }
 }
 
@@ -56,6 +64,8 @@ pub enum ReceiverError {
     ConfigError(String),
     #[error(transparent)]
     VerifyError(#[from] ReceiverVerifyError),
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<ReceiverError> for OTError {
@@ -64,6 +74,12 @@ impl From<ReceiverError> for OTError {
             ReceiverError::IOError(e) => e.into(),
             e => OTError::ReceiverError(Box::new(e)),
         }
+    }
+}
+
+impl From<mpz_ot_core::kos::ReceiverError> for OTError {
+    fn from(err: mpz_ot_core::kos::ReceiverError) -> Self {
+        ReceiverError::from(err).into()
     }
 }
 

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -9,6 +9,9 @@ use futures_util::{SinkExt, StreamExt};
 pub use receiver::Receiver;
 pub use sender::Sender;
 
+pub(crate) use receiver::State as ReceiverState;
+pub(crate) use sender::State as SenderState;
+
 pub use mpz_ot_core::kos::{
     msgs, PayloadRecord, ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError,
     ReceiverKeys, SenderConfig, SenderConfigBuilder, SenderConfigBuilderError, SenderKeys,

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -59,7 +59,7 @@ mod tests {
 
     use crate::{
         mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
-        CommittedOTSender, OTReceiver, OTSender, OTSetup, VerifiableOTReceiver,
+        OTReceiver, OTSender, OTSetup, VerifiableOTReceiver,
     };
 
     #[fixture]

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -238,7 +238,7 @@ where
             self.cointoss_receiver = Some(cointoss_receiver);
         }
 
-        // Set up base OT if not already done
+        // Set up base OT
         self.base
             .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
             .await?;

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -68,7 +68,7 @@ where
         &self.state
     }
 
-    /// Returns a mutable refernce to the inner receiver state.
+    /// Returns a mutable reference to the inner receiver state.
     pub(crate) fn state_mut(&mut self) -> &mut State {
         &mut self.state
     }
@@ -101,7 +101,7 @@ where
 
         let extend = extend?;
 
-        // Commit to cointoss seed
+        // Commit to coin toss seed
         let seed: Block = thread_rng().gen();
         let (cointoss_sender, cointoss_commitment) = cointoss::Sender::new(vec![seed]).send();
 
@@ -111,7 +111,7 @@ where
             .await?;
         sink.flush().await?;
 
-        // Receive cointoss
+        // Receive coin toss
         let cointoss_payload = stream
             .expect_next()
             .await?
@@ -131,7 +131,7 @@ where
 
         let check = check?;
 
-        // Send cointoss decommitment and correlation check value.
+        // Send coin toss decommitment and correlation check value.
         sink.feed(Message::CointossSenderPayload(payload)).await?;
         sink.feed(Message::Check(check)).await?;
         sink.flush().await?;
@@ -156,7 +156,7 @@ where
     ) -> Result<(), ReceiverError> {
         let receiver = self.state.replace(State::Error).into_extension()?;
 
-        // Finalize cointoss to determine expected delta
+        // Finalize coin toss to determine expected delta
         let cointoss_payload = stream
             .expect_next()
             .await?
@@ -221,7 +221,7 @@ where
             .into_initialized()
             .map_err(ReceiverError::from)?;
 
-        // If the sender is committed, we run a cointoss
+        // If the sender is committed, we run a coin toss
         if ext_receiver.config().sender_commit() {
             let commitment = stream
                 .expect_next()

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -66,7 +66,7 @@ where
         Ok(self.state.as_extension()?.remaining())
     }
 
-    /// Returns a mutable refernce to the inner sender state.
+    /// Returns a mutable reference to the inner sender state.
     pub(crate) fn state_mut(&mut self) -> &mut State {
         &mut self.state
     }
@@ -150,7 +150,7 @@ where
             .into_extend()
             .map_err(SenderError::from)?;
 
-        // Receive cointoss commitments from the receiver.
+        // Receive coin toss commitments from the receiver.
         let commitment = stream.expect_next().await?.into_cointoss_commit()?;
 
         // Extend the OTs, adding padding for the consistency check.
@@ -161,17 +161,17 @@ where
         })
         .await?;
 
-        // Execute cointoss protocol for consistency check.
+        // Execute coin toss protocol for consistency check.
         let seed: Block = thread_rng().gen();
         let cointoss_receiver = cointoss::Receiver::new(vec![seed]);
 
         let (cointoss_receiver, cointoss_payload) = cointoss_receiver.reveal(commitment)?;
 
-        // Send cointoss payload to the receiver.
+        // Send coin toss payload to the receiver.
         sink.send(Message::CointossReceiverPayload(cointoss_payload))
             .await?;
 
-        // Receive cointoss sender payload from the receiver.
+        // Receive coin toss sender payload from the receiver.
         let cointoss_sender_payload = stream.expect_next().await?.into_cointoss_sender_payload()?;
 
         // Receive consistency check from the receiver.
@@ -212,7 +212,7 @@ where
             .into_extension()
             .map_err(SenderError::from)?;
 
-        // Reveal cointoss payload
+        // Reveal coin toss payload
         let Some(payload) = self.cointoss_payload.take() else {
             return Err(SenderError::ConfigError(
                 "committed sender not configured".to_string(),
@@ -259,7 +259,7 @@ where
             return Ok(());
         }
 
-        // If the sender is committed, we sample delta using a cointoss.
+        // If the sender is committed, we sample delta using a coin toss.
         let delta = if self
             .state
             .as_initialized()

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -4,6 +4,8 @@
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
 
+#[cfg(feature = "actor")]
+pub mod actor;
 pub mod chou_orlandi;
 pub mod kos;
 #[cfg(feature = "mock")]


### PR DESCRIPTION
This PR re-implements the KOS actors, removing our dependency on `xtra`. Keep in mind that these modules are already dead-on-arrival in a way, as we are going to be replacing them with SoftSpokenOT. Don't get too bogged down on all the edge-cases for now :slightly_smiling_face: 

# Changes
1. Adjusted the verifiable OT interface a bit to support parallel verification.
2. Added `Verify` as a typed state into the KOS receiver core, adding a bit of safety and saving the outer layer from having to manually distribute copies of $\Delta$
3. Implemented the actors.