### PR TITLE
Add test configuration for tokio dep

### DIFF
--- a/share-conversion/mpz-share-conversion/Cargo.toml
+++ b/share-conversion/mpz-share-conversion/Cargo.toml
@@ -26,4 +26,9 @@ derive_builder.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = [
+    "net",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }


### PR DESCRIPTION
This PR repairs the tokio dependency in `mpz-share-conversion` so that the tests can also be run from the crate itself.