### PR TITLE
feat(mpz-common): add try_/join convenience macros

### DIFF
--- a/crates/mpz-common/src/context.rs
+++ b/crates/mpz-common/src/context.rs
@@ -44,3 +44,70 @@ pub trait Context: Send {
         RB: Send + 'a,
         E: Send + 'a;
 }
+
+/// A convenience macro for forking a context and joining two tasks concurrently.
+///
+/// This macro calls `Context::join` under the hood.
+#[macro_export]
+macro_rules! join {
+    ($ctx:ident, $task_0:expr, $task_1:expr) => {
+        async {
+            use $crate::{scoped_futures::ScopedFutureExt, Context};
+            $ctx.join(
+                |$ctx| async { $task_0.await }.scope_boxed(),
+                |$ctx| async { $task_1.await }.scope_boxed(),
+            )
+            .await
+        }
+        .await
+    };
+}
+
+/// A convenience macro for forking a context and joining two tasks concurrently, returning an error
+/// if one of the tasks fails.
+///
+/// This macro calls `Context::try_join` under the hood.
+#[macro_export]
+macro_rules! try_join {
+    ($ctx:ident, $task_0:expr, $task_1:expr) => {
+        async {
+            use $crate::{scoped_futures::ScopedFutureExt, Context};
+            $ctx.try_join(
+                |$ctx| async { $task_0.await }.scope_boxed(),
+                |$ctx| async { $task_1.await }.scope_boxed(),
+            )
+            .await
+        }
+        .await
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::executor::test_st_executor;
+
+    #[test]
+    fn test_join_macro() {
+        let (mut ctx, _) = test_st_executor(1);
+
+        futures::executor::block_on(async {
+            join!(ctx, async { println!("{:?}", ctx.id()) }, async {
+                println!("{:?}", ctx.id())
+            })
+        });
+    }
+
+    #[test]
+    fn test_try_join_macro() {
+        let (mut ctx, _) = test_st_executor(1);
+
+        futures::executor::block_on(async {
+            try_join!(
+                ctx,
+                async { Ok::<_, ()>(println!("{:?}", ctx.id())) },
+                async { Ok::<_, ()>(println!("{:?}", ctx.id())) }
+            )
+            .unwrap();
+        });
+    }
+}


### PR DESCRIPTION
This PR adds a couple macros which makes it easier to call the `Context::join` methods without having to deal with importing the scoped future stuff or the verbosity of closures.