### PR TITLE
Add operators &, |, ! for Tracer<Bit>

### DIFF
--- a/mpz-circuits/src/ops/binary.rs
+++ b/mpz-circuits/src/ops/binary.rs
@@ -1,4 +1,4 @@
-use std::ops::BitXor;
+use std::ops::{BitXor, BitAnd, Not, BitOr};
 
 use crate::{
     components::{Feed, Node},
@@ -212,7 +212,7 @@ pub(crate) fn inv_nbit<const N: usize>(
     std::array::from_fn(|n| state.add_inv_gate(a[n]))
 }
 
-impl<'a> BitXor<Tracer<'a, Bit>> for Tracer<'a, Bit> {
+impl<'a> BitXor for Tracer<'a, Bit> {
     type Output = Tracer<'a, Bit>;
 
     fn bitxor(self, rhs: Tracer<'a, Bit>) -> Self::Output {
@@ -225,6 +225,46 @@ impl<'a> BitXor<Tracer<'a, Bit>> for Tracer<'a, Bit> {
         drop(state);
 
         Tracer::new(self.state, value)
+    }
+}
+
+impl<'a> BitAnd for Tracer<'a, Bit> {
+    type Output = Tracer<'a, Bit>;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        let mut state = self.state.borrow_mut();
+
+        let out = state.add_and_gate(self.to_inner().nodes()[0], rhs.to_inner().nodes()[0]);
+
+        let value = Bit::new([out]);
+
+        drop(state);
+
+        Tracer::new(self.state, value)
+    }
+}
+
+impl<'a> Not for Tracer<'a, Bit> {
+    type Output = Tracer<'a, Bit>;
+
+    fn not(self) -> Self::Output {
+        let mut state = self.state.borrow_mut();
+
+        let out = state.add_inv_gate(self.to_inner().nodes()[0]);
+
+        let value = Bit::new([out]);
+
+        drop(state);
+
+        Tracer::new(self.state, value)
+    }
+}
+
+impl<'a> BitOr for Tracer<'a, Bit> {
+    type Output = Tracer<'a, Bit>;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        !(!self & !rhs)
     }
 }
 

--- a/mpz-circuits/src/ops/binary.rs
+++ b/mpz-circuits/src/ops/binary.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitXor, BitAnd, Not, BitOr};
+use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use crate::{
     components::{Feed, Node},
@@ -216,15 +216,12 @@ impl<'a> BitXor for Tracer<'a, Bit> {
     type Output = Tracer<'a, Bit>;
 
     fn bitxor(self, rhs: Tracer<'a, Bit>) -> Self::Output {
-        let mut state = self.state.borrow_mut();
+        let out = self
+            .state
+            .borrow_mut()
+            .add_xor_gate(self.node(), rhs.node());
 
-        let out = state.add_xor_gate(self.to_inner().nodes()[0], rhs.to_inner().nodes()[0]);
-
-        let value = Bit::new([out]);
-
-        drop(state);
-
-        Tracer::new(self.state, value)
+        Tracer::new(self.state, Bit::new([out]))
     }
 }
 
@@ -232,15 +229,12 @@ impl<'a> BitAnd for Tracer<'a, Bit> {
     type Output = Tracer<'a, Bit>;
 
     fn bitand(self, rhs: Self) -> Self::Output {
-        let mut state = self.state.borrow_mut();
+        let out = self
+            .state
+            .borrow_mut()
+            .add_and_gate(self.node(), rhs.node());
 
-        let out = state.add_and_gate(self.to_inner().nodes()[0], rhs.to_inner().nodes()[0]);
-
-        let value = Bit::new([out]);
-
-        drop(state);
-
-        Tracer::new(self.state, value)
+        Tracer::new(self.state, Bit::new([out]))
     }
 }
 
@@ -248,15 +242,9 @@ impl<'a> Not for Tracer<'a, Bit> {
     type Output = Tracer<'a, Bit>;
 
     fn not(self) -> Self::Output {
-        let mut state = self.state.borrow_mut();
+        let out = self.state.borrow_mut().add_inv_gate(self.node());
 
-        let out = state.add_inv_gate(self.to_inner().nodes()[0]);
-
-        let value = Bit::new([out]);
-
-        drop(state);
-
-        Tracer::new(self.state, value)
+        Tracer::new(self.state, Bit::new([out]))
     }
 }
 

--- a/mpz-circuits/src/tracer.rs
+++ b/mpz-circuits/src/tracer.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::{builder::BuilderState, types::BinaryRepr};
+use crate::{builder::BuilderState, types::{BinaryRepr, Bit}, Node, Feed};
 
 /// A wrapper type for tracing operations applied to a value.
 ///
@@ -48,5 +48,12 @@ where
 {
     fn from(tracer: Vec<Tracer<'a, T>>) -> Self {
         BinaryRepr::Array(tracer.into_iter().map(|tracer| tracer.into()).collect())
+    }
+}
+
+impl<'a> Tracer<'a, Bit> {
+    /// Returns the single node associated with the bit.
+    pub fn node(&self) -> Node<Feed> {
+        self.to_inner().nodes()[0]
     }
 }

--- a/mpz-circuits/src/tracer.rs
+++ b/mpz-circuits/src/tracer.rs
@@ -1,6 +1,10 @@
 use std::cell::RefCell;
 
-use crate::{builder::BuilderState, types::{BinaryRepr, Bit}, Node, Feed};
+use crate::{
+    builder::BuilderState,
+    types::{BinaryRepr, Bit},
+    Feed, Node,
+};
 
 /// A wrapper type for tracing operations applied to a value.
 ///


### PR DESCRIPTION
Enables you to write eg:

```rs
let a = builder.add_input::<bool>();
let b = builder.add_input::<bool>();
let a_or_b = a | b; // Same as `!(!a & !b)`
```

I wanted these ops when I made a circuit for [Rock Paper Scissors Lizard Spock](https://github.com/voltrevo/mpz/blob/a9d48fe/rock-paper-sls/src/build_circuit.rs#L30).