### PR TITLE
feat(mpz-common): scoped! macro

### DIFF
--- a/crates/mpz-common/src/executor/dummy.rs
+++ b/crates/mpz-common/src/executor/dummy.rs
@@ -125,7 +125,8 @@ impl Context for DummyExecutor {
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
-    use scoped_futures::ScopedFutureExt;
+
+    use crate::scoped;
 
     use super::*;
 
@@ -142,18 +143,8 @@ mod tests {
             let a = &mut self.a;
             let b = &mut self.b;
             ctx.join(
-                |ctx| {
-                    async move {
-                        *a = ctx.id().clone();
-                    }
-                    .scope_boxed()
-                },
-                |ctx| {
-                    async move {
-                        *b = ctx.id().clone();
-                    }
-                    .scope_boxed()
-                },
+                scoped!(|ctx| *a = ctx.id().clone()),
+                scoped!(|ctx| *b = ctx.id().clone()),
             )
             .await
             .unwrap();

--- a/crates/mpz-common/src/lib.rs
+++ b/crates/mpz-common/src/lib.rs
@@ -28,3 +28,84 @@ pub use id::{Counter, ThreadId};
 
 // Re-export scoped-futures for use with the callback-like API in `Context`.
 pub use scoped_futures;
+
+/// A convenience macro for creating a closure which returns a scoped future.
+///
+/// # Example
+///
+/// ```
+/// # use mpz_common::scoped;
+///
+/// let closure = scoped!(|a: u8, b: u16| a as u16 + b);
+/// let fut = closure(1, 2);
+///
+/// fn is_future<T: futures::Future<Output = u16>>(_: T) {}
+///
+/// is_future(fut);
+/// ```
+#[macro_export]
+macro_rules! scoped {
+    // Async move block.
+    (| $($arg:ident $(: $typ:ty)?),* | async move $body:block) => {{
+        #[allow(unused_imports)]
+        use $crate::scoped_futures::ScopedFutureExt;
+        | $($arg $( : $typ )?),* | async move $body.scope_boxed()
+    }};
+    // Async move block, move.
+    (move | $($arg:ident $(: $typ:ty)?),* | async move $body:block) => {{
+        #[allow(unused_imports)]
+        use $crate::scoped_futures::ScopedFutureExt;
+        move | $($arg $( : $typ )?),* | async move $body.scope_boxed()
+    }};
+    // No async block.
+    (| $($arg:ident $(: $typ:ty)?),* | $body:expr) => {{
+        #[allow(unused_imports)]
+        use $crate::scoped_futures::ScopedFutureExt;
+        | $($arg $( : $typ )?),* | async move { $body }.scope_boxed()
+    }};
+    // No async block, move.
+    (move | $($arg:ident $(: $typ:ty)?),* | $body:expr) => {{
+        #[allow(unused_imports)]
+        use $crate::scoped_futures::ScopedFutureExt;
+        move | $($arg $( : $typ )?),* | async move { $body }.scope_boxed()
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::Future;
+
+    #[test]
+    fn test_scoped_macro() {
+        fn assert_signature<T, Fut>(_: T)
+        where
+            T: Fn(u8, u16) -> Fut,
+            Fut: Future<Output = u8>,
+        {
+        }
+
+        assert_signature(scoped! {
+            |a: u8, _b: u16| async move { a }
+        });
+
+        assert_signature(scoped! {
+            move |a, _b| async move { a }
+        });
+
+        assert_signature(scoped! {
+            |a, _b| a
+        });
+
+        assert_signature(scoped! {
+            move |a: u8, _b| a
+        });
+
+        assert_signature(scoped! {
+            |a: u8, _b| a
+        });
+
+        assert_signature(scoped! {
+            |a, _b: u16| a
+        });
+    }
+}


### PR DESCRIPTION
This PR adds a `scoped!` macro which makes it easy to write closures which return scoped futures. This macro may end up being preferable to using the `join` and `try_join` macros.