### PR TITLE
Fix PRNG seeds for benches & tests

### DIFF
--- a/clmul/benches/clmul.rs
+++ b/clmul/benches/clmul.rs
@@ -5,7 +5,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut rng = ChaCha12Rng::from_entropy();
+    let mut rng = ChaCha12Rng::seed_from_u64(0);
     let a: [u8; 16] = rng.gen();
     let b: [u8; 16] = rng.gen();
     let mut a = Clmul::new(&a);

--- a/garble/mpz-garble-core/src/lib.rs
+++ b/garble/mpz-garble-core/src/lib.rs
@@ -84,7 +84,7 @@ mod tests {
     fn test_and_gate() {
         use crate::{evaluator as ev, generator as gen};
 
-        let mut rng = ChaCha12Rng::from_entropy();
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
         let cipher = &(*FIXED_KEY_AES);
 
         let delta = Delta::random(&mut rng);

--- a/ot/mpz-ot-core/benches/ot.rs
+++ b/ot/mpz-ot-core/benches/ot.rs
@@ -10,7 +10,7 @@ fn chou_orlandi(c: &mut Criterion) {
     for n in [128, 256, 1024] {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             let msgs = vec![[Block::ONES; 2]; n];
-            let mut rng = ChaCha12Rng::from_entropy();
+            let mut rng = ChaCha12Rng::seed_from_u64(0);
             let mut choices = vec![0u8; n / 8];
             rng.fill_bytes(&mut choices);
             b.iter(|| {
@@ -33,7 +33,7 @@ fn kos(c: &mut Criterion) {
     for n in [1024, 262144] {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             let msgs = vec![[Block::ONES; 2]; n];
-            let mut rng = ChaCha12Rng::from_entropy();
+            let mut rng = ChaCha12Rng::seed_from_u64(0);
             let mut choices = vec![0u8; n / 8];
             rng.fill_bytes(&mut choices);
             let choices = choices.into_lsb0_vec();

--- a/share-conversion/mpz-share-conversion-core/benches/inverse_gf2_128.rs
+++ b/share-conversion/mpz-share-conversion-core/benches/inverse_gf2_128.rs
@@ -4,7 +4,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 
 fn bench_gf2_128_inverse(c: &mut Criterion) {
-    let mut rng = ChaCha12Rng::from_entropy();
+    let mut rng = ChaCha12Rng::seed_from_u64(0);
     let a: Gf2_128 = rng.gen();
 
     c.bench_function("inverse", move |bench| {

--- a/share-conversion/mpz-share-conversion-core/src/fields/gf2_128.rs
+++ b/share-conversion/mpz-share-conversion-core/src/fields/gf2_128.rs
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     // Test multiplication against RustCrypto
     fn test_gf2_128_against_ghash_impl() {
-        let mut rng = ChaCha12Rng::seed_from_u64(0u64);
+        let mut rng = ChaCha12Rng::seed_from_u64(0);
 
         let a = Block::random(&mut rng);
         let b = Block::random(&mut rng);


### PR DESCRIPTION
Fix #15 
I modified some of the codes in the which uses seeding using **from_entropy()** to use **seed_from_u64(0)**.

I modified:
- codes in benches/
- test codes that use from_entropy()

There are still three parts of code that use **from_entropy()**.
- ot/mpz-ot-core/src/chou_orlandi/receiver.rs
- ot/mpz-ot-core/src/chou_orlandi/sender.rs
- share-conversion/mpz-share-conversion/src/sender.rs

Yet I left them since I was not sure whether having fixed seed for them was appropriate.
