### PR TITLE
Refactor `clmul` to use Union

### DIFF
--- a/clmul/Cargo.toml
+++ b/clmul/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 cfg-if.workspace = true
 bytemuck = {workspace = true, features = ["derive"]}
+lazy_static = "1.4.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures.workspace = true

--- a/clmul/Cargo.toml
+++ b/clmul/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 cfg-if.workspace = true
 bytemuck = {workspace = true, features = ["derive"]}
-lazy_static = "1.4.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures.workspace = true

--- a/clmul/src/backend.rs
+++ b/clmul/src/backend.rs
@@ -74,6 +74,7 @@ lazy_static! {
 }
 
 #[derive(Clone, Copy)]
+/// Carryless multiplication
 pub struct Clmul {
     inner: Inner,
 }
@@ -95,35 +96,6 @@ impl core::fmt::Debug for Clmul {
         }
     }
 }
-
-/*
-cfg_if! {
-    if #[cfg(any(all(target_arch = "aarch64", feature = "armv8"), any(target_arch = "x86_64", target_arch = "x86")))]{
-        #[derive(Clone, Copy, Debug)]
-        /// Carryless multiplication
-        pub struct Clmul {
-            intrinsics: Option<intrinsics::Clmul>,
-            soft: Option<soft::Clmul>,
-        }
-    } else {
-        #[derive(Clone, Copy, Debug)]
-        /// Carryless multiplication
-        pub struct Clmul {
-            // intrinsics will never be used on a non-supported arch but Rust
-            // won't allow to declare it with a None type, so we need to
-            // provide some type
-            intrinsics: Option<soft::Clmul>,
-            soft: Option<soft::Clmul>,
-        }
-    }
-}
-*/
-
-// #[derive(Clone, Copy)]
-// pub struct Clmul {
-//     intrinsics: Option<intrinsics::Clmul>,
-//     soft: Option<soft::Clmul>,
-// }
 
 impl Clmul {
     pub fn new(h: &[u8; 16]) -> Self {

--- a/clmul/src/backend.rs
+++ b/clmul/src/backend.rs
@@ -69,10 +69,17 @@ union Inner {
     soft: soft::Clmul,
 }
 
+impl mul_intrinsics::InitToken {
+    #[inline(always)]
+    fn get_intr(&self) -> bool {
+        !cfg!(feature = "force-soft") && self.get()
+    }
+}
+
 impl core::fmt::Debug for Clmul {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         unsafe {
-            if self.token.get() {
+            if self.token.get_intr() {
                 self.inner.intrinsics.fmt(f)
             } else {
                 self.inner.soft.fmt(f)
@@ -103,9 +110,10 @@ impl Clmul {
     }
 
     /// Performs carryless multiplication
+    #[inline]
     pub fn clmul(self, x: Self) -> (Self, Self) {
         unsafe {
-            let (in0, in1) = if self.token.get() {
+            let (in0, in1) = if self.token.get_intr() {
                 let s_intr = self.inner.intrinsics;
                 let x_intr = x.inner.intrinsics;
 
@@ -136,9 +144,10 @@ impl Clmul {
     /// operands to return the result. This gives a ~6x speed up compared
     /// to clmul() where we create new objects containing the result.
     /// The high bits will be placed in `self`, the low bits - in `x`.
+    #[inline]
     pub fn clmul_reuse(&mut self, x: &mut Self) {
         unsafe {
-            if self.token.get() {
+            if self.token.get_intr() {
                 let s_intr = self.inner.intrinsics;
                 let x_intr = x.inner.intrinsics;
 
@@ -158,9 +167,10 @@ impl Clmul {
 
     /// Reduces the polynomial represented in bits modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1.
     /// x and y are resp. upper and lower bits of the polynomial.
+    #[inline]
     pub fn reduce_gcm(x: Self, y: Self) -> Self {
         unsafe {
-            if x.token.get() {
+            if x.token.get_intr() {
                 let x_intr = x.inner.intrinsics;
                 let y_intr = y.inner.intrinsics;
 
@@ -187,7 +197,7 @@ impl From<Clmul> for [u8; 16] {
     #[inline]
     fn from(m: Clmul) -> [u8; 16] {
         unsafe {
-            if m.token.get() {
+            if m.token.get_intr() {
                 m.inner.intrinsics.into()
             } else {
                 m.inner.soft.into()
@@ -202,7 +212,7 @@ impl BitXor for Clmul {
     #[inline]
     fn bitxor(self, other: Self) -> Self::Output {
         unsafe {
-            let inner = if self.token.get() {
+            let inner = if self.token.get_intr() {
                 let a = self.inner.intrinsics;
                 let b = other.inner.intrinsics;
                 Inner { intrinsics: a ^ b }
@@ -224,7 +234,7 @@ impl BitXorAssign for Clmul {
     #[inline]
     fn bitxor_assign(&mut self, other: Self) {
         unsafe {
-            if self.token.get() {
+            if self.token.get_intr() {
                 let a = self.inner.intrinsics;
                 let b = other.inner.intrinsics;
                 self.inner.intrinsics = a ^ b;
@@ -238,9 +248,10 @@ impl BitXorAssign for Clmul {
 }
 
 impl PartialEq for Clmul {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            if self.token.get() {
+            if self.token.get_intr() {
                 self.inner.intrinsics == other.inner.intrinsics
             } else {
                 self.inner.soft == other.inner.soft

--- a/clmul/src/backend.rs
+++ b/clmul/src/backend.rs
@@ -56,14 +56,27 @@ cfg_if! {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct Clmul {
     inner: Inner,
     is_intr: bool,
 }
 
+#[derive(Clone, Copy)]
 union Inner {
     intrinsics: intrinsics::Clmul,
     soft: soft::Clmul,
+}
+
+impl core::fmt::Debug for Clmul {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        unsafe {
+            match self.is_intr {
+                true => self.inner.intrinsics.fmt(f),
+                false => self.inner.soft.fmt(f),
+            }
+        }
+    }
 }
 
 /*

--- a/ot/mpz-ot/src/kos/receiver.rs
+++ b/ot/mpz-ot/src/kos/receiver.rs
@@ -182,7 +182,7 @@ where
         let actual_delta = <[u8; 16]>::from_lsb0_iter(choices).into();
 
         if expected_delta != actual_delta {
-            return Err(ReceiverVerifyError::InconsistentDelta).map_err(ReceiverError::from)?;
+            return Err(ReceiverError::from(ReceiverVerifyError::InconsistentDelta));
         }
 
         self.state = State::Verify(receiver.start_verification(actual_delta)?);


### PR DESCRIPTION
# Summary
It resolves #44.
Struct `Clmul` is modified to:
```rust
pub struct Clmul {
    inner: Inner,
    token: mul_intrinsics::InitToken,
}
```
with Union type `Inner`:
```rust
union Inner {
    intrinsics: intrinsics::Clmul,
    soft: soft::Clmul,
}
```
It follows the implementation of [polyval](https://github.com/RustCrypto/universal-hashes/blob/master/polyval/src/backend/autodetect.rs) using [`InitToken`](https://github.com/RustCrypto/utils/blob/master/cpufeatures/src/lib.rs).

# Results
https://github.com/privacy-scaling-explorations/mpz/pull/73#issuecomment-1741284297

# References
https://doc.rust-lang.org/reference/items/unions.html
https://github.com/RustCrypto/universal-hashes/blob/master/polyval/src/backend/autodetect.rs
https://github.com/RustCrypto/utils/blob/master/cpufeatures/src/lib.rs