### PR TITLE
OTSetup trait

### DIFF
--- a/ot/mpz-ot/benches/ot.rs
+++ b/ot/mpz-ot/benches/ot.rs
@@ -3,7 +3,7 @@ use futures_util::StreamExt;
 use mpz_core::Block;
 use mpz_ot::{
     chou_orlandi::{Receiver, ReceiverConfig, Sender, SenderConfig},
-    OTReceiver, OTSender,
+    OTReceiver, OTSender, OTSetup,
 };
 use utils_aio::duplex::MemoryDuplex;
 

--- a/ot/mpz-ot/src/chou_orlandi/mod.rs
+++ b/ot/mpz-ot/src/chou_orlandi/mod.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use utils_aio::duplex::MemoryDuplex;
 //! use mpz_ot::chou_orlandi::{Receiver, Sender, SenderConfig, ReceiverConfig};
-//! use mpz_ot::{OTReceiver, OTSender};
+//! use mpz_ot::{OTReceiver, OTSender, OTSetup};
 //! use mpz_core::Block;
 //! use futures::StreamExt;
 //!
@@ -54,7 +54,7 @@
 //! ```
 //! use utils_aio::duplex::MemoryDuplex;
 //! use mpz_ot::chou_orlandi::{Receiver, Sender, SenderConfig, ReceiverConfig};
-//! use mpz_ot::{OTReceiver, OTSender, CommittedOTReceiver, VerifiableOTSender};
+//! use mpz_ot::{OTReceiver, OTSender, CommittedOTReceiver, VerifiableOTSender, OTSetup};
 //! use mpz_core::Block;
 //! use futures::StreamExt;
 //!
@@ -128,7 +128,7 @@ mod tests {
     use rand_core::SeedableRng;
     use utils_aio::{duplex::MemoryDuplex, sink::IoSink, stream::IoStream};
 
-    use crate::{CommittedOTReceiver, OTReceiver, OTSender, VerifiableOTSender};
+    use crate::{CommittedOTReceiver, OTReceiver, OTSender, OTSetup, VerifiableOTSender};
 
     use super::*;
     use rstest::*;

--- a/ot/mpz-ot/src/chou_orlandi/receiver.rs
+++ b/ot/mpz-ot/src/chou_orlandi/receiver.rs
@@ -80,6 +80,10 @@ impl OTSetup for Receiver {
         sink: &mut Si,
         stream: &mut St,
     ) -> Result<(), OTError> {
+        if self.state.is_setup() {
+            return Ok(());
+        }
+
         let (config, seed) = self
             .state
             .replace(State::Error)

--- a/ot/mpz-ot/src/chou_orlandi/receiver.rs
+++ b/ot/mpz-ot/src/chou_orlandi/receiver.rs
@@ -15,7 +15,7 @@ use utils_aio::{
     stream::{ExpectStreamExt, IoStream},
 };
 
-use crate::{CommittedOTReceiver, OTError, OTReceiver};
+use crate::{CommittedOTReceiver, OTError, OTReceiver, OTSetup};
 
 use super::ReceiverError;
 
@@ -71,26 +71,27 @@ impl Receiver {
             cointoss_payload: None,
         }
     }
+}
 
-    /// Sets up the receiver.
-    ///
-    /// # Arguments
-    ///
-    /// * `sink` - The sink to send messages to the sender
-    /// * `stream` - The stream to receive messages from the sender
-    pub async fn setup<Si: IoSink<Message> + Send + Unpin, St: IoStream<Message> + Send + Unpin>(
+#[async_trait]
+impl OTSetup for Receiver {
+    async fn setup<Si: IoSink<Message> + Send + Unpin, St: IoStream<Message> + Send + Unpin>(
         &mut self,
         sink: &mut Si,
         stream: &mut St,
-    ) -> Result<(), ReceiverError> {
-        let (config, seed) = self.state.replace(State::Error).into_initialized()?;
+    ) -> Result<(), OTError> {
+        let (config, seed) = self
+            .state
+            .replace(State::Error)
+            .into_initialized()
+            .map_err(ReceiverError::from)?;
 
         // If the receiver is committed, we generate the seed using a cointoss.
         let receiver = if config.receiver_commit() {
             if seed.is_some() {
                 return Err(ReceiverError::InvalidConfig(
                     "committed receiver seed must be generated using coin toss".to_string(),
-                ));
+                ))?;
             }
 
             let (seed, cointoss_payload) = execute_cointoss(sink, stream).await?;
@@ -102,7 +103,11 @@ impl Receiver {
             ReceiverCore::new_with_seed(config, seed.unwrap_or_else(|| thread_rng().gen()))
         };
 
-        let sender_setup = stream.expect_next().await?.into_sender_setup()?;
+        let sender_setup = stream
+            .expect_next()
+            .await?
+            .into_sender_setup()
+            .map_err(ReceiverError::from)?;
 
         let receiver = Backend::spawn(move || receiver.setup(sender_setup)).await;
 

--- a/ot/mpz-ot/src/chou_orlandi/sender.rs
+++ b/ot/mpz-ot/src/chou_orlandi/sender.rs
@@ -1,4 +1,4 @@
-use crate::{chou_orlandi::SenderError, OTError, OTSender, VerifiableOTSender};
+use crate::{chou_orlandi::SenderError, OTError, OTSender, OTSetup, VerifiableOTSender};
 
 use async_trait::async_trait;
 use futures_util::SinkExt;
@@ -63,19 +63,20 @@ impl Sender {
             cointoss_receiver: None,
         }
     }
+}
 
-    /// Sets up the Sender.
-    ///
-    /// # Arguments
-    ///
-    /// * `sink` - The sink to send messages to the receiver
-    /// * `stream` - The stream to receive messages from the receiver
-    pub async fn setup<Si: IoSink<Message> + Send + Unpin, St: IoStream<Message> + Send + Unpin>(
+#[async_trait]
+impl OTSetup for Sender {
+    async fn setup<Si: IoSink<Message> + Send + Unpin, St: IoStream<Message> + Send + Unpin>(
         &mut self,
         sink: &mut Si,
         stream: &mut St,
-    ) -> Result<(), SenderError> {
-        let sender = self.state.replace(State::Error).into_initialized()?;
+    ) -> Result<(), OTError> {
+        let sender = self
+            .state
+            .replace(State::Error)
+            .into_initialized()
+            .map_err(SenderError::from)?;
 
         // If the receiver is committed, we run the cointoss protocol
         if sender.config().receiver_commit() {

--- a/ot/mpz-ot/src/chou_orlandi/sender.rs
+++ b/ot/mpz-ot/src/chou_orlandi/sender.rs
@@ -72,6 +72,10 @@ impl OTSetup for Sender {
         sink: &mut Si,
         stream: &mut St,
     ) -> Result<(), OTError> {
+        if self.state.is_setup() {
+            return Ok(());
+        }
+
         let sender = self
             .state
             .replace(State::Error)

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -56,7 +56,7 @@ mod tests {
 
     use crate::{
         mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
-        CommittedOTSender, OTReceiver, OTSender, VerifiableOTReceiver,
+        CommittedOTSender, OTReceiver, OTSender, OTSetup, VerifiableOTReceiver,
     };
 
     #[fixture]

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -164,11 +164,6 @@ where
             .into_initialized()
             .map_err(ReceiverError::from)?;
 
-        // Set up base OT if not already done
-        self.base
-            .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
-            .await?;
-
         // If the sender is committed, we run a cointoss
         if ext_receiver.config().sender_commit() {
             let commitment = stream
@@ -185,6 +180,11 @@ where
 
             self.cointoss_receiver = Some(cointoss_receiver);
         }
+
+        // Set up base OT if not already done
+        self.base
+            .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
+            .await?;
 
         let seeds: [[Block; 2]; CSP] = std::array::from_fn(|_| thread_rng().gen());
 

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -213,6 +213,11 @@ where
             return Ok(());
         }
 
+        // Set up base OT if not already done
+        self.base
+            .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
+            .await?;
+
         // If the sender is committed, we sample delta using a cointoss.
         let delta = if self
             .state

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -213,11 +213,6 @@ where
             return Ok(());
         }
 
-        // Set up base OT if not already done
-        self.base
-            .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
-            .await?;
-
         // If the sender is committed, we sample delta using a cointoss.
         let delta = if self
             .state
@@ -247,6 +242,11 @@ where
         } else {
             Block::random(&mut thread_rng())
         };
+
+        // Set up base OT if not already done
+        self.base
+            .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
+            .await?;
 
         self._setup_with_delta(sink, stream, delta)
             .await

--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -1,5 +1,6 @@
 use crate::{
     kos::SenderError, CommittedOTReceiver, CommittedOTSender, OTError, OTReceiver, OTSender,
+    OTSetup,
 };
 
 use async_trait::async_trait;
@@ -63,44 +64,6 @@ where
     /// The number of remaining OTs which can be consumed.
     pub fn remaining(&self) -> Result<usize, SenderError> {
         Ok(self.state.as_extension()?.remaining())
-    }
-
-    /// Performs the base OT setup using a random delta.
-    ///
-    /// # Arguments
-    ///
-    /// * `sink` - The sink to send messages to the base OT sender
-    /// * `stream` - The stream to receive messages from the base OT sender
-    pub async fn setup<
-        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
-        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
-    >(
-        &mut self,
-        sink: &mut Si,
-        stream: &mut St,
-    ) -> Result<(), SenderError> {
-        // If the sender is committed, we sample delta using a cointoss.
-        let delta = if self.state.as_initialized()?.config().sender_commit() {
-            let (cointoss_sender, commitment) =
-                cointoss::Sender::new(vec![thread_rng().gen()]).send();
-
-            sink.send(Message::CointossCommit(commitment)).await?;
-            let payload = stream
-                .expect_next()
-                .await?
-                .into_cointoss_receiver_payload()?;
-
-            let (seeds, payload) = cointoss_sender.finalize(payload)?;
-
-            // Store the payload to reveal to the receiver later.
-            self.cointoss_payload = Some(payload);
-
-            seeds[0]
-        } else {
-            Block::random(&mut thread_rng())
-        };
-
-        self._setup_with_delta(sink, stream, delta).await
     }
 
     /// Performs the base OT setup with the provided delta.
@@ -231,6 +194,59 @@ where
     BaseOT: ProtocolMessage,
 {
     type Msg = Message<BaseOT::Msg>;
+}
+
+#[async_trait]
+impl<BaseOT> OTSetup for Sender<BaseOT>
+where
+    BaseOT: OTSetup + OTReceiver<bool, Block> + Send,
+{
+    async fn setup<
+        Si: IoSink<Message<BaseOT::Msg>> + Send + Unpin,
+        St: IoStream<Message<BaseOT::Msg>> + Send + Unpin,
+    >(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+    ) -> Result<(), OTError> {
+        if self.state.is_extension() {
+            return Ok(());
+        }
+
+        // If the sender is committed, we sample delta using a cointoss.
+        let delta = if self
+            .state
+            .as_initialized()
+            .map_err(SenderError::from)?
+            .config()
+            .sender_commit()
+        {
+            let (cointoss_sender, commitment) =
+                cointoss::Sender::new(vec![thread_rng().gen()]).send();
+
+            sink.send(Message::CointossCommit(commitment)).await?;
+            let payload = stream
+                .expect_next()
+                .await?
+                .into_cointoss_receiver_payload()
+                .map_err(SenderError::from)?;
+
+            let (seeds, payload) = cointoss_sender
+                .finalize(payload)
+                .map_err(SenderError::from)?;
+
+            // Store the payload to reveal to the receiver later.
+            self.cointoss_payload = Some(payload);
+
+            seeds[0]
+        } else {
+            Block::random(&mut thread_rng())
+        };
+
+        self._setup_with_delta(sink, stream, delta)
+            .await
+            .map_err(OTError::from)
+    }
 }
 
 #[async_trait]

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -29,6 +29,22 @@ pub enum OTError {
 // ######################## Exclusive Reference ###########################
 // ########################################################################
 
+/// An oblivious transfer protocol that needs to perform a one-time setup.
+#[async_trait]
+pub trait OTSetup: ProtocolMessage {
+    /// Runs any one-time setup for the protocol.
+    ///
+    /// # Arguments
+    ///
+    /// * `sink` - The IO sink to the peer.
+    /// * `stream` - The IO stream from the peer.
+    async fn setup<Si: IoSink<Self::Msg> + Send + Unpin, St: IoStream<Self::Msg> + Send + Unpin>(
+        &mut self,
+        sink: &mut Si,
+        stream: &mut St,
+    ) -> Result<(), OTError>;
+}
+
 /// An oblivious transfer sender.
 #[async_trait]
 pub trait OTSender<T>: ProtocolMessage

--- a/ot/mpz-ot/src/mock/owned.rs
+++ b/ot/mpz-ot/src/mock/owned.rs
@@ -1,7 +1,7 @@
 use crate::{
     CommittedOTReceiver, CommittedOTSender, CommittedOTSenderWithIo, OTError, OTReceiver,
-    OTReceiverWithIo, OTSender, OTSenderWithIo, VerifiableOTReceiver, VerifiableOTReceiverWithIo,
-    VerifiableOTSender,
+    OTReceiverWithIo, OTSender, OTSenderWithIo, OTSetup, VerifiableOTReceiver,
+    VerifiableOTReceiverWithIo, VerifiableOTSender,
 };
 use async_trait::async_trait;
 use futures::{
@@ -55,6 +55,20 @@ pub fn mock_ot_pair<T: Send + Sync + 'static>() -> (MockOTSender<T>, MockOTRecei
 }
 
 #[async_trait]
+impl<T> OTSetup for MockOTSender<T>
+where
+    T: Send + Sync,
+{
+    async fn setup<Si: IoSink<()> + Send + Unpin, St: IoStream<()> + Send + Unpin>(
+        &mut self,
+        _sink: &mut Si,
+        _stream: &mut St,
+    ) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl<T> OTSender<[T; 2]> for MockOTSender<T>
 where
     T: Send + Sync + Clone + 'static,
@@ -81,6 +95,20 @@ where
             .try_send(msgs.to_vec())
             .expect("DummySender should be able to send");
 
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<T> OTSetup for MockOTReceiver<T>
+where
+    T: Send + Sync,
+{
+    async fn setup<Si: IoSink<()> + Send + Unpin, St: IoStream<()> + Send + Unpin>(
+        &mut self,
+        _sink: &mut Si,
+        _stream: &mut St,
+    ) -> Result<(), OTError> {
         Ok(())
     }
 }


### PR DESCRIPTION
This PR introduces the `OTSetup` trait for performing any one-time setup that needs to be done before using other functionalities. One day I would like this to be a more general trait for any protocol (not just OT), but this will work for now.

This saves us from having to set up base OT before injecting it into OT extension.