### PR TITLE
Add crate `mpz-ole-core`

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -112,6 +112,8 @@ hex = "0.4"
 lazy_static = "1"
 derive_builder = "0.11"
 once_cell = "1"
+hybrid-array = "0.2.0-rc.8"
+typenum = "1"
 # DO NOT BUMP, SEE https://github.com/privacy-scaling-explorations/mpz/issues/61
 generic-array = "0.14"
 itybity = "0.2"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "mpz-share-conversion-core",
     "matrix-transpose",
     "clmul",
+    "mpz-ole-core",
 ]
 resolver = "2"
 
@@ -38,6 +39,7 @@ mpz-garble = { path = "mpz-garble" }
 mpz-garble-core = { path = "mpz-garble-core" }
 mpz-share-conversion = { path = "mpz-share-conversion" }
 mpz-share-conversion-core = { path = "mpz-share-conversion-core" }
+mpz-ole-core = { path = "mpz-ole-core" }
 clmul = { path = "clmul" }
 matrix-transpose = { path = "matrix-transpose" }
 

--- a/crates/mpz-fields/Cargo.toml
+++ b/crates/mpz-fields/Cargo.toml
@@ -20,6 +20,8 @@ num-bigint.workspace = true
 opaque-debug.workspace = true
 serde.workspace = true
 itybity.workspace = true
+typenum.workspace = true
+hybrid-array.workspace = true
 
 [dev-dependencies]
 ghash_rc.workspace = true

--- a/crates/mpz-fields/src/gf2_128.rs
+++ b/crates/mpz-fields/src/gf2_128.rs
@@ -99,8 +99,7 @@ impl Neg for Gf2_128 {
 }
 
 impl Field for Gf2_128 {
-    const BIT_SIZE: u32 = 128;
-    type BitSizeType = U128;
+    type BitSize = U128;
 
     fn zero() -> Self {
         Self::new(0)

--- a/crates/mpz-fields/src/gf2_128.rs
+++ b/crates/mpz-fields/src/gf2_128.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use mpz_core::Block;
 use typenum::U128;
 
-use crate::{ByteRepr, Field};
+use crate::Field;
 
 /// A type for holding field elements of Gf(2^128).
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,10 +96,6 @@ impl Neg for Gf2_128 {
     fn neg(self) -> Self::Output {
         self
     }
-}
-
-impl ByteRepr for Gf2_128 {
-    type Serialized = [u8; 16];
 }
 
 impl Field for Gf2_128 {

--- a/crates/mpz-fields/src/gf2_128.rs
+++ b/crates/mpz-fields/src/gf2_128.rs
@@ -7,8 +7,9 @@ use rand::{distributions::Standard, prelude::Distribution};
 use serde::{Deserialize, Serialize};
 
 use mpz_core::Block;
+use typenum::U128;
 
-use super::Field;
+use crate::{ByteRepr, Field};
 
 /// A type for holding field elements of Gf(2^128).
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
@@ -97,8 +98,13 @@ impl Neg for Gf2_128 {
     }
 }
 
+impl ByteRepr for Gf2_128 {
+    type Serialized = [u8; 16];
+}
+
 impl Field for Gf2_128 {
     const BIT_SIZE: u32 = 128;
+    type BitSizeType = U128;
 
     fn zero() -> Self {
         Self::new(0)

--- a/crates/mpz-fields/src/lib.rs
+++ b/crates/mpz-fields/src/lib.rs
@@ -37,7 +37,6 @@ pub trait Field:
     + GetBit<Msb0>
     + BitLength
     + Unpin
-    + ByteRepr
 {
     /// The number of bits of a field element.
     const BIT_SIZE: u32;
@@ -71,14 +70,6 @@ pub trait Field:
 pub trait UniformRand: Sized {
     /// Return a random field element.
     fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
-}
-
-/// The byte representation of the field.
-///
-/// This trait introduces an associated type for field elements to simplify usage.
-pub trait ByteRepr {
-    /// The underlying representation of the field element
-    type Serialized: AsRef<[u8]> + Send + Sync + Unpin + 'static;
 }
 
 impl<T> UniformRand for T

--- a/crates/mpz-fields/src/lib.rs
+++ b/crates/mpz-fields/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     ops::{Add, Mul, Neg},
 };
 
+use hybrid_array::ArraySize;
 use itybity::{BitLength, FromBitIterator, GetBit, Lsb0, Msb0};
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
@@ -35,9 +36,14 @@ pub trait Field:
     + GetBit<Lsb0>
     + GetBit<Msb0>
     + BitLength
+    + Unpin
+    + ByteRepr
 {
     /// The number of bits of a field element.
     const BIT_SIZE: u32;
+
+    /// The number of bits of a field element as a type number.
+    type BitSizeType: ArraySize;
 
     /// Return the additive identity element.
     fn zero() -> Self;
@@ -65,6 +71,14 @@ pub trait Field:
 pub trait UniformRand: Sized {
     /// Return a random field element.
     fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
+}
+
+/// The byte representation of the field.
+///
+/// This trait introduces an associated type for field elements to simplify usage.
+pub trait ByteRepr {
+    /// The underlying representation of the field element
+    type Serialized: AsRef<[u8]> + Send + Sync + Unpin + 'static;
 }
 
 impl<T> UniformRand for T

--- a/crates/mpz-fields/src/lib.rs
+++ b/crates/mpz-fields/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 use hybrid_array::ArraySize;
 use itybity::{BitLength, FromBitIterator, GetBit, Lsb0, Msb0};
 use rand::{distributions::Standard, prelude::Distribution, Rng};
+use typenum::Unsigned;
 
 /// A trait for finite fields.
 pub trait Field:
@@ -39,10 +40,10 @@ pub trait Field:
     + Unpin
 {
     /// The number of bits of a field element.
-    const BIT_SIZE: u32;
+    const BIT_SIZE: usize = <Self::BitSize as Unsigned>::USIZE;
 
     /// The number of bits of a field element as a type number.
-    type BitSizeType: ArraySize;
+    type BitSize: ArraySize;
 
     /// Return the additive identity element.
     fn zero() -> Self;
@@ -136,11 +137,11 @@ mod tests {
     }
 
     pub(crate) fn test_field_bit_ops<T: Field>() {
-        let mut a = vec![false; T::BIT_SIZE as usize];
-        let mut b = vec![false; T::BIT_SIZE as usize];
+        let mut a = vec![false; T::BIT_SIZE];
+        let mut b = vec![false; T::BIT_SIZE];
 
         a[0] = true;
-        b[T::BIT_SIZE as usize - 1] = true;
+        b[T::BIT_SIZE - 1] = true;
 
         let a = T::from_lsb0_iter(a);
         let b = T::from_lsb0_iter(b);
@@ -148,7 +149,7 @@ mod tests {
         assert_eq!(a, T::one());
         assert!(GetBit::<Lsb0>::get_bit(&a, 0));
 
-        assert_eq!(b, T::two_pow(T::BIT_SIZE - 1));
+        assert_eq!(b, T::two_pow(T::BIT_SIZE as u32 - 1));
         assert!(GetBit::<Lsb0>::get_bit(&b, (T::BIT_SIZE - 1) as usize));
     }
 }

--- a/crates/mpz-fields/src/p256.rs
+++ b/crates/mpz-fields/src/p256.rs
@@ -11,7 +11,7 @@ use rand::{distributions::Standard, prelude::Distribution};
 use serde::{Deserialize, Serialize};
 use typenum::U256;
 
-use crate::{ByteRepr, Field};
+use crate::Field;
 
 /// A type for holding field elements of P256.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,10 +78,6 @@ impl Neg for P256 {
     fn neg(self) -> Self::Output {
         Self(-self.0)
     }
-}
-
-impl ByteRepr for P256 {
-    type Serialized = [u8; 32];
 }
 
 impl Field for P256 {

--- a/crates/mpz-fields/src/p256.rs
+++ b/crates/mpz-fields/src/p256.rs
@@ -9,8 +9,9 @@ use itybity::{BitLength, FromBitIterator, GetBit, Lsb0, Msb0};
 use num_bigint::ToBigUint;
 use rand::{distributions::Standard, prelude::Distribution};
 use serde::{Deserialize, Serialize};
+use typenum::U256;
 
-use super::Field;
+use crate::{ByteRepr, Field};
 
 /// A type for holding field elements of P256.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,8 +80,13 @@ impl Neg for P256 {
     }
 }
 
+impl ByteRepr for P256 {
+    type Serialized = [u8; 32];
+}
+
 impl Field for P256 {
     const BIT_SIZE: u32 = 256;
+    type BitSizeType = U256;
 
     fn zero() -> Self {
         P256(<Fq as Zero>::zero())

--- a/crates/mpz-fields/src/p256.rs
+++ b/crates/mpz-fields/src/p256.rs
@@ -81,8 +81,7 @@ impl Neg for P256 {
 }
 
 impl Field for P256 {
-    const BIT_SIZE: u32 = 256;
-    type BitSizeType = U256;
+    type BitSize = U256;
 
     fn zero() -> Self {
         P256(<Fq as Zero>::zero())

--- a/crates/mpz-ole-core/Cargo.toml
+++ b/crates/mpz-ole-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mpz-ole-core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "mpz_ole_core"
+
+[dependencies]
+rand.workspace = true
+itybity.workspace = true
+thiserror.workspace = true
+
+mpz-fields.workspace = true
+mpz-core.workspace = true
+mpz-ot-core.workspace = true

--- a/crates/mpz-ole-core/Cargo.toml
+++ b/crates/mpz-ole-core/Cargo.toml
@@ -11,6 +11,7 @@ rand.workspace = true
 itybity.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }
+hybrid-array.workspace = true
 
 mpz-fields.workspace = true
 mpz-core.workspace = true

--- a/crates/mpz-ole-core/Cargo.toml
+++ b/crates/mpz-ole-core/Cargo.toml
@@ -10,6 +10,7 @@ name = "mpz_ole_core"
 rand.workspace = true
 itybity.workspace = true
 thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 mpz-fields.workspace = true
 mpz-core.workspace = true

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -34,7 +34,8 @@ pub struct MaskedInput<const N: usize, F>(pub(crate) [F; N]);
 /// The exchange field element for share adjustment.
 ///
 /// This needs to be sent to each other in order to complete the share adjustment.
-pub struct ShareAdjust<F>(F);
+#[derive(Debug)]
+pub struct ShareAdjust<F>(pub(crate) F);
 
 #[cfg(test)]
 mod tests {

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -8,28 +8,16 @@
 mod receiver;
 mod sender;
 
+use hybrid_array::Array;
 pub use receiver::{ReceiverAdjust, ReceiverShare};
 pub use sender::{SenderAdjust, SenderShare};
 
 use mpz_fields::Field;
 
-/// Workaround because of feature `generic_const_exprs` not available in stable.
-///
-/// This is used to check at compile-time that the correct const-generic implementation is used for
-/// a specific field.
-struct Check<const N: usize, F: Field>(std::marker::PhantomData<F>);
-
-impl<const N: usize, F: Field> Check<N, F> {
-    const IS_BITSIZE_CORRECT: () = assert!(
-        N as u32 == F::BIT_SIZE,
-        "Wrong bit size used for field. You need to use `F::BIT_SIZE` for N."
-    );
-}
-
 /// The masked input of the sender.
 ///
 /// This is the correlation which is sent to the receiver and hides the sender's input.
-pub struct MaskedInput<const N: usize, F>(pub(crate) [F; N]);
+pub struct MaskedInput<F: Field>(pub(crate) Array<F, F::BitSizeType>);
 
 /// The exchange field element for share adjustment.
 ///
@@ -74,7 +62,7 @@ mod tests {
         let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
 
         let (sender_shares, masked) =
-            SenderShare::new_vec::<256>(sender_input.clone(), ot_messages).unwrap();
+            SenderShare::new_vec(sender_input.clone(), ot_messages).unwrap();
         let receiver_shares =
             ReceiverShare::new_vec(receiver_input.clone(), ot_message_choices, masked).unwrap();
 

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -4,6 +4,7 @@
 //! - The `Initialize` stage is instantiated using random OT rather than chosen-input OT.
 //! - The `Extend` stage can only be called once, since our goal is to implement oblivious linear
 //!   function evaluation (OLE) rather than vector OLE (VOLE) (which means that we do not use PRGs).                                                  
+//! - The evaluated function is f(b)=a*b+x rather than f(b)=a*b-x.                                                  
 //!                                                                                       
 //! Note that this is an OLE with errors implementation. A malicious sender is allowed to set its own
 //! output and can introduce additive errors into the receiver's output.

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -20,7 +20,7 @@ use mpz_fields::Field;
 /// The masked correlation of the sender.
 ///
 /// This is the correlation which is sent to the receiver.
-pub struct MaskedCorrelation<F: Field>(pub(crate) Array<F, F::BitSizeType>);
+pub struct MaskedCorrelation<F: Field>(pub(crate) Array<F, F::BitSize>);
 
 /// The exchange field element for share adjustment.
 ///

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -88,7 +88,6 @@ mod tests {
         assert_eq!(y, a * b + x);
     }
 
-    // N should be BIT_SIZE of F
     fn create_ole(
         sender_input: P256,
         receiver_input: P256,

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -17,10 +17,10 @@ pub use sender::{SenderAdjust, SenderShare};
 
 use mpz_fields::Field;
 
-/// The masked input of the sender.
+/// The masked correlation of the sender.
 ///
-/// This is the correlation which is sent to the receiver and hides the sender's input.
-pub struct MaskedInput<F: Field>(pub(crate) Array<F, F::BitSizeType>);
+/// This is the correlation which is sent to the receiver.
+pub struct MaskedCorrelation<F: Field>(pub(crate) Array<F, F::BitSizeType>);
 
 /// The exchange field element for share adjustment.
 ///

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -4,13 +4,12 @@
 //! vector OLE (VOLE), which means that we do not use PRGs, i.e. Extend can only be called once.                                                  
 //!                                                                                       
 //! Note that this is an OLE with errors implementation. The sender can introduce additive errors.
-//! Input privacy is guaranteed, but output privacy is not, when `0` is chosen as an input value.
 
 mod receiver;
 mod sender;
 
-pub(crate) use receiver::{ReceiverAdjust, ReceiverShare};
-pub(crate) use sender::{SenderAdjust, SenderShare};
+pub use receiver::{ReceiverAdjust, ReceiverShare};
+pub use sender::{SenderAdjust, SenderShare};
 
 use mpz_fields::Field;
 
@@ -30,7 +29,7 @@ impl<const N: usize, F: Field> Check<N, F> {
 /// The masked input of the sender.
 ///
 /// This is the correlation which is sent to the receiver and hides the sender's input.
-pub struct MaskedInput<const N: usize, F>([F; N]);
+pub struct MaskedInput<const N: usize, F>(pub(crate) [F; N]);
 
 /// The exchange field element for share adjustment.
 ///
@@ -39,7 +38,7 @@ pub struct ShareAdjust<F>(F);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::core::{ReceiverShare, SenderShare};
     use crate::tests::create_rot;
     use mpz_core::{prg::Prg, Block};
     use mpz_fields::{p256::P256, UniformRand};
@@ -60,6 +59,30 @@ mod tests {
         let y = receiver_share.inner();
 
         assert_eq!(y, a * b + x);
+    }
+
+    #[test]
+    fn test_ole_core_vec() {
+        let count = 12;
+        let from_seed = Prg::from_seed(Block::ZERO);
+        let mut rng = from_seed;
+
+        let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
+
+        let (sender_shares, masked) =
+            SenderShare::new_vec::<256>(sender_input.clone(), ot_messages).unwrap();
+        let receiver_shares =
+            ReceiverShare::new_vec(receiver_input.clone(), ot_message_choices, masked).unwrap();
+
+        sender_input
+            .iter()
+            .zip(receiver_input)
+            .zip(sender_shares)
+            .zip(receiver_shares)
+            .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
     }
 
     #[test]

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -1,0 +1,113 @@
+//! This implementation uses the COPEe protocol from <https://eprint.iacr.org/2016/505> page 10.
+//!
+//! We use this construction to implement oblivious linear function evaluation (OLE) instead of
+//! vector OLE (VOLE), which means that we do not use PRGs, i.e. Extend can only be called once.                                                  
+//!                                                                                       
+//! Note that this is an OLE with errors implementation. The sender can introduce additive errors.
+//! Input privacy is guaranteed, but output privacy is not, when `0` is chosen as an input value.
+
+mod receiver;
+mod sender;
+
+pub(crate) use receiver::{ReceiverAdjust, ReceiverShare};
+pub(crate) use sender::{SenderAdjust, SenderShare};
+
+use mpz_fields::Field;
+
+/// Workaround because of feature `generic_const_exprs` not available in stable.
+///
+/// This is used to check at compile-time that the correct const-generic implementation is used for
+/// a specific field.
+struct Check<const N: usize, F: Field>(std::marker::PhantomData<F>);
+
+impl<const N: usize, F: Field> Check<N, F> {
+    const IS_BITSIZE_CORRECT: () = assert!(
+        N as u32 == F::BIT_SIZE,
+        "Wrong bit size used for field. You need to use `F::BIT_SIZE` for N."
+    );
+}
+
+/// The masked input of the sender.
+///
+/// This is the correlation which is sent to the receiver and hides the sender's input.
+pub struct MaskedInput<const N: usize, F>([F; N]);
+
+/// The exchange field element for share adjustment.
+///
+/// This needs to be sent to each other in order to complete the share adjustment.
+pub struct ShareAdjust<F>(F);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::create_rot;
+    use mpz_core::{prg::Prg, Block};
+    use mpz_fields::{p256::P256, Field, UniformRand};
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_ole_core() {
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        let sender_input = P256::rand(&mut rng);
+        let receiver_input = P256::rand(&mut rng);
+
+        let (sender_share, receiver_share) =
+            create_ole::<256, 32, P256>(sender_input, receiver_input);
+
+        let a = sender_input;
+        let b = receiver_input;
+        let x = sender_share.inner();
+        let y = receiver_share.inner();
+
+        assert_eq!(y, a * b + x);
+    }
+
+    #[test]
+    fn test_ole_adjust() {
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        let sender_input = P256::rand(&mut rng);
+        let receiver_input = P256::rand(&mut rng);
+
+        let sender_target = P256::rand(&mut rng);
+        let receiver_target = P256::rand(&mut rng);
+
+        let (sender_share, receiver_share) =
+            create_ole::<256, 32, P256>(sender_input, receiver_input);
+
+        let (sender_adjust, s_to_r_adjust) = sender_share.adjust(sender_target);
+        let (receiver_adjust, r_to_s_adjust) = receiver_share.adjust(receiver_target);
+
+        let sender_share_adjusted = sender_adjust.finish(r_to_s_adjust);
+        let receiver_share_adjusted = receiver_adjust.finish(s_to_r_adjust);
+
+        let a = sender_target;
+        let b = receiver_target;
+        let x = sender_share_adjusted.inner();
+        let y = receiver_share_adjusted.inner();
+
+        assert_eq!(y, a * b + x);
+    }
+
+    // Unergonomic API because of lack of proper const generic support
+    // N should be BIT_SIZE of F
+    // K should be BYTE_SIZE of F
+    fn create_ole<const N: usize, const K: usize, F: Field>(
+        sender_input: F,
+        receiver_input: F,
+    ) -> (SenderShare<F>, ReceiverShare<F>) {
+        let receiver_input_vec = vec![receiver_input];
+
+        let (ot_messages, ot_message_choices) = create_rot::<K, F>(receiver_input_vec);
+
+        let ot_messages: [[F; 2]; N] = ot_messages.try_into().unwrap();
+        let ot_message_choices: [F; N] = ot_message_choices.try_into().unwrap();
+        let ot_choice = receiver_input;
+
+        let (sender_share, correlation) = SenderShare::new(sender_input, ot_messages);
+        let receiver_share = ReceiverShare::new(ot_choice, ot_message_choices, correlation);
+
+        (sender_share, receiver_share)
+    }
+}

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -1,9 +1,12 @@
-//! This implementation uses the COPEe protocol from <https://eprint.iacr.org/2016/505> page 10.
+//! This implementation is based on the COPEe protocol from <https://eprint.iacr.org/2016/505> page 10
+//! with the following modification:
 //!
-//! We use this construction to implement oblivious linear function evaluation (OLE) instead of
-//! vector OLE (VOLE), which means that we do not use PRGs, i.e. Extend can only be called once.                                                  
+//! - The `Initialize` stage is instantiated using random OT rather than chosen-input OT.
+//! - The `Extend` stage can only be called once, since our goal is to implement oblivious linear
+//!   function evaluation (OLE) rather than vector OLE (VOLE) (which means that we do not use PRGs).                                                  
 //!                                                                                       
-//! Note that this is an OLE with errors implementation. The sender can introduce additive errors.
+//! Note that this is an OLE with errors implementation. A malicious sender is allowed to set its own
+//! output and can introduce additive errors into the receiver's output.
 
 mod receiver;
 mod sender;

--- a/crates/mpz-ole-core/src/core/mod.rs
+++ b/crates/mpz-ole-core/src/core/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use crate::tests::create_rot;
     use mpz_core::{prg::Prg, Block};
-    use mpz_fields::{p256::P256, Field, UniformRand};
+    use mpz_fields::{p256::P256, UniformRand};
     use rand::SeedableRng;
 
     #[test]
@@ -52,8 +52,7 @@ mod tests {
         let sender_input = P256::rand(&mut rng);
         let receiver_input = P256::rand(&mut rng);
 
-        let (sender_share, receiver_share) =
-            create_ole::<256, 32, P256>(sender_input, receiver_input);
+        let (sender_share, receiver_share) = create_ole(sender_input, receiver_input);
 
         let a = sender_input;
         let b = receiver_input;
@@ -73,8 +72,7 @@ mod tests {
         let sender_target = P256::rand(&mut rng);
         let receiver_target = P256::rand(&mut rng);
 
-        let (sender_share, receiver_share) =
-            create_ole::<256, 32, P256>(sender_input, receiver_input);
+        let (sender_share, receiver_share) = create_ole(sender_input, receiver_input);
 
         let (sender_adjust, s_to_r_adjust) = sender_share.adjust(sender_target);
         let (receiver_adjust, r_to_s_adjust) = receiver_share.adjust(receiver_target);
@@ -90,19 +88,17 @@ mod tests {
         assert_eq!(y, a * b + x);
     }
 
-    // Unergonomic API because of lack of proper const generic support
     // N should be BIT_SIZE of F
-    // K should be BYTE_SIZE of F
-    fn create_ole<const N: usize, const K: usize, F: Field>(
-        sender_input: F,
-        receiver_input: F,
-    ) -> (SenderShare<F>, ReceiverShare<F>) {
+    fn create_ole(
+        sender_input: P256,
+        receiver_input: P256,
+    ) -> (SenderShare<P256>, ReceiverShare<P256>) {
         let receiver_input_vec = vec![receiver_input];
 
-        let (ot_messages, ot_message_choices) = create_rot::<K, F>(receiver_input_vec);
+        let (ot_messages, ot_message_choices) = create_rot(receiver_input_vec);
 
-        let ot_messages: [[F; 2]; N] = ot_messages.try_into().unwrap();
-        let ot_message_choices: [F; N] = ot_message_choices.try_into().unwrap();
+        let ot_messages: [[P256; 2]; 256] = ot_messages.try_into().unwrap();
+        let ot_message_choices: [P256; 256] = ot_message_choices.try_into().unwrap();
         let ot_choice = receiver_input;
 
         let (sender_share, correlation) = SenderShare::new(sender_input, ot_messages);

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -1,7 +1,7 @@
 //! Receiver shares for Oblivious Linear Function Evaluation (OLE).
 
 use crate::{
-    core::{MaskedInput, ShareAdjust},
+    core::{MaskedCorrelation, ShareAdjust},
     OLEError,
 };
 use hybrid_array::Array;
@@ -22,7 +22,7 @@ impl<F: Field> ReceiverShare<F> {
     ///
     /// * `input` - The receiver's input share.
     /// * `random` - Uniformly random field elements.
-    /// * `masked` - The correlation masking the sender's input.
+    /// * `masked` - The correlation from the sender.
     ///
     /// # Returns
     ///
@@ -30,7 +30,7 @@ impl<F: Field> ReceiverShare<F> {
     pub(crate) fn new(
         input: F,
         random: impl Into<Array<F, F::BitSizeType>>,
-        masked: MaskedInput<F>,
+        masked: MaskedCorrelation<F>,
     ) -> Self {
         let random = random.into();
 
@@ -63,7 +63,7 @@ impl<F: Field> ReceiverShare<F> {
     pub fn new_vec(
         input: Vec<F>,
         random: Vec<F>,
-        masked: Vec<MaskedInput<F>>,
+        masked: Vec<MaskedCorrelation<F>>,
     ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
         if input.len() * F::BIT_SIZE as usize != random.len() {
             return Err(OLEError::ExpectedMultipleOf(

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -1,0 +1,92 @@
+//! Receiver shares for Oblivious Linear Function Evaluation (OLE).
+
+use super::{Check, MaskedInput, ShareAdjust};
+use itybity::ToBits;
+use mpz_fields::Field;
+
+/// Receiver share for OLE.
+#[derive(Debug)]
+pub struct ReceiverShare<F> {
+    input: F,
+    output: F,
+}
+
+impl<F: Field> ReceiverShare<F> {
+    /// Creates a new [`ReceiverShare`].
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The receiver's input share. This is his OT choice bits as a field element.
+    /// * `ot_message_choices` - The receiver's OT message choices as field elements.
+    /// * `masked` - The correlation masking the sender's input.
+    ///
+    /// # Returns
+    ///
+    /// * The receiver's share.
+    pub(crate) fn new<const N: usize>(
+        input: F,
+        ot_message_choices: [F; N],
+        masked: MaskedInput<N, F>,
+    ) -> Self {
+        // Check that the right N is used depending on the needed bit size of the field.
+        let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
+
+        let delta_i = input.iter_lsb0();
+        let ui = masked.0.iter();
+        let t_delta_i = ot_message_choices.iter();
+
+        let output = delta_i.zip(ui).zip(t_delta_i).enumerate().fold(
+            F::zero(),
+            |acc, (i, ((delta, &u), &t))| {
+                let delta = if delta { F::one() } else { F::zero() };
+                acc + F::two_pow(i as u32) * (delta * u + t)
+            },
+        );
+
+        Self { input, output }
+    }
+
+    /// Returns the receiver's output share.
+    pub fn inner(self) -> F {
+        self.output
+    }
+
+    /// Adjust a preprocessed share.
+    ///
+    /// This is an implementation of <https://crypto.stackexchange.com/questions/100634/converting-a-random-ole-oblivious-linear-function-evaluation-to-an-ole>.
+    ///
+    /// # Arguments
+    ///
+    ///  * `target` - The new target input of the OLE.
+    ///
+    /// # Returns
+    ///
+    /// * The intermediate receiver share, which needs the sender's adjustment.
+    /// * The receiver adjustment which needs to be sent to the sender.
+    pub(crate) fn adjust(self, target: F) -> (ReceiverAdjust<F>, ShareAdjust<F>) {
+        (
+            ReceiverAdjust {
+                old_output: self.output,
+                new_input: target,
+            },
+            ShareAdjust(self.input + target),
+        )
+    }
+}
+
+/// Intermediate type for share adjustment of the receiver.
+#[derive(Debug)]
+pub struct ReceiverAdjust<F> {
+    old_output: F,
+    new_input: F,
+}
+
+impl<F: Field> ReceiverAdjust<F> {
+    /// Finishes the adjustment and returns the adjusted receiver's share.
+    pub(crate) fn finish(self, adjust: ShareAdjust<F>) -> ReceiverShare<F> {
+        ReceiverShare {
+            input: self.new_input,
+            output: self.old_output + self.new_input * adjust.0,
+        }
+    }
+}

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -1,6 +1,9 @@
 //! Receiver shares for Oblivious Linear Function Evaluation (OLE).
 
-use super::{Check, MaskedInput, ShareAdjust};
+use crate::{
+    core::{Check, MaskedInput, ShareAdjust},
+    OLEError,
+};
 use itybity::ToBits;
 use mpz_fields::Field;
 
@@ -16,24 +19,20 @@ impl<F: Field> ReceiverShare<F> {
     ///
     /// # Arguments
     ///
-    /// * `input` - The receiver's input share. This is his OT choice bits as a field element.
-    /// * `ot_message_choices` - The receiver's OT message choices as field elements.
+    /// * `input` - The receiver's input share.
+    /// * `random` - Uniformly random field elements.
     /// * `masked` - The correlation masking the sender's input.
     ///
     /// # Returns
     ///
     /// * The receiver's share.
-    pub(crate) fn new<const N: usize>(
-        input: F,
-        ot_message_choices: [F; N],
-        masked: MaskedInput<N, F>,
-    ) -> Self {
+    pub(crate) fn new<const N: usize>(input: F, random: [F; N], masked: MaskedInput<N, F>) -> Self {
         // Check that the right N is used depending on the needed bit size of the field.
         let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
 
         let delta_i = input.iter_lsb0();
         let ui = masked.0.iter();
-        let t_delta_i = ot_message_choices.iter();
+        let t_delta_i = random.iter();
 
         let output = delta_i.zip(ui).zip(t_delta_i).enumerate().fold(
             F::zero(),
@@ -44,6 +43,51 @@ impl<F: Field> ReceiverShare<F> {
         );
 
         Self { input, output }
+    }
+
+    /// Generates a vector of new [`ReceiverShare`]s.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The receiver's input share.
+    /// * `random` - Uniformly random field elements.
+    /// * `masked` - The correlations from the sender.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
+    pub fn new_vec<const N: usize>(
+        input: Vec<F>,
+        random: Vec<F>,
+        masked: Vec<MaskedInput<N, F>>,
+    ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        if input.len() * F::BIT_SIZE as usize != random.len() {
+            return Err(OLEError::ExpectedMultipleOf(
+                input.len() * F::BIT_SIZE as usize,
+                random.len(),
+            ));
+        }
+
+        if input.len() != masked.len() {
+            return Err(OLEError::WrongNumberOfMasks(masked.len(), input.len()));
+        }
+
+        let shares: Vec<ReceiverShare<F>> = input
+            .iter()
+            .zip(random.chunks_exact(F::BIT_SIZE as usize))
+            .zip(masked)
+            .map(|((&f, chunk), m)| {
+                ReceiverShare::new::<N>(
+                    f,
+                    chunk
+                        .try_into()
+                        .expect("Slice should have length of bit size of field element"),
+                    m,
+                )
+            })
+            .collect();
+
+        Ok(shares)
     }
 
     /// Returns the receiver's output share.

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -98,7 +98,7 @@ impl<F: Field> ReceiverShare<F> {
         self.output
     }
 
-    /// Adjust a preprocessed share.
+    /// Adjusts a preprocessed share.
     ///
     /// This is an implementation of <https://crypto.stackexchange.com/questions/100634/converting-a-random-ole-oblivious-linear-function-evaluation-to-an-ole>.
     ///

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -1,9 +1,10 @@
 //! Receiver shares for Oblivious Linear Function Evaluation (OLE).
 
 use crate::{
-    core::{Check, MaskedInput, ShareAdjust},
+    core::{MaskedInput, ShareAdjust},
     OLEError,
 };
+use hybrid_array::Array;
 use itybity::ToBits;
 use mpz_fields::Field;
 
@@ -26,9 +27,12 @@ impl<F: Field> ReceiverShare<F> {
     /// # Returns
     ///
     /// * The receiver's share.
-    pub(crate) fn new<const N: usize>(input: F, random: [F; N], masked: MaskedInput<N, F>) -> Self {
-        // Check that the right N is used depending on the needed bit size of the field.
-        let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
+    pub(crate) fn new(
+        input: F,
+        random: impl Into<Array<F, F::BitSizeType>>,
+        masked: MaskedInput<F>,
+    ) -> Self {
+        let random = random.into();
 
         let delta_i = input.iter_lsb0();
         let ui = masked.0.iter();
@@ -56,10 +60,10 @@ impl<F: Field> ReceiverShare<F> {
     /// # Returns
     ///
     /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
-    pub fn new_vec<const N: usize>(
+    pub fn new_vec(
         input: Vec<F>,
         random: Vec<F>,
-        masked: Vec<MaskedInput<N, F>>,
+        masked: Vec<MaskedInput<F>>,
     ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
         if input.len() * F::BIT_SIZE as usize != random.len() {
             return Err(OLEError::ExpectedMultipleOf(
@@ -77,10 +81,9 @@ impl<F: Field> ReceiverShare<F> {
             .zip(random.chunks_exact(F::BIT_SIZE as usize))
             .zip(masked)
             .map(|((&f, chunk), m)| {
-                ReceiverShare::new::<N>(
+                ReceiverShare::new(
                     f,
-                    chunk
-                        .try_into()
+                    Array::<F, F::BitSizeType>::try_from(chunk)
                         .expect("Slice should have length of bit size of field element"),
                     m,
                 )

--- a/crates/mpz-ole-core/src/core/receiver.rs
+++ b/crates/mpz-ole-core/src/core/receiver.rs
@@ -29,7 +29,7 @@ impl<F: Field> ReceiverShare<F> {
     /// * The receiver's share.
     pub(crate) fn new(
         input: F,
-        random: impl Into<Array<F, F::BitSizeType>>,
+        random: impl Into<Array<F, F::BitSize>>,
         masked: MaskedCorrelation<F>,
     ) -> Self {
         let random = random.into();
@@ -65,9 +65,9 @@ impl<F: Field> ReceiverShare<F> {
         random: Vec<F>,
         masked: Vec<MaskedCorrelation<F>>,
     ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
-        if input.len() * F::BIT_SIZE as usize != random.len() {
+        if input.len() * F::BIT_SIZE != random.len() {
             return Err(OLEError::ExpectedMultipleOf(
-                input.len() * F::BIT_SIZE as usize,
+                input.len() * F::BIT_SIZE,
                 random.len(),
             ));
         }
@@ -78,12 +78,12 @@ impl<F: Field> ReceiverShare<F> {
 
         let shares: Vec<ReceiverShare<F>> = input
             .iter()
-            .zip(random.chunks_exact(F::BIT_SIZE as usize))
+            .zip(random.chunks_exact(F::BIT_SIZE))
             .zip(masked)
             .map(|((&f, chunk), m)| {
                 ReceiverShare::new(
                     f,
-                    Array::<F, F::BitSizeType>::try_from(chunk)
+                    Array::<F, F::BitSize>::try_from(chunk)
                         .expect("Slice should have length of bit size of field element"),
                     m,
                 )

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -94,7 +94,7 @@ impl<F: Field> SenderShare<F> {
         self.output
     }
 
-    /// Adjust a preprocessed share.
+    /// Adjusts a preprocessed share.
     ///
     /// This is an implementation of <https://crypto.stackexchange.com/questions/100634/converting-a-random-ole-oblivious-linear-function-evaluation-to-an-ole>.
     ///

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -1,7 +1,7 @@
 //! Sender shares for Oblivious Linear Function Evaluation (OLE).
 
 use crate::{
-    core::{MaskedInput, ShareAdjust},
+    core::{MaskedCorrelation, ShareAdjust},
     OLEError,
 };
 use hybrid_array::Array;
@@ -29,7 +29,7 @@ impl<F: Field> SenderShare<F> {
     pub(crate) fn new(
         input: F,
         random: impl Into<Array<[F; 2], F::BitSizeType>>,
-    ) -> (Self, MaskedInput<F>) {
+    ) -> (Self, MaskedCorrelation<F>) {
         let random = random.into();
 
         let output = random
@@ -46,7 +46,7 @@ impl<F: Field> SenderShare<F> {
             .iter_mut()
             .zip(random)
             .for_each(|(u, [zero, one])| *u = zero + -one + input);
-        let masked = MaskedInput(ui);
+        let masked = MaskedCorrelation(ui);
 
         (share, masked)
     }
@@ -66,7 +66,7 @@ impl<F: Field> SenderShare<F> {
     pub fn new_vec(
         input: Vec<F>,
         random: Vec<[F; 2]>,
-    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<F>>), OLEError> {
+    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedCorrelation<F>>), OLEError> {
         if input.len() * F::BIT_SIZE as usize != random.len() {
             return Err(OLEError::ExpectedMultipleOf(
                 input.len() * F::BIT_SIZE as usize,
@@ -74,7 +74,7 @@ impl<F: Field> SenderShare<F> {
             ));
         }
 
-        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<F>>) = input
+        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedCorrelation<F>>) = input
             .iter()
             .zip(random.chunks_exact(F::BIT_SIZE as usize))
             .map(|(&f, chunk)| {

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -1,6 +1,9 @@
 //! Sender shares for Oblivious Linear Function Evaluation (OLE).
 
-use super::{Check, MaskedInput, ShareAdjust};
+use crate::{
+    core::{Check, MaskedInput, ShareAdjust},
+    OLEError,
+};
 use mpz_fields::Field;
 
 /// Sender share for OLE.
@@ -16,20 +19,17 @@ impl<F: Field> SenderShare<F> {
     /// # Arguments
     ///
     /// * `input` - The sender's input share.
-    /// * `ot_messages` - OT messages needed for the correlation.
+    /// * `random` - Uniformly random field elements for the correlation.
     ///
     /// # Returns
     ///
     /// * The sender's share.
     /// * The correlation which will be sent to the receiver.
-    pub(crate) fn new<const N: usize>(
-        input: F,
-        ot_messages: [[F; 2]; N],
-    ) -> (Self, MaskedInput<N, F>) {
+    pub(crate) fn new<const N: usize>(input: F, random: [[F; 2]; N]) -> (Self, MaskedInput<N, F>) {
         // Check that the right N is used depending on the needed bit size of the field.
         let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
 
-        let output = ot_messages
+        let output = random
             .iter()
             .enumerate()
             .fold(F::zero(), |acc, (i, &[zero, _])| {
@@ -39,11 +39,49 @@ impl<F: Field> SenderShare<F> {
 
         let mut ui = [F::zero(); N];
         ui.iter_mut()
-            .zip(ot_messages)
+            .zip(random)
             .for_each(|(u, [zero, one])| *u = zero + -one + input);
         let masked = MaskedInput(ui);
 
         (share, masked)
+    }
+
+    /// Generates a vector of new [`SenderShare`]s.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The sender's input share.
+    /// * `random` - Uniformly random field elements for the correlation.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of sender shares.
+    /// * A vector of correlations, which are to be sent to the receiver.
+    pub fn new_vec<const N: usize>(
+        input: Vec<F>,
+        random: Vec<[F; 2]>,
+    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>), OLEError> {
+        if input.len() * F::BIT_SIZE as usize != random.len() {
+            return Err(OLEError::ExpectedMultipleOf(
+                input.len() * F::BIT_SIZE as usize,
+                random.len(),
+            ));
+        }
+
+        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>) = input
+            .iter()
+            .zip(random.chunks_exact(F::BIT_SIZE as usize))
+            .map(|(&f, chunk)| {
+                SenderShare::new::<N>(
+                    f,
+                    chunk
+                        .try_into()
+                        .expect("Slice should have length of bit size of field element"),
+                )
+            })
+            .unzip();
+
+        Ok((shares, masked))
     }
 
     /// Returns the sender's output share.

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -28,7 +28,7 @@ impl<F: Field> SenderShare<F> {
     /// * The correlation which will be sent to the receiver.
     pub(crate) fn new(
         input: F,
-        random: impl Into<Array<[F; 2], F::BitSizeType>>,
+        random: impl Into<Array<[F; 2], F::BitSize>>,
     ) -> (Self, MaskedCorrelation<F>) {
         let random = random.into();
 
@@ -41,7 +41,7 @@ impl<F: Field> SenderShare<F> {
             });
         let share = Self { input, output };
 
-        let ui: Array<F, F::BitSizeType> = Array::from_fn(|i| {
+        let ui: Array<F, F::BitSize> = Array::from_fn(|i| {
             let [zero, one] = random[i];
             zero + -one + input
         });
@@ -66,20 +66,20 @@ impl<F: Field> SenderShare<F> {
         input: Vec<F>,
         random: Vec<[F; 2]>,
     ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedCorrelation<F>>), OLEError> {
-        if input.len() * F::BIT_SIZE as usize != random.len() {
+        if input.len() * F::BIT_SIZE != random.len() {
             return Err(OLEError::ExpectedMultipleOf(
-                input.len() * F::BIT_SIZE as usize,
+                input.len() * F::BIT_SIZE,
                 random.len(),
             ));
         }
 
         let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedCorrelation<F>>) = input
             .iter()
-            .zip(random.chunks_exact(F::BIT_SIZE as usize))
+            .zip(random.chunks_exact(F::BIT_SIZE))
             .map(|(&f, chunk)| {
                 SenderShare::new(
                     f,
-                    Array::<[F; 2], F::BitSizeType>::try_from(chunk)
+                    Array::<[F; 2], F::BitSize>::try_from(chunk)
                         .expect("Slice should have length of bit size of field element"),
                 )
             })

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -1,0 +1,94 @@
+//! Sender shares for Oblivious Linear Function Evaluation (OLE).
+
+use super::{Check, MaskedInput, ShareAdjust};
+use mpz_fields::Field;
+
+/// Sender share for OLE.
+#[derive(Debug)]
+pub struct SenderShare<F> {
+    input: F,
+    output: F,
+}
+
+impl<F: Field> SenderShare<F> {
+    /// Creates a new [`SenderShare`].
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The sender's input share.
+    /// * `ot_messages` - OT messages needed for the correlation.
+    ///
+    /// # Returns
+    ///
+    /// * The sender's share.
+    /// * The correlation which will be sent to the receiver.
+    pub(crate) fn new<const N: usize>(
+        input: F,
+        ot_messages: [[F; 2]; N],
+    ) -> (Self, MaskedInput<N, F>) {
+        // Check that the right N is used depending on the needed bit size of the field.
+        let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
+
+        let output = ot_messages
+            .iter()
+            .enumerate()
+            .fold(F::zero(), |acc, (i, &[zero, _])| {
+                acc + F::two_pow(i as u32) * zero
+            });
+        let share = Self { input, output };
+
+        let mut ui = [F::zero(); N];
+        ui.iter_mut()
+            .zip(ot_messages)
+            .for_each(|(u, [zero, one])| *u = zero + -one + input);
+        let masked = MaskedInput(ui);
+
+        (share, masked)
+    }
+
+    /// Returns the sender's output share.
+    pub fn inner(self) -> F {
+        self.output
+    }
+
+    /// Adjust a preprocessed share.
+    ///
+    /// This is an implementation of <https://crypto.stackexchange.com/questions/100634/converting-a-random-ole-oblivious-linear-function-evaluation-to-an-ole>.
+    ///
+    /// # Arguments
+    ///
+    ///  * `target` - The new target input for the OLE.
+    ///
+    /// # Returns
+    ///
+    /// * The intermediate sender share, which needs the receiver's adjustment.
+    /// * The sender adjustment which needs to be sent to the receiver.
+    pub(crate) fn adjust(self, target: F) -> (SenderAdjust<F>, ShareAdjust<F>) {
+        (
+            SenderAdjust {
+                old_input: self.input,
+                old_output: self.output,
+                new_input: target,
+            },
+            ShareAdjust(self.input + target),
+        )
+    }
+}
+
+/// Intermediate type for share adjustment of the sender.
+#[derive(Debug)]
+pub struct SenderAdjust<F> {
+    old_input: F,
+    old_output: F,
+    new_input: F,
+}
+
+impl<F: Field> SenderAdjust<F> {
+    /// Finishes the adjustment and returns the adjusted sender's share.
+    pub(crate) fn finish(self, adjust: ShareAdjust<F>) -> SenderShare<F> {
+        SenderShare {
+            input: self.new_input,
+            output: self.old_output + self.old_input * adjust.0,
+        }
+    }
+}

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -41,11 +41,10 @@ impl<F: Field> SenderShare<F> {
             });
         let share = Self { input, output };
 
-        let mut ui: Array<F, F::BitSizeType> = Array::from_fn(|_| F::zero());
-        ui.as_mut_slice()
-            .iter_mut()
-            .zip(random)
-            .for_each(|(u, [zero, one])| *u = zero + -one + input);
+        let ui: Array<F, F::BitSizeType> = Array::from_fn(|i| {
+            let [zero, one] = random[i];
+            zero + -one + input
+        });
         let masked = MaskedCorrelation(ui);
 
         (share, masked)

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -57,6 +57,7 @@ impl<F: Field> SenderShare<F> {
     ///
     /// * A vector of sender shares.
     /// * A vector of correlations, which are to be sent to the receiver.
+    #[allow(clippy::type_complexity)]
     pub fn new_vec<const N: usize>(
         input: Vec<F>,
         random: Vec<[F; 2]>,

--- a/crates/mpz-ole-core/src/core/sender.rs
+++ b/crates/mpz-ole-core/src/core/sender.rs
@@ -1,9 +1,10 @@
 //! Sender shares for Oblivious Linear Function Evaluation (OLE).
 
 use crate::{
-    core::{Check, MaskedInput, ShareAdjust},
+    core::{MaskedInput, ShareAdjust},
     OLEError,
 };
+use hybrid_array::Array;
 use mpz_fields::Field;
 
 /// Sender share for OLE.
@@ -25,11 +26,14 @@ impl<F: Field> SenderShare<F> {
     ///
     /// * The sender's share.
     /// * The correlation which will be sent to the receiver.
-    pub(crate) fn new<const N: usize>(input: F, random: [[F; 2]; N]) -> (Self, MaskedInput<N, F>) {
-        // Check that the right N is used depending on the needed bit size of the field.
-        let _: () = Check::<N, F>::IS_BITSIZE_CORRECT;
+    pub(crate) fn new(
+        input: F,
+        random: impl Into<Array<[F; 2], F::BitSizeType>>,
+    ) -> (Self, MaskedInput<F>) {
+        let random = random.into();
 
         let output = random
+            .as_slice()
             .iter()
             .enumerate()
             .fold(F::zero(), |acc, (i, &[zero, _])| {
@@ -37,8 +41,9 @@ impl<F: Field> SenderShare<F> {
             });
         let share = Self { input, output };
 
-        let mut ui = [F::zero(); N];
-        ui.iter_mut()
+        let mut ui: Array<F, F::BitSizeType> = Array::from_fn(|_| F::zero());
+        ui.as_mut_slice()
+            .iter_mut()
             .zip(random)
             .for_each(|(u, [zero, one])| *u = zero + -one + input);
         let masked = MaskedInput(ui);
@@ -58,10 +63,10 @@ impl<F: Field> SenderShare<F> {
     /// * A vector of sender shares.
     /// * A vector of correlations, which are to be sent to the receiver.
     #[allow(clippy::type_complexity)]
-    pub fn new_vec<const N: usize>(
+    pub fn new_vec(
         input: Vec<F>,
         random: Vec<[F; 2]>,
-    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>), OLEError> {
+    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<F>>), OLEError> {
         if input.len() * F::BIT_SIZE as usize != random.len() {
             return Err(OLEError::ExpectedMultipleOf(
                 input.len() * F::BIT_SIZE as usize,
@@ -69,14 +74,13 @@ impl<F: Field> SenderShare<F> {
             ));
         }
 
-        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>) = input
+        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<F>>) = input
             .iter()
             .zip(random.chunks_exact(F::BIT_SIZE as usize))
             .map(|(&f, chunk)| {
-                SenderShare::new::<N>(
+                SenderShare::new(
                     f,
-                    chunk
-                        .try_into()
+                    Array::<[F; 2], F::BitSizeType>::try_from(chunk)
                         .expect("Slice should have length of bit size of field element"),
                 )
             })

--- a/crates/mpz-ole-core/src/ideal.rs
+++ b/crates/mpz-ole-core/src/ideal.rs
@@ -28,14 +28,14 @@ impl IdealOLE {
             .map(|_| F::rand(&mut self.0))
             .collect();
 
-        let reciever_output: Vec<F> = sender_input
+        let receiver_output: Vec<F> = sender_input
             .iter()
             .zip(receiver_input)
             .zip(sender_output.iter().copied())
             .map(|((&a, &b), x)| a * b + x)
             .collect();
 
-        (sender_output, reciever_output)
+        (sender_output, receiver_output)
     }
 }
 
@@ -47,7 +47,7 @@ impl Default for IdealOLE {
 
 #[cfg(test)]
 mod tests {
-    use super::IdealOLE;
+    use crate::ideal::IdealOLE;
     use mpz_core::{prg::Prg, Block};
     use mpz_fields::{p256::P256, UniformRand};
     use rand::SeedableRng;

--- a/crates/mpz-ole-core/src/ideal.rs
+++ b/crates/mpz-ole-core/src/ideal.rs
@@ -3,7 +3,7 @@
 use mpz_fields::Field;
 use rand::{rngs::ThreadRng, thread_rng};
 
-/// The OLE functionality
+/// The OLE functionality.
 pub struct IdealOLE(ThreadRng);
 
 impl IdealOLE {

--- a/crates/mpz-ole-core/src/ideal.rs
+++ b/crates/mpz-ole-core/src/ideal.rs
@@ -1,0 +1,72 @@
+//! Ideal functionality for Oblivious Linear Function Evaluation (OLE).
+
+use mpz_fields::Field;
+use rand::{rngs::ThreadRng, thread_rng};
+
+/// The OLE functionality
+pub struct IdealOLE(ThreadRng);
+
+impl IdealOLE {
+    /// Creates a new functionality.
+    pub fn new() -> Self {
+        Self(thread_rng())
+    }
+
+    /// Generates OLEs.
+    pub fn generate<F: Field>(
+        &mut self,
+        sender_input: &[F],
+        receiver_input: &[F],
+    ) -> (Vec<F>, Vec<F>) {
+        assert_eq!(
+            sender_input.len(),
+            receiver_input.len(),
+            "Vectors of field elements should have equal length."
+        );
+
+        let sender_output: Vec<F> = (0..sender_input.len())
+            .map(|_| F::rand(&mut self.0))
+            .collect();
+
+        let reciever_output: Vec<F> = sender_input
+            .iter()
+            .zip(receiver_input)
+            .zip(sender_output.iter().copied())
+            .map(|((&a, &b), x)| a * b + x)
+            .collect();
+
+        (sender_output, reciever_output)
+    }
+}
+
+impl Default for IdealOLE {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IdealOLE;
+    use mpz_core::{prg::Prg, Block};
+    use mpz_fields::{p256::P256, UniformRand};
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_ole_functionality() {
+        let count = 12;
+        let mut ole = IdealOLE::default();
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        let ak: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let bk: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (xk, yk) = ole.generate(&ak, &bk);
+
+        yk.iter()
+            .zip(xk)
+            .zip(ak)
+            .zip(bk)
+            .for_each(|(((&y, x), a), b)| assert_eq!(y, a * b + x));
+    }
+}

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -71,10 +71,8 @@ mod tests {
         let from_seed = Prg::from_seed(Block::ZERO);
         let mut rng = from_seed;
 
-        let (mut sender, mut receiver) = (
-            OLESender::<256, P256>::default(),
-            OLEReceiver::<256, P256>::default(),
-        );
+        let (mut sender, mut receiver) =
+            (OLESender::<P256>::default(), OLEReceiver::<P256>::default());
 
         let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
         let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
@@ -105,10 +103,8 @@ mod tests {
         let from_seed = Prg::from_seed(Block::ZERO);
         let mut rng = from_seed;
 
-        let (mut sender, mut receiver) = (
-            OLESender::<256, P256>::default(),
-            OLEReceiver::<256, P256>::default(),
-        );
+        let (mut sender, mut receiver) =
+            (OLESender::<P256>::default(), OLEReceiver::<P256>::default());
 
         let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
         let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -15,6 +15,30 @@ mod sender;
 
 pub use receiver::OLEReceiver;
 pub use sender::OLESender;
+use serde::{Deserialize, Serialize};
+
+/// An OLE transfer identifier.
+///
+/// Multiple transfers may be batched together under the same transfer ID.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct TransferId(u64);
+
+impl std::fmt::Display for TransferId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransferId({})", self.0)
+    }
+}
+
+impl TransferId {
+    /// Returns the current transfer ID, incrementing `self` in-place.
+    pub(crate) fn next(&mut self) -> Self {
+        let id = *self;
+        self.0 += 1;
+        id
+    }
+}
 
 /// An error for OLE
 #[allow(missing_docs)]

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
     use crate::{OLEReceiver, OLESender};
     use itybity::ToBits;
     use mpz_core::{prg::Prg, Block};
-    use mpz_fields::{p256::P256, Field, UniformRand};
+    use mpz_fields::{p256::P256, UniformRand};
     use mpz_ot_core::ideal::rot::IdealROT;
     use rand::SeedableRng;
 
@@ -52,7 +52,7 @@ mod tests {
         let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
         let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
 
-        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+        let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
 
         let (sender_shares, masked) = sender.generate(sender_input.clone(), ot_messages).unwrap();
         let receiver_shares = receiver
@@ -81,7 +81,7 @@ mod tests {
         let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
         let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
 
-        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+        let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
 
         let masked = sender
             .preprocess(sender_input.clone(), ot_messages)
@@ -115,7 +115,7 @@ mod tests {
         let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
         let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
 
-        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+        let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
 
         let masked = sender
             .preprocess(sender_input.clone(), ot_messages)
@@ -143,36 +143,13 @@ mod tests {
             .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
     }
 
-    // K should be BYTE_SIZE of F
-    pub(crate) fn create_rot<const K: usize, F: Field>(
-        receiver_choices: Vec<F>,
-    ) -> (Vec<[F; 2]>, Vec<F>) {
-        assert_eq!(
-            K,
-            F::BIT_SIZE as usize / 8,
-            "K has to be equal to the byte size of the field"
-        );
-
+    pub(crate) fn create_rot(receiver_choices: Vec<P256>) -> (Vec<[P256; 2]>, Vec<P256>) {
         let mut rot = IdealROT::default();
         let receiver_choices: Vec<bool> = receiver_choices.iter_lsb0().collect();
-        let (rot_sender, rot_receiver) = rot.random_with_choices::<K>(receiver_choices);
+        let (rot_sender, rot_receiver) = rot.random_with_choices::<P256>(receiver_choices);
 
-        let ot_messages: Vec<[F; 2]> = rot_sender
-            .msgs
-            .iter()
-            .map(|[a, b]| {
-                [
-                    F::from_lsb0_iter(a.iter_lsb0()),
-                    F::from_lsb0_iter(b.iter_lsb0()),
-                ]
-            })
-            .collect();
-
-        let ot_message_choices: Vec<F> = rot_receiver
-            .msgs
-            .iter()
-            .map(|bytes| F::from_lsb0_iter(bytes.iter_lsb0()))
-            .collect();
+        let ot_messages: Vec<[P256; 2]> = rot_sender.msgs;
+        let ot_message_choices: Vec<P256> = rot_receiver.msgs;
 
         (ot_messages, ot_message_choices)
     }

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -68,8 +68,7 @@ mod tests {
     #[test]
     fn test_ole_sender_receiver_preprocess() {
         let count = 12;
-        let from_seed = Prg::from_seed(Block::ZERO);
-        let mut rng = from_seed;
+        let mut rng = Prg::from_seed(Block::ZERO);
 
         let (mut sender, mut receiver) =
             (OLESender::<P256>::default(), OLEReceiver::<P256>::default());
@@ -100,8 +99,7 @@ mod tests {
     #[test]
     fn test_ole_sender_receiver_adjust() {
         let count = 12;
-        let from_seed = Prg::from_seed(Block::ZERO);
-        let mut rng = from_seed;
+        let mut rng = Prg::from_seed(Block::ZERO);
 
         let (mut sender, mut receiver) =
             (OLESender::<P256>::default(), OLEReceiver::<P256>::default());

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -23,8 +23,6 @@ pub enum OLEError {
     #[error("The number of provided elements do not match. Got {0}, expected {1}")]
     ExpectedMultipleOf(usize, usize),
     #[error("Not enough prepared OLEs available. Requested {0}, but only {1} are available")]
-    InsufficientOLEs(usize, usize),
-    #[error("Number of adjustments has to be equal. Got {0} and {1}")]
     UnequalAdjustments(usize, usize),
     #[error("Provided number of masks is incorrect. Got {0}, expected {1}")]
     WrongNumberOfMasks(usize, usize),

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -14,7 +14,7 @@ mod receiver;
 mod sender;
 
 pub use receiver::OLEReceiver;
-pub use sender::OLESender;
+pub use sender::{BatchSenderAdjust, OLESender};
 use serde::{Deserialize, Serialize};
 
 /// An OLE transfer identifier.
@@ -46,12 +46,14 @@ impl TransferId {
 pub enum OLEError {
     #[error("The number of provided elements do not match. Got {0}, expected {1}")]
     ExpectedMultipleOf(usize, usize),
-    #[error("Not enough prepared OLEs available. Requested {0}, but only {1} are available")]
+    #[error("Wrong number of adjustments. Got {0}, expected {1}")]
     UnequalAdjustments(usize, usize),
     #[error("Provided number of masks is incorrect. Got {0}, expected {1}")]
     WrongNumberOfMasks(usize, usize),
     #[error("Got {0}, but expected a multiple of {1}")]
     MultipleOf(usize, usize),
+    #[error("Wrong transfer id. Got {0}, expected {1}")]
+    WrongId(TransferId, TransferId),
 }
 
 #[cfg(test)]
@@ -126,10 +128,8 @@ mod tests {
         let (sender_adjust, s_to_r_adjust) = sender.adjust(sender_targets.clone()).unwrap();
         let (receiver_adjust, r_to_s_adjust) = receiver.adjust(receiver_targets.clone()).unwrap();
 
-        let sender_shares_adjusted = sender.finish_adjust(sender_adjust, r_to_s_adjust).unwrap();
-        let receiver_shares_adjusted = receiver
-            .finish_adjust(receiver_adjust, s_to_r_adjust)
-            .unwrap();
+        let sender_shares_adjusted = sender_adjust.finish_adjust(r_to_s_adjust).unwrap();
+        let receiver_shares_adjusted = receiver_adjust.finish_adjust(s_to_r_adjust).unwrap();
 
         sender_targets
             .iter()

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -1,0 +1,179 @@
+//! Implementations of Oblivious Linear Function Evaluation (OLE).
+//!
+//! Core logic of the protocol without I/O.
+
+#![deny(missing_docs, unreachable_pub, unused_must_use)]
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+
+pub mod ideal;
+
+mod core;
+mod receiver;
+mod sender;
+
+pub use receiver::OLEReceiver;
+pub use sender::OLESender;
+
+/// An error for OLE
+#[allow(missing_docs)]
+#[derive(Debug, thiserror::Error)]
+pub enum OLEError {
+    #[error("The number of OTs is incorrect. Got {0}, expected {1}")]
+    ExpectedMultipleOf(usize, usize),
+    #[error("Not enough prepared OLEs available. Requested {0}, but only {1} are available")]
+    InsufficientOLEs(usize, usize),
+    #[error("Number of adjustments has to be equal. Got {0} and {1}")]
+    UnequalAdjustments(usize, usize),
+    #[error("Provided number of masks is incorrect. Got {0}, expected {1}")]
+    WrongNumerOfMasks(usize, usize),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{OLEReceiver, OLESender};
+    use itybity::ToBits;
+    use mpz_core::{prg::Prg, Block};
+    use mpz_fields::{p256::P256, Field, UniformRand};
+    use mpz_ot_core::ideal::rot::IdealROT;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_ole_sender_receiver_generate() {
+        let count = 12;
+        let from_seed = Prg::from_seed(Block::ZERO);
+        let mut rng = from_seed;
+
+        let (sender, receiver) = (
+            OLESender::<256, P256>::default(),
+            OLEReceiver::<256, P256>::default(),
+        );
+
+        let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+
+        let (sender_shares, masked) = sender.generate(sender_input.clone(), ot_messages).unwrap();
+        let receiver_shares = receiver
+            .generate(receiver_input.clone(), ot_message_choices, masked)
+            .unwrap();
+
+        sender_input
+            .iter()
+            .zip(receiver_input)
+            .zip(sender_shares)
+            .zip(receiver_shares)
+            .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
+    }
+
+    #[test]
+    fn test_ole_sender_receiver_preprocess() {
+        let count = 12;
+        let from_seed = Prg::from_seed(Block::ZERO);
+        let mut rng = from_seed;
+
+        let (mut sender, mut receiver) = (
+            OLESender::<256, P256>::default(),
+            OLEReceiver::<256, P256>::default(),
+        );
+
+        let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+
+        let masked = sender
+            .preprocess(sender_input.clone(), ot_messages)
+            .unwrap();
+        receiver
+            .preprocess(receiver_input.clone(), ot_message_choices, masked)
+            .unwrap();
+
+        let sender_shares = sender.consume(count).unwrap();
+        let receiver_shares = receiver.consume(count).unwrap();
+
+        sender_input
+            .iter()
+            .zip(receiver_input)
+            .zip(sender_shares)
+            .zip(receiver_shares)
+            .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
+    }
+
+    #[test]
+    fn test_ole_sender_receiver_adjust() {
+        let count = 12;
+        let from_seed = Prg::from_seed(Block::ZERO);
+        let mut rng = from_seed;
+
+        let (mut sender, mut receiver) = (
+            OLESender::<256, P256>::default(),
+            OLEReceiver::<256, P256>::default(),
+        );
+
+        let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (ot_messages, ot_message_choices) = create_rot::<32, P256>(receiver_input.clone());
+
+        let masked = sender
+            .preprocess(sender_input.clone(), ot_messages)
+            .unwrap();
+        receiver
+            .preprocess(receiver_input.clone(), ot_message_choices, masked)
+            .unwrap();
+
+        let sender_targets: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+        let receiver_targets: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
+
+        let (sender_adjust, s_to_r_adjust) = sender.adjust(sender_targets.clone()).unwrap();
+        let (receiver_adjust, r_to_s_adjust) = receiver.adjust(receiver_targets.clone()).unwrap();
+
+        let sender_shares_adjusted = sender.finish_adjust(sender_adjust, r_to_s_adjust).unwrap();
+        let receiver_shares_adjusted = receiver
+            .finish_adjust(receiver_adjust, s_to_r_adjust)
+            .unwrap();
+
+        sender_targets
+            .iter()
+            .zip(receiver_targets)
+            .zip(sender_shares_adjusted)
+            .zip(receiver_shares_adjusted)
+            .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
+    }
+
+    // K should be BYTE_SIZE of F
+    pub(crate) fn create_rot<const K: usize, F: Field>(
+        receiver_choices: Vec<F>,
+    ) -> (Vec<[F; 2]>, Vec<F>) {
+        assert_eq!(
+            K,
+            F::BIT_SIZE as usize / 8,
+            "K has to be equal to the byte size of the field"
+        );
+
+        let mut rot = IdealROT::default();
+        let receiver_choices: Vec<bool> = receiver_choices.iter_lsb0().collect();
+        let (rot_sender, rot_receiver) = rot.random_with_choices::<K>(receiver_choices);
+
+        let ot_messages: Vec<[F; 2]> = rot_sender
+            .msgs
+            .iter()
+            .map(|[a, b]| {
+                [
+                    F::from_lsb0_iter(a.iter_lsb0()),
+                    F::from_lsb0_iter(b.iter_lsb0()),
+                ]
+            })
+            .collect();
+
+        let ot_message_choices: Vec<F> = rot_receiver
+            .msgs
+            .iter()
+            .map(|bytes| F::from_lsb0_iter(bytes.iter_lsb0()))
+            .collect();
+
+        (ot_messages, ot_message_choices)
+    }
+}

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -8,7 +8,8 @@
 
 pub mod ideal;
 
-mod core;
+pub mod core;
+pub mod msg;
 mod receiver;
 mod sender;
 
@@ -19,14 +20,16 @@ pub use sender::OLESender;
 #[allow(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum OLEError {
-    #[error("The number of OTs is incorrect. Got {0}, expected {1}")]
+    #[error("The number of provided elements do not match. Got {0}, expected {1}")]
     ExpectedMultipleOf(usize, usize),
     #[error("Not enough prepared OLEs available. Requested {0}, but only {1} are available")]
     InsufficientOLEs(usize, usize),
     #[error("Number of adjustments has to be equal. Got {0} and {1}")]
     UnequalAdjustments(usize, usize),
     #[error("Provided number of masks is incorrect. Got {0}, expected {1}")]
-    WrongNumerOfMasks(usize, usize),
+    WrongNumberOfMasks(usize, usize),
+    #[error("Got {0}, but expected a multiple of {1}")]
+    MultipleOf(usize, usize),
 }
 
 #[cfg(test)]
@@ -37,35 +40,6 @@ mod tests {
     use mpz_fields::{p256::P256, UniformRand};
     use mpz_ot_core::ideal::rot::IdealROT;
     use rand::SeedableRng;
-
-    #[test]
-    fn test_ole_sender_receiver_generate() {
-        let count = 12;
-        let from_seed = Prg::from_seed(Block::ZERO);
-        let mut rng = from_seed;
-
-        let (sender, receiver) = (
-            OLESender::<256, P256>::default(),
-            OLEReceiver::<256, P256>::default(),
-        );
-
-        let sender_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
-        let receiver_input: Vec<P256> = (0..count).map(|_| P256::rand(&mut rng)).collect();
-
-        let (ot_messages, ot_message_choices) = create_rot(receiver_input.clone());
-
-        let (sender_shares, masked) = sender.generate(sender_input.clone(), ot_messages).unwrap();
-        let receiver_shares = receiver
-            .generate(receiver_input.clone(), ot_message_choices, masked)
-            .unwrap();
-
-        sender_input
-            .iter()
-            .zip(receiver_input)
-            .zip(sender_shares)
-            .zip(receiver_shares)
-            .for_each(|(((&a, b), x), y)| assert_eq!(y.inner(), a * b + x.inner()));
-    }
 
     #[test]
     fn test_ole_sender_receiver_preprocess() {

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -1,14 +1,12 @@
 //! Message types for OLE.
 
+use crate::{core::MaskedInput, OLEError};
 use mpz_fields::Field;
-
-use crate::{
-    core::{MaskedInput, ShareAdjust},
-    OLEError,
-};
+use serde::{Deserialize, Serialize};
 
 /// Message type for sending a vector [`MaskedInput`]s to the receiver.
 #[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MaskedInputs<F> {
     pub masks: Vec<F>,
 }
@@ -38,8 +36,9 @@ impl<const N: usize, F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<N, F
     }
 }
 
-/// Message type for sending a vector of [`ShareAdjust`] to the other party.
+/// Message type for sending a vector of [`crate::core::ShareAdjust`] to the other party.
 #[allow(missing_docs)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BatchAdjust<F> {
-    pub adjustments: Vec<ShareAdjust<F>>,
+    pub adjustments: Vec<F>,
 }

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -1,34 +1,34 @@
 //! Message types for OLE.
 
-use crate::{core::MaskedInput, OLEError, TransferId};
+use crate::{core::MaskedCorrelation, OLEError, TransferId};
 use mpz_fields::Field;
 use serde::{Deserialize, Serialize};
 
-/// Message type for sending a vector of [`MaskedInput`]s to the receiver.
+/// Message type for sending a vector of [`MaskedCorrelation`]s to the receiver.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MaskedInputs<F> {
+pub struct MaskedCorrelations<F> {
     pub masks: Vec<F>,
 }
 
-impl<F: Field> From<Vec<MaskedInput<F>>> for MaskedInputs<F> {
-    fn from(value: Vec<MaskedInput<F>>) -> Self {
+impl<F: Field> From<Vec<MaskedCorrelation<F>>> for MaskedCorrelations<F> {
+    fn from(value: Vec<MaskedCorrelation<F>>) -> Self {
         let masks = value.into_iter().flat_map(|mask| mask.0).collect();
         Self { masks }
     }
 }
 
-impl<F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<F>> {
+impl<F: Field> TryFrom<MaskedCorrelations<F>> for Vec<MaskedCorrelation<F>> {
     type Error = OLEError;
 
-    fn try_from(value: MaskedInputs<F>) -> Result<Self, Self::Error> {
+    fn try_from(value: MaskedCorrelations<F>) -> Result<Self, Self::Error> {
         let masks = value
             .masks
             .chunks(F::BIT_SIZE as usize)
             .map(|chunk| {
                 chunk
                     .try_into()
-                    .map(MaskedInput)
+                    .map(MaskedCorrelation)
                     .map_err(|_| OLEError::MultipleOf(chunk.len(), F::BIT_SIZE as usize))
             })
             .collect();

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -1,6 +1,6 @@
 //! Message types for OLE.
 
-use crate::{core::MaskedInput, OLEError};
+use crate::{core::MaskedInput, OLEError, TransferId};
 use mpz_fields::Field;
 use serde::{Deserialize, Serialize};
 
@@ -40,5 +40,6 @@ impl<const N: usize, F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<N, F
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BatchAdjust<F> {
+    pub id: TransferId,
     pub adjustments: Vec<F>,
 }

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -11,25 +11,25 @@ pub struct MaskedInputs<F> {
     pub masks: Vec<F>,
 }
 
-impl<const N: usize, F: Field> From<Vec<MaskedInput<N, F>>> for MaskedInputs<F> {
-    fn from(value: Vec<MaskedInput<N, F>>) -> Self {
+impl<F: Field> From<Vec<MaskedInput<F>>> for MaskedInputs<F> {
+    fn from(value: Vec<MaskedInput<F>>) -> Self {
         let masks = value.into_iter().flat_map(|mask| mask.0).collect();
         Self { masks }
     }
 }
 
-impl<const N: usize, F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<N, F>> {
+impl<F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<F>> {
     type Error = OLEError;
 
     fn try_from(value: MaskedInputs<F>) -> Result<Self, Self::Error> {
         let masks = value
             .masks
-            .chunks(N)
+            .chunks(F::BIT_SIZE as usize)
             .map(|chunk| {
                 chunk
                     .try_into()
                     .map(MaskedInput)
-                    .map_err(|_| OLEError::MultipleOf(chunk.len(), N))
+                    .map_err(|_| OLEError::MultipleOf(chunk.len(), F::BIT_SIZE as usize))
             })
             .collect();
         masks

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -24,12 +24,12 @@ impl<F: Field> TryFrom<MaskedCorrelations<F>> for Vec<MaskedCorrelation<F>> {
     fn try_from(value: MaskedCorrelations<F>) -> Result<Self, Self::Error> {
         let masks = value
             .masks
-            .chunks(F::BIT_SIZE as usize)
+            .chunks(F::BIT_SIZE)
             .map(|chunk| {
                 chunk
                     .try_into()
                     .map(MaskedCorrelation)
-                    .map_err(|_| OLEError::MultipleOf(chunk.len(), F::BIT_SIZE as usize))
+                    .map_err(|_| OLEError::MultipleOf(chunk.len(), F::BIT_SIZE))
             })
             .collect();
         masks

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -1,0 +1,45 @@
+//! Message types for OLE.
+
+use mpz_fields::Field;
+
+use crate::{
+    core::{MaskedInput, ShareAdjust},
+    OLEError,
+};
+
+/// Message type for sending a vector [`MaskedInput`]s to the receiver.
+#[allow(missing_docs)]
+pub struct MaskedInputs<F> {
+    pub masks: Vec<F>,
+}
+
+impl<const N: usize, F: Field> From<Vec<MaskedInput<N, F>>> for MaskedInputs<F> {
+    fn from(value: Vec<MaskedInput<N, F>>) -> Self {
+        let masks = value.into_iter().flat_map(|mask| mask.0).collect();
+        Self { masks }
+    }
+}
+
+impl<const N: usize, F: Field> TryFrom<MaskedInputs<F>> for Vec<MaskedInput<N, F>> {
+    type Error = OLEError;
+
+    fn try_from(value: MaskedInputs<F>) -> Result<Self, Self::Error> {
+        let masks = value
+            .masks
+            .chunks(N)
+            .map(|chunk| {
+                chunk
+                    .try_into()
+                    .map(MaskedInput)
+                    .map_err(|_| OLEError::MultipleOf(chunk.len(), N))
+            })
+            .collect();
+        masks
+    }
+}
+
+/// Message type for sending a vector of [`ShareAdjust`] to the other party.
+#[allow(missing_docs)]
+pub struct BatchAdjust<F> {
+    pub adjustments: Vec<ShareAdjust<F>>,
+}

--- a/crates/mpz-ole-core/src/msg.rs
+++ b/crates/mpz-ole-core/src/msg.rs
@@ -4,7 +4,7 @@ use crate::{core::MaskedInput, OLEError, TransferId};
 use mpz_fields::Field;
 use serde::{Deserialize, Serialize};
 
-/// Message type for sending a vector [`MaskedInput`]s to the receiver.
+/// Message type for sending a vector of [`MaskedInput`]s to the receiver.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MaskedInputs<F> {

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -29,7 +29,7 @@ impl<F: Field> OLEReceiver<F> {
     ///
     /// # Arguments
     ///
-    /// * `input` - The receiver's OLE input factors.
+    /// * `input` - The receiver's OLE input shares.
     /// * `random` - Uniformly random field elements.
     /// * `masked` - The correlations from the sender.
     pub fn preprocess(
@@ -74,7 +74,7 @@ impl<F: Field> OLEReceiver<F> {
     /// # Returns
     ///
     /// * [`BatchReceiverAdjust`] which needs to be converted by [`BatchReceiverAdjust::finish_adjust`].
-    /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLESender`].
+    /// * [`BatchAdjust`] which needs to be sent to the sender.
     pub fn adjust(&mut self, targets: Vec<F>) -> Option<(BatchReceiverAdjust<F>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
         let (receiver_adjust, adjustments) = shares

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -1,25 +1,25 @@
 //! Receiver implementation.
 
-use mpz_fields::Field;
-
 use crate::{
     core::{ReceiverAdjust, ReceiverShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
     OLEError, TransferId,
 };
+use mpz_fields::Field;
+use std::collections::VecDeque;
 
 /// A receiver for batched OLE.
 #[derive(Debug)]
 pub struct OLEReceiver<const N: usize, F> {
     id: TransferId,
-    cache: Vec<ReceiverShare<F>>,
+    cache: VecDeque<ReceiverShare<F>>,
 }
 
 impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
     fn default() -> Self {
         OLEReceiver {
             id: TransferId::default(),
-            cache: Vec::default(),
+            cache: VecDeque::default(),
         }
     }
 }
@@ -61,7 +61,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
             return None;
         }
 
-        let shares = self.cache.split_off(self.cache.len() - count);
+        let shares = self.cache.drain(..count).collect();
         Some(shares)
     }
 
@@ -134,7 +134,7 @@ impl<F: Field> BatchReceiverAdjust<F> {
 
         let shares = receiver_adjust
             .into_iter()
-            .zip(adjustments.into_iter())
+            .zip(adjustments)
             .map(|(s, a)| s.finish(ShareAdjust(a)))
             .collect();
 

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -1,0 +1,166 @@
+//! Receiver implementation.
+
+use mpz_fields::Field;
+
+use crate::{
+    core::{MaskedInput, ReceiverAdjust, ReceiverShare, ShareAdjust},
+    OLEError,
+};
+
+/// A receiver for batched OLE.
+#[derive(Debug)]
+pub struct OLEReceiver<const N: usize, F> {
+    cache: Vec<ReceiverShare<F>>,
+}
+
+impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
+    fn default() -> Self {
+        OLEReceiver { cache: vec![] }
+    }
+}
+
+impl<const N: usize, F: Field> OLEReceiver<N, F> {
+    /// Generates new OLEs.
+    ///
+    /// OLEs are not stored and directly returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The receiver's OLE input factors.
+    /// * `ot_message_choices` - The OT messages chosen by the receiver.
+    /// * `masked` - The correlations from the sender.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
+    pub fn generate(
+        &self,
+        input: Vec<F>,
+        ot_message_choices: Vec<F>,
+        masked: Vec<MaskedInput<N, F>>,
+    ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        if input.len() * F::BIT_SIZE as usize != ot_message_choices.len() {
+            return Err(OLEError::ExpectedMultipleOf(
+                input.len() * F::BIT_SIZE as usize,
+                ot_message_choices.len(),
+            ));
+        }
+
+        if input.len() != masked.len() {
+            return Err(OLEError::WrongNumerOfMasks(masked.len(), input.len()));
+        }
+
+        let shares: Vec<ReceiverShare<F>> = input
+            .iter()
+            .zip(ot_message_choices.chunks_exact(F::BIT_SIZE as usize))
+            .zip(masked)
+            .map(|((&f, chunk), m)| {
+                ReceiverShare::new::<N>(
+                    f,
+                    chunk
+                        .try_into()
+                        .expect("Slice should have length of bit size of field element"),
+                    m,
+                )
+            })
+            .collect();
+
+        Ok(shares)
+    }
+
+    /// Generates new OLEs and stores them internally.
+    ///
+    /// This method is similar to [`OLEReceiver::generate`], except that [`ReceiverShare`]s are stored
+    /// for later adjustment.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The receiver's OLE input factors.
+    /// * `ot_message_choices` - The OT messages chosen by the receiver.
+    /// * `masked` - The correlations from the sender.
+    pub fn preprocess(
+        &mut self,
+        input: Vec<F>,
+        ot_message_choices: Vec<F>,
+        masked: Vec<MaskedInput<N, F>>,
+    ) -> Result<(), OLEError> {
+        let shares = self.generate(input, ot_message_choices, masked)?;
+        self.cache.extend(shares);
+
+        Ok(())
+    }
+
+    /// Returns OLEs from internal cache.
+    ///
+    /// For consumption of OLEs which have been stored by [`OLEReceiver::preprocess`].
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of shares to return.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
+    pub fn consume(&mut self, count: usize) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        if count > self.cache.len() {
+            return Err(OLEError::InsufficientOLEs(count, self.cache.len()));
+        }
+
+        let shares = self.cache.drain(..count).collect();
+        Ok(shares)
+    }
+
+    /// Adjusts OLEs in the internal cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `targets` - The new OLE receiver inputs.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`ReceiverAdjust`] which needs to be converted by [`OLEReceiver::finish_adjust`].
+    /// * A vector of [`ShareAdjust`] which needs to be sent to the [`super::OLESender`].
+    pub fn adjust(
+        &mut self,
+        targets: Vec<F>,
+    ) -> Result<(Vec<ReceiverAdjust<F>>, Vec<ShareAdjust<F>>), OLEError> {
+        let shares = self.consume(targets.len())?;
+        let (sender_adjusted, adjustments) = shares
+            .into_iter()
+            .zip(targets)
+            .map(|(s, t)| s.adjust(t))
+            .unzip();
+
+        Ok((sender_adjusted, adjustments))
+    }
+
+    /// Completes the adjustment and returns the new shares.
+    ///
+    /// # Arguments
+    ///
+    /// * `receiver_adjust` - The receiver's intermediate shares from [`OLEReceiver::adjust`].
+    /// * `adjustments` - The sender's adjustments.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`ReceiverShare`]s containing the new OLE outputs for the receiver.
+    pub fn finish_adjust(
+        &self,
+        receiver_adjust: Vec<ReceiverAdjust<F>>,
+        adjustments: Vec<ShareAdjust<F>>,
+    ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        if receiver_adjust.len() != adjustments.len() {
+            return Err(OLEError::UnequalAdjustments(
+                receiver_adjust.len(),
+                adjustments.len(),
+            ));
+        }
+        let shares = receiver_adjust
+            .into_iter()
+            .zip(adjustments.into_iter())
+            .map(|(s, a)| s.finish(a))
+            .collect();
+
+        Ok(shares)
+    }
+}

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     core::{ReceiverAdjust, ReceiverShare, ShareAdjust},
-    msg::{BatchAdjust, MaskedInputs},
+    msg::{BatchAdjust, MaskedCorrelations},
     OLEError, TransferId,
 };
 use mpz_fields::Field;
@@ -36,7 +36,7 @@ impl<F: Field> OLEReceiver<F> {
         &mut self,
         input: Vec<F>,
         random: Vec<F>,
-        masked: MaskedInputs<F>,
+        masked: MaskedCorrelations<F>,
     ) -> Result<(), OLEError> {
         let masks = masked.try_into()?;
         let shares = ReceiverShare::new_vec(input, random, masks)?;

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -61,7 +61,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
             return None;
         }
 
-        let shares = self.cache.split_off(count);
+        let shares = self.cache.split_off(self.cache.len() - count);
         Some(shares)
     }
 

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -3,7 +3,8 @@
 use mpz_fields::Field;
 
 use crate::{
-    core::{MaskedInput, ReceiverAdjust, ReceiverShare, ShareAdjust},
+    core::{ReceiverAdjust, ReceiverShare},
+    msg::{BatchAdjust, MaskedInputs},
     OLEError,
 };
 
@@ -20,73 +21,23 @@ impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
 }
 
 impl<const N: usize, F: Field> OLEReceiver<N, F> {
-    /// Generates new OLEs.
-    ///
-    /// OLEs are not stored and directly returned.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - The receiver's OLE input factors.
-    /// * `ot_message_choices` - The OT messages chosen by the receiver.
-    /// * `masked` - The correlations from the sender.
-    ///
-    /// # Returns
-    ///
-    /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
-    pub fn generate(
-        &self,
-        input: Vec<F>,
-        ot_message_choices: Vec<F>,
-        masked: Vec<MaskedInput<N, F>>,
-    ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
-        if input.len() * F::BIT_SIZE as usize != ot_message_choices.len() {
-            return Err(OLEError::ExpectedMultipleOf(
-                input.len() * F::BIT_SIZE as usize,
-                ot_message_choices.len(),
-            ));
-        }
-
-        if input.len() != masked.len() {
-            return Err(OLEError::WrongNumerOfMasks(masked.len(), input.len()));
-        }
-
-        let shares: Vec<ReceiverShare<F>> = input
-            .iter()
-            .zip(ot_message_choices.chunks_exact(F::BIT_SIZE as usize))
-            .zip(masked)
-            .map(|((&f, chunk), m)| {
-                ReceiverShare::new::<N>(
-                    f,
-                    chunk
-                        .try_into()
-                        .expect("Slice should have length of bit size of field element"),
-                    m,
-                )
-            })
-            .collect();
-
-        Ok(shares)
-    }
-
     /// Generates new OLEs and stores them internally.
     ///
-    /// This method is similar to [`OLEReceiver::generate`], except that [`ReceiverShare`]s are stored
-    /// for later adjustment.
-    ///
     /// # Arguments
     ///
     /// * `input` - The receiver's OLE input factors.
-    /// * `ot_message_choices` - The OT messages chosen by the receiver.
+    /// * `random` - Uniformly random field elements.
     /// * `masked` - The correlations from the sender.
     pub fn preprocess(
         &mut self,
         input: Vec<F>,
-        ot_message_choices: Vec<F>,
-        masked: Vec<MaskedInput<N, F>>,
+        random: Vec<F>,
+        masked: MaskedInputs<F>,
     ) -> Result<(), OLEError> {
-        let shares = self.generate(input, ot_message_choices, masked)?;
-        self.cache.extend(shares);
+        let masks = masked.try_into()?;
+        let shares = ReceiverShare::new_vec::<N>(input, random, masks)?;
 
+        self.cache.extend(shares);
         Ok(())
     }
 
@@ -119,17 +70,19 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     /// # Returns
     ///
     /// * A vector of [`ReceiverAdjust`] which needs to be converted by [`OLEReceiver::finish_adjust`].
-    /// * A vector of [`ShareAdjust`] which needs to be sent to the [`super::OLESender`].
+    /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLESender`].
     pub fn adjust(
         &mut self,
         targets: Vec<F>,
-    ) -> Result<(Vec<ReceiverAdjust<F>>, Vec<ShareAdjust<F>>), OLEError> {
+    ) -> Result<(Vec<ReceiverAdjust<F>>, BatchAdjust<F>), OLEError> {
         let shares = self.consume(targets.len())?;
         let (sender_adjusted, adjustments) = shares
             .into_iter()
             .zip(targets)
             .map(|(s, t)| s.adjust(t))
             .unzip();
+
+        let adjustments = BatchAdjust { adjustments };
 
         Ok((sender_adjusted, adjustments))
     }
@@ -139,7 +92,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     /// # Arguments
     ///
     /// * `receiver_adjust` - The receiver's intermediate shares from [`OLEReceiver::adjust`].
-    /// * `adjustments` - The sender's adjustments.
+    /// * `batch_adjust` - The sender's adjustments.
     ///
     /// # Returns
     ///
@@ -147,8 +100,10 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     pub fn finish_adjust(
         &self,
         receiver_adjust: Vec<ReceiverAdjust<F>>,
-        adjustments: Vec<ShareAdjust<F>>,
+        batch_adjust: BatchAdjust<F>,
     ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        let adjustments = batch_adjust.adjustments;
+
         if receiver_adjust.len() != adjustments.len() {
             return Err(OLEError::UnequalAdjustments(
                 receiver_adjust.len(),

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -61,7 +61,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
             return None;
         }
 
-        let shares = self.cache.drain(..count).collect();
+        let shares = self.cache.split_off(count);
         Some(shares)
     }
 

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -10,12 +10,12 @@ use std::collections::VecDeque;
 
 /// A receiver for batched OLE.
 #[derive(Debug)]
-pub struct OLEReceiver<const N: usize, F> {
+pub struct OLEReceiver<F> {
     id: TransferId,
     cache: VecDeque<ReceiverShare<F>>,
 }
 
-impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
+impl<F: Field> Default for OLEReceiver<F> {
     fn default() -> Self {
         OLEReceiver {
             id: TransferId::default(),
@@ -24,7 +24,7 @@ impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
     }
 }
 
-impl<const N: usize, F: Field> OLEReceiver<N, F> {
+impl<F: Field> OLEReceiver<F> {
     /// Generates new OLEs and stores them internally.
     ///
     /// # Arguments
@@ -39,7 +39,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
         masked: MaskedInputs<F>,
     ) -> Result<(), OLEError> {
         let masks = masked.try_into()?;
-        let shares = ReceiverShare::new_vec::<N>(input, random, masks)?;
+        let shares = ReceiverShare::new_vec(input, random, masks)?;
 
         self.cache.extend(shares);
         Ok(())

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -3,7 +3,7 @@
 use mpz_fields::Field;
 
 use crate::{
-    core::{ReceiverAdjust, ReceiverShare},
+    core::{ReceiverAdjust, ReceiverShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
     OLEError,
 };
@@ -79,7 +79,10 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
         let (sender_adjusted, adjustments) = shares
             .into_iter()
             .zip(targets)
-            .map(|(s, t)| s.adjust(t))
+            .map(|(s, t)| {
+                let (share, adjust) = s.adjust(t);
+                (share, adjust.0)
+            })
             .unzip();
 
         let adjustments = BatchAdjust { adjustments };
@@ -113,7 +116,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
         let shares = receiver_adjust
             .into_iter()
             .zip(adjustments.into_iter())
-            .map(|(s, a)| s.finish(a))
+            .map(|(s, a)| s.finish(ShareAdjust(a)))
             .collect();
 
         Ok(shares)

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -5,18 +5,22 @@ use mpz_fields::Field;
 use crate::{
     core::{ReceiverAdjust, ReceiverShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
-    OLEError,
+    OLEError, TransferId,
 };
 
 /// A receiver for batched OLE.
 #[derive(Debug)]
 pub struct OLEReceiver<const N: usize, F> {
+    id: TransferId,
     cache: Vec<ReceiverShare<F>>,
 }
 
 impl<const N: usize, F: Field> Default for OLEReceiver<N, F> {
     fn default() -> Self {
-        OLEReceiver { cache: vec![] }
+        OLEReceiver {
+            id: TransferId::default(),
+            cache: Vec::default(),
+        }
     }
 }
 
@@ -69,11 +73,11 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     ///
     /// # Returns
     ///
-    /// * A vector of [`ReceiverAdjust`] which needs to be converted by [`OLEReceiver::finish_adjust`].
+    /// * [`BatchReceiverAdjust`] which needs to be converted by [`BatchReceiverAdjust::finish_adjust`].
     /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLESender`].
-    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(Vec<ReceiverAdjust<F>>, BatchAdjust<F>)> {
+    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(BatchReceiverAdjust<F>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
-        let (sender_adjusted, adjustments) = shares
+        let (receiver_adjust, adjustments) = shares
             .into_iter()
             .zip(targets)
             .map(|(s, t)| {
@@ -82,34 +86,52 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
             })
             .unzip();
 
-        let adjustments = BatchAdjust { adjustments };
+        let id = self.id.next();
 
-        Some((sender_adjusted, adjustments))
+        let receiver_adjust = BatchReceiverAdjust {
+            id,
+            adjust: receiver_adjust,
+        };
+        let adjustments = BatchAdjust { id, adjustments };
+
+        Some((receiver_adjust, adjustments))
     }
+}
 
+/// Receiver adjustments waiting for [`BatchAdjust`] from the sender.
+pub struct BatchReceiverAdjust<F> {
+    id: TransferId,
+    adjust: Vec<ReceiverAdjust<F>>,
+}
+
+impl<F: Field> BatchReceiverAdjust<F> {
     /// Completes the adjustment and returns the new shares.
     ///
     /// # Arguments
     ///
-    /// * `receiver_adjust` - The receiver's intermediate shares from [`OLEReceiver::adjust`].
     /// * `batch_adjust` - The sender's adjustments.
     ///
     /// # Returns
     ///
     /// * A vector of [`ReceiverShare`]s containing the new OLE outputs for the receiver.
     pub fn finish_adjust(
-        &self,
-        receiver_adjust: Vec<ReceiverAdjust<F>>,
+        self,
         batch_adjust: BatchAdjust<F>,
     ) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+        if self.id != batch_adjust.id {
+            return Err(OLEError::WrongId(batch_adjust.id, self.id));
+        }
+
+        let receiver_adjust = self.adjust;
         let adjustments = batch_adjust.adjustments;
 
         if receiver_adjust.len() != adjustments.len() {
             return Err(OLEError::UnequalAdjustments(
-                receiver_adjust.len(),
                 adjustments.len(),
+                receiver_adjust.len(),
             ));
         }
+
         let shares = receiver_adjust
             .into_iter()
             .zip(adjustments.into_iter())

--- a/crates/mpz-ole-core/src/receiver.rs
+++ b/crates/mpz-ole-core/src/receiver.rs
@@ -52,13 +52,13 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     /// # Returns
     ///
     /// * A vector of [`ReceiverShare`]s containing the OLE outputs for the receiver.
-    pub fn consume(&mut self, count: usize) -> Result<Vec<ReceiverShare<F>>, OLEError> {
+    pub fn consume(&mut self, count: usize) -> Option<Vec<ReceiverShare<F>>> {
         if count > self.cache.len() {
-            return Err(OLEError::InsufficientOLEs(count, self.cache.len()));
+            return None;
         }
 
         let shares = self.cache.drain(..count).collect();
-        Ok(shares)
+        Some(shares)
     }
 
     /// Adjusts OLEs in the internal cache.
@@ -71,10 +71,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
     ///
     /// * A vector of [`ReceiverAdjust`] which needs to be converted by [`OLEReceiver::finish_adjust`].
     /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLESender`].
-    pub fn adjust(
-        &mut self,
-        targets: Vec<F>,
-    ) -> Result<(Vec<ReceiverAdjust<F>>, BatchAdjust<F>), OLEError> {
+    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(Vec<ReceiverAdjust<F>>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
         let (sender_adjusted, adjustments) = shares
             .into_iter()
@@ -87,7 +84,7 @@ impl<const N: usize, F: Field> OLEReceiver<N, F> {
 
         let adjustments = BatchAdjust { adjustments };
 
-        Ok((sender_adjusted, adjustments))
+        Some((sender_adjusted, adjustments))
     }
 
     /// Completes the adjustment and returns the new shares.

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -29,12 +29,12 @@ impl<F: Field> OLESender<F> {
     ///
     /// # Arguments
     ///
-    /// * `input` - The sender's OLE input factors.
+    /// * `input` - The sender's OLE input shares.
     /// * `random` - Uniformly random field elements for the correlation.
     ///
     /// # Returns
     ///
-    /// * [`MaskedInputs`], which are to be sent to the [`crate::OLEReceiver`].
+    /// * [`MaskedInputs`], which are to be sent to the receiver.
     pub fn preprocess(
         &mut self,
         input: Vec<F>,
@@ -75,7 +75,7 @@ impl<F: Field> OLESender<F> {
     /// # Returns
     ///
     /// * [`BatchSenderAdjust`] which needs to be converted by [`BatchSenderAdjust::finish_adjust`].
-    /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLEReceiver`].
+    /// * [`BatchAdjust`] which needs to be sent to the receiver.
     pub fn adjust(&mut self, targets: Vec<F>) -> Option<(BatchSenderAdjust<F>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
         let (sender_adjust, adjustments) = shares

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -3,7 +3,7 @@
 use mpz_fields::Field;
 
 use crate::{
-    core::{SenderAdjust, SenderShare},
+    core::{SenderAdjust, SenderShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
     OLEError,
 };
@@ -80,7 +80,10 @@ impl<const N: usize, F: Field> OLESender<N, F> {
         let (sender_adjusted, adjustments) = shares
             .into_iter()
             .zip(targets)
-            .map(|(s, t)| s.adjust(t))
+            .map(|(s, t)| {
+                let (share, adjust) = s.adjust(t);
+                (share, adjust.0)
+            })
             .unzip();
 
         let adjustments = BatchAdjust { adjustments };
@@ -114,7 +117,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
         let shares = sender_adjust
             .into_iter()
             .zip(adjustments.into_iter())
-            .map(|(s, a)| s.finish(a))
+            .map(|(s, a)| s.finish(ShareAdjust(a)))
             .collect();
 
         Ok(shares)

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -62,7 +62,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
             return None;
         }
 
-        let shares = self.cache.split_off(count);
+        let shares = self.cache.split_off(self.cache.len() - count);
         Some(shares)
     }
 

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -1,25 +1,25 @@
 //! Sender implementation.
 
-use mpz_fields::Field;
-
 use crate::{
     core::{SenderAdjust, SenderShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
     OLEError, TransferId,
 };
+use mpz_fields::Field;
+use std::collections::VecDeque;
 
 /// A sender for batched OLE.
 #[derive(Debug)]
 pub struct OLESender<const N: usize, F> {
     id: TransferId,
-    cache: Vec<SenderShare<F>>,
+    cache: VecDeque<SenderShare<F>>,
 }
 
 impl<const N: usize, F: Field> Default for OLESender<N, F> {
     fn default() -> Self {
         OLESender {
             id: TransferId::default(),
-            cache: Vec::default(),
+            cache: VecDeque::default(),
         }
     }
 }
@@ -62,7 +62,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
             return None;
         }
 
-        let shares = self.cache.split_off(self.cache.len() - count);
+        let shares = self.cache.drain(..count).collect();
         Some(shares)
     }
 
@@ -135,7 +135,7 @@ impl<F: Field> BatchSenderAdjust<F> {
 
         let shares = sender_adjust
             .into_iter()
-            .zip(adjustments.into_iter())
+            .zip(adjustments)
             .map(|(s, a)| s.finish(ShareAdjust(a)))
             .collect();
 

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -62,7 +62,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
             return None;
         }
 
-        let shares = self.cache.drain(..count).collect();
+        let shares = self.cache.split_off(count);
         Some(shares)
     }
 

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -3,7 +3,8 @@
 use mpz_fields::Field;
 
 use crate::{
-    core::{MaskedInput, SenderAdjust, SenderShare, ShareAdjust},
+    core::{SenderAdjust, SenderShare},
+    msg::{BatchAdjust, MaskedInputs},
     OLEError,
 };
 
@@ -20,69 +21,25 @@ impl<const N: usize, F: Field> Default for OLESender<N, F> {
 }
 
 impl<const N: usize, F: Field> OLESender<N, F> {
-    /// Generates new OLEs.
-    ///
-    /// OLEs are not stored and directly returned.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - The sender's OLE input factors.
-    /// * `ot_messages` - The OT messages used for generating correlations.
-    ///
-    /// # Returns
-    ///
-    /// * A vector of [`SenderShare`]s containing the OLE outputs for the sender.
-    /// * A vector of [`MaskedInput`]s, which is to be sent to the receiver.
-    pub fn generate(
-        &self,
-        input: Vec<F>,
-        ot_messages: Vec<[F; 2]>,
-    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>), OLEError> {
-        if input.len() * F::BIT_SIZE as usize != ot_messages.len() {
-            return Err(OLEError::ExpectedMultipleOf(
-                input.len() * F::BIT_SIZE as usize,
-                ot_messages.len(),
-            ));
-        }
-
-        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>) = input
-            .iter()
-            .zip(ot_messages.chunks_exact(F::BIT_SIZE as usize))
-            .map(|(&f, chunk)| {
-                SenderShare::new::<N>(
-                    f,
-                    chunk
-                        .try_into()
-                        .expect("Slice should have length of bit size of field element"),
-                )
-            })
-            .unzip();
-
-        Ok((shares, masked))
-    }
-
     /// Generates new OLEs and stores them internally.
     ///
-    /// This method is similar to [`OLESender::generate`], except that [`SenderShare`]s are stored
-    /// for later adjustment.
-    ///
     /// # Arguments
     ///
     /// * `input` - The sender's OLE input factors.
-    /// * `ot_messages` - The OT messages used for generating correlations.
+    /// * `random` - Uniformly random field elements for the correlation.
     ///
     /// # Returns
     ///
-    /// * A vector of [`MaskedInput`]s, which is to be sent to the [`super::OLEReceiver`].
+    /// * A vector of [`MaskedInput`]s, which is to be sent to the [`crate::OLEReceiver`].
     pub fn preprocess(
         &mut self,
         input: Vec<F>,
-        ot_messages: Vec<[F; 2]>,
-    ) -> Result<Vec<MaskedInput<N, F>>, OLEError> {
-        let (shares, masked) = self.generate(input, ot_messages)?;
+        random: Vec<[F; 2]>,
+    ) -> Result<MaskedInputs<F>, OLEError> {
+        let (shares, masked) = SenderShare::new_vec::<N>(input, random)?;
         self.cache.extend(shares);
 
-        Ok(masked)
+        Ok(masked.into())
     }
 
     /// Returns OLEs from internal cache.
@@ -114,17 +71,19 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     /// # Returns
     ///
     /// * A vector of [`SenderAdjust`]s which needs to be converted by [`OLESender::finish_adjust`].
-    /// * A vector of [`ShareAdjust`]s which needs to be sent to the [`super::OLEReceiver`].
+    /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLEReceiver`].
     pub fn adjust(
         &mut self,
         targets: Vec<F>,
-    ) -> Result<(Vec<SenderAdjust<F>>, Vec<ShareAdjust<F>>), OLEError> {
+    ) -> Result<(Vec<SenderAdjust<F>>, BatchAdjust<F>), OLEError> {
         let shares = self.consume(targets.len())?;
         let (sender_adjusted, adjustments) = shares
             .into_iter()
             .zip(targets)
             .map(|(s, t)| s.adjust(t))
             .unzip();
+
+        let adjustments = BatchAdjust { adjustments };
 
         Ok((sender_adjusted, adjustments))
     }
@@ -134,7 +93,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     /// # Arguments
     ///
     /// * `sender_adjust` - The sender's intermediate shares from [`OLESender::adjust`].
-    /// * `adjustments` - The receiver's adjustments.
+    /// * `batch_adjust` - The receiver's adjustments.
     ///
     /// # Returns
     ///
@@ -142,8 +101,10 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     pub fn finish_adjust(
         &self,
         sender_adjust: Vec<SenderAdjust<F>>,
-        adjustments: Vec<ShareAdjust<F>>,
+        batch_adjust: BatchAdjust<F>,
     ) -> Result<Vec<SenderShare<F>>, OLEError> {
+        let adjustments = batch_adjust.adjustments;
+
         if sender_adjust.len() != adjustments.len() {
             return Err(OLEError::UnequalAdjustments(
                 sender_adjust.len(),

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -53,13 +53,13 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     /// # Returns
     ///
     /// * A vector of [`SenderShare`]s containing the OLE output for the sender.
-    pub fn consume(&mut self, count: usize) -> Result<Vec<SenderShare<F>>, OLEError> {
+    pub fn consume(&mut self, count: usize) -> Option<Vec<SenderShare<F>>> {
         if count > self.cache.len() {
-            return Err(OLEError::InsufficientOLEs(count, self.cache.len()));
+            return None;
         }
 
         let shares = self.cache.drain(..count).collect();
-        Ok(shares)
+        Some(shares)
     }
 
     /// Adjusts OLEs in the internal cache.
@@ -72,10 +72,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     ///
     /// * A vector of [`SenderAdjust`]s which needs to be converted by [`OLESender::finish_adjust`].
     /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLEReceiver`].
-    pub fn adjust(
-        &mut self,
-        targets: Vec<F>,
-    ) -> Result<(Vec<SenderAdjust<F>>, BatchAdjust<F>), OLEError> {
+    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(Vec<SenderAdjust<F>>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
         let (sender_adjusted, adjustments) = shares
             .into_iter()
@@ -88,7 +85,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
 
         let adjustments = BatchAdjust { adjustments };
 
-        Ok((sender_adjusted, adjustments))
+        Some((sender_adjusted, adjustments))
     }
 
     /// Completes the adjustment and returns the new shares.

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     core::{SenderAdjust, SenderShare, ShareAdjust},
-    msg::{BatchAdjust, MaskedInputs},
+    msg::{BatchAdjust, MaskedCorrelations},
     OLEError, TransferId,
 };
 use mpz_fields::Field;
@@ -34,12 +34,12 @@ impl<F: Field> OLESender<F> {
     ///
     /// # Returns
     ///
-    /// * [`MaskedInputs`], which are to be sent to the receiver.
+    /// * [`MaskedCorrelations`], which are to be sent to the receiver.
     pub fn preprocess(
         &mut self,
         input: Vec<F>,
         random: Vec<[F; 2]>,
-    ) -> Result<MaskedInputs<F>, OLEError> {
+    ) -> Result<MaskedCorrelations<F>, OLEError> {
         let (shares, masked) = SenderShare::new_vec(input, random)?;
         self.cache.extend(shares);
 

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -10,12 +10,12 @@ use std::collections::VecDeque;
 
 /// A sender for batched OLE.
 #[derive(Debug)]
-pub struct OLESender<const N: usize, F> {
+pub struct OLESender<F> {
     id: TransferId,
     cache: VecDeque<SenderShare<F>>,
 }
 
-impl<const N: usize, F: Field> Default for OLESender<N, F> {
+impl<F: Field> Default for OLESender<F> {
     fn default() -> Self {
         OLESender {
             id: TransferId::default(),
@@ -24,7 +24,7 @@ impl<const N: usize, F: Field> Default for OLESender<N, F> {
     }
 }
 
-impl<const N: usize, F: Field> OLESender<N, F> {
+impl<F: Field> OLESender<F> {
     /// Generates new OLEs and stores them internally.
     ///
     /// # Arguments
@@ -40,7 +40,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
         input: Vec<F>,
         random: Vec<[F; 2]>,
     ) -> Result<MaskedInputs<F>, OLEError> {
-        let (shares, masked) = SenderShare::new_vec::<N>(input, random)?;
+        let (shares, masked) = SenderShare::new_vec(input, random)?;
         self.cache.extend(shares);
 
         Ok(masked.into())

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -1,0 +1,161 @@
+//! Sender implementation.
+
+use mpz_fields::Field;
+
+use crate::{
+    core::{MaskedInput, SenderAdjust, SenderShare, ShareAdjust},
+    OLEError,
+};
+
+/// A sender for batched OLE.
+#[derive(Debug)]
+pub struct OLESender<const N: usize, F> {
+    cache: Vec<SenderShare<F>>,
+}
+
+impl<const N: usize, F: Field> Default for OLESender<N, F> {
+    fn default() -> Self {
+        OLESender { cache: vec![] }
+    }
+}
+
+impl<const N: usize, F: Field> OLESender<N, F> {
+    /// Generates new OLEs.
+    ///
+    /// OLEs are not stored and directly returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The sender's OLE input factors.
+    /// * `ot_messages` - The OT messages used for generating correlations.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`SenderShare`]s containing the OLE outputs for the sender.
+    /// * A vector of [`MaskedInput`]s, which is to be sent to the receiver.
+    pub fn generate(
+        &self,
+        input: Vec<F>,
+        ot_messages: Vec<[F; 2]>,
+    ) -> Result<(Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>), OLEError> {
+        if input.len() * F::BIT_SIZE as usize != ot_messages.len() {
+            return Err(OLEError::ExpectedMultipleOf(
+                input.len() * F::BIT_SIZE as usize,
+                ot_messages.len(),
+            ));
+        }
+
+        let (shares, masked): (Vec<SenderShare<F>>, Vec<MaskedInput<N, F>>) = input
+            .iter()
+            .zip(ot_messages.chunks_exact(F::BIT_SIZE as usize))
+            .map(|(&f, chunk)| {
+                SenderShare::new::<N>(
+                    f,
+                    chunk
+                        .try_into()
+                        .expect("Slice should have length of bit size of field element"),
+                )
+            })
+            .unzip();
+
+        Ok((shares, masked))
+    }
+
+    /// Generates new OLEs and stores them internally.
+    ///
+    /// This method is similar to [`OLESender::generate`], except that [`SenderShare`]s are stored
+    /// for later adjustment.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The sender's OLE input factors.
+    /// * `ot_messages` - The OT messages used for generating correlations.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`MaskedInput`]s, which is to be sent to the [`super::OLEReceiver`].
+    pub fn preprocess(
+        &mut self,
+        input: Vec<F>,
+        ot_messages: Vec<[F; 2]>,
+    ) -> Result<Vec<MaskedInput<N, F>>, OLEError> {
+        let (shares, masked) = self.generate(input, ot_messages)?;
+        self.cache.extend(shares);
+
+        Ok(masked)
+    }
+
+    /// Returns OLEs from internal cache.
+    ///
+    /// For consumption of OLEs which have been stored by [`OLESender::preprocess`].
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - The number of shares to return.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`SenderShare`]s containing the OLE output for the sender.
+    pub fn consume(&mut self, count: usize) -> Result<Vec<SenderShare<F>>, OLEError> {
+        if count > self.cache.len() {
+            return Err(OLEError::InsufficientOLEs(count, self.cache.len()));
+        }
+
+        let shares = self.cache.drain(..count).collect();
+        Ok(shares)
+    }
+
+    /// Adjusts OLEs in the internal cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `targets` - The new OLE sender inputs.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`SenderAdjust`]s which needs to be converted by [`OLESender::finish_adjust`].
+    /// * A vector of [`ShareAdjust`]s which needs to be sent to the [`super::OLEReceiver`].
+    pub fn adjust(
+        &mut self,
+        targets: Vec<F>,
+    ) -> Result<(Vec<SenderAdjust<F>>, Vec<ShareAdjust<F>>), OLEError> {
+        let shares = self.consume(targets.len())?;
+        let (sender_adjusted, adjustments) = shares
+            .into_iter()
+            .zip(targets)
+            .map(|(s, t)| s.adjust(t))
+            .unzip();
+
+        Ok((sender_adjusted, adjustments))
+    }
+
+    /// Completes the adjustment and returns the new shares.
+    ///
+    /// # Arguments
+    ///
+    /// * `sender_adjust` - The sender's intermediate shares from [`OLESender::adjust`].
+    /// * `adjustments` - The receiver's adjustments.
+    ///
+    /// # Returns
+    ///
+    /// * A vector of [`SenderShare`]s containing the new OLE outputs for the sender.
+    pub fn finish_adjust(
+        &self,
+        sender_adjust: Vec<SenderAdjust<F>>,
+        adjustments: Vec<ShareAdjust<F>>,
+    ) -> Result<Vec<SenderShare<F>>, OLEError> {
+        if sender_adjust.len() != adjustments.len() {
+            return Err(OLEError::UnequalAdjustments(
+                sender_adjust.len(),
+                adjustments.len(),
+            ));
+        }
+        let shares = sender_adjust
+            .into_iter()
+            .zip(adjustments.into_iter())
+            .map(|(s, a)| s.finish(a))
+            .collect();
+
+        Ok(shares)
+    }
+}

--- a/crates/mpz-ole-core/src/sender.rs
+++ b/crates/mpz-ole-core/src/sender.rs
@@ -5,18 +5,22 @@ use mpz_fields::Field;
 use crate::{
     core::{SenderAdjust, SenderShare, ShareAdjust},
     msg::{BatchAdjust, MaskedInputs},
-    OLEError,
+    OLEError, TransferId,
 };
 
 /// A sender for batched OLE.
 #[derive(Debug)]
 pub struct OLESender<const N: usize, F> {
+    id: TransferId,
     cache: Vec<SenderShare<F>>,
 }
 
 impl<const N: usize, F: Field> Default for OLESender<N, F> {
     fn default() -> Self {
-        OLESender { cache: vec![] }
+        OLESender {
+            id: TransferId::default(),
+            cache: Vec::default(),
+        }
     }
 }
 
@@ -30,7 +34,7 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     ///
     /// # Returns
     ///
-    /// * A vector of [`MaskedInput`]s, which is to be sent to the [`crate::OLEReceiver`].
+    /// * [`MaskedInputs`], which are to be sent to the [`crate::OLEReceiver`].
     pub fn preprocess(
         &mut self,
         input: Vec<F>,
@@ -70,11 +74,11 @@ impl<const N: usize, F: Field> OLESender<N, F> {
     ///
     /// # Returns
     ///
-    /// * A vector of [`SenderAdjust`]s which needs to be converted by [`OLESender::finish_adjust`].
+    /// * [`BatchSenderAdjust`] which needs to be converted by [`BatchSenderAdjust::finish_adjust`].
     /// * [`BatchAdjust`] which needs to be sent to the [`crate::OLEReceiver`].
-    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(Vec<SenderAdjust<F>>, BatchAdjust<F>)> {
+    pub fn adjust(&mut self, targets: Vec<F>) -> Option<(BatchSenderAdjust<F>, BatchAdjust<F>)> {
         let shares = self.consume(targets.len())?;
-        let (sender_adjusted, adjustments) = shares
+        let (sender_adjust, adjustments) = shares
             .into_iter()
             .zip(targets)
             .map(|(s, t)| {
@@ -83,34 +87,52 @@ impl<const N: usize, F: Field> OLESender<N, F> {
             })
             .unzip();
 
-        let adjustments = BatchAdjust { adjustments };
+        let id = self.id.next();
 
-        Some((sender_adjusted, adjustments))
+        let sender_adjust = BatchSenderAdjust {
+            id,
+            adjust: sender_adjust,
+        };
+        let adjustments = BatchAdjust { id, adjustments };
+
+        Some((sender_adjust, adjustments))
     }
+}
 
+/// Sender adjustments waiting for [`BatchAdjust`] from the receiver.
+pub struct BatchSenderAdjust<F> {
+    id: TransferId,
+    adjust: Vec<SenderAdjust<F>>,
+}
+
+impl<F: Field> BatchSenderAdjust<F> {
     /// Completes the adjustment and returns the new shares.
     ///
     /// # Arguments
     ///
-    /// * `sender_adjust` - The sender's intermediate shares from [`OLESender::adjust`].
     /// * `batch_adjust` - The receiver's adjustments.
     ///
     /// # Returns
     ///
     /// * A vector of [`SenderShare`]s containing the new OLE outputs for the sender.
     pub fn finish_adjust(
-        &self,
-        sender_adjust: Vec<SenderAdjust<F>>,
+        self,
         batch_adjust: BatchAdjust<F>,
     ) -> Result<Vec<SenderShare<F>>, OLEError> {
+        if self.id != batch_adjust.id {
+            return Err(OLEError::WrongId(batch_adjust.id, self.id));
+        }
+
+        let sender_adjust = self.adjust;
         let adjustments = batch_adjust.adjustments;
 
         if sender_adjust.len() != adjustments.len() {
             return Err(OLEError::UnequalAdjustments(
-                sender_adjust.len(),
                 adjustments.len(),
+                sender_adjust.len(),
             ));
         }
+
         let shares = sender_adjust
             .into_iter()
             .zip(adjustments.into_iter())

--- a/crates/mpz-ot-core/src/ideal/rot.rs
+++ b/crates/mpz-ot-core/src/ideal/rot.rs
@@ -43,18 +43,22 @@ impl IdealROT {
     /// # Arguments
     ///
     /// * `count` - The number of OTs to execute.
-    pub fn random(
+    pub fn random<const N: usize>(
         &mut self,
         count: usize,
-    ) -> (ROTSenderOutput<[Block; 2]>, ROTReceiverOutput<bool, Block>) {
+    ) -> (
+        ROTSenderOutput<[[u8; N]; 2]>,
+        ROTReceiverOutput<bool, [u8; N]>,
+    ) {
         let mut choices = vec![false; count];
 
         self.prg.random_bools(&mut choices);
 
-        let msgs: Vec<[Block; 2]> = (0..count)
+        let msgs: Vec<[[u8; N]; 2]> = (0..count)
             .map(|_| {
-                let mut msg = [Block::ZERO, Block::ZERO];
-                self.prg.random_blocks(&mut msg);
+                let mut msg = [[0; N], [0; N]];
+                self.prg.random_bytes(&mut msg[0]);
+                self.prg.random_bytes(&mut msg[1]);
                 msg
             })
             .collect();
@@ -83,14 +87,18 @@ impl IdealROT {
     /// # Arguments
     ///
     /// * `choices` - The choices made by the receiver.
-    pub fn random_with_choices(
+    pub fn random_with_choices<const N: usize>(
         &mut self,
         choices: Vec<bool>,
-    ) -> (ROTSenderOutput<[Block; 2]>, ROTReceiverOutput<bool, Block>) {
-        let msgs: Vec<[Block; 2]> = (0..choices.len())
+    ) -> (
+        ROTSenderOutput<[[u8; N]; 2]>,
+        ROTReceiverOutput<bool, [u8; N]>,
+    ) {
+        let msgs: Vec<[[u8; N]; 2]> = (0..choices.len())
             .map(|_| {
-                let mut msg = [Block::ZERO, Block::ZERO];
-                self.prg.random_blocks(&mut msg);
+                let mut msg = [[0; N], [0; N]];
+                self.prg.random_bytes(&mut msg[0]);
+                self.prg.random_bytes(&mut msg[1]);
                 msg
             })
             .collect();
@@ -137,7 +145,7 @@ mod tests {
                 msgs: received,
                 ..
             },
-        ) = IdealROT::default().random(100);
+        ) = IdealROT::default().random::<16>(100);
 
         assert_rot(&choices, &msgs, &received)
     }
@@ -155,7 +163,7 @@ mod tests {
                 msgs: received,
                 ..
             },
-        ) = IdealROT::default().random_with_choices(choices);
+        ) = IdealROT::default().random_with_choices::<16>(choices);
 
         assert_rot(&choices, &msgs, &received)
     }

--- a/crates/mpz-ot-core/src/ideal/rot.rs
+++ b/crates/mpz-ot-core/src/ideal/rot.rs
@@ -1,7 +1,10 @@
 //! Ideal Random Oblivious Transfer functionality.
 
 use mpz_core::{prg::Prg, Block};
-use rand::{Rng, SeedableRng};
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng, SeedableRng,
+};
 use rand_chacha::ChaCha8Rng;
 
 use crate::{ROTReceiverOutput, ROTSenderOutput, TransferId};
@@ -43,24 +46,19 @@ impl IdealROT {
     /// # Arguments
     ///
     /// * `count` - The number of OTs to execute.
-    pub fn random<const N: usize>(
+    pub fn random<T: Copy>(
         &mut self,
         count: usize,
-    ) -> (
-        ROTSenderOutput<[[u8; N]; 2]>,
-        ROTReceiverOutput<bool, [u8; N]>,
-    ) {
+    ) -> (ROTSenderOutput<[T; 2]>, ROTReceiverOutput<bool, T>)
+    where
+        Standard: Distribution<T>,
+    {
         let mut choices = vec![false; count];
 
         self.prg.random_bools(&mut choices);
 
-        let msgs: Vec<[[u8; N]; 2]> = (0..count)
-            .map(|_| {
-                let mut msg = [[0; N], [0; N]];
-                self.prg.random_bytes(&mut msg[0]);
-                self.prg.random_bytes(&mut msg[1]);
-                msg
-            })
+        let msgs: Vec<[T; 2]> = (0..count)
+            .map(|_| [self.prg.sample(Standard), self.prg.sample(Standard)])
             .collect();
 
         let chosen = choices
@@ -87,20 +85,15 @@ impl IdealROT {
     /// # Arguments
     ///
     /// * `choices` - The choices made by the receiver.
-    pub fn random_with_choices<const N: usize>(
+    pub fn random_with_choices<T: Copy>(
         &mut self,
         choices: Vec<bool>,
-    ) -> (
-        ROTSenderOutput<[[u8; N]; 2]>,
-        ROTReceiverOutput<bool, [u8; N]>,
-    ) {
-        let msgs: Vec<[[u8; N]; 2]> = (0..choices.len())
-            .map(|_| {
-                let mut msg = [[0; N], [0; N]];
-                self.prg.random_bytes(&mut msg[0]);
-                self.prg.random_bytes(&mut msg[1]);
-                msg
-            })
+    ) -> (ROTSenderOutput<[T; 2]>, ROTReceiverOutput<bool, T>)
+    where
+        Standard: Distribution<T>,
+    {
+        let msgs: Vec<[T; 2]> = (0..choices.len())
+            .map(|_| [self.prg.sample(Standard), self.prg.sample(Standard)])
             .collect();
 
         let chosen = choices
@@ -145,7 +138,7 @@ mod tests {
                 msgs: received,
                 ..
             },
-        ) = IdealROT::default().random::<16>(100);
+        ) = IdealROT::default().random::<Block>(100);
 
         assert_rot(&choices, &msgs, &received)
     }
@@ -163,7 +156,7 @@ mod tests {
                 msgs: received,
                 ..
             },
-        ) = IdealROT::default().random_with_choices::<16>(choices);
+        ) = IdealROT::default().random_with_choices::<Block>(choices);
 
         assert_rot(&choices, &msgs, &received)
     }

--- a/crates/mpz-ot/src/ideal/rot.rs
+++ b/crates/mpz-ot/src/ideal/rot.rs
@@ -6,19 +6,19 @@ use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
     Context,
 };
-use mpz_core::Block;
 use mpz_ot_core::{ideal::rot::IdealROT, ROTReceiverOutput, ROTSenderOutput};
+use rand::distributions::{Distribution, Standard};
 
 use crate::{OTError, OTSetup, RandomOTReceiver, RandomOTSender};
 
-fn rot<const N: usize>(
+fn rot<T: Copy>(
     f: &mut IdealROT,
     sender_count: usize,
     receiver_count: usize,
-) -> (
-    ROTSenderOutput<[[u8; N]; 2]>,
-    ROTReceiverOutput<bool, [u8; N]>,
-) {
+) -> (ROTSenderOutput<[T; 2]>, ROTReceiverOutput<bool, T>)
+where
+    Standard: Distribution<T>,
+{
     assert_eq!(sender_count, receiver_count);
 
     f.random(sender_count)
@@ -45,35 +45,15 @@ where
 }
 
 #[async_trait]
-impl<Ctx: Context> RandomOTSender<Ctx, [Block; 2]> for IdealROTSender {
+impl<T: Copy + Send + 'static, Ctx: Context> RandomOTSender<Ctx, [T; 2]> for IdealROTSender
+where
+    Standard: Distribution<T>,
+{
     async fn send_random(
         &mut self,
         ctx: &mut Ctx,
         count: usize,
-    ) -> Result<ROTSenderOutput<[Block; 2]>, OTError> {
-        let output = RandomOTSender::<Ctx, [[u8; 16]; 2]>::send_random(self, ctx, count).await?;
-
-        let block_msgs = output
-            .msgs
-            .iter()
-            .map(|&value| [Block::new(value[0]), Block::new(value[1])])
-            .collect();
-        let block_output = ROTSenderOutput {
-            id: output.id,
-            msgs: block_msgs,
-        };
-
-        Ok(block_output)
-    }
-}
-
-#[async_trait]
-impl<const N: usize, Ctx: Context> RandomOTSender<Ctx, [[u8; N]; 2]> for IdealROTSender {
-    async fn send_random(
-        &mut self,
-        ctx: &mut Ctx,
-        count: usize,
-    ) -> Result<ROTSenderOutput<[[u8; N]; 2]>, OTError> {
+    ) -> Result<ROTSenderOutput<[T; 2]>, OTError> {
         Ok(self.0.call(ctx, count, rot).await)
     }
 }
@@ -93,33 +73,16 @@ where
 }
 
 #[async_trait]
-impl<Ctx: Context> RandomOTReceiver<Ctx, bool, Block> for IdealROTReceiver {
+impl<T: Copy + Send + Sync + 'static, Ctx: Context> RandomOTReceiver<Ctx, bool, T>
+    for IdealROTReceiver
+where
+    Standard: Distribution<T>,
+{
     async fn receive_random(
         &mut self,
         ctx: &mut Ctx,
         count: usize,
-    ) -> Result<ROTReceiverOutput<bool, Block>, OTError> {
-        let output =
-            RandomOTReceiver::<Ctx, bool, [u8; 16]>::receive_random(self, ctx, count).await?;
-
-        let block_msgs = output.msgs.iter().map(|&value| Block::new(value)).collect();
-        let block_output = ROTReceiverOutput {
-            id: output.id,
-            choices: output.choices,
-            msgs: block_msgs,
-        };
-
-        Ok(block_output)
-    }
-}
-
-#[async_trait]
-impl<const N: usize, Ctx: Context> RandomOTReceiver<Ctx, bool, [u8; N]> for IdealROTReceiver {
-    async fn receive_random(
-        &mut self,
-        ctx: &mut Ctx,
-        count: usize,
-    ) -> Result<ROTReceiverOutput<bool, [u8; N]>, OTError> {
+    ) -> Result<ROTReceiverOutput<bool, T>, OTError> {
         Ok(self.0.call(ctx, count, rot).await)
     }
 }

--- a/crates/mpz-ot/src/ideal/rot.rs
+++ b/crates/mpz-ot/src/ideal/rot.rs
@@ -11,11 +11,14 @@ use mpz_ot_core::{ideal::rot::IdealROT, ROTReceiverOutput, ROTSenderOutput};
 
 use crate::{OTError, OTSetup, RandomOTReceiver, RandomOTSender};
 
-fn rot(
+fn rot<const N: usize>(
     f: &mut IdealROT,
     sender_count: usize,
     receiver_count: usize,
-) -> (ROTSenderOutput<[Block; 2]>, ROTReceiverOutput<bool, Block>) {
+) -> (
+    ROTSenderOutput<[[u8; N]; 2]>,
+    ROTReceiverOutput<bool, [u8; N]>,
+) {
     assert_eq!(sender_count, receiver_count);
 
     f.random(sender_count)
@@ -48,6 +51,29 @@ impl<Ctx: Context> RandomOTSender<Ctx, [Block; 2]> for IdealROTSender {
         ctx: &mut Ctx,
         count: usize,
     ) -> Result<ROTSenderOutput<[Block; 2]>, OTError> {
+        let output = RandomOTSender::<Ctx, [[u8; 16]; 2]>::send_random(self, ctx, count).await?;
+
+        let block_msgs = output
+            .msgs
+            .iter()
+            .map(|&value| [Block::new(value[0]), Block::new(value[1])])
+            .collect();
+        let block_output = ROTSenderOutput {
+            id: output.id,
+            msgs: block_msgs,
+        };
+
+        Ok(block_output)
+    }
+}
+
+#[async_trait]
+impl<const N: usize, Ctx: Context> RandomOTSender<Ctx, [[u8; N]; 2]> for IdealROTSender {
+    async fn send_random(
+        &mut self,
+        ctx: &mut Ctx,
+        count: usize,
+    ) -> Result<ROTSenderOutput<[[u8; N]; 2]>, OTError> {
         Ok(self.0.call(ctx, count, rot).await)
     }
 }
@@ -73,6 +99,27 @@ impl<Ctx: Context> RandomOTReceiver<Ctx, bool, Block> for IdealROTReceiver {
         ctx: &mut Ctx,
         count: usize,
     ) -> Result<ROTReceiverOutput<bool, Block>, OTError> {
+        let output =
+            RandomOTReceiver::<Ctx, bool, [u8; 16]>::receive_random(self, ctx, count).await?;
+
+        let block_msgs = output.msgs.iter().map(|&value| Block::new(value)).collect();
+        let block_output = ROTReceiverOutput {
+            id: output.id,
+            choices: output.choices,
+            msgs: block_msgs,
+        };
+
+        Ok(block_output)
+    }
+}
+
+#[async_trait]
+impl<const N: usize, Ctx: Context> RandomOTReceiver<Ctx, bool, [u8; N]> for IdealROTReceiver {
+    async fn receive_random(
+        &mut self,
+        ctx: &mut Ctx,
+        count: usize,
+    ) -> Result<ROTReceiverOutput<bool, [u8; N]>, OTError> {
         Ok(self.0.call(ctx, count, rot).await)
     }
 }


### PR DESCRIPTION
This PR adds the core crate for OLE, and makes ideal random OT more generic.