### PR TITLE
Add `miri` to github ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,11 +50,11 @@ jobs:
           rustup override set nightly
           cargo miri setup
       
-      - name: Test with Miri - clmul
-        run: cargo miri test --package clmul
+      - name: Test with Miri on x86_64
+        run: cargo miri test -p clmul -p matrix-transpose --target x86_64-unknown-linux-gnu
       
-      - name: Test with Miri - matrix-transpose
-        run: cargo miri test --package matrix-transpose
+      - name: Test with Miri on aarch64
+        run: cargo miri test -p clmul -p matrix-transpose --target aarch64-unknown-linux-gnu
 
   rustfmt_and_clippy:
     name: Rustfmt and Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,11 @@ jobs:
           rustup override set nightly
           cargo miri setup
       
-      - name: Test with Miri
-        run: cargo miri test
+      - name: Test with Miri - clmul
+        run: cargo miri test --package clmul
+      
+      - name: Test with Miri - matrix-transpose
+        run: cargo miri test --package matrix-transpose
 
   rustfmt_and_clippy:
     name: Rustfmt and Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,22 @@ jobs:
         #   RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --workspace --lib --document-private-items --examples
 
+  miri:
+    if: ( ! github.event.pull_request.draft )
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      
+      - name: Test with Miri
+        run: cargo miri test
+
   rustfmt_and_clippy:
     name: Rustfmt and Clippy
     runs-on: ubuntu-latest

--- a/clmul/src/backend/clmul.rs
+++ b/clmul/src/backend/clmul.rs
@@ -154,8 +154,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(enable = "pclmulqdq")]
     fn test_against_emptool_impl() {
+        if !is_x86_feature_detected!("pclmulqdq") {
+            return;
+        }
+
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let a: [u8; 16] = rng.gen();
         let b: [u8; 16] = rng.gen();

--- a/clmul/src/backend/clmul.rs
+++ b/clmul/src/backend/clmul.rs
@@ -155,6 +155,10 @@ mod tests {
 
     #[test]
     fn test_against_emptool_impl() {
+        if !is_x86_feature_detected!("pclmulqdq") {
+            return;
+        }
+
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let a: [u8; 16] = rng.gen();
         let b: [u8; 16] = rng.gen();

--- a/clmul/src/backend/clmul.rs
+++ b/clmul/src/backend/clmul.rs
@@ -154,11 +154,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg(enable = "pclmulqdq")]
     fn test_against_emptool_impl() {
-        if !is_x86_feature_detected!("pclmulqdq") {
-            return;
-        }
-
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let a: [u8; 16] = rng.gen();
         let b: [u8; 16] = rng.gen();

--- a/matrix-transpose/src/lib.rs
+++ b/matrix-transpose/src/lib.rs
@@ -110,8 +110,8 @@ mod tests {
 
     #[test]
     fn test_transpose_bits() {
-        let rows = 512;
-        let columns = 256;
+        let rows = 128;
+        let columns = 64;
 
         let mut matrix: Vec<u8> = random_vec::<u8>(columns * rows);
         let naive = transpose_naive(&matrix, columns);

--- a/matrix-transpose/src/lib.rs
+++ b/matrix-transpose/src/lib.rs
@@ -110,8 +110,8 @@ mod tests {
 
     #[test]
     fn test_transpose_bits() {
-        let rows = 128;
-        let columns = 64;
+        let rows = 64;
+        let columns = 32;
 
         let mut matrix: Vec<u8> = random_vec::<u8>(columns * rows);
         let naive = transpose_naive(&matrix, columns);
@@ -154,9 +154,9 @@ mod tests {
 
     #[test]
     fn test_transpose() {
-        let rounds = 7_u32;
+        let rounds = 6_u32;
         let mut rows = 2_usize.pow(rounds);
-        let mut columns = 64;
+        let mut columns = 32;
 
         let mut matrix: Vec<u8> = random_vec::<u8>(columns * rows);
         let original = matrix.clone();
@@ -177,8 +177,8 @@ mod tests {
 
     #[test]
     fn test_bitmask_shift() {
-        let columns = 64;
-        let rows = 128;
+        let columns = 32;
+        let rows = 64;
 
         let mut matrix: Vec<u8> = random_vec::<u8>(columns * rows);
         let mut original = matrix.clone();

--- a/mpz-circuits/src/circuits/big_num.rs
+++ b/mpz-circuits/src/circuits/big_num.rs
@@ -82,6 +82,7 @@ pub fn nbyte_add_mod_trace<'a, const N: usize>(
 #[cfg(test)]
 mod tests {
     use mpz_circuits_macros::evaluate;
+    use rand::Rng;
 
     use crate::CircuitBuilder;
 
@@ -101,15 +102,19 @@ mod tests {
 
         let circ = builder.build().unwrap();
 
-        for a in 0u8..modulus[1] {
-            for b in 0u8..modulus[1] {
-                let expected_sum = ((a as u16 + b as u16) % modulus[1] as u16) as u8;
+        let rounds = 100;
+        let mut rng = rand::thread_rng();
 
-                let sum: [u8; 2] = evaluate!(circ, fn([0u8, a], [0u8, b]) -> [u8; 2]).unwrap();
-                let sum = u16::from_be_bytes(sum) as u8;
+        for _ in 0..rounds {
+            let a = rng.gen_range(0u8..modulus[1]);
+            let b = rng.gen_range(0u8..modulus[1]);
 
-                assert_eq!(sum, expected_sum);
-            }
+            let expected_sum = ((a as u16 + b as u16) % modulus[1] as u16) as u8;
+
+            let sum: [u8; 2] = evaluate!(circ, fn([0u8, a], [0u8, b]) -> [u8; 2]).unwrap();
+            let sum = u16::from_be_bytes(sum) as u8;
+
+            assert_eq!(sum, expected_sum);
         }
     }
 }

--- a/mpz-circuits/src/circuits/big_num.rs
+++ b/mpz-circuits/src/circuits/big_num.rs
@@ -82,7 +82,6 @@ pub fn nbyte_add_mod_trace<'a, const N: usize>(
 #[cfg(test)]
 mod tests {
     use mpz_circuits_macros::evaluate;
-    use rand::Rng;
 
     use crate::CircuitBuilder;
 
@@ -102,19 +101,15 @@ mod tests {
 
         let circ = builder.build().unwrap();
 
-        let rounds = 100;
-        let mut rng = rand::thread_rng();
+        for a in 0u8..modulus[1] {
+            for b in 0u8..modulus[1] {
+                let expected_sum = ((a as u16 + b as u16) % modulus[1] as u16) as u8;
 
-        for _ in 0..rounds {
-            let a = rng.gen_range(0u8..modulus[1]);
-            let b = rng.gen_range(0u8..modulus[1]);
+                let sum: [u8; 2] = evaluate!(circ, fn([0u8, a], [0u8, b]) -> [u8; 2]).unwrap();
+                let sum = u16::from_be_bytes(sum) as u8;
 
-            let expected_sum = ((a as u16 + b as u16) % modulus[1] as u16) as u8;
-
-            let sum: [u8; 2] = evaluate!(circ, fn([0u8, a], [0u8, b]) -> [u8; 2]).unwrap();
-            let sum = u16::from_be_bytes(sum) as u8;
-
-            assert_eq!(sum, expected_sum);
+                assert_eq!(sum, expected_sum);
+            }
         }
     }
 }

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -182,7 +182,7 @@ where
         let actual_delta = <[u8; 16]>::from_lsb0_iter(choices).into();
 
         if expected_delta != actual_delta {
-            return Err(ReceiverVerifyError::InconsistentDelta).map_err(ReceiverError::from)?;
+            return Err(ReceiverError::from(ReceiverVerifyError::InconsistentDelta));
         }
 
         self.state = State::Verify(receiver.start_verification(actual_delta)?);


### PR DESCRIPTION
# Summary
It resolves #45.
I don't know the exact reason but running tests via `miri` is very slow, so I've reduce test input sizes.

Test with miri runs for `clmul` and `matrix-transpose` packages. 
It runs for both platforms `x86_64` and `aarch64`.
It takes 3 mins in my fork repo.

# References
https://github.com/rust-lang/miri
my ci results: https://github.com/000wan/mpz/pull/1
