### PR TITLE
Add RandomOT traits and implement them for KOS15

### DIFF
--- a/ot/mpz-ot-core/src/kos/receiver.rs
+++ b/ot/mpz-ot-core/src/kos/receiver.rs
@@ -581,6 +581,11 @@ impl ReceiverKeys {
             })
             .collect())
     }
+
+    /// Returns the choices and the keys
+    pub fn take_choices_and_keys(self) -> (Vec<bool>, Vec<Block>) {
+        (self.choices, self.keys)
+    }
 }
 
 struct PayloadRecordNoDelta {

--- a/ot/mpz-ot-core/src/kos/sender.rs
+++ b/ot/mpz-ot-core/src/kos/sender.rs
@@ -448,6 +448,11 @@ impl SenderKeys {
             },
         })
     }
+
+    /// Returns the keys
+    pub fn take_keys(self) -> Vec<[Block; 2]> {
+        self.keys
+    }
 }
 
 /// The sender's state.

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -6,8 +6,6 @@ mod sender;
 
 pub use error::{ReceiverError, ReceiverVerifyError, SenderError};
 use futures_util::{SinkExt, StreamExt};
-use rand_chacha::ChaCha20Rng;
-use rand_core::{RngCore, SeedableRng};
 pub use receiver::Receiver;
 pub use sender::Sender;
 
@@ -37,19 +35,6 @@ pub(crate) fn into_base_stream<'a, St: IoStream<msgs::Message<T>> + Send + Unpin
         Ok(msg) => msg.try_into_base_msg().map_err(From::from),
         Err(err) => Err(err),
     })
-}
-
-/// Stretches a 16-byte seed to arbitrary length using ChaCha20.
-fn random_bytes_from_seed<const N: usize>(seed: [u8; 16]) -> [u8; N] {
-    let mut stretched_seed = [0_u8; 32];
-    let double_seed = [seed, seed].concat();
-
-    stretched_seed.copy_from_slice(&double_seed);
-    let mut rng = ChaCha20Rng::from_seed(stretched_seed);
-
-    let mut output = [0_u8; N];
-    rng.fill_bytes(&mut output);
-    output
 }
 
 #[cfg(test)]

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -80,7 +80,7 @@ where
     ///
     /// * `sink` - The IO sink to the receiver.
     /// * `stream` - The IO stream from the receiver.
-    /// * `count` - The number of random messages to get.
+    /// * `count` - The number of pairs of random messages to output.
     async fn send_random<
         Si: IoSink<Self::Msg> + Send + Unpin,
         St: IoStream<Self::Msg> + Send + Unpin,

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -71,16 +71,16 @@ where
 /// A random OT sender.
 ///
 /// The OT sender gets two messages which are guaranteed to be random by the protocol.
-///
-/// # Arguments
-///
-/// * `count` - The number of random messages to get.
 #[async_trait]
 pub trait RandomOTSender<T>
 where
     T: Send + Sync,
 {
     /// Outputs two random messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of random messages to get.
     async fn random_messages(&mut self, count: usize) -> Result<Vec<T>, OTError>;
 }
 

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -74,7 +74,7 @@ pub trait RandomOTSender<T>: ProtocolMessage
 where
     T: Send + Sync,
 {
-    /// Outputs two random messages.
+    /// Outputs pairs of random messages.
     ///
     /// # Arguments
     ///

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -68,6 +68,22 @@ where
     ) -> Result<(), OTError>;
 }
 
+/// A random OT sender.
+///
+/// The OT sender gets two messages which are guaranteed to be random by the protocol.
+///
+/// # Arguments
+///
+/// * `count` - The number of random messages to get.
+#[async_trait]
+pub trait RandomOTSender<T>
+where
+    T: Send + Sync,
+{
+    /// Outputs two random messages.
+    async fn random_messages(&mut self, count: usize) -> Result<Vec<T>, OTError>;
+}
+
 /// An oblivious transfer receiver.
 #[async_trait]
 pub trait OTReceiver<T, U>: ProtocolMessage
@@ -88,6 +104,26 @@ where
         stream: &mut St,
         choices: &[T],
     ) -> Result<Vec<U>, OTError>;
+}
+
+/// A random OT receiver.
+///
+/// ATTENTION: This is a random OT receiver trait where from a security perspective the receiver
+/// could make the choice of which message to receive. Although this is not exposed in the interface,
+/// this trait is meant for protocols, where the receiver could choose the choice bit. So do NOT
+/// use this trait in your protocol if it is required that the receiver's choices are random.
+#[async_trait]
+pub trait ChosenMessageRandomOTReceiver<T, U>
+where
+    T: Send + Sync,
+    U: Send + Sync,
+{
+    /// Outputs the choice bits and the corresponding messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of random messages to receive.
+    async fn receive(&mut self, count: usize) -> Result<(Vec<T>, Vec<U>), OTError>;
 }
 
 /// An oblivious transfer sender that is committed to its messages and can reveal them


### PR DESCRIPTION
This PR adds the traits `RandomOTSender` and `ChosenMessageRandomOTReceiver` and implements them for KOS15.