### PR TITLE
feat(mpz-common): Context::blocking

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -74,6 +74,7 @@ futures-util = "0.3"
 tokio = "1.23"
 tokio-util = "0.7"
 scoped-futures = "0.1.3"
+pollster = "0.3"
 
 # serialization
 ark-serialize = "0.4"

--- a/crates/mpz-common/Cargo.toml
+++ b/crates/mpz-common/Cargo.toml
@@ -8,6 +8,8 @@ default = ["sync"]
 sync = []
 test-utils = ["uid-mux/test-utils"]
 ideal = []
+rayon = ["dep:rayon"]
+force-st = []
 
 [dependencies]
 mpz-core.workspace = true
@@ -19,6 +21,9 @@ thiserror.workspace = true
 serio.workspace = true
 uid-mux.workspace = true
 serde = { workspace = true, features = ["derive"] }
+pollster.workspace = true
+rayon = { workspace = true, optional = true }
+cfg-if.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = [
@@ -29,3 +34,9 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true, features = ["compat"] }
 uid-mux = { workspace = true, features = ["test-utils"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+criterion.workspace = true
+
+[[bench]]
+name = "context"
+harness = false
+required-features = ["test-utils", "rayon"]

--- a/crates/mpz-common/benches/context.rs
+++ b/crates/mpz-common/benches/context.rs
@@ -1,0 +1,53 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use mpz_common::{
+    executor::{test_mt_executor, test_st_executor},
+    Context,
+};
+use pollster::block_on;
+use scoped_futures::ScopedFutureExt;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("context");
+
+    // Measures the overhead of making a `Context::blocking` call, which
+    // moves the context to a worker thread and back.
+    group.bench_function("st/blocking", |b| {
+        let (mut ctx, _) = test_st_executor(1024);
+        b.iter(|| {
+            block_on(async {
+                ctx.blocking(|ctx| {
+                    async move {
+                        black_box(ctx.id());
+                    }
+                    .scope_boxed()
+                })
+                .await
+                .unwrap();
+            });
+        })
+    });
+
+    // Measures the overhead of making a `Context::blocking` call, which
+    // moves the context to a worker thread and back.
+    group.bench_function("mt/blocking", |b| {
+        let (mut exec_a, _) = test_mt_executor(8);
+
+        let mut ctx = block_on(exec_a.new_thread()).unwrap();
+
+        b.iter(|| {
+            block_on(async {
+                ctx.blocking(|ctx| {
+                    async move {
+                        black_box(ctx.id());
+                    }
+                    .scope_boxed()
+                })
+                .await
+                .unwrap();
+            });
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/mpz-common/src/cpu.rs
+++ b/crates/mpz-common/src/cpu.rs
@@ -1,0 +1,122 @@
+//! CPU backend shim.
+
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "force-st")] {
+        pub use st::SingleThreadedBackend as CpuBackend;
+    } else if #[cfg(feature = "rayon")] {
+        pub use rayon_backend::RayonBackend as CpuBackend;
+    } else {
+        pub use st::SingleThreadedBackend as CpuBackend;
+    }
+}
+
+#[cfg(any(feature = "force-st", not(feature = "rayon")))]
+mod st {
+    use futures::Future;
+
+    /// A single-threaded CPU backend.
+    #[derive(Debug)]
+    pub struct SingleThreadedBackend;
+
+    impl SingleThreadedBackend {
+        /// Execute a future on the CPU backend.
+        #[inline]
+        pub fn blocking_async<F>(fut: F) -> impl Future<Output = F::Output> + Send
+        where
+            F: Future + Send + 'static,
+            F::Output: Send,
+        {
+            fut
+        }
+
+        /// Execute a closure on the CPU backend.
+        #[inline]
+        pub fn blocking<F, R>(f: F) -> impl Future<Output = R> + Send
+        where
+            F: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            async move { f() }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use pollster::block_on;
+
+        #[test]
+        fn test_st_backend_blocking() {
+            let output = block_on(SingleThreadedBackend::blocking(|| 42));
+            assert_eq!(output, 42);
+        }
+
+        #[test]
+        fn test_st_backend_blocking_async() {
+            let output = block_on(SingleThreadedBackend::blocking_async(async { 42 }));
+            assert_eq!(output, 42);
+        }
+    }
+}
+
+#[cfg(all(feature = "rayon", not(feature = "force-st")))]
+mod rayon_backend {
+    use futures::{channel::oneshot, Future};
+    use pollster::block_on;
+
+    /// A Rayon CPU backend.
+    #[derive(Debug)]
+    pub struct RayonBackend;
+
+    impl RayonBackend {
+        /// Execute a future on the CPU backend.
+        pub fn blocking_async<F>(fut: F) -> impl Future<Output = F::Output> + Send
+        where
+            F: Future + Send + 'static,
+            F::Output: Send,
+        {
+            async move {
+                let (sender, receiver) = oneshot::channel();
+                rayon::spawn(move || {
+                    let output = block_on(fut);
+                    _ = sender.send(output);
+                });
+                receiver.await.expect("worker thread does not drop channel")
+            }
+        }
+
+        /// Execute a closure on the CPU backend.
+        pub fn blocking<F, R>(f: F) -> impl Future<Output = R> + Send
+        where
+            F: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            async move {
+                let (sender, receiver) = oneshot::channel();
+                rayon::spawn(move || {
+                    _ = sender.send(f());
+                });
+                receiver.await.expect("worker thread does not drop channel")
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_rayon_backend_blocking() {
+            let output = block_on(RayonBackend::blocking(|| 42));
+            assert_eq!(output, 42);
+        }
+
+        #[test]
+        fn test_rayon_backend_blocking_async() {
+            let output = block_on(RayonBackend::blocking_async(async { 42 }));
+            assert_eq!(output, 42);
+        }
+    }
+}

--- a/crates/mpz-common/src/cpu.rs
+++ b/crates/mpz-common/src/cpu.rs
@@ -21,7 +21,7 @@ mod st {
     pub struct SingleThreadedBackend;
 
     impl SingleThreadedBackend {
-        /// Execute a future on the CPU backend.
+        /// Executes a future on the CPU backend.
         #[inline]
         pub fn blocking_async<F>(fut: F) -> impl Future<Output = F::Output> + Send
         where
@@ -31,7 +31,7 @@ mod st {
             fut
         }
 
-        /// Execute a closure on the CPU backend.
+        /// Executes a closure on the CPU backend.
         #[inline]
         pub fn blocking<F, R>(f: F) -> impl Future<Output = R> + Send
         where
@@ -71,7 +71,7 @@ mod rayon_backend {
     pub struct RayonBackend;
 
     impl RayonBackend {
-        /// Execute a future on the CPU backend.
+        /// Executes a future on the CPU backend.
         pub fn blocking_async<F>(fut: F) -> impl Future<Output = F::Output> + Send
         where
             F: Future + Send + 'static,
@@ -87,7 +87,7 @@ mod rayon_backend {
             }
         }
 
-        /// Execute a closure on the CPU backend.
+        /// Executes a closure on the CPU backend.
         pub fn blocking<F, R>(f: F) -> impl Future<Output = R> + Send
         where
             F: FnOnce() -> R + Send + 'static,

--- a/crates/mpz-common/src/executor/mod.rs
+++ b/crates/mpz-common/src/executor/mod.rs
@@ -5,7 +5,7 @@ mod mt;
 mod st;
 
 pub use dummy::{DummyExecutor, DummyIo};
-pub use mt::MTExecutor;
+pub use mt::{MTContext, MTExecutor};
 pub use st::STExecutor;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/mpz-common/src/lib.rs
+++ b/crates/mpz-common/src/lib.rs
@@ -15,6 +15,7 @@
 )]
 
 mod context;
+pub mod cpu;
 pub mod executor;
 mod id;
 #[cfg(any(test, feature = "ideal"))]


### PR DESCRIPTION
This PR adds the `Context::blocking` method which supports temporarily moving a context to a separate thread to perform blocking computation. I've also moved the CPU backend shim abstraction into `mpz-common`.

This method is needed to avoid deadlocks on single threaded machines. The alternative approach is to use an `mpsc` channel between the worker thread and the calling context, but that doesn't work if single-threaded.