### PR TITLE
refactor: mpz-cointoss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,16 @@ members = [
     "matrix-transpose",
     "clmul",
     "mpz-common",
+    "mpz-cointoss",
+    "mpz-cointoss-core",
 ]
 
 [workspace.dependencies]
 mpz-core = { path = "mpz-core" }
 mpz-common = { path = "mpz-common" }
 mpz-circuits = { path = "mpz-circuits" }
+mpz-cointoss-core = { path = "mpz-cointoss-core" }
+mpz-cointoss = { path = "mpz-cointoss" }
 mpz-ot-core = { path = "ot/mpz-ot-core" }
 mpz-ot = { path = "ot/mpz-ot" }
 mpz-garble-core = { path = "garble/mpz-garble-core" }

--- a/mpz-cointoss-core/Cargo.toml
+++ b/mpz-cointoss-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mpz-cointoss-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mpz-core.workspace = true
+
+serde.workspace = true
+thiserror.workspace = true
+opaque-debug.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/mpz-cointoss-core/src/lib.rs
+++ b/mpz-cointoss-core/src/lib.rs
@@ -4,8 +4,7 @@
 //!
 //! ```
 //! use rand::{thread_rng, Rng};
-//! use mpz_core::cointoss::{Sender, Receiver};
-//! # use mpz_core::cointoss::CointossError;
+//! use mpz_cointoss_core::{Sender, Receiver, CointossError};
 //! use mpz_core::Block;
 //!
 //! # fn main() -> Result<(), CointossError> {
@@ -17,13 +16,23 @@
 //!
 //! let (sender, commitment) = sender.send();
 //! let (receiver, receiver_payload) = receiver.reveal(commitment)?;
-//! let (sender_output, sender_payload) = sender.finalize(receiver_payload)?;
+//! let (sender_output, sender) = sender.receive(receiver_payload)?;
+//! let sender_payload = sender.finalize();
 //! let receiver_output = receiver.finalize(sender_payload)?;
 //!
 //! assert_eq!(sender_output, receiver_output);
 //! # Ok(())
 //! # }
 //! ```
+
+#![deny(
+    unsafe_code,
+    missing_docs,
+    unused_imports,
+    unused_must_use,
+    unreachable_pub,
+    clippy::all
+)]
 
 pub mod msgs;
 mod receiver;
@@ -36,8 +45,8 @@ pub use sender::{sender_state, Sender};
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum CointossError {
-    #[error(transparent)]
-    CommitmentError(#[from] crate::commit::CommitmentError),
+    #[error("commitment error")]
+    CommitmentError(#[from] mpz_core::commit::CommitmentError),
     #[error("count mismatch, expected {expected}, got {actual}")]
     CountMismatch { expected: usize, actual: usize },
 }

--- a/mpz-cointoss-core/src/msgs.rs
+++ b/mpz-cointoss-core/src/msgs.rs
@@ -2,16 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{commit::Decommitment, hash::Hash, Block};
-
-/// A coin-toss message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_docs)]
-pub enum Message {
-    SenderCommitments(SenderCommitment),
-    SenderPayload(SenderPayload),
-    ReceiverPayload(ReceiverPayload),
-}
+use mpz_core::{commit::Decommitment, hash::Hash, Block};
 
 /// The coin-toss sender's commitment.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/mpz-cointoss-core/src/receiver.rs
+++ b/mpz-cointoss-core/src/receiver.rs
@@ -1,10 +1,8 @@
+use mpz_core::{hash::Hash, Block};
+
 use crate::{
-    cointoss::{
-        msgs::{ReceiverPayload, SenderCommitment, SenderPayload},
-        CointossError,
-    },
-    hash::Hash,
-    Block,
+    msgs::{ReceiverPayload, SenderCommitment, SenderPayload},
+    CointossError,
 };
 
 /// A coin-toss receiver.

--- a/mpz-cointoss/Cargo.toml
+++ b/mpz-cointoss/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mpz-cointoss"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mpz-core.workspace = true
+mpz-common.workspace = true
+mpz-cointoss-core.workspace = true
+
+futures.workspace = true
+serio.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+mpz-common = { workspace = true, features = ["test-utils"] }
+
+rand.workspace = true

--- a/mpz-cointoss/src/lib.rs
+++ b/mpz-cointoss/src/lib.rs
@@ -1,0 +1,197 @@
+//! A simple 2-party coin-toss protocol.
+//!
+//! # Example
+//!
+//! ```
+//! use rand::{thread_rng, Rng};
+//! use mpz_core::Block;
+//! use mpz_common::executor::test_st_executor;
+//! use mpz_cointoss::{cointoss_receiver, cointoss_sender};
+//! # use mpz_cointoss::CointossError;
+//! # use futures::executor::block_on;
+//!
+//! # fn main() {
+//! # block_on(async {
+//! let (mut ctx_sender, mut ctx_receiver) = test_st_executor(8);
+//! let sender_seeds = (0..8).map(|_| Block::random(&mut thread_rng())).collect();
+//! let receiver_seeds = (0..8).map(|_| Block::random(&mut thread_rng())).collect();
+//!
+//! let (sender_output, receiver_output) =
+//!     futures::try_join!(
+//!         cointoss_sender(&mut ctx_sender, sender_seeds),
+//!         cointoss_receiver(&mut ctx_receiver, receiver_seeds),
+//!     )?;
+//!
+//! assert_eq!(sender_output, receiver_output);
+//! # Ok::<_, CointossError>(())
+//! # }).unwrap();
+//! # }
+//! ```
+
+#![deny(
+    unsafe_code,
+    missing_docs,
+    unused_imports,
+    unused_must_use,
+    unreachable_pub,
+    clippy::all
+)]
+
+use mpz_cointoss_core::{
+    CointossError as CoreError, Receiver as CoreReceiver, Sender as CoreSender,
+};
+use mpz_common::Context;
+use mpz_core::Block;
+use serio::{stream::IoStreamExt, SinkExt};
+
+pub use mpz_cointoss_core::{msgs, receiver_state, sender_state};
+
+/// Coin-toss protocol error.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CointossError {
+    /// An I/O error occurred.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// A core error occurred.
+    #[error("core error: {0}")]
+    Core(#[from] CoreError),
+}
+
+/// A coin-toss sender.
+#[derive(Debug)]
+pub struct Sender<T: sender_state::State = sender_state::Initialized> {
+    inner: CoreSender<T>,
+}
+
+impl Sender {
+    /// Create a new sender.
+    pub fn new(seeds: Vec<Block>) -> Self {
+        Self {
+            inner: CoreSender::new(seeds),
+        }
+    }
+
+    /// Sends the coin-toss commitment.
+    pub async fn commit(
+        self,
+        ctx: &mut impl Context,
+    ) -> Result<Sender<sender_state::Committed>, CointossError> {
+        let (inner, commitment) = self.inner.send();
+        ctx.io_mut().send(commitment).await?;
+        Ok(Sender { inner })
+    }
+
+    /// Executes the coin-toss protocol to completion.
+    pub async fn execute(self, ctx: &mut impl Context) -> Result<Vec<Block>, CointossError> {
+        let (seeds, sender) = self.commit(ctx).await?.receive(ctx).await?;
+        sender.finalize(ctx).await?;
+        Ok(seeds)
+    }
+}
+
+impl Sender<sender_state::Committed> {
+    /// Receives the receiver's payload and computes the output of the coin-toss.
+    pub async fn receive(
+        self,
+        ctx: &mut impl Context,
+    ) -> Result<(Vec<Block>, Sender<sender_state::Received>), CointossError> {
+        let payload = ctx.io_mut().expect_next().await?;
+        let (seeds, sender) = self.inner.receive(payload)?;
+        Ok((seeds, Sender { inner: sender }))
+    }
+}
+
+impl Sender<sender_state::Received> {
+    /// Finalizes the coin-toss, decommitting the sender's seeds.
+    pub async fn finalize(self, ctx: &mut impl Context) -> Result<(), CointossError> {
+        ctx.io_mut().send(self.inner.finalize()).await?;
+        Ok(())
+    }
+}
+
+/// A coin-toss receiver.
+#[derive(Debug)]
+pub struct Receiver<T: receiver_state::State = receiver_state::Initialized> {
+    inner: CoreReceiver<T>,
+}
+
+impl Receiver {
+    /// Create a new receiver.
+    pub fn new(seeds: Vec<Block>) -> Self {
+        Self {
+            inner: CoreReceiver::new(seeds),
+        }
+    }
+
+    /// Reveals the receiver's seeds after receiving the sender's commitment.
+    pub async fn receive(
+        self,
+        ctx: &mut impl Context,
+    ) -> Result<Receiver<receiver_state::Received>, CointossError> {
+        let commitment = ctx.io_mut().expect_next().await?;
+        let (inner, payload) = self.inner.reveal(commitment)?;
+        ctx.io_mut().send(payload).await?;
+        Ok(Receiver { inner })
+    }
+
+    /// Executes the coin-toss protocol to completion.
+    pub async fn execute(self, ctx: &mut impl Context) -> Result<Vec<Block>, CointossError> {
+        self.receive(ctx).await?.finalize(ctx).await
+    }
+}
+
+impl Receiver<receiver_state::Received> {
+    /// Finalizes the coin-toss, returning the random seeds.
+    pub async fn finalize(self, ctx: &mut impl Context) -> Result<Vec<Block>, CointossError> {
+        let payload = ctx.io_mut().expect_next().await?;
+        let seeds = self.inner.finalize(payload)?;
+        Ok(seeds)
+    }
+}
+
+/// Executes the coin-toss protocol as the sender.
+///
+/// # Arguments
+///
+/// * `ctx` - The thread context.
+/// * `seeds` - The seeds to use for the coin-toss.
+pub async fn cointoss_sender(
+    ctx: &mut impl Context,
+    seeds: Vec<Block>,
+) -> Result<Vec<Block>, CointossError> {
+    Sender::new(seeds).execute(ctx).await
+}
+
+/// Executes the coin-toss protocol as the receiver.
+///
+/// # Arguments
+///
+/// * `ctx` - The thread context.
+/// * `seeds` - The seeds to use for the coin-toss.
+pub async fn cointoss_receiver(
+    ctx: &mut impl Context,
+    seeds: Vec<Block>,
+) -> Result<Vec<Block>, CointossError> {
+    Receiver::new(seeds).execute(ctx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::executor::block_on;
+    use mpz_common::executor::test_st_executor;
+
+    #[test]
+    fn test_cointoss() {
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        block_on(async {
+            futures::try_join!(
+                cointoss_sender(&mut ctx_a, vec![Block::ZERO, Block::ONES]),
+                cointoss_receiver(&mut ctx_b, vec![Block::ONES, Block::ZERO]),
+            )
+            .unwrap()
+        });
+    }
+}

--- a/mpz-core/src/lib.rs
+++ b/mpz-core/src/lib.rs
@@ -4,7 +4,6 @@
 
 pub mod aes;
 pub mod block;
-pub mod cointoss;
 pub mod commit;
 pub mod ggm_tree;
 pub mod hash;


### PR DESCRIPTION
This PR builds on #107 and refactors our cointoss protocol into its own crate.