### PR TITLE
feat: use tccr_many in garble

### DIFF
--- a/garble/mpz-garble-core/src/evaluator.rs
+++ b/garble/mpz-garble-core/src/evaluator.rs
@@ -43,8 +43,10 @@ pub(crate) fn and_gate(
     let j = Block::new((gid as u128).to_be_bytes());
     let k = Block::new(((gid + 1) as u128).to_be_bytes());
 
-    let hx = cipher.tccr(j, x);
-    let hy = cipher.tccr(k, y);
+    let mut h = [x, y];
+    cipher.tccr_many_inplace(&[j, k], &mut h);
+
+    let [hx, hy] = h;
 
     let w_g = hx ^ (encrypted_gate[0] & Block::SELECT_MASK[s_a]);
     let w_e = hy ^ (Block::SELECT_MASK[s_b] & (encrypted_gate[1] ^ x));

--- a/garble/mpz-garble-core/src/generator.rs
+++ b/garble/mpz-garble-core/src/generator.rs
@@ -45,15 +45,17 @@ pub(crate) fn and_gate(
     let j = Block::new((gid as u128).to_be_bytes());
     let k = Block::new(((gid + 1) as u128).to_be_bytes());
 
-    let hx_0 = cipher.tccr(j, x_0);
-    let hy_0 = cipher.tccr(k, y_0);
+    let mut h = [x_0, y_0, x_1, y_1];
+    cipher.tccr_many_inplace(&[j, k, j, k], &mut h);
+
+    let [hx_0, hy_0, hx_1, hy_1] = h;
 
     // Garbled row of generator half-gate
-    let t_g = hx_0 ^ cipher.tccr(j, x_1) ^ (Block::SELECT_MASK[p_b] & delta);
+    let t_g = hx_0 ^ hx_1 ^ (Block::SELECT_MASK[p_b] & delta);
     let w_g = hx_0 ^ (Block::SELECT_MASK[p_a] & t_g);
 
     // Garbled row of evaluator half-gate
-    let t_e = hy_0 ^ cipher.tccr(k, y_1) ^ x_0;
+    let t_e = hy_0 ^ hy_1 ^ x_0;
     let w_e = hy_0 ^ (Block::SELECT_MASK[p_b] & (t_e ^ x_0));
 
     let z_0 = Label::new(w_g ^ w_e);


### PR DESCRIPTION
This PR builds on #59, now using `tccr_many` in the garble crate. This yields 2x speed-up on my machine.