### PR TITLE
fix: update enum-try-as-inner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,4 @@ once_cell = "1"
 # DO NOT BUMP, SEE https://github.com/privacy-scaling-explorations/mpz/issues/61
 generic-array = "0.14"
 itybity = "0.2"
+enum-try-as-inner = "0.1.0"

--- a/ot/mpz-ot-core/Cargo.toml
+++ b/ot/mpz-ot-core/Cargo.toml
@@ -32,8 +32,8 @@ derive_builder.workspace = true
 itybity.workspace = true
 opaque-debug.workspace = true
 cfg-if.workspace = true
-enum-try-as-inner = { tag = "0.1.0", git = "https://github.com/sinui0/enum-try-as-inner" }
 bytemuck = { workspace = true, features = ["derive"] }
+enum-try-as-inner.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/ot/mpz-ot-core/src/chou_orlandi/msgs.rs
+++ b/ot/mpz-ot-core/src/chou_orlandi/msgs.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// A CO15 protocol message.
 #[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[derive_err(Debug)]
 #[allow(missing_docs)]
 pub enum Message {
     SenderSetup(SenderSetup),
@@ -16,6 +17,12 @@ pub enum Message {
     CointossSenderCommitment(cointoss::msgs::SenderCommitment),
     CointossSenderPayload(cointoss::msgs::SenderPayload),
     CointossReceiverPayload(cointoss::msgs::ReceiverPayload),
+}
+
+impl From<MessageError> for std::io::Error {
+    fn from(err: MessageError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+    }
 }
 
 /// Sender setup message.

--- a/ot/mpz-ot-core/src/kos/msgs.rs
+++ b/ot/mpz-ot-core/src/kos/msgs.rs
@@ -14,6 +14,7 @@ use crate::msgs::Derandomize;
 
 /// A KOS15 protocol message.
 #[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[derive_err(Debug)]
 #[allow(missing_docs)]
 pub enum Message<BaseMsg> {
     BaseMsg(BaseMsg),
@@ -24,6 +25,12 @@ pub enum Message<BaseMsg> {
     CointossCommit(SenderCommitment),
     CointossReceiverPayload(CointossReceiverPayload),
     CointossSenderPayload(CointossSenderPayload),
+}
+
+impl<BaseMsg> From<MessageError<BaseMsg>> for std::io::Error {
+    fn from(err: MessageError<BaseMsg>) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+    }
 }
 
 /// Extension message sent by the receiver.

--- a/ot/mpz-ot/Cargo.toml
+++ b/ot/mpz-ot/Cargo.toml
@@ -29,7 +29,7 @@ p256 = { workspace = true, optional = true }
 thiserror.workspace = true
 rayon = { workspace = true }
 itybity.workspace = true
-enum-try-as-inner = { tag = "0.1.0", git = "https://github.com/sinui0/enum-try-as-inner" }
+enum-try-as-inner.workspace = true
 opaque-debug.workspace = true
 serde = { workspace = true, optional = true }
 

--- a/ot/mpz-ot/src/actor/kos/error.rs
+++ b/ot/mpz-ot/src/actor/kos/error.rs
@@ -1,5 +1,5 @@
 use crate::{
-    actor::kos::msgs::Message,
+    actor::kos::msgs::MessageError,
     kos::{ReceiverError, SenderError},
 };
 
@@ -33,9 +33,9 @@ impl From<crate::OTError> for SenderActorError {
     }
 }
 
-impl From<enum_try_as_inner::Error<crate::kos::SenderState>> for SenderActorError {
-    fn from(value: enum_try_as_inner::Error<crate::kos::SenderState>) -> Self {
-        SenderError::StateError(value.to_string()).into()
+impl From<crate::kos::SenderStateError> for SenderActorError {
+    fn from(err: crate::kos::SenderStateError) -> Self {
+        SenderError::from(err).into()
     }
 }
 
@@ -51,11 +51,11 @@ impl<T> From<futures::channel::mpsc::TrySendError<T>> for SenderActorError {
     }
 }
 
-impl<T> From<enum_try_as_inner::Error<Message<T>>> for SenderActorError {
-    fn from(value: enum_try_as_inner::Error<Message<T>>) -> Self {
+impl<T> From<MessageError<T>> for SenderActorError {
+    fn from(err: MessageError<T>) -> Self {
         SenderActorError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }
@@ -104,9 +104,9 @@ impl From<crate::OTError> for ReceiverActorError {
     }
 }
 
-impl From<enum_try_as_inner::Error<crate::kos::ReceiverState>> for ReceiverActorError {
-    fn from(value: enum_try_as_inner::Error<crate::kos::ReceiverState>) -> Self {
-        ReceiverError::StateError(value.to_string()).into()
+impl From<crate::kos::ReceiverStateError> for ReceiverActorError {
+    fn from(err: crate::kos::ReceiverStateError) -> Self {
+        ReceiverError::from(err).into()
     }
 }
 
@@ -122,11 +122,11 @@ impl<T> From<futures::channel::mpsc::TrySendError<T>> for ReceiverActorError {
     }
 }
 
-impl<T> From<enum_try_as_inner::Error<Message<T>>> for ReceiverActorError {
-    fn from(value: enum_try_as_inner::Error<Message<T>>) -> Self {
+impl<T> From<MessageError<T>> for ReceiverActorError {
+    fn from(err: MessageError<T>) -> Self {
         ReceiverActorError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }

--- a/ot/mpz-ot/src/actor/kos/msgs.rs
+++ b/ot/mpz-ot/src/actor/kos/msgs.rs
@@ -10,10 +10,17 @@ use mpz_ot_core::{
 
 /// KOS actor message
 #[derive(Debug, Clone, EnumTryAsInner, Serialize, Deserialize)]
+#[derive_err(Debug)]
 #[allow(missing_docs)]
 pub enum Message<BaseOT> {
     ActorMessage(ActorMessage),
     Protocol(KosMessage<BaseOT>),
+}
+
+impl<BaseOT> From<MessageError<BaseOT>> for std::io::Error {
+    fn from(err: MessageError<BaseOT>) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+    }
 }
 
 impl<T> From<ActorMessage> for Message<T> {

--- a/ot/mpz-ot/src/actor/kos/receiver.rs
+++ b/ot/mpz-ot/src/actor/kos/receiver.rs
@@ -153,7 +153,7 @@ where
         let mut keys = self
             .receiver
             .state_mut()
-            .as_extension_mut()?
+            .try_as_extension_mut()?
             .keys(choices.len())?;
 
         let derandomize = keys.derandomize(choices)?;
@@ -205,7 +205,7 @@ where
                 _ = caller_response.send(
                     self.receiver
                         .state_mut()
-                        .as_verify_mut()
+                        .try_as_verify_mut()
                         .map_err(ReceiverError::from)
                         .and_then(|receiver| {
                             receiver.remove_record(*id).map_err(ReceiverError::from)
@@ -262,7 +262,7 @@ where
 
     /// Handles a message from the KOS sender actor.
     async fn handle_msg(&mut self, msg: Message<BaseOT::Msg>) -> Result<(), ReceiverActorError> {
-        let msg = msg.into_actor_message()?;
+        let msg = msg.try_into_actor_message()?;
 
         match msg {
             ActorMessage::TransferPayload(TransferPayload { id, payload }) => {

--- a/ot/mpz-ot/src/actor/kos/sender.rs
+++ b/ot/mpz-ot/src/actor/kos/sender.rs
@@ -132,7 +132,7 @@ where
             futures::select! {
                 // Processes a message received from the Receiver.
                 msg = self.stream.select_next_some() => {
-                    self.handle_msg(msg?.into_actor_message()?)?;
+                    self.handle_msg(msg?.try_into_actor_message()?)?;
                 }
                 // Processes a command from a controller.
                 cmd = self.commands.select_next_some() => {
@@ -185,7 +185,7 @@ where
                 let keys = self
                     .sender
                     .state_mut()
-                    .as_extension_mut()
+                    .try_as_extension_mut()
                     .map_err(SenderError::from)
                     .and_then(|sender| {
                         sender

--- a/ot/mpz-ot/src/chou_orlandi/error.rs
+++ b/ot/mpz-ot/src/chou_orlandi/error.rs
@@ -1,4 +1,4 @@
-use mpz_ot_core::chou_orlandi::msgs::Message;
+use mpz_ot_core::chou_orlandi::msgs::MessageError;
 
 use crate::OTError;
 
@@ -10,7 +10,7 @@ pub enum SenderError {
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     CoreError(#[from] mpz_ot_core::chou_orlandi::SenderError),
-    #[error("invalid state: expected {0}")]
+    #[error("{0}")]
     StateError(String),
     #[error(transparent)]
     CointossError(#[from] mpz_core::cointoss::CointossError),
@@ -27,11 +27,17 @@ impl From<SenderError> for OTError {
     }
 }
 
-impl From<enum_try_as_inner::Error<Message>> for SenderError {
-    fn from(value: enum_try_as_inner::Error<Message>) -> Self {
+impl From<crate::chou_orlandi::sender::StateError> for SenderError {
+    fn from(err: crate::chou_orlandi::sender::StateError) -> Self {
+        SenderError::StateError(err.to_string())
+    }
+}
+
+impl From<MessageError> for SenderError {
+    fn from(err: MessageError) -> Self {
         SenderError::from(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }
@@ -44,7 +50,7 @@ pub enum ReceiverError {
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     CoreError(#[from] mpz_ot_core::chou_orlandi::ReceiverError),
-    #[error("invalid state: expected {0}")]
+    #[error("{0}")]
     StateError(String),
     #[error(transparent)]
     CointossError(#[from] mpz_core::cointoss::CointossError),
@@ -61,11 +67,17 @@ impl From<ReceiverError> for OTError {
     }
 }
 
-impl From<enum_try_as_inner::Error<Message>> for ReceiverError {
-    fn from(value: enum_try_as_inner::Error<Message>) -> Self {
+impl From<crate::chou_orlandi::receiver::StateError> for ReceiverError {
+    fn from(err: crate::chou_orlandi::receiver::StateError) -> Self {
+        ReceiverError::StateError(err.to_string())
+    }
+}
+
+impl From<MessageError> for ReceiverError {
+    fn from(err: MessageError) -> Self {
         ReceiverError::from(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }

--- a/ot/mpz-ot/src/kos/error.rs
+++ b/ot/mpz-ot/src/kos/error.rs
@@ -1,4 +1,4 @@
-use mpz_ot_core::kos::msgs::Message;
+use mpz_ot_core::kos::msgs::MessageError;
 
 use crate::OTError;
 
@@ -14,7 +14,7 @@ pub enum SenderError {
     BaseOTError(#[from] crate::OTError),
     #[error(transparent)]
     CointossError(#[from] mpz_core::cointoss::CointossError),
-    #[error("invalid state: expected {0}")]
+    #[error("{0}")]
     StateError(String),
     #[error("configuration error: {0}")]
     ConfigError(String),
@@ -31,17 +31,23 @@ impl From<SenderError> for OTError {
     }
 }
 
+impl From<crate::kos::SenderStateError> for SenderError {
+    fn from(err: crate::kos::SenderStateError) -> Self {
+        SenderError::StateError(err.to_string())
+    }
+}
+
 impl From<mpz_ot_core::kos::SenderError> for OTError {
     fn from(err: mpz_ot_core::kos::SenderError) -> Self {
         SenderError::from(err).into()
     }
 }
 
-impl<BaseMsg> From<enum_try_as_inner::Error<Message<BaseMsg>>> for SenderError {
-    fn from(value: enum_try_as_inner::Error<Message<BaseMsg>>) -> Self {
+impl<BaseMsg> From<MessageError<BaseMsg>> for SenderError {
+    fn from(err: MessageError<BaseMsg>) -> Self {
         SenderError::from(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }
@@ -58,7 +64,7 @@ pub enum ReceiverError {
     BaseOTError(#[from] crate::OTError),
     #[error(transparent)]
     CointossError(#[from] mpz_core::cointoss::CointossError),
-    #[error("invalid state: expected {0}")]
+    #[error("{0}")]
     StateError(String),
     #[error("configuration error: {0}")]
     ConfigError(String),
@@ -77,17 +83,23 @@ impl From<ReceiverError> for OTError {
     }
 }
 
+impl From<crate::kos::ReceiverStateError> for ReceiverError {
+    fn from(err: crate::kos::ReceiverStateError) -> Self {
+        ReceiverError::StateError(err.to_string())
+    }
+}
+
 impl From<mpz_ot_core::kos::ReceiverError> for OTError {
     fn from(err: mpz_ot_core::kos::ReceiverError) -> Self {
         ReceiverError::from(err).into()
     }
 }
 
-impl<BaseMsg> From<enum_try_as_inner::Error<Message<BaseMsg>>> for ReceiverError {
-    fn from(value: enum_try_as_inner::Error<Message<BaseMsg>>) -> Self {
+impl<BaseMsg> From<MessageError<BaseMsg>> for ReceiverError {
+    fn from(err: MessageError<BaseMsg>) -> Self {
         ReceiverError::from(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            value.to_string(),
+            err.to_string(),
         ))
     }
 }


### PR DESCRIPTION
This PR updates to the `crates.io` release of [`enum-try-as-inner`](https://crates.io/crates/enum-try-as-inner) which contains breaking changes.

# Changes
- Update `enum-try-as-inner` to pull from `crates.io`
- Fix breaking changes