### PR TITLE
fix: set kos state after base OT

### DIFF
--- a/ot/mpz-ot/src/kos/sender.rs
+++ b/ot/mpz-ot/src/kos/sender.rs
@@ -289,12 +289,12 @@ where
             Block::random(&mut thread_rng())
         };
 
-        self.state = State::Initialized(sender);
-
         // Set up base OT if not already done
         self.base
             .setup(&mut into_base_sink(sink), &mut into_base_stream(stream))
             .await?;
+
+        self.state = State::Initialized(sender);
 
         self._setup_with_delta(sink, stream, delta)
             .await


### PR DESCRIPTION
As it is now the KOS sender is set to a non-error state too early. If base OT setup fails, KOS sender will **not** be in an error state. This PR fixes it.