### PR TITLE
Rename Mock OT impls to Ideal OT

### DIFF
--- a/garble/mpz-garble/Cargo.toml
+++ b/garble/mpz-garble/Cargo.toml
@@ -8,7 +8,7 @@ name = "mpz_garble"
 
 [features]
 default = ["mock"]
-mock = ["mpz-ot/mock"]
+mock = ["mpz-ot/ideal"]
 
 [dependencies]
 mpz-circuits.workspace = true
@@ -34,7 +34,7 @@ itybity.workspace = true
 opaque-debug.workspace = true
 
 [dev-dependencies]
-mpz-ot = { workspace = true, features = ["mock"] }
+mpz-ot = { workspace = true, features = ["ideal"] }
 rstest = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 tlsn-utils-aio = { workspace = true, features = ["duplex"] }

--- a/garble/mpz-garble/src/ot.rs
+++ b/garble/mpz-garble/src/ot.rs
@@ -126,12 +126,12 @@ mod tests {
 
     use mpz_circuits::circuits::AES128;
     use mpz_garble_core::{ChaChaEncoder, Encoder};
-    use mpz_ot::mock::mock_ot_shared_pair;
+    use mpz_ot::ideal::ideal_ot_shared_pair;
 
     #[tokio::test]
     async fn test_encoding_transfer() {
         let encoder = ChaChaEncoder::new([0u8; 32]);
-        let (sender, receiver) = mock_ot_shared_pair();
+        let (sender, receiver) = ideal_ot_shared_pair();
 
         let inputs = AES128
             .inputs()

--- a/garble/mpz-garble/src/protocol/deap/mock.rs
+++ b/garble/mpz-garble/src/protocol/deap/mock.rs
@@ -1,6 +1,6 @@
 //! Mocked DEAP VMs for testing
 
-use mpz_ot::mock::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};
+use mpz_ot::ideal::{ideal_ot_shared_pair, IdealSharedOTReceiver, IdealSharedOTSender};
 use utils_aio::mux::{mock::MockMuxChannelFactory, MuxChannel};
 
 use crate::config::Role;
@@ -8,24 +8,24 @@ use crate::config::Role;
 use super::{vm::DEAPVm, DEAPThread};
 
 /// Mock DEAP Leader VM.
-pub type MockLeader = DEAPVm<MockSharedOTSender, MockSharedOTReceiver>;
+pub type MockLeader = DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>;
 /// Mock DEAP Leader thread.
-pub type MockLeaderThread = DEAPThread<MockSharedOTSender, MockSharedOTReceiver>;
+pub type MockLeaderThread = DEAPThread<IdealSharedOTSender, IdealSharedOTReceiver>;
 /// Mock DEAP Follower VM.
-pub type MockFollower = DEAPVm<MockSharedOTSender, MockSharedOTReceiver>;
+pub type MockFollower = DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>;
 /// Mock DEAP Follower thread.
-pub type MockFollowerThread = DEAPThread<MockSharedOTSender, MockSharedOTReceiver>;
+pub type MockFollowerThread = DEAPThread<IdealSharedOTSender, IdealSharedOTReceiver>;
 
 /// Create a pair of mocked DEAP VMs
 pub async fn create_mock_deap_vm(
     id: &str,
 ) -> (
-    DEAPVm<MockSharedOTSender, MockSharedOTReceiver>,
-    DEAPVm<MockSharedOTSender, MockSharedOTReceiver>,
+    DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
+    DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
 ) {
     let mut mux_factory = MockMuxChannelFactory::new();
-    let (leader_ot_send, follower_ot_recv) = mock_ot_shared_pair();
-    let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+    let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
+    let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
     let leader_channel = mux_factory.get_channel(id).await.unwrap();
     let follower_channel = mux_factory.get_channel(id).await.unwrap();

--- a/garble/mpz-garble/src/protocol/deap/mod.rs
+++ b/garble/mpz-garble/src/protocol/deap/mod.rs
@@ -889,7 +889,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use mpz_circuits::{circuits::AES128, ops::WrappingAdd, CircuitBuilder};
-    use mpz_ot::mock::mock_ot_shared_pair;
+    use mpz_ot::ideal::ideal_ot_shared_pair;
     use utils_aio::duplex::MemoryDuplex;
 
     use crate::Memory;
@@ -912,8 +912,8 @@ mod tests {
     #[tokio::test]
     async fn test_deap() {
         let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = mock_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
+        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1005,8 +1005,8 @@ mod tests {
     #[tokio::test]
     async fn test_deap_load() {
         let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = mock_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
+        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1120,8 +1120,8 @@ mod tests {
     #[tokio::test]
     async fn test_deap_decode_private() {
         let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = mock_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
+        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1228,8 +1228,8 @@ mod tests {
     #[tokio::test]
     async fn test_deap_decode_shared() {
         let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = mock_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
+        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1366,8 +1366,8 @@ mod tests {
 
     async fn run_zk(key: [u8; 16], msg: [u8; 16], expected_ciphertext: [u8; 16]) {
         let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (_, follower_ot_recv) = mock_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = mock_ot_shared_pair();
+        let (_, follower_ot_recv) = ideal_ot_shared_pair();
+        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);

--- a/garble/mpz-garble/src/protocol/deap/vm.rs
+++ b/garble/mpz-garble/src/protocol/deap/vm.rs
@@ -482,15 +482,15 @@ mod tests {
     use crate::protocol::deap::mock::create_mock_deap_vm;
 
     use core::{future::Future, pin::Pin};
-    use mpz_ot::mock::{MockSharedOTReceiver, MockSharedOTSender};
+    use mpz_ot::ideal::{IdealSharedOTReceiver, IdealSharedOTSender};
     use rstest::{fixture, rstest};
 
     // Leader and follower VMs in a set up state and the futures which need to be awaited
     // to trigger circuit execution.
     struct VmFixture {
-        leader_vm: DEAPVm<MockSharedOTSender, MockSharedOTReceiver>,
+        leader_vm: DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
         leader_fut: Pin<Box<dyn Future<Output = Vec<Value>>>>,
-        follower_vm: DEAPVm<MockSharedOTSender, MockSharedOTReceiver>,
+        follower_vm: DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
         follower_fut: Pin<Box<dyn Future<Output = Vec<Value>>>>,
     }
 

--- a/garble/mpz-garble/tests/offline-garble.rs
+++ b/garble/mpz-garble/tests/offline-garble.rs
@@ -1,6 +1,6 @@
 use mpz_circuits::{circuits::AES128, types::StaticValueType};
 use mpz_garble_core::msg::GarbleMessage;
-use mpz_ot::mock::mock_ot_shared_pair;
+use mpz_ot::ideal::ideal_ot_shared_pair;
 use utils_aio::duplex::MemoryDuplex;
 
 use mpz_garble::{config::Visibility, Evaluator, Generator, GeneratorConfigBuilder, ValueMemory};
@@ -8,7 +8,7 @@ use mpz_garble::{config::Visibility, Evaluator, Generator, GeneratorConfigBuilde
 #[tokio::test]
 async fn test_offline_garble() {
     let (mut gen_channel, mut ev_channel) = MemoryDuplex::<GarbleMessage>::new();
-    let (ot_send, ot_recv) = mock_ot_shared_pair();
+    let (ot_send, ot_recv) = ideal_ot_shared_pair();
 
     let gen = Generator::new(
         GeneratorConfigBuilder::default().build().unwrap(),

--- a/garble/mpz-garble/tests/semihonest.rs
+++ b/garble/mpz-garble/tests/semihonest.rs
@@ -1,6 +1,6 @@
 use mpz_circuits::{circuits::AES128, types::StaticValueType};
 use mpz_garble_core::msg::GarbleMessage;
-use mpz_ot::mock::mock_ot_shared_pair;
+use mpz_ot::ideal::ideal_ot_shared_pair;
 use utils_aio::duplex::MemoryDuplex;
 
 use mpz_garble::{config::Visibility, Evaluator, Generator, GeneratorConfigBuilder, ValueMemory};
@@ -8,7 +8,7 @@ use mpz_garble::{config::Visibility, Evaluator, Generator, GeneratorConfigBuilde
 #[tokio::test]
 async fn test_semi_honest() {
     let (mut gen_channel, mut ev_channel) = MemoryDuplex::<GarbleMessage>::new();
-    let (ot_send, ot_recv) = mock_ot_shared_pair();
+    let (ot_send, ot_recv) = ideal_ot_shared_pair();
 
     let gen = Generator::new(
         GeneratorConfigBuilder::default().build().unwrap(),

--- a/ot/mpz-ot/Cargo.toml
+++ b/ot/mpz-ot/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 name = "mpz_ot"
 
 [features]
-default = ["mock", "rayon", "actor"]
+default = ["ideal", "rayon", "actor"]
 rayon = ["mpz-ot-core/rayon"]
 actor = ["dep:serde"]
-mock = []
+ideal = []
 
 [dependencies]
 mpz-core.workspace = true

--- a/ot/mpz-ot/src/actor/kos/mod.rs
+++ b/ot/mpz-ot/src/actor/kos/mod.rs
@@ -34,8 +34,8 @@ pub(crate) fn into_kos_stream<'a, St: IoStream<msgs::Message<T>> + Send + Unpin,
 #[cfg(test)]
 mod tests {
     use crate::{
+        ideal::{ideal_ot_pair, IdealOTReceiver, IdealOTSender},
         kos::{Receiver, Sender},
-        mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
         OTReceiverShared, OTSenderShared, VerifiableOTReceiverShared,
     };
 
@@ -83,12 +83,12 @@ mod tests {
         count: usize,
     ) -> (
         SenderActor<
-            MockOTReceiver<Block>,
+            IdealOTReceiver<Block>,
             SplitSink<MemoryDuplex<Message<()>>, Message<()>>,
             SplitStream<MemoryDuplex<Message<()>>>,
         >,
         ReceiverActor<
-            MockOTSender<Block>,
+            IdealOTSender<Block>,
             SplitSink<MemoryDuplex<Message<()>>, Message<()>>,
             SplitStream<MemoryDuplex<Message<()>>>,
         >,
@@ -98,7 +98,7 @@ mod tests {
         let (sender_sink, sender_stream) = sender_channel.split();
         let (receiver_sink, receiver_stream) = receiver_channel.split();
 
-        let (base_sender, base_receiver) = mock_ot_pair();
+        let (base_sender, base_receiver) = ideal_ot_pair();
 
         let sender = Sender::new(sender_config, base_receiver);
         let receiver = Receiver::new(receiver_config, base_sender);

--- a/ot/mpz-ot/src/ideal/mod.rs
+++ b/ot/mpz-ot/src/ideal/mod.rs
@@ -1,4 +1,4 @@
-//! Mock implementations of the OT protocols.
+//! Ideal implementations of the OT protocols.
 
 mod owned;
 mod shared;

--- a/ot/mpz-ot/src/ideal/mod.rs
+++ b/ot/mpz-ot/src/ideal/mod.rs
@@ -1,0 +1,7 @@
+//! Mock implementations of the OT protocols.
+
+mod owned;
+mod shared;
+
+pub use owned::{ideal_ot_pair, IdealOTReceiver, IdealOTSender};
+pub use shared::{ideal_ot_shared_pair, IdealSharedOTReceiver, IdealSharedOTSender};

--- a/ot/mpz-ot/src/ideal/owned.rs
+++ b/ot/mpz-ot/src/ideal/owned.rs
@@ -11,42 +11,42 @@ use futures::{
 use mpz_core::ProtocolMessage;
 use utils_aio::{sink::IoSink, stream::IoStream};
 
-/// Mock OT sender.
+/// Ideal OT sender.
 #[derive(Debug)]
-pub struct MockOTSender<T> {
+pub struct IdealOTSender<T> {
     sender: mpsc::Sender<Vec<[T; 2]>>,
     msgs: Vec<[T; 2]>,
     choices_receiver: Option<oneshot::Receiver<Vec<bool>>>,
 }
 
-/// Mock OT receiver.
+/// Ideal OT receiver.
 #[derive(Debug)]
-pub struct MockOTReceiver<T> {
+pub struct IdealOTReceiver<T> {
     receiver: mpsc::Receiver<Vec<[T; 2]>>,
     choices: Vec<bool>,
     choices_sender: Option<oneshot::Sender<Vec<bool>>>,
 }
 
-impl<T> ProtocolMessage for MockOTSender<T> {
+impl<T> ProtocolMessage for IdealOTSender<T> {
     type Msg = ();
 }
 
-impl<T> ProtocolMessage for MockOTReceiver<T> {
+impl<T> ProtocolMessage for IdealOTReceiver<T> {
     type Msg = ();
 }
 
-/// Creates a pair of mock OT sender and receiver.
-pub fn mock_ot_pair<T: Send + Sync + 'static>() -> (MockOTSender<T>, MockOTReceiver<T>) {
+/// Creates a pair of ideal OT sender and receiver.
+pub fn ideal_ot_pair<T: Send + Sync + 'static>() -> (IdealOTSender<T>, IdealOTReceiver<T>) {
     let (sender, receiver) = mpsc::channel(10);
     let (choices_sender, choices_receiver) = oneshot::channel();
 
     (
-        MockOTSender {
+        IdealOTSender {
             sender,
             msgs: Vec::default(),
             choices_receiver: Some(choices_receiver),
         },
-        MockOTReceiver {
+        IdealOTReceiver {
             receiver,
             choices: Vec::default(),
             choices_sender: Some(choices_sender),
@@ -55,7 +55,7 @@ pub fn mock_ot_pair<T: Send + Sync + 'static>() -> (MockOTSender<T>, MockOTRecei
 }
 
 #[async_trait]
-impl<T> OTSetup for MockOTSender<T>
+impl<T> OTSetup for IdealOTSender<T>
 where
     T: Send + Sync,
 {
@@ -69,7 +69,7 @@ where
 }
 
 #[async_trait]
-impl<T> OTSender<[T; 2]> for MockOTSender<T>
+impl<T> OTSender<[T; 2]> for IdealOTSender<T>
 where
     T: Send + Sync + Clone + 'static,
 {
@@ -84,7 +84,7 @@ where
 }
 
 #[async_trait]
-impl<T> OTSenderWithIo<[T; 2]> for MockOTSender<T>
+impl<T> OTSenderWithIo<[T; 2]> for IdealOTSender<T>
 where
     T: Send + Sync + Clone + 'static,
 {
@@ -100,7 +100,7 @@ where
 }
 
 #[async_trait]
-impl<T> OTSetup for MockOTReceiver<T>
+impl<T> OTSetup for IdealOTReceiver<T>
 where
     T: Send + Sync,
 {
@@ -114,7 +114,7 @@ where
 }
 
 #[async_trait]
-impl<T> OTReceiver<bool, T> for MockOTReceiver<T>
+impl<T> OTReceiver<bool, T> for IdealOTReceiver<T>
 where
     T: Send + Sync + 'static,
 {
@@ -129,7 +129,7 @@ where
 }
 
 #[async_trait]
-impl<T> OTReceiverWithIo<bool, T> for MockOTReceiver<T>
+impl<T> OTReceiverWithIo<bool, T> for IdealOTReceiver<T>
 where
     T: Send + Sync + 'static,
 {
@@ -158,7 +158,7 @@ where
 }
 
 #[async_trait]
-impl<U, V> VerifiableOTReceiver<bool, U, V> for MockOTReceiver<U>
+impl<U, V> VerifiableOTReceiver<bool, U, V> for IdealOTReceiver<U>
 where
     U: Send + Sync + 'static,
     V: Send + Sync + 'static,
@@ -175,7 +175,7 @@ where
 }
 
 #[async_trait]
-impl<T> VerifiableOTReceiverWithIo<[T; 2]> for MockOTReceiver<T>
+impl<T> VerifiableOTReceiverWithIo<[T; 2]> for IdealOTReceiver<T>
 where
     T: Send + Sync + 'static,
 {
@@ -185,7 +185,7 @@ where
 }
 
 #[async_trait]
-impl<T> CommittedOTSender<[T; 2]> for MockOTSender<T>
+impl<T> CommittedOTSender<[T; 2]> for IdealOTSender<T>
 where
     T: Send + Sync + Clone + 'static,
 {
@@ -199,7 +199,7 @@ where
 }
 
 #[async_trait]
-impl<T> CommittedOTSenderWithIo for MockOTSender<T>
+impl<T> CommittedOTSenderWithIo for IdealOTSender<T>
 where
     T: Send + 'static,
 {
@@ -209,7 +209,7 @@ where
 }
 
 #[async_trait]
-impl<T> CommittedOTReceiver<bool, T> for MockOTReceiver<T>
+impl<T> CommittedOTReceiver<bool, T> for IdealOTReceiver<T>
 where
     T: Send + Sync + 'static,
 {
@@ -229,7 +229,7 @@ where
 }
 
 #[async_trait]
-impl<T> VerifiableOTSender<bool, [T; 2]> for MockOTSender<T>
+impl<T> VerifiableOTSender<bool, [T; 2]> for IdealOTSender<T>
 where
     T: Send + Sync + Clone + 'static,
 {
@@ -253,10 +253,10 @@ mod tests {
 
     // Test that the sender and receiver can be used to send and receive values
     #[tokio::test]
-    async fn test_mock_ot_owned() {
+    async fn test_ideal_ot_owned() {
         let values = vec![[0, 1], [2, 3]];
         let choices = vec![false, true];
-        let (mut sender, mut receiver) = mock_ot_pair::<u8>();
+        let (mut sender, mut receiver) = ideal_ot_pair::<u8>();
 
         OTSenderWithIo::send(&mut sender, &values).await.unwrap();
 

--- a/ot/mpz-ot/src/ideal/shared.rs
+++ b/ot/mpz-ot/src/ideal/shared.rs
@@ -29,7 +29,7 @@ pub fn ideal_ot_shared_pair() -> (IdealSharedOTSender, IdealSharedOTReceiver) {
     (sender, receiver)
 }
 
-/// A mock oblivious transfer sender.
+/// A ideal oblivious transfer sender.
 #[derive(Clone, Debug)]
 #[allow(clippy::type_complexity)]
 pub struct IdealSharedOTSender {
@@ -66,7 +66,7 @@ impl<T: Clone + std::fmt::Debug + Send + Sync + 'static> CommittedOTSenderShared
     }
 }
 
-/// A mock oblivious transfer receiver.
+/// A ideal oblivious transfer receiver.
 #[derive(Clone, Debug)]
 #[allow(clippy::type_complexity)]
 pub struct IdealSharedOTReceiver {

--- a/ot/mpz-ot/src/kos/mod.rs
+++ b/ot/mpz-ot/src/kos/mod.rs
@@ -52,7 +52,7 @@ mod tests {
     use utils_aio::{duplex::MemoryDuplex, sink::IoSink, stream::IoStream};
 
     use crate::{
-        mock::{mock_ot_pair, MockOTReceiver, MockOTSender},
+        ideal::{ideal_ot_pair, IdealOTReceiver, IdealOTSender},
         OTReceiver, OTSender, OTSetup, RandomOTReceiver, RandomOTSender, VerifiableOTReceiver,
     };
 
@@ -89,8 +89,11 @@ mod tests {
         receiver_sink: &mut Si,
         receiver_stream: &mut St,
         count: usize,
-    ) -> (Sender<MockOTReceiver<Block>>, Receiver<MockOTSender<Block>>) {
-        let (base_sender, base_receiver) = mock_ot_pair();
+    ) -> (
+        Sender<IdealOTReceiver<Block>>,
+        Receiver<IdealOTSender<Block>>,
+    ) {
+        let (base_sender, base_receiver) = ideal_ot_pair();
 
         let mut sender = Sender::new(sender_config, base_receiver);
         let mut receiver = Receiver::new(receiver_config, base_sender);

--- a/ot/mpz-ot/src/lib.rs
+++ b/ot/mpz-ot/src/lib.rs
@@ -7,9 +7,9 @@
 #[cfg(feature = "actor")]
 pub mod actor;
 pub mod chou_orlandi;
+#[cfg(feature = "ideal")]
+pub mod ideal;
 pub mod kos;
-#[cfg(feature = "mock")]
-pub mod mock;
 
 use async_trait::async_trait;
 use mpz_core::ProtocolMessage;

--- a/ot/mpz-ot/src/mock/mod.rs
+++ b/ot/mpz-ot/src/mock/mod.rs
@@ -1,7 +1,0 @@
-//! Mock implementations of the OT protocols.
-
-mod owned;
-mod shared;
-
-pub use owned::{mock_ot_pair, MockOTReceiver, MockOTSender};
-pub use shared::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};

--- a/share-conversion/mpz-share-conversion/src/lib.rs
+++ b/share-conversion/mpz-share-conversion/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
 
     use crate::config::{ReceiverConfig, SenderConfig};
 
-    use mpz_ot::mock::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};
+    use mpz_ot::ideal::{ideal_ot_shared_pair, IdealSharedOTReceiver, IdealSharedOTSender};
     use mpz_share_conversion_core::{
         fields::{gf2_128::Gf2_128, p256::P256, Field},
         ShareType,
@@ -132,10 +132,10 @@ mod tests {
         #[case] _pd: PhantomData<T>,
         #[values(false, true)] malicious: bool,
     ) where
-        MockSharedOTSender: OTSendElement<T>,
-        MockSharedOTReceiver: OTReceiveElement<T>,
+        IdealSharedOTSender: OTSendElement<T>,
+        IdealSharedOTReceiver: OTReceiveElement<T>,
     {
-        let (ot_sender, ot_receiver) = mock_ot_shared_pair();
+        let (ot_sender, ot_receiver) = ideal_ot_shared_pair();
         let (mut sender_channel, mut receiver_channel) = MemoryDuplex::new();
         let (mut sender, mut receiver) = create_pair::<T>();
         let mut rng = ChaCha20Rng::from_seed([0; 32]);

--- a/share-conversion/mpz-share-conversion/src/mock.rs
+++ b/share-conversion/mpz-share-conversion/src/mock.rs
@@ -3,14 +3,14 @@
 use crate::{OTReceiveElement, OTSendElement};
 
 use super::{ConverterReceiver, ConverterSender, ReceiverConfig, SenderConfig};
-use mpz_ot::mock::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};
+use mpz_ot::ideal::{ideal_ot_shared_pair, IdealSharedOTReceiver, IdealSharedOTSender};
 use mpz_share_conversion_core::fields::Field;
 use utils_aio::duplex::MemoryDuplex;
 
 /// A mock converter sender
-pub type MockConverterSender<F> = ConverterSender<F, MockSharedOTSender>;
+pub type MockConverterSender<F> = ConverterSender<F, IdealSharedOTSender>;
 /// A mock converter receiver
-pub type MockConverterReceiver<F> = ConverterReceiver<F, MockSharedOTReceiver>;
+pub type MockConverterReceiver<F> = ConverterReceiver<F, IdealSharedOTReceiver>;
 
 /// Creates a mock sender and receiver for testing the share conversion protocol.
 #[allow(clippy::type_complexity)]
@@ -18,16 +18,16 @@ pub fn mock_converter_pair<F: Field>(
     sender_config: SenderConfig,
     receiver_config: ReceiverConfig,
 ) -> (
-    ConverterSender<F, MockSharedOTSender>,
-    ConverterReceiver<F, MockSharedOTReceiver>,
+    ConverterSender<F, IdealSharedOTSender>,
+    ConverterReceiver<F, IdealSharedOTReceiver>,
 )
 where
-    MockSharedOTSender: OTSendElement<F>,
-    MockSharedOTReceiver: OTReceiveElement<F>,
+    IdealSharedOTSender: OTSendElement<F>,
+    IdealSharedOTReceiver: OTReceiveElement<F>,
 {
     let (c1, c2) = MemoryDuplex::new();
 
-    let (ot_sender, ot_receiver) = mock_ot_shared_pair();
+    let (ot_sender, ot_receiver) = ideal_ot_shared_pair();
 
     let sender = ConverterSender::new(sender_config, ot_sender, Box::new(c1));
     let receiver = ConverterReceiver::new(receiver_config, ot_receiver, Box::new(c2));

--- a/share-conversion/mpz-share-conversion/tests/converter.rs
+++ b/share-conversion/mpz-share-conversion/tests/converter.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use rstest::*;
 
-use mpz_ot::mock::{mock_ot_shared_pair, MockSharedOTReceiver, MockSharedOTSender};
+use mpz_ot::ideal::{ideal_ot_shared_pair, IdealSharedOTReceiver, IdealSharedOTSender};
 use mpz_share_conversion::{
     AdditiveToMultiplicative, ConverterReceiver, ConverterSender, Field, Gf2_128,
     MultiplicativeToAdditive, OTReceiveElement, OTSendElement, ReceiverConfig, SenderConfig,
@@ -19,12 +19,12 @@ use rand_chacha::ChaCha12Rng;
 #[tokio::test]
 async fn test_converter<T: Field>(#[case] _pd: PhantomData<T>)
 where
-    MockSharedOTSender: OTSendElement<T>,
-    MockSharedOTReceiver: OTReceiveElement<T>,
+    IdealSharedOTSender: OTSendElement<T>,
+    IdealSharedOTReceiver: OTReceiveElement<T>,
 {
     let mut rng = ChaCha12Rng::seed_from_u64(0);
 
-    let (ot_sender, ot_receiver) = mock_ot_shared_pair();
+    let (ot_sender, ot_receiver) = ideal_ot_shared_pair();
     let (sender_channel, receiver_channel) = MemoryDuplex::new();
 
     let mut sender = ConverterSender::<T, _>::new(


### PR DESCRIPTION
It's more conventional to call these "ideal" implementations of each functionality. This PR only updates OT, we'll want to rename stuff in other crates as well.