### PR TITLE
feat: generic array casts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ bincode = "1.3.3"
 prost-build = "0.9"
 bytes = "1"
 yamux = "0.10"
-bytemuck = {version = "1.13", features = ["derive"]}
+bytemuck = { version = "1.13", features = ["derive"] }
 
 # testing
 prost = "0.9"
@@ -89,5 +89,6 @@ hex = "0.4"
 lazy_static = "1"
 derive_builder = "0.11"
 once_cell = "1"
+# DO NOT BUMP, SEE https://github.com/privacy-scaling-explorations/mpz/issues/61
 generic-array = "0.14"
 itybity = "0.2"

--- a/mpz-core/Cargo.toml
+++ b/mpz-core/Cargo.toml
@@ -24,7 +24,8 @@ itybity.workspace = true
 opaque-debug.workspace = true
 bcs = "0.1.5"
 rand_core = "0.6.4"
-bytemuck = {workspace = true, features = ["derive"]}
+bytemuck = { workspace = true, features = ["derive"] }
+generic-array.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/mpz-core/src/aes.rs
+++ b/mpz-core/src/aes.rs
@@ -85,6 +85,10 @@ impl FixedKeyAes {
     /// (cf. <https://eprint.iacr.org/2019/074>, §7.2).
     ///
     /// `π(x) ⊕ x`, where `π` is instantiated using fixed-key AES.
+    /// 
+    /// # Arguments
+    ///
+    /// * `blocks` - The blocks to hash in-place.
     #[inline]
     pub fn cr_many_inplace<const N: usize>(&self, blocks: &mut [Block; N]) {
         let mut buf = *blocks;
@@ -115,6 +119,10 @@ impl FixedKeyAes {
     /// `π(σ(x)) ⊕ σ(x)`, where `π` is instantiated using fixed-key AES
     ///
     /// See [`Block::sigma`](Block::sigma) for more details on `σ`.
+    ///
+    /// # Arguments
+    ///
+    /// * `blocks` - The blocks to hash in-place.
     #[inline]
     pub fn ccr_many_inplace<const N: usize>(&self, blocks: &mut [Block; N]) {
         blocks.iter_mut().for_each(|b| *b = Block::sigma(*b));
@@ -161,7 +169,7 @@ impl AesEncryptor {
 
     /// Encrypt many blocks with many keys.
     ///
-    /// Each batch of NM blocks are encrypted by a corresponding AES key.
+    /// Each batch of NM blocks is encrypted by a corresponding AES key.
     ///
     /// **Only the first NK * NM blocks of blks are handled, the rest are ignored.**
     ///

--- a/mpz-core/src/aes.rs
+++ b/mpz-core/src/aes.rs
@@ -85,7 +85,7 @@ impl FixedKeyAes {
     /// (cf. <https://eprint.iacr.org/2019/074>, §7.2).
     ///
     /// `π(x) ⊕ x`, where `π` is instantiated using fixed-key AES.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `blocks` - The blocks to hash in-place.

--- a/mpz-core/src/block.rs
+++ b/mpz-core/src/block.rs
@@ -1,9 +1,9 @@
 //! A block of 128 bits and its operations.
 
 use bytemuck::{Pod, Zeroable};
-use cipher::{consts::U16, generic_array::GenericArray};
 use clmul::Clmul;
 use core::ops::{BitAnd, BitAndAssign, BitXor, BitXorAssign};
+use generic_array::{typenum::consts::U16, GenericArray};
 use itybity::{BitIterable, BitLength, GetBit, Lsb0, Msb0};
 use rand::{distributions::Standard, prelude::Distribution, CryptoRng, Rng};
 use serde::{Deserialize, Serialize};

--- a/mpz-core/src/block.rs
+++ b/mpz-core/src/block.rs
@@ -124,6 +124,7 @@ impl Block {
 
     /// Converts a block to a [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
     /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    #[allow(dead_code)]
     pub(crate) fn as_generic_array(&self) -> &GenericArray<u8, U16> {
         (&self.0).into()
     }
@@ -136,6 +137,7 @@ impl Block {
 
     /// Converts a slice of blocks to a slice of [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
     /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    #[allow(dead_code)]
     pub(crate) fn as_generic_array_slice(slice: &[Self]) -> &[GenericArray<u8, U16>] {
         // # Safety
         // This is always safe because `Block` and `GenericArray<u8, U16>` have the same memory layout.
@@ -146,7 +148,7 @@ impl Block {
 
     /// Converts a mutable slice of blocks to a mutable slice of [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
     /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
-    pub(crate) fn as_generic_array_slice_mut(slice: &mut [Self]) -> &mut [GenericArray<u8, U16>] {
+    pub(crate) fn as_generic_array_mut_slice(slice: &mut [Self]) -> &mut [GenericArray<u8, U16>] {
         // # Safety
         // This is always safe because `Block` and `GenericArray<u8, U16>` have the same memory layout.
         // See https://github.com/fizyk20/generic-array/blob/37dc6aefc3ed5c423ad7402d4febf06a3e78a223/src/lib.rs#L847-L854

--- a/mpz-core/src/block.rs
+++ b/mpz-core/src/block.rs
@@ -121,6 +121,38 @@ impl Block {
         x[0] ^= x[1];
         bytemuck::cast([x[1], x[0]])
     }
+
+    /// Converts a block to a [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
+    /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    pub(crate) fn as_generic_array(&self) -> &GenericArray<u8, U16> {
+        (&self.0).into()
+    }
+
+    /// Converts a mutable block to a mutable [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
+    /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    pub(crate) fn as_generic_array_mut(&mut self) -> &mut GenericArray<u8, U16> {
+        (&mut self.0).into()
+    }
+
+    /// Converts a slice of blocks to a slice of [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
+    /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    pub(crate) fn as_generic_array_slice(slice: &[Self]) -> &[GenericArray<u8, U16>] {
+        // # Safety
+        // This is always safe because `Block` and `GenericArray<u8, U16>` have the same memory layout.
+        // See https://github.com/fizyk20/generic-array/blob/37dc6aefc3ed5c423ad7402d4febf06a3e78a223/src/lib.rs#L838-L845
+        // TODO: Use methods provided by `generic-array` once 1.0 is released.
+        unsafe { std::mem::transmute(slice) }
+    }
+
+    /// Converts a mutable slice of blocks to a mutable slice of [`GenericArray<u8, U16>`](cipher::generic_array::GenericArray)
+    /// from the [`generic-array`](https://docs.rs/generic-array/latest/generic_array/) crate.
+    pub(crate) fn as_generic_array_slice_mut(slice: &mut [Self]) -> &mut [GenericArray<u8, U16>] {
+        // # Safety
+        // This is always safe because `Block` and `GenericArray<u8, U16>` have the same memory layout.
+        // See https://github.com/fizyk20/generic-array/blob/37dc6aefc3ed5c423ad7402d4febf06a3e78a223/src/lib.rs#L847-L854
+        // TODO: Use methods provided by `generic-array` once 1.0 is released.
+        unsafe { std::mem::transmute(slice) }
+    }
 }
 
 /// A trait for converting a type to blocks
@@ -160,6 +192,12 @@ impl From<[u8; 16]> for Block {
     }
 }
 
+impl<'a> From<&'a [u8; 16]> for &'a Block {
+    fn from(bytes: &'a [u8; 16]) -> Self {
+        bytemuck::cast_ref(bytes)
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for Block {
     type Error = <[u8; 16] as TryFrom<&'a [u8]>>::Error;
 
@@ -175,6 +213,13 @@ impl From<Block> for GenericArray<u8, U16> {
     }
 }
 
+impl<'a> From<&'a Block> for &'a GenericArray<u8, U16> {
+    #[inline]
+    fn from(b: &'a Block) -> Self {
+        (&b.0).into()
+    }
+}
+
 impl From<GenericArray<u8, U16>> for Block {
     #[inline]
     fn from(b: GenericArray<u8, U16>) -> Self {
@@ -182,10 +227,25 @@ impl From<GenericArray<u8, U16>> for Block {
     }
 }
 
+impl<'a> From<&'a GenericArray<u8, U16>> for &'a Block {
+    #[inline]
+    fn from(b: &'a GenericArray<u8, U16>) -> Self {
+        let b: &'a [u8; 16] = b.as_ref();
+        b.into()
+    }
+}
+
 impl From<Block> for [u8; 16] {
     #[inline]
     fn from(b: Block) -> Self {
         b.0
+    }
+}
+
+impl<'a> From<&'a Block> for &'a [u8; 16] {
+    #[inline]
+    fn from(b: &'a Block) -> Self {
+        &b.0
     }
 }
 


### PR DESCRIPTION
This PR adds helper methods for converting variations of `Block` into `GenericArray<u8, U16>` from the `generic-array` crate. This reduces copies in a few places and lets us take better advantage of instruction-level parallelism provided by RustCrypto crates.