### PR TITLE
Reimplement ConverterReceiver, ConverterSender using ShareConversion trait.

### DIFF
--- a/share-conversion/mpz-share-conversion/src/converter.rs
+++ b/share-conversion/mpz-share-conversion/src/converter.rs
@@ -55,7 +55,7 @@ where
 impl<F, OT> ShareConversionReveal for ConverterSender<F, OT>
 where
     F: Field,
-    OT: OTSendElement<F> + Clone,
+    OT: OTSendElement<F>,
 {
     /// Reveals the Sender's seed and tape to the Receiver for verification.
     async fn reveal(&mut self) -> Result<(), ShareConversionError> {
@@ -205,7 +205,7 @@ where
 impl<F, OT> ShareConversionVerify for ConverterReceiver<F, OT>
 where
     F: Field,
-    OT: OTReceiveElement<F> + Clone,
+    OT: OTReceiveElement<F>,
 {
     /// Verifies the Sender's seed and tape.
     async fn verify(&mut self) -> Result<(), ShareConversionError> {

--- a/share-conversion/mpz-share-conversion/src/converter.rs
+++ b/share-conversion/mpz-share-conversion/src/converter.rs
@@ -6,7 +6,7 @@ use mpz_share_conversion_core::{Field, Share};
 use crate::{
     AdditiveToMultiplicative, GilboaReceiver, GilboaSender, MultiplicativeToAdditive,
     OTReceiveElement, OTSendElement, ReceiverConfig, SenderConfig, ShareConversionChannel,
-    ShareConversionError,
+    ShareConversionError, ShareConversionReveal, ShareConversionVerify,
 };
 
 /// The share conversion sender
@@ -49,9 +49,16 @@ where
             ),
         })
     }
+}
 
+#[async_trait]
+impl<F, OT> ShareConversionReveal for ConverterSender<F, OT>
+where
+    F: Field,
+    OT: OTSendElement<F> + Clone,
+{
     /// Reveals the Sender's seed and tape to the Receiver for verification.
-    pub async fn reveal(&mut self) -> Result<(), ShareConversionError> {
+    async fn reveal(&mut self) -> Result<(), ShareConversionError> {
         let sender = self
             .sender
             .take()
@@ -192,9 +199,16 @@ where
             ),
         })
     }
+}
 
+#[async_trait]
+impl<F, OT> ShareConversionVerify for ConverterReceiver<F, OT>
+where
+    F: Field,
+    OT: OTReceiveElement<F> + Clone,
+{
     /// Verifies the Sender's seed and tape.
-    pub async fn verify(&mut self) -> Result<(), ShareConversionError> {
+    async fn verify(&mut self) -> Result<(), ShareConversionError> {
         let receiver = self
             .receiver
             .take()

--- a/share-conversion/mpz-share-conversion/src/lib.rs
+++ b/share-conversion/mpz-share-conversion/src/lib.rs
@@ -77,7 +77,7 @@ where
 #[async_trait]
 pub trait ShareConversionReveal {
     /// Reveals the private inputs of the sender to the receiver for verification.
-    async fn reveal(self) -> Result<(), ShareConversionError>;
+    async fn reveal(&mut self) -> Result<(), ShareConversionError>;
 }
 
 /// Verify the recorded inputs of the sender
@@ -87,7 +87,7 @@ pub trait ShareConversionReveal {
 #[async_trait]
 pub trait ShareConversionVerify {
     /// Verifies all share conversions.
-    async fn verify(self) -> Result<(), ShareConversionError>;
+    async fn verify(&mut self) -> Result<(), ShareConversionError>;
 }
 
 #[cfg(test)]

--- a/share-conversion/mpz-share-conversion/tests/converter.rs
+++ b/share-conversion/mpz-share-conversion/tests/converter.rs
@@ -5,7 +5,8 @@ use rstest::*;
 use mpz_ot::mock::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};
 use mpz_share_conversion::{
     AdditiveToMultiplicative, ConverterReceiver, ConverterSender, Field, Gf2_128,
-    MultiplicativeToAdditive, OTReceiveElement, OTSendElement, ReceiverConfig, SenderConfig, P256,
+    MultiplicativeToAdditive, OTReceiveElement, OTSendElement, ReceiverConfig, SenderConfig,
+    ShareConversionReveal, ShareConversionVerify, P256,
 };
 use utils_aio::duplex::MemoryDuplex;
 


### PR DESCRIPTION
Fix #32 
I have reimplemented 1) ConverterSender, 2) Converter Receiver.
- **reveal** function of **ConverterSender** is now inside **ShareConversionReveal** trait.
- **verify** function of **ConverterReceiver** is now inside **ShareConversionVerify** trait.

Yet, I am not sure about how the reveal and verify functions to be private.
Could you a bit more specific about how you want the functions to be used?
I will try to make appropriate adjustment upon the answer. 
