### PR TITLE
fix: rename encrypt fns

### DIFF
--- a/garble/mpz-garble-core/src/evaluator.rs
+++ b/garble/mpz-garble-core/src/evaluator.rs
@@ -44,7 +44,7 @@ pub(crate) fn and_gate(
     let k = Block::new(((gid + 1) as u128).to_be_bytes());
 
     let mut h = [x, y];
-    cipher.tccr_many_inplace(&[j, k], &mut h);
+    cipher.tccr_many(&[j, k], &mut h);
 
     let [hx, hy] = h;
 

--- a/garble/mpz-garble-core/src/generator.rs
+++ b/garble/mpz-garble-core/src/generator.rs
@@ -46,7 +46,7 @@ pub(crate) fn and_gate(
     let k = Block::new(((gid + 1) as u128).to_be_bytes());
 
     let mut h = [x_0, y_0, x_1, y_1];
-    cipher.tccr_many_inplace(&[j, k, j, k], &mut h);
+    cipher.tccr_many(&[j, k, j, k], &mut h);
 
     let [hx_0, hy_0, hx_1, hy_1] = h;
 

--- a/mpz-core/benches/aes.rs
+++ b/mpz-core/benches/aes.rs
@@ -18,10 +18,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("aes::encrypt_many_blocks::<8>", move |bench| {
         let key = rand::random::<Block>();
         let aes = AesEncryptor::new(key);
-        let blks = rand::random::<[Block; 8]>();
+        let mut blks = rand::random::<[Block; 8]>();
 
         bench.iter(|| {
-            let z = aes.encrypt_many_blocks(black_box(blks));
+            let z = aes.encrypt_many_blocks(black_box(&mut blks));
             black_box(z);
         });
     });

--- a/mpz-core/src/aes.rs
+++ b/mpz-core/src/aes.rs
@@ -51,7 +51,7 @@ impl FixedKeyAes {
     /// * `tweaks` - The tweaks to use for each block in `blocks`.
     /// * `blocks` - The blocks to hash in-place.
     #[inline]
-    pub fn tccr_many_inplace<const N: usize>(&self, tweaks: &[Block; N], blocks: &mut [Block; N]) {
+    pub fn tccr_many<const N: usize>(&self, tweaks: &[Block; N], blocks: &mut [Block; N]) {
         // Store π(x) in `blocks`
         self.aes
             .encrypt_blocks(Block::as_generic_array_mut_slice(blocks));
@@ -90,7 +90,7 @@ impl FixedKeyAes {
     ///
     /// * `blocks` - The blocks to hash in-place.
     #[inline]
-    pub fn cr_many_inplace<const N: usize>(&self, blocks: &mut [Block; N]) {
+    pub fn cr_many<const N: usize>(&self, blocks: &mut [Block; N]) {
         let mut buf = *blocks;
 
         self.aes
@@ -124,9 +124,9 @@ impl FixedKeyAes {
     ///
     /// * `blocks` - The blocks to hash in-place.
     #[inline]
-    pub fn ccr_many_inplace<const N: usize>(&self, blocks: &mut [Block; N]) {
+    pub fn ccr_many<const N: usize>(&self, blocks: &mut [Block; N]) {
         blocks.iter_mut().for_each(|b| *b = Block::sigma(*b));
-        self.cr_many_inplace(blocks);
+        self.cr_many(blocks);
     }
 }
 
@@ -160,9 +160,9 @@ impl AesEncryptor {
         blks
     }
 
-    /// Encrypt many blocks in-place.
+    /// Encrypt slice of blocks in-place.
     #[inline]
-    pub fn encrypt_many_blocks_inplace(&self, blks: &mut [Block]) {
+    pub fn encrypt_blocks(&self, blks: &mut [Block]) {
         self.0
             .encrypt_blocks(Block::as_generic_array_mut_slice(blks));
     }
@@ -188,7 +188,7 @@ impl AesEncryptor {
         keys.iter()
             .zip(blks.chunks_exact_mut(NM))
             .for_each(|(key, blks)| {
-                key.encrypt_many_blocks_inplace(blks);
+                key.encrypt_blocks(blks);
             });
     }
 }

--- a/mpz-core/src/aes.rs
+++ b/mpz-core/src/aes.rs
@@ -152,12 +152,11 @@ impl AesEncryptor {
         blk
     }
 
-    /// Encrypt many blocks.
+    /// Encrypt many blocks in-place.
     #[inline(always)]
-    pub fn encrypt_many_blocks<const N: usize>(&self, mut blks: [Block; N]) -> [Block; N] {
+    pub fn encrypt_many_blocks<const N: usize>(&self, blks: &mut [Block; N]) {
         self.0
             .encrypt_blocks(Block::as_generic_array_mut_slice(blks.as_mut_slice()));
-        blks
     }
 
     /// Encrypt slice of blocks in-place.

--- a/mpz-core/src/prg.rs
+++ b/mpz-core/src/prg.rs
@@ -21,7 +21,7 @@ impl BlockRngCore for PrgCore {
     // Compute [AES(state)..AES(state+8)]
     #[inline(always)]
     fn generate(&mut self, results: &mut Self::Results) {
-        let states = [0; AesEncryptor::AES_BLOCK_COUNT].map(
+        let mut states = [0; AesEncryptor::AES_BLOCK_COUNT].map(
             #[inline(always)]
             |_| {
                 let x = self.state;
@@ -29,7 +29,8 @@ impl BlockRngCore for PrgCore {
                 Block::from(bytemuck::cast::<_, [u8; 16]>([x, 0u64]))
             },
         );
-        *results = bytemuck::cast(self.aes.encrypt_many_blocks(states))
+        self.aes.encrypt_many_blocks(&mut states);
+        *results = bytemuck::cast(states);
     }
 }
 


### PR DESCRIPTION
This PR renames functions in `mpz-core/aes` to be more consistent, and updates the `many` variant to operate in-place.