### PR TITLE
refactor: decouple zk execution from proving output

### DIFF
--- a/garble/mpz-garble/src/evaluator/mod.rs
+++ b/garble/mpz-garble/src/evaluator/mod.rs
@@ -111,6 +111,24 @@ impl Evaluator {
         self.state().memory.get_encoding(value)
     }
 
+    /// Returns the encodings for a slice of values.
+    pub fn get_encodings(
+        &self,
+        values: &[ValueRef],
+    ) -> Result<Vec<EncodedValue<encoding_state::Active>>, EvaluatorError> {
+        let state = self.state();
+
+        values
+            .iter()
+            .map(|value| {
+                state
+                    .memory
+                    .get_encoding(value)
+                    .ok_or_else(|| EvaluatorError::MissingEncoding(value.clone()))
+            })
+            .collect()
+    }
+
     /// Adds a decoding log entry.
     pub(crate) fn add_decoding_log(&self, value: &ValueRef, decoding: Decoding) {
         self.state().decoding_logs.insert(value.clone(), decoding);

--- a/garble/mpz-garble/src/generator/mod.rs
+++ b/garble/mpz-garble/src/generator/mod.rs
@@ -81,6 +81,23 @@ impl Generator {
         self.state().memory.get_encoding(value)
     }
 
+    /// Returns the encodings for a slice of values.
+    pub fn get_encodings(
+        &self,
+        values: &[ValueRef],
+    ) -> Result<Vec<EncodedValue<encoding_state::Full>>, GeneratorError> {
+        let state = self.state();
+        values
+            .iter()
+            .map(|value| {
+                state
+                    .memory
+                    .get_encoding(value)
+                    .ok_or_else(|| GeneratorError::MissingEncoding(value.clone()))
+            })
+            .collect()
+    }
+
     pub(crate) fn get_encodings_by_id(
         &self,
         ids: &[ValueId],

--- a/garble/mpz-garble/src/lib.rs
+++ b/garble/mpz-garble/src/lib.rs
@@ -338,25 +338,34 @@ pub trait Execute {
 /// This trait provides methods for proving the output of a circuit.
 #[async_trait]
 pub trait Prove {
-    /// Proves the output of the circuit with the provided inputs, assigning to the provided output values
-    async fn prove(
+    /// Executes the provided circuit as the prover, assigning to the provided output values.
+    async fn execute_prove(
         &mut self,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), ProveError>;
+
+    /// Proves the provided values.
+    async fn prove(&mut self, values: &[ValueRef]) -> Result<(), ProveError>;
 }
 
 /// This trait provides methods for verifying the output of a circuit.
 #[async_trait]
 pub trait Verify {
-    /// Verifies the output of the circuit with the provided inputs, assigning to the provided output values
-    async fn verify(
+    /// Executes the provided circuit as the verifier, assigning to the provided output values.
+    async fn execute_verify(
         &mut self,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        expected_outputs: &[Value],
+    ) -> Result<(), VerifyError>;
+
+    /// Verifies the provided values against the expected values.
+    async fn verify(
+        &mut self,
+        values: &[ValueRef],
+        expected_values: &[Value],
     ) -> Result<(), VerifyError>;
 }
 

--- a/garble/mpz-garble/src/memory.rs
+++ b/garble/mpz-garble/src/memory.rs
@@ -388,6 +388,7 @@ where
         value: &ValueRef,
         encoding: EncodedValue<T>,
     ) -> Result<(), EncodingMemoryError> {
+        let encoding_type = encoding.value_type();
         match (value, encoding) {
             (ValueRef::Value { id }, encoding) => self.set_encoding_by_id(id, encoding)?,
             (ValueRef::Array(array), EncodedValue::Array(encodings))
@@ -397,7 +398,10 @@ where
                     self.set_encoding_by_id(id, encoding)?
                 }
             }
-            _ => panic!("value type {:?} does not match encoding type", value),
+            _ => panic!(
+                "value type {:?} does not match encoding type: {:?}",
+                value, encoding_type
+            ),
         }
 
         Ok(())

--- a/garble/mpz-garble/src/protocol/deap/vm.rs
+++ b/garble/mpz-garble/src/protocol/deap/vm.rs
@@ -290,21 +290,31 @@ where
     OTS: VerifiableOTSendEncoding + Send + Sync,
     OTR: VerifiableOTReceiveEncoding + Send + Sync,
 {
-    async fn prove(
+    async fn execute_prove(
         &mut self,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), ProveError> {
         self.deap()
-            .defer_prove(
+            .execute_prove(
                 &self.op_id.increment_in_place().to_string(),
                 circ,
                 inputs,
                 outputs,
-                &mut self.sink,
                 &mut self.stream,
                 &*self.ot_recv,
+            )
+            .map_err(ProveError::from)
+            .await
+    }
+
+    async fn prove(&mut self, values: &[ValueRef]) -> Result<(), ProveError> {
+        self.deap()
+            .defer_prove(
+                &self.op_id.increment_in_place().to_string(),
+                values,
+                &mut self.sink,
             )
             .map_err(ProveError::from)
             .await
@@ -317,23 +327,36 @@ where
     OTS: VerifiableOTSendEncoding + Send + Sync,
     OTR: VerifiableOTReceiveEncoding + Send + Sync,
 {
-    async fn verify(
+    async fn execute_verify(
         &mut self,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        expected_outputs: &[Value],
     ) -> Result<(), VerifyError> {
         self.deap()
-            .defer_verify(
+            .execute_verify(
                 &self.op_id.increment_in_place().to_string(),
                 circ,
                 inputs,
                 outputs,
-                expected_outputs,
                 &mut self.sink,
-                &mut self.stream,
                 &*self.ot_send,
+            )
+            .map_err(VerifyError::from)
+            .await
+    }
+
+    async fn verify(
+        &mut self,
+        values: &[ValueRef],
+        expected_values: &[Value],
+    ) -> Result<(), VerifyError> {
+        self.deap()
+            .defer_verify(
+                &self.op_id.increment_in_place().to_string(),
+                values,
+                expected_values,
+                &mut self.stream,
             )
             .map_err(VerifyError::from)
             .await


### PR DESCRIPTION
This PR decouples execution of a circuit from proving of the output in the ZK setting. This is needed to support incremental computation as we do with MPC. This also unblocks https://github.com/tlsnotary/tlsn/pull/379 which requires this feature.