### PR TITLE
feature: pre-garbling

### DIFF
--- a/garble/mpz-garble-core/src/circuit.rs
+++ b/garble/mpz-garble-core/src/circuit.rs
@@ -3,6 +3,8 @@ use std::ops::Index;
 use mpz_core::Block;
 use serde::{Deserialize, Serialize};
 
+use crate::EncodingCommitment;
+
 /// Encrypted gate truth table
 ///
 /// For the half-gate garbling scheme a truth table will typically have 2 rows, except for in
@@ -31,4 +33,13 @@ impl Index<usize> for EncryptedGate {
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }
+}
+
+/// A garbled circuit
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GarbledCircuit {
+    /// Encrypted gates of the circuit
+    pub gates: Vec<EncryptedGate>,
+    /// Encoding commitments of the circuit outputs
+    pub commitments: Option<Vec<EncodingCommitment>>,
 }

--- a/garble/mpz-garble-core/src/lib.rs
+++ b/garble/mpz-garble-core/src/lib.rs
@@ -59,7 +59,7 @@ mod evaluator;
 mod generator;
 pub mod msg;
 
-pub use circuit::EncryptedGate;
+pub use circuit::{EncryptedGate, GarbledCircuit};
 pub use encoding::{
     state as encoding_state, ChaChaEncoder, Decoding, Delta, Encode, EncodedValue, Encoder,
     EncodingCommitment, EqualityCheck, Label, ValueError,

--- a/garble/mpz-garble/src/evaluator/config.rs
+++ b/garble/mpz-garble/src/evaluator/config.rs
@@ -12,9 +12,6 @@ pub struct EvaluatorConfig {
     /// Whether to log decodings.
     #[builder(default = "false", setter(custom))]
     pub(crate) log_decodings: bool,
-    /// The number of encrypted gates to evaluate per batch.
-    #[builder(default = "1024")]
-    pub(crate) batch_size: usize,
 }
 
 impl EvaluatorConfig {

--- a/garble/mpz-garble/src/evaluator/error.rs
+++ b/garble/mpz-garble/src/evaluator/error.rs
@@ -21,6 +21,8 @@ pub enum EvaluatorError {
     EncodingRegistryError(#[from] crate::memory::EncodingMemoryError),
     #[error("missing active encoding for value")]
     MissingEncoding(ValueRef),
+    #[error("duplicate garbled circuit")]
+    DuplicateCircuit,
     #[error("duplicate decoding for value: {0:?}")]
     DuplicateDecoding(ValueId),
     #[error(transparent)]

--- a/garble/mpz-garble/src/evaluator/mod.rs
+++ b/garble/mpz-garble/src/evaluator/mod.rs
@@ -372,16 +372,14 @@ impl Evaluator {
         let encoded_outputs = if let Some(GarbledCircuit { gates, commitments }) =
             existing_garbled_circuit
         {
-            while !ev.is_complete() {
-                for batch in gates.chunks(self.config.batch_size) {
-                    let batch = batch.to_vec();
-                    // Move the evaluator to a new thread to process the batch then send it back
-                    ev = Backend::spawn(move || {
-                        ev.evaluate(batch.iter());
-                        ev
-                    })
-                    .await;
-                }
+            for batch in gates.chunks(self.config.batch_size) {
+                let batch = batch.to_vec();
+                // Move the evaluator to a new thread to process the batch then send it back
+                ev = Backend::spawn(move || {
+                    ev.evaluate(batch.iter());
+                    ev
+                })
+                .await;
             }
 
             let encoded_outputs = ev.outputs()?;

--- a/garble/mpz-garble/src/evaluator/mod.rs
+++ b/garble/mpz-garble/src/evaluator/mod.rs
@@ -63,7 +63,7 @@ struct State {
     decoded_values: HashSet<ValueId>,
     /// Pre-transferred garbled circuits
     ///
-    /// (inputs, outputs) => garbled circuit
+    /// A map used to look up a garbled circuit by its unique (inputs, outputs) reference.
     garbled_circuits: HashMap<CircuitRefs, GarbledCircuit>,
     /// OT logs
     ot_log: HashMap<String, Vec<ValueId>>,

--- a/garble/mpz-garble/src/generator/error.rs
+++ b/garble/mpz-garble/src/generator/error.rs
@@ -15,7 +15,9 @@ pub enum GeneratorError {
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     ValueError(#[from] ValueError),
-    #[error("missing encoding for value")]
+    #[error("duplicate encoding for value: {0:?}")]
+    DuplicateEncoding(ValueRef),
+    #[error("missing encoding for value: {0:?}")]
     MissingEncoding(ValueRef),
     #[error(transparent)]
     EncodingRegistryError(#[from] crate::memory::EncodingMemoryError),

--- a/garble/mpz-garble/src/generator/mod.rs
+++ b/garble/mpz-garble/src/generator/mod.rs
@@ -45,6 +45,8 @@ struct State {
     /// Encodings of values
     memory: EncodingMemory<encoding_state::Full>,
     /// Transferred garbled circuits
+    ///
+    /// Each circuit is uniquely identified by its (input, output) references. Optionally, the garbled circuit may have been hashed.
     garbled: HashMap<CircuitRefs, Option<Hash>>,
     /// The set of values that are currently active.
     ///
@@ -370,10 +372,6 @@ impl State {
     /// Generates an encoding for a value
     ///
     /// If an encoding for the value already exists, it is returned instead.
-    ///
-    /// # Panics
-    ///
-    /// If the provided value type does not match the value reference.
     fn encode(&mut self, value: &ValueRef, ty: &ValueType) -> EncodedValue<encoding_state::Full> {
         match (value, ty) {
             (ValueRef::Value { id }, ty) if !ty.is_array() => self.encode_by_id(id, ty),

--- a/garble/mpz-garble/src/lib.rs
+++ b/garble/mpz-garble/src/lib.rs
@@ -98,6 +98,17 @@ pub enum AssignmentError {
     },
 }
 
+/// Errors that can occur when loading a circuit.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    /// IO error.
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    /// Protocol error.
+    #[error(transparent)]
+    ProtocolError(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
 /// Errors that can occur when executing a circuit.
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
@@ -296,6 +307,20 @@ pub trait Memory {
 
         Ok(ValueRef::Array(ArrayRef::new(ids)))
     }
+}
+
+/// This trait provides methods for loading a circuit.
+///
+/// Implementations may perform pre-processing prior to execution.
+#[async_trait]
+pub trait Load {
+    /// Loads a circuit with the provided inputs and output values.
+    async fn load(
+        &mut self,
+        circ: Arc<Circuit>,
+        inputs: &[ValueRef],
+        outputs: &[ValueRef],
+    ) -> Result<(), LoadError>;
 }
 
 /// This trait provides methods for executing a circuit.

--- a/garble/mpz-garble/src/lib.rs
+++ b/garble/mpz-garble/src/lib.rs
@@ -314,7 +314,7 @@ pub trait Memory {
 /// Implementations may perform pre-processing prior to execution.
 #[async_trait]
 pub trait Load {
-    /// Loads a circuit with the provided inputs and output values.
+    /// Loads a circuit with the provided input and output values.
     async fn load(
         &mut self,
         circ: Arc<Circuit>,

--- a/garble/mpz-garble/src/protocol/deap/error.rs
+++ b/garble/mpz-garble/src/protocol/deap/error.rs
@@ -1,6 +1,6 @@
 use mpz_garble_core::{msg::GarbleMessage, ValueError};
 
-use crate::{value::ValueRef, DecodeError, ExecutionError, ProveError, VerifyError};
+use crate::{value::ValueRef, DecodeError, ExecutionError, LoadError, ProveError, VerifyError};
 
 /// Errors that can occur during the DEAP protocol.
 #[derive(Debug, thiserror::Error)]
@@ -50,6 +50,15 @@ pub enum PeerEncodingsError {
     ValueIdNotFound(String),
     #[error("Encoding is not available for value: {0:?}")]
     EncodingNotAvailable(ValueRef),
+}
+
+impl From<DEAPError> for LoadError {
+    fn from(err: DEAPError) -> Self {
+        match err {
+            DEAPError::IOError(err) => LoadError::IOError(err),
+            err => LoadError::ProtocolError(Box::new(err)),
+        }
+    }
 }
 
 impl From<DEAPError> for ExecutionError {

--- a/garble/mpz-garble/src/protocol/deap/memory.rs
+++ b/garble/mpz-garble/src/protocol/deap/memory.rs
@@ -11,7 +11,9 @@ impl Memory for DEAP {
         typ: ValueType,
         visibility: Visibility,
     ) -> Result<ValueRef, MemoryError> {
-        self.state().memory.new_input(id, typ, visibility)
+        let value_ref = self.state().memory.new_input(id, typ.clone(), visibility)?;
+        self.gen.generate_input_encoding(&value_ref, &typ);
+        Ok(value_ref)
     }
 
     fn new_output_with_type(&self, id: &str, typ: ValueType) -> Result<ValueRef, MemoryError> {

--- a/garble/mpz-garble/src/protocol/deap/vm.rs
+++ b/garble/mpz-garble/src/protocol/deap/vm.rs
@@ -21,8 +21,8 @@ use crate::{
     config::{Role, Visibility},
     ot::{VerifiableOTReceiveEncoding, VerifiableOTSendEncoding},
     value::ValueRef,
-    Decode, DecodeError, DecodePrivate, Execute, ExecutionError, Memory, MemoryError, Prove,
-    ProveError, Thread, Verify, VerifyError, Vm, VmError,
+    Decode, DecodeError, DecodePrivate, Execute, ExecutionError, Load, LoadError, Memory,
+    MemoryError, Prove, ProveError, Thread, Verify, VerifyError, Vm, VmError,
 };
 
 use super::{
@@ -234,6 +234,25 @@ impl<OTS, OTR> Memory for DEAPThread<OTS, OTR> {
 
     fn get_value_type_by_id(&self, id: &str) -> Option<ValueType> {
         self.deap().get_value_type_by_id(id)
+    }
+}
+
+#[async_trait]
+impl<OTS, OTR> Load for DEAPThread<OTS, OTR>
+where
+    OTS: VerifiableOTSendEncoding + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+{
+    async fn load(
+        &mut self,
+        circ: Arc<Circuit>,
+        inputs: &[ValueRef],
+        outputs: &[ValueRef],
+    ) -> Result<(), LoadError> {
+        self.deap()
+            .load(circ, inputs, outputs, &mut self.sink, &mut self.stream)
+            .map_err(LoadError::from)
+            .await
     }
 }
 

--- a/garble/mpz-garble/src/value.rs
+++ b/garble/mpz-garble/src/value.rs
@@ -150,3 +150,10 @@ impl<'a> Iterator for ValueRefIter<'a> {
         }
     }
 }
+
+/// References to the inputs and outputs of a circuit.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CircuitRefs {
+    pub(crate) inputs: Vec<ValueRef>,
+    pub(crate) outputs: Vec<ValueRef>,
+}


### PR DESCRIPTION
This PR implements "pre-garbling", aka the offline-online paradigm, for garbled circuits.

# Changes
- Adds the `Load` trait, an abstraction of this feature
- Modifies the `Generator` and `Evaluator` to support transferring of the encrypted gates prior to execution
- Implements `Load` for `DEAPVM`