### PR TITLE
refactor(mpz-garble): fix threading breaking changes

### DIFF
--- a/crates/mpz-common/src/id.rs
+++ b/crates/mpz-common/src/id.rs
@@ -64,6 +64,19 @@ impl AsRef<[u8]> for ThreadId {
     }
 }
 
+impl fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, byte) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, "/")?;
+            }
+            write!(f, "{}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// A simple counter.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Counter(u32);

--- a/crates/mpz-garble/Cargo.toml
+++ b/crates/mpz-garble/Cargo.toml
@@ -11,15 +11,18 @@ name = "mpz_garble"
 
 [features]
 default = ["mock"]
+rayon = ["mpz-common/rayon"]
 mock = ["mpz-ot/ideal"]
 
 [dependencies]
 mpz-circuits.workspace = true
+mpz-common = { workspace = true, features = ["test-utils"] }
 mpz-ot.workspace = true
 mpz-garble-core.workspace = true
 mpz-core.workspace = true
 tlsn-utils.workspace = true
 tlsn-utils-aio.workspace = true
+serio.workspace = true
 
 async-trait.workspace = true
 prost.workspace = true
@@ -31,12 +34,13 @@ rand_core.workspace = true
 rand_chacha = { workspace = true }
 thiserror.workspace = true
 aes = { workspace = true }
-rayon = { workspace = true }
 derive_builder.workspace = true
 itybity.workspace = true
+tracing.workspace = true
 opaque-debug.workspace = true
 
 [dev-dependencies]
+mpz-common = { workspace = true, features = ["test-utils", "ideal"] }
 mpz-ot = { workspace = true, features = ["ideal"] }
 rstest = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
@@ -48,6 +52,7 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 async_executors = { version = "0.6", features = ["notwasm", "tokio_tp"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [[bench]]
 name = "deap"

--- a/crates/mpz-garble/benches/deap.rs
+++ b/crates/mpz-garble/benches/deap.rs
@@ -1,154 +1,90 @@
-use std::pin::Pin;
+use criterion::{criterion_group, criterion_main, Criterion};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use futures::Future;
 use mpz_circuits::circuits::AES128;
-use mpz_garble::{
-    protocol::deap::mock::create_mock_deap_vm, Decode, Execute, Memory, Thread, Vm, VmError,
-};
-
-async fn bench_deap() {
-    let (mut leader_vm, mut follower_vm) = create_mock_deap_vm("mock").await;
-    let mut leader_thread = leader_vm.new_thread("mock_thread").await.unwrap();
-    let mut follower_thread = follower_vm.new_thread("mock_thread").await.unwrap();
-
-    let key = [0u8; 16];
-    let msg = [0u8; 16];
-
-    let leader_fut = {
-        let key_ref = leader_thread.new_private_input::<[u8; 16]>("key").unwrap();
-        let msg_ref = leader_thread.new_blind_input::<[u8; 16]>("msg").unwrap();
-        let ciphertext_ref = leader_thread.new_output::<[u8; 16]>("ciphertext").unwrap();
-
-        leader_thread.assign(&key_ref, key).unwrap();
-
-        async {
-            leader_thread
-                .execute(
-                    AES128.clone(),
-                    &[key_ref, msg_ref],
-                    &[ciphertext_ref.clone()],
-                )
-                .await
-                .unwrap();
-
-            leader_thread.decode(&[ciphertext_ref]).await.unwrap();
-
-            leader_vm.finalize().await.unwrap();
-        }
-    };
-
-    let follower_fut = {
-        let key_ref = follower_thread.new_blind_input::<[u8; 16]>("key").unwrap();
-        let msg_ref = follower_thread
-            .new_private_input::<[u8; 16]>("msg")
-            .unwrap();
-        let ciphertext_ref = follower_thread
-            .new_output::<[u8; 16]>("ciphertext")
-            .unwrap();
-
-        follower_thread.assign(&msg_ref, msg).unwrap();
-
-        async {
-            follower_thread
-                .execute(
-                    AES128.clone(),
-                    &[key_ref, msg_ref],
-                    &[ciphertext_ref.clone()],
-                )
-                .await
-                .unwrap();
-
-            follower_thread.decode(&[ciphertext_ref]).await.unwrap();
-
-            follower_vm.finalize().await.unwrap();
-        }
-    };
-
-    _ = futures::join!(leader_fut, follower_fut)
-}
-
-fn bench_aes_leader<T: Thread + Execute + Decode + Send>(
-    thread: &mut T,
-    block: usize,
-) -> Pin<Box<dyn Future<Output = Result<[u8; 16], VmError>> + Send + '_>> {
-    Box::pin(async move {
-        let key = thread.new_private_input::<[u8; 16]>(&format!("key/{block}"))?;
-        let msg = thread.new_private_input::<[u8; 16]>(&format!("msg/{block}"))?;
-        let ciphertext = thread.new_output::<[u8; 16]>(&format!("ciphertext/{block}"))?;
-
-        thread.assign(&key, [0u8; 16])?;
-        thread.assign(&msg, [0u8; 16])?;
-
-        thread
-            .execute(AES128.clone(), &[key, msg], &[ciphertext.clone()])
-            .await?;
-
-        let mut values = thread.decode(&[ciphertext]).await?;
-
-        Ok(values.pop().unwrap().try_into().unwrap())
-    })
-}
-
-fn bench_aes_follower<T: Thread + Execute + Decode + Send>(
-    thread: &mut T,
-    block: usize,
-) -> Pin<Box<dyn Future<Output = Result<[u8; 16], VmError>> + Send + '_>> {
-    Box::pin(async move {
-        let key = thread.new_blind_input::<[u8; 16]>(&format!("key/{block}"))?;
-        let msg = thread.new_blind_input::<[u8; 16]>(&format!("msg/{block}"))?;
-        let ciphertext = thread.new_output::<[u8; 16]>(&format!("ciphertext/{block}"))?;
-
-        thread
-            .execute(AES128.clone(), &[key, msg], &[ciphertext.clone()])
-            .await?;
-
-        let mut values = thread.decode(&[ciphertext]).await?;
-
-        Ok(values.pop().unwrap().try_into().unwrap())
-    })
-}
-
-async fn bench_aes_threadpool(thread_count: usize, block_count: usize) {
-    let (mut leader_vm, mut follower_vm) = create_mock_deap_vm("bench_vm").await;
-
-    let (mut leader_pool, mut follower_pool) = futures::try_join!(
-        leader_vm.new_thread_pool("bench_pool", thread_count),
-        follower_vm.new_thread_pool("bench_pool", thread_count),
-    )
-    .unwrap();
-
-    let mut leader_scope = leader_pool.new_scope();
-    let mut follower_scope = follower_pool.new_scope();
-
-    for block in 0..block_count {
-        leader_scope.push(move |thread| bench_aes_leader(thread, block));
-        follower_scope.push(move |thread| bench_aes_follower(thread, block));
-    }
-
-    _ = futures::join!(leader_scope.wait(), follower_scope.wait());
-
-    futures::try_join!(leader_vm.finalize(), follower_vm.finalize()).unwrap();
-}
+use mpz_common::executor::test_mt_executor;
+use mpz_garble::{config::Role, protocol::deap::DEAPVm, Decode, Execute, Memory};
+use mpz_ot::ideal::ot::ideal_ot;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("deap");
-    let thread_count = 4;
-    let block_count = 128;
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     group.bench_function("aes", |b| {
         b.to_async(&rt).iter(|| async {
-            bench_deap().await;
-            black_box(())
-        })
-    });
+            let (mut leader_exec, mut follower_exec) = test_mt_executor(8);
 
-    group.throughput(criterion::Throughput::Bytes(block_count as u64 * 16));
-    group.bench_function("aes_mt", |b| {
-        b.to_async(&rt).iter(|| async {
-            bench_aes_threadpool(thread_count, block_count).await;
-            black_box(())
+            let (leader_ot_send, follower_ot_recv) = ideal_ot();
+            let (follower_ot_send, leader_ot_recv) = ideal_ot();
+
+            let key = [0u8; 16];
+            let msg = [0u8; 16];
+
+            let leader_fut = {
+                async move {
+                    let leader_ctx = leader_exec.new_thread().await.unwrap();
+
+                    let mut leader_vm = DEAPVm::new(
+                        Role::Leader,
+                        [42u8; 32],
+                        leader_ctx,
+                        leader_ot_send,
+                        leader_ot_recv,
+                    );
+
+                    let key_ref = leader_vm.new_private_input::<[u8; 16]>("key").unwrap();
+                    let msg_ref = leader_vm.new_private_input::<[u8; 16]>("msg").unwrap();
+                    let ciphertext_ref = leader_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
+
+                    leader_vm.assign(&key_ref, key).unwrap();
+                    leader_vm.assign(&msg_ref, msg).unwrap();
+
+                    leader_vm
+                        .execute(
+                            AES128.clone(),
+                            &[key_ref.clone(), msg_ref],
+                            &[ciphertext_ref.clone()],
+                        )
+                        .await
+                        .unwrap();
+
+                    leader_vm.decode(&[ciphertext_ref]).await.unwrap();
+
+                    leader_vm.finalize().await.unwrap();
+                }
+            };
+
+            let follower_fut = {
+                async move {
+                    let follower_ctx = follower_exec.new_thread().await.unwrap();
+
+                    let mut follower_vm = DEAPVm::new(
+                        Role::Follower,
+                        [69u8; 32],
+                        follower_ctx,
+                        follower_ot_send,
+                        follower_ot_recv,
+                    );
+
+                    let key_ref = follower_vm.new_blind_input::<[u8; 16]>("key").unwrap();
+                    let msg_ref = follower_vm.new_blind_input::<[u8; 16]>("msg").unwrap();
+                    let ciphertext_ref = follower_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
+
+                    follower_vm
+                        .execute(
+                            AES128.clone(),
+                            &[key_ref.clone(), msg_ref],
+                            &[ciphertext_ref.clone()],
+                        )
+                        .await
+                        .unwrap();
+
+                    follower_vm.decode(&[ciphertext_ref]).await.unwrap();
+
+                    follower_vm.finalize().await.unwrap();
+                }
+            };
+
+            futures::join!(leader_fut, follower_fut);
         })
     });
 }

--- a/crates/mpz-garble/src/config.rs
+++ b/crates/mpz-garble/src/config.rs
@@ -1,11 +1,22 @@
 //! Various configuration used in the protocol
 
+use core::fmt;
+
 /// Role in 2PC.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(missing_docs)]
 pub enum Role {
     Leader,
     Follower,
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Role::Leader => write!(f, "Leader"),
+            Role::Follower => write!(f, "Follower"),
+        }
+    }
 }
 
 /// Visibility of a value

--- a/crates/mpz-garble/src/evaluator/error.rs
+++ b/crates/mpz-garble/src/evaluator/error.rs
@@ -8,6 +8,8 @@ pub enum EvaluatorError {
     CoreError(#[from] mpz_garble_core::EvaluatorError),
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+    #[error("context error: {0}")]
+    ContextError(#[from] mpz_common::ContextError),
     // TODO: Fix the size of this error
     #[error(transparent)]
     OTError(Box<mpz_ot::OTError>),

--- a/crates/mpz-garble/src/generator/config.rs
+++ b/crates/mpz-garble/src/generator/config.rs
@@ -6,9 +6,6 @@ pub struct GeneratorConfig {
     /// Whether to send commitments to output encodings.
     #[builder(default = "false", setter(custom))]
     pub(crate) encoding_commitments: bool,
-    /// The batch size for encrypted gates sent to the evaluator.
-    #[builder(default = "1024")]
-    pub(crate) batch_size: usize,
 }
 
 impl GeneratorConfig {

--- a/crates/mpz-garble/src/generator/error.rs
+++ b/crates/mpz-garble/src/generator/error.rs
@@ -13,6 +13,8 @@ pub enum GeneratorError {
     OTError(Box<mpz_ot::OTError>),
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+    #[error("context error: {0}")]
+    ContextError(#[from] mpz_common::ContextError),
     #[error(transparent)]
     ValueError(#[from] ValueError),
     #[error("duplicate encoding for value: {0:?}")]

--- a/crates/mpz-garble/src/generator/mod.rs
+++ b/crates/mpz-garble/src/generator/mod.rs
@@ -9,17 +9,18 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use futures::{Sink, SinkExt};
 use mpz_circuits::{
     types::{Value, ValueType},
     Circuit,
 };
+use mpz_common::{scoped, Context};
 use mpz_core::hash::Hash;
 use mpz_garble_core::{
-    encoding_state, msg::GarbleMessage, ChaChaEncoder, EncodedValue, Encoder,
-    Generator as GeneratorCore,
+    encoding_state, ChaChaEncoder, EncodedValue, Encoder, EncodingCommitment,
+    Generator as GeneratorCore, GeneratorOutput,
 };
-use utils_aio::non_blocking_backend::{Backend, NonBlockingBackend};
+use serio::SinkExt;
+use tracing::{span, Level};
 
 use crate::{
     memory::EncodingMemory,
@@ -142,24 +143,27 @@ impl Generator {
     /// - `values` - The assigned values
     /// - `sink` - The sink to send the encodings to the evaluator
     /// - `ot` - The OT sender
-    pub async fn setup_assigned_values<
-        S: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        OT: OTSendEncoding,
-    >(
+    pub async fn setup_assigned_values<Ctx: Context, OT: OTSendEncoding<Ctx> + Send>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &AssignedValues,
-        sink: &mut S,
-        ot: &OT,
+        ot: &mut OT,
     ) -> Result<(), GeneratorError> {
         let ot_send_values = values.blind.clone();
         let mut direct_send_values = values.public.clone();
         direct_send_values.extend(values.private.iter().cloned());
 
-        futures::try_join!(
-            self.ot_send_active_encodings(id, &ot_send_values, ot),
-            self.direct_send_active_encodings(&direct_send_values, sink)
-        )?;
+        ctx.try_join(
+            scoped!(|ctx| async move {
+                self.direct_send_active_encodings(ctx, &direct_send_values)
+                    .await
+            }),
+            scoped!(|ctx| async move {
+                self.ot_send_active_encodings(ctx, &ot_send_values, ot)
+                    .await
+            }),
+        )
+        .await??;
 
         Ok(())
     }
@@ -171,11 +175,12 @@ impl Generator {
     /// - `id` - The ID of this operation
     /// - `values` - The values to send
     /// - `ot` - The OT sender
-    pub(crate) async fn ot_send_active_encodings<OT: OTSendEncoding>(
+    #[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+    pub(crate) async fn ot_send_active_encodings<Ctx: Context, OT: OTSendEncoding<Ctx>>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[(ValueId, ValueType)],
-        ot: &OT,
+        ot: &mut OT,
     ) -> Result<(), GeneratorError> {
         if values.is_empty() {
             return Ok(());
@@ -196,7 +201,7 @@ impl Generator {
                 .collect::<Result<Vec<_>, GeneratorError>>()?
         };
 
-        ot.send(id, full_encodings).await?;
+        ot.send(ctx, full_encodings).await?;
 
         Ok(())
     }
@@ -207,12 +212,11 @@ impl Generator {
     ///
     /// - `values` - The values to send
     /// - `sink` - The sink to send the encodings to the evaluator
-    pub(crate) async fn direct_send_active_encodings<
-        S: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-    >(
+    #[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+    pub(crate) async fn direct_send_active_encodings<Ctx: Context>(
         &self,
+        ctx: &mut Ctx,
         values: &[(ValueId, Value)],
-        sink: &mut S,
     ) -> Result<(), GeneratorError> {
         if values.is_empty() {
             return Ok(());
@@ -236,8 +240,7 @@ impl Generator {
                 .collect::<Result<Vec<_>, GeneratorError>>()?
         };
 
-        sink.send(GarbleMessage::ActiveValues(active_encodings))
-            .await?;
+        ctx.io_mut().send(active_encodings).await?;
 
         Ok(())
     }
@@ -253,18 +256,20 @@ impl Generator {
     /// * `outputs` - The outputs of the circuit
     /// * `sink` - The sink to send the garbled circuit to the evaluator
     /// * `hash` - Whether to hash the circuit
-    pub async fn generate<S: Sink<GarbleMessage, Error = std::io::Error> + Unpin>(
+    #[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+    pub async fn generate<Ctx: Context>(
         &self,
+        ctx: &mut Ctx,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        sink: &mut S,
         hash: bool,
     ) -> Result<(Vec<EncodedValue<encoding_state::Full>>, Option<Hash>), GeneratorError> {
         let refs = CircuitRefs {
             inputs: inputs.to_vec(),
             outputs: outputs.to_vec(),
         };
+
         let (delta, inputs) = {
             let state = self.state();
 
@@ -298,40 +303,39 @@ impl Generator {
             (delta, inputs)
         };
 
-        let mut gen = if hash {
-            GeneratorCore::new_with_hasher(circ.clone(), delta, &inputs)?
-        } else {
-            GeneratorCore::new(circ.clone(), delta, &inputs)?
-        };
+        // Garble the circuit in batches, streaming the encrypted gates from the worker thread.
+        let span = span!(Level::TRACE, "worker");
+        let GeneratorOutput {
+            outputs: encoded_outputs,
+            hash,
+        } = ctx
+            .blocking(scoped!(move |ctx| async move {
+                let _enter = span.enter();
+                let mut gen = GeneratorCore::default();
+                let mut gen_iter = gen.generate_batched(&circ, delta, inputs)?;
+                let io = ctx.io_mut();
 
-        let mut batch: Vec<_>;
-        let batch_size = self.config.batch_size;
-        while !gen.is_complete() {
-            // Move the generator to another thread to produce the next batch
-            // then send it back
-            (gen, batch) = Backend::spawn(move || {
-                let batch = gen.by_ref().take(batch_size).collect();
-                (gen, batch)
-            })
-            .await;
+                if hash {
+                    gen_iter.enable_hasher();
+                }
 
-            if !batch.is_empty() {
-                sink.send(GarbleMessage::EncryptedGates(batch)).await?;
-            }
-        }
+                while let Some(batch) = gen_iter.by_ref().next() {
+                    io.feed(batch).await?;
+                }
 
-        let encoded_outputs = gen.outputs()?;
-        let hash = gen.hash();
+                gen_iter.finish().map_err(GeneratorError::from)
+            }))
+            .await??;
 
         if self.config.encoding_commitments {
-            let commitments = encoded_outputs
+            let commitments: Vec<EncodingCommitment> = encoded_outputs
                 .iter()
                 .map(|output| output.commit())
                 .collect();
-
-            sink.send(GarbleMessage::EncodingCommitments(commitments))
-                .await?;
+            ctx.io_mut().feed(commitments).await?;
         }
+
+        ctx.io_mut().flush().await?;
 
         // Add the outputs to the memory and set as active.
         let mut state = self.state();
@@ -353,10 +357,10 @@ impl Generator {
     ///
     /// * `values` - The values to decode
     /// * `sink` - The sink to send the decodings with
-    pub async fn decode<S: Sink<GarbleMessage, Error = std::io::Error> + Unpin>(
+    pub async fn decode<Ctx: Context>(
         &self,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut S,
     ) -> Result<(), GeneratorError> {
         let decodings = {
             let state = self.state();
@@ -372,7 +376,7 @@ impl Generator {
                 .collect::<Result<Vec<_>, _>>()?
         };
 
-        sink.send(GarbleMessage::ValueDecodings(decodings)).await?;
+        ctx.io_mut().send(decodings).await?;
 
         Ok(())
     }

--- a/crates/mpz-garble/src/ot.rs
+++ b/crates/mpz-garble/src/ot.rs
@@ -3,72 +3,95 @@
 use async_trait::async_trait;
 use itybity::IntoBits;
 use mpz_circuits::types::Value;
+use mpz_common::Context;
 use mpz_core::Block;
 use mpz_garble_core::{encoding_state, EncodedValue, Label};
+use mpz_ot::TransferId;
 
 /// A trait for sending encodings via oblivious transfer.
 #[async_trait]
-pub trait OTSendEncoding {
+pub trait OTSendEncoding<Ctx> {
     /// Sends encodings to the receiver.
     async fn send(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
         input: Vec<EncodedValue<encoding_state::Full>>,
-    ) -> Result<(), mpz_ot::OTError>;
+    ) -> Result<EncodingSenderOutput, mpz_ot::OTError>;
+}
+
+/// The output of an encoding sender.
+#[derive(Debug)]
+pub struct EncodingSenderOutput {
+    /// The transfer id.
+    pub id: TransferId,
 }
 
 #[async_trait]
-impl<T> OTSendEncoding for T
+impl<Ctx: Context, T> OTSendEncoding<Ctx> for T
 where
-    T: mpz_ot::OTSenderShared<[Block; 2]> + Send + Sync,
+    T: mpz_ot::OTSender<Ctx, [Block; 2]> + Send + Sync,
 {
     async fn send(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
         input: Vec<EncodedValue<encoding_state::Full>>,
-    ) -> Result<(), mpz_ot::OTError> {
+    ) -> Result<EncodingSenderOutput, mpz_ot::OTError> {
         let blocks: Vec<[Block; 2]> = input
             .into_iter()
             .flat_map(|v| v.iter_blocks().collect::<Vec<_>>())
             .collect();
-        self.send(id, &blocks).await
+
+        let output = self.send(ctx, &blocks).await?;
+
+        Ok(EncodingSenderOutput { id: output.id })
     }
 }
 
 /// A trait for receiving encodings via oblivious transfer.
 #[async_trait]
-pub trait OTReceiveEncoding {
+pub trait OTReceiveEncoding<Ctx> {
     /// Receives encodings from the sender.
     async fn receive(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
         choice: Vec<Value>,
-    ) -> Result<Vec<EncodedValue<encoding_state::Active>>, mpz_ot::OTError>;
+    ) -> Result<EncodingReceiverOutput, mpz_ot::OTError>;
+}
+
+/// The output of an encoding receiver.
+#[derive(Debug)]
+pub struct EncodingReceiverOutput {
+    /// The transfer id.
+    pub id: TransferId,
+    /// The encodings.
+    pub encodings: Vec<EncodedValue<encoding_state::Active>>,
 }
 
 #[async_trait]
-impl<T> OTReceiveEncoding for T
+impl<Ctx: Context, T> OTReceiveEncoding<Ctx> for T
 where
-    T: mpz_ot::OTReceiverShared<bool, Block> + Send + Sync,
+    T: mpz_ot::OTReceiver<Ctx, bool, Block> + Send + Sync,
 {
     async fn receive(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
         choice: Vec<Value>,
-    ) -> Result<Vec<EncodedValue<encoding_state::Active>>, mpz_ot::OTError> {
-        let mut blocks = self
+    ) -> Result<EncodingReceiverOutput, mpz_ot::OTError> {
+        let mut output = self
             .receive(
-                id,
+                ctx,
                 &choice
                     .iter()
                     .flat_map(|value| value.clone().into_iter_lsb0())
                     .collect::<Vec<bool>>(),
             )
             .await?;
+
         let encodings = choice
             .iter()
             .map(|value| {
-                let labels = blocks
+                let labels = output
+                    .msgs
                     .drain(..value.value_type().len())
                     .map(Label::new)
                     .collect::<Vec<_>>();
@@ -77,61 +100,72 @@ where
             })
             .collect();
 
-        Ok(encodings)
+        Ok(EncodingReceiverOutput {
+            id: output.id,
+            encodings,
+        })
     }
 }
 
 /// A trait for verifying encodings sent via oblivious transfer.
 #[async_trait]
-pub trait OTVerifyEncoding {
+pub trait OTVerifyEncoding<Ctx> {
     /// Verifies that the encodings sent by the sender are correct.
     async fn verify(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
+        id: TransferId,
         input: Vec<EncodedValue<encoding_state::Full>>,
     ) -> Result<(), mpz_ot::OTError>;
 }
 
 #[async_trait]
-impl<T> OTVerifyEncoding for T
+impl<Ctx: Context, T> OTVerifyEncoding<Ctx> for T
 where
-    T: mpz_ot::VerifiableOTReceiverShared<bool, Block, [Block; 2]> + Send + Sync,
+    T: mpz_ot::VerifiableOTReceiver<Ctx, bool, Block, [Block; 2]> + Send + Sync,
 {
     async fn verify(
-        &self,
-        id: &str,
+        &mut self,
+        ctx: &mut Ctx,
+        id: TransferId,
         input: Vec<EncodedValue<encoding_state::Full>>,
     ) -> Result<(), mpz_ot::OTError> {
         let blocks: Vec<[Block; 2]> = input
             .into_iter()
             .flat_map(|v| v.iter_blocks().collect::<Vec<_>>())
             .collect();
-        self.verify(id, &blocks).await
+
+        mpz_ot::VerifiableOTReceiver::verify(self, ctx, id, &blocks).await
     }
 }
 
 /// A trait for verifiable oblivious transfer of encodings.
-pub trait VerifiableOTSendEncoding: mpz_ot::CommittedOTSenderShared<[Block; 2]> {}
+pub trait VerifiableOTSendEncoding<Ctx>: mpz_ot::CommittedOTSender<Ctx, [Block; 2]> {}
 
-impl<T> VerifiableOTSendEncoding for T where T: mpz_ot::CommittedOTSenderShared<[Block; 2]> {}
+impl<Ctx, T> VerifiableOTSendEncoding<Ctx> for T where T: mpz_ot::CommittedOTSender<Ctx, [Block; 2]> {}
 
 /// A trait for verifiable oblivious transfer of encodings.
-pub trait VerifiableOTReceiveEncoding: OTReceiveEncoding + OTVerifyEncoding {}
+pub trait VerifiableOTReceiveEncoding<Ctx>: OTReceiveEncoding<Ctx> + OTVerifyEncoding<Ctx> {}
 
-impl<T> VerifiableOTReceiveEncoding for T where T: OTReceiveEncoding + OTVerifyEncoding {}
+impl<Ctx, T> VerifiableOTReceiveEncoding<Ctx> for T where
+    T: OTReceiveEncoding<Ctx> + OTVerifyEncoding<Ctx>
+{
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use mpz_circuits::circuits::AES128;
+    use mpz_common::executor::test_st_executor;
     use mpz_garble_core::{ChaChaEncoder, Encoder};
-    use mpz_ot::ideal::ideal_ot_shared_pair;
+    use mpz_ot::ideal::ot::ideal_ot;
 
     #[tokio::test]
     async fn test_encoding_transfer() {
         let encoder = ChaChaEncoder::new([0u8; 32]);
-        let (sender, receiver) = ideal_ot_shared_pair();
+        let (mut sender, mut receiver) = ideal_ot();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
 
         let inputs = AES128
             .inputs()
@@ -141,8 +175,11 @@ mod tests {
             .collect::<Vec<_>>();
         let choices = vec![Value::from([42u8; 16]), Value::from([69u8; 16])];
 
-        sender.send("", inputs.clone()).await.unwrap();
-        let received = receiver.receive("", choices.clone()).await.unwrap();
+        let (_, output_receiver) = futures::try_join!(
+            sender.send(&mut ctx_a, inputs.clone()),
+            receiver.receive(&mut ctx_b, choices.clone())
+        )
+        .unwrap();
 
         let expected = choices
             .into_iter()
@@ -150,6 +187,6 @@ mod tests {
             .map(|(choice, full)| full.select(choice).unwrap())
             .collect::<Vec<_>>();
 
-        assert_eq!(received, expected);
+        assert_eq!(output_receiver.encodings, expected);
     }
 }

--- a/crates/mpz-garble/src/protocol/deap/error.rs
+++ b/crates/mpz-garble/src/protocol/deap/error.rs
@@ -1,4 +1,4 @@
-use mpz_garble_core::{msg::GarbleMessage, ValueError};
+use mpz_garble_core::ValueError;
 
 use crate::{value::ValueRef, DecodeError, ExecutionError, LoadError, ProveError, VerifyError};
 
@@ -8,10 +8,10 @@ use crate::{value::ValueRef, DecodeError, ExecutionError, LoadError, ProveError,
 pub enum DEAPError {
     #[error("role error: {0}")]
     RoleError(String),
-    #[error("unexpected message: {0:?}")]
-    UnexpectedMessage(GarbleMessage),
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+    #[error("context error: {0}")]
+    ContextError(#[from] mpz_common::ContextError),
     #[error(transparent)]
     GeneratorError(#[from] crate::generator::GeneratorError),
     #[error(transparent)]
@@ -30,6 +30,8 @@ pub enum DEAPError {
 pub enum FinalizationError {
     #[error("DEAP instance already finalized")]
     AlreadyFinalized,
+    #[error("Only main thread can finalize DEAP instance")]
+    NotMainThread,
     #[error(transparent)]
     CommitmentError(#[from] mpz_core::commit::CommitmentError),
     #[error("invalid encoder seed")]

--- a/crates/mpz-garble/src/protocol/deap/mod.rs
+++ b/crates/mpz-garble/src/protocol/deap/mod.rs
@@ -9,22 +9,24 @@ mod vm;
 
 use std::{
     collections::HashMap,
+    mem,
     ops::DerefMut,
     sync::{Arc, Mutex},
 };
 
-use futures::{Sink, SinkExt, Stream, StreamExt, TryFutureExt};
+use futures::TryFutureExt;
 use mpz_circuits::{
     types::{Value, ValueType},
     Circuit,
 };
+use mpz_common::{try_join, Context, Counter, ThreadId};
 use mpz_core::{
     commit::{Decommitment, HashCommit},
     hash::{Hash, SecureHash},
 };
-use mpz_garble_core::{msg::GarbleMessage, EqualityCheck};
+use mpz_garble_core::EqualityCheck;
 use rand::thread_rng;
-use utils_aio::expect_msg_or_err;
+use serio::{stream::IoStreamExt, SinkExt};
 
 use crate::{
     config::{Role, Visibility},
@@ -37,7 +39,7 @@ use crate::{
 };
 
 pub use error::{DEAPError, PeerEncodingsError};
-pub use vm::{DEAPThread, DEAPVm, PeerEncodings};
+pub use vm::{DEAPThread, PeerEncodings};
 
 use self::error::FinalizationError;
 
@@ -54,38 +56,49 @@ pub struct DEAP {
 #[derive(Debug, Default)]
 struct State {
     memory: ValueMemory,
+    logs: HashMap<ThreadId, ThreadLog>,
+}
 
+#[derive(Debug, Default)]
+struct ThreadLog {
+    /// A counter for the number of operations performed by the thread.
+    operation_counter: Counter,
     /// Equality check decommitments withheld by the leader
     /// prior to finalization
-    ///
-    /// Operation ID => Equality check decommitment
-    eq_decommitments: HashMap<String, Decommitment<EqualityCheck>>,
+    eq_decommitments: Vec<Decommitment<EqualityCheck>>,
     /// Equality check commitments from the leader
     ///
-    /// Operation ID => (Expected eq. check value, hash commitment from leader)
-    eq_commitments: HashMap<String, (EqualityCheck, Hash)>,
+    /// (Expected eq. check value, hash commitment from leader)
+    eq_commitments: Vec<(EqualityCheck, Hash)>,
     /// Proof decommitments withheld by the leader
     /// prior to finalization
     ///
-    /// Operation ID => GC output hash decommitment
-    proof_decommitments: HashMap<String, Decommitment<Hash>>,
+    /// GC output hash decommitment
+    proof_decommitments: Vec<Decommitment<Hash>>,
     /// Proof commitments from the leader
     ///
-    /// Operation ID => (Expected GC output hash, hash commitment from leader)
-    proof_commitments: HashMap<String, (Hash, Hash)>,
+    /// (Expected GC output hash, hash commitment from leader)
+    proof_commitments: Vec<(Hash, Hash)>,
 }
 
+#[derive(Default)]
 struct FinalizedState {
     /// Equality check decommitments withheld by the leader
     /// prior to finalization
-    eq_decommitments: Vec<(String, Decommitment<EqualityCheck>)>,
+    eq_decommitments: Vec<Decommitment<EqualityCheck>>,
     /// Equality check commitments from the leader
-    eq_commitments: Vec<(String, (EqualityCheck, Hash))>,
+    ///
+    /// (Expected eq. check value, hash commitment from leader)
+    eq_commitments: Vec<(EqualityCheck, Hash)>,
     /// Proof decommitments withheld by the leader
     /// prior to finalization
-    proof_decommitments: Vec<(String, Decommitment<Hash>)>,
+    ///
+    /// GC output hash decommitment
+    proof_decommitments: Vec<Decommitment<Hash>>,
     /// Proof commitments from the leader
-    proof_commitments: Vec<(String, (Hash, Hash))>,
+    ///
+    /// (Expected GC output hash, hash commitment from leader)
+    proof_commitments: Vec<(Hash, Hash)>,
 }
 
 impl DEAP {
@@ -135,28 +148,40 @@ impl DEAP {
     /// * `outputs` - The outputs of the circuit.
     /// * `sink` - The sink to send messages to.
     /// * `stream` - The stream to receive messages from.
-    pub async fn load<T, U>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn load<Ctx: Context>(
         &self,
+        ctx: &mut Ctx,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
-    ) -> Result<(), DEAPError>
-    where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-    {
+    ) -> Result<(), DEAPError> {
         // Generate and receive concurrently.
         // Drop the encoded outputs, we don't need them here
-        _ = futures::try_join!(
-            self.gen
-                .generate(circ.clone(), inputs, outputs, sink, false)
-                .map_err(DEAPError::from),
-            self.ev
-                .receive_garbled_circuit(circ.clone(), inputs, outputs, stream)
-                .map_err(DEAPError::from)
-        )?;
+        match self.role {
+            Role::Leader => {
+                try_join!(
+                    ctx,
+                    self.gen
+                        .generate(ctx, circ.clone(), inputs, outputs, false)
+                        .map_err(DEAPError::from),
+                    self.ev
+                        .receive_garbled_circuit(ctx, circ.clone(), inputs, outputs)
+                        .map_err(DEAPError::from)
+                )??;
+            }
+            Role::Follower => {
+                try_join!(
+                    ctx,
+                    self.ev
+                        .receive_garbled_circuit(ctx, circ.clone(), inputs, outputs)
+                        .map_err(DEAPError::from),
+                    self.gen
+                        .generate(ctx, circ.clone(), inputs, outputs, false)
+                        .map_err(DEAPError::from)
+                )??;
+            }
+        }
 
         Ok(())
     }
@@ -174,53 +199,75 @@ impl DEAP {
     /// * `ot_send` - The OT sender.
     /// * `ot_recv` - The OT receiver.
     #[allow(clippy::too_many_arguments)]
-    pub async fn execute<T, U, OTS, OTR>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn execute<Ctx, OTS, OTR>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
-        ot_send: &OTS,
-        ot_recv: &OTR,
+        ot_send: &mut OTS,
+        ot_recv: &mut OTR,
     ) -> Result<(), DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OTS: OTSendEncoding,
-        OTR: OTReceiveEncoding,
+        Ctx: Context,
+        OTS: OTSendEncoding<Ctx> + Send,
+        OTR: OTReceiveEncoding<Ctx> + Send,
     {
         let assigned_values = self.state().memory.drain_assigned(inputs);
 
-        let id_0 = format!("{}/0", id);
-        let id_1 = format!("{}/1", id);
+        match self.role {
+            Role::Leader => {
+                try_join! {
+                    ctx,
+                    async {
+                        self.gen
+                            .setup_assigned_values(ctx, &assigned_values, ot_send)
+                            .await?;
 
-        let (gen_id, ev_id) = match self.role {
-            Role::Leader => (id_0, id_1),
-            Role::Follower => (id_1, id_0),
+                        self.gen
+                            .generate(ctx, circ.clone(), inputs, outputs, false)
+                            .await
+                            .map_err(DEAPError::from)
+                    },
+                    async {
+                        self.ev
+                            .setup_assigned_values(ctx, &assigned_values, ot_recv)
+                            .await?;
+
+                        self.ev
+                            .evaluate(ctx, circ.clone(), inputs, outputs)
+                            .await
+                            .map_err(DEAPError::from)
+                    }
+                }??;
+            }
+            Role::Follower => {
+                try_join! {
+                    ctx,
+                    async {
+                        self.ev
+                            .setup_assigned_values(ctx, &assigned_values, ot_recv)
+                            .await?;
+
+                        self.ev
+                            .evaluate(ctx, circ.clone(), inputs, outputs)
+                            .await
+                            .map_err(DEAPError::from)
+                    },
+                    async {
+                        self.gen
+                            .setup_assigned_values(ctx, &assigned_values, ot_send)
+                            .await?;
+
+                        self.gen
+                            .generate(ctx, circ.clone(), inputs, outputs, false)
+                            .await
+                            .map_err(DEAPError::from)
+                    }
+                }??;
+            }
         };
-
-        // Setup inputs concurrently.
-        futures::try_join!(
-            self.gen
-                .setup_assigned_values(&gen_id, &assigned_values, sink, ot_send)
-                .map_err(DEAPError::from),
-            self.ev
-                .setup_assigned_values(&ev_id, &assigned_values, stream, ot_recv)
-                .map_err(DEAPError::from)
-        )?;
-
-        // Generate and evaluate concurrently.
-        // Drop the encoded outputs, we don't need them here
-        _ = futures::try_join!(
-            self.gen
-                .generate(circ.clone(), inputs, outputs, sink, false)
-                .map_err(DEAPError::from),
-            self.ev
-                .evaluate(circ.clone(), inputs, outputs, stream)
-                .map_err(DEAPError::from)
-        )?;
 
         Ok(())
     }
@@ -245,18 +292,18 @@ impl DEAP {
     /// * `stream` - The stream to receive messages from.
     /// * `ot_recv` - The OT receiver.
     #[allow(clippy::too_many_arguments)]
-    pub async fn execute_prove<S, OTR>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn execute_prove<Ctx, OTR>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        stream: &mut S,
-        ot_recv: &OTR,
+        ot_recv: &mut OTR,
     ) -> Result<(), DEAPError>
     where
-        S: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OTR: OTReceiveEncoding,
+        Ctx: Context,
+        OTR: OTReceiveEncoding<Ctx> + Send,
     {
         if matches!(self.role, Role::Follower) {
             return Err(DEAPError::RoleError(
@@ -269,12 +316,12 @@ impl DEAP {
         // The prover only acts as the evaluator for ZKPs instead of
         // dual-execution.
         self.ev
-            .setup_assigned_values(id, &assigned_values, stream, ot_recv)
+            .setup_assigned_values(ctx, &assigned_values, ot_recv)
             .map_err(DEAPError::from)
             .await?;
 
         self.ev
-            .evaluate(circ, inputs, outputs, stream)
+            .evaluate(ctx, circ, inputs, outputs)
             .map_err(DEAPError::from)
             .await?;
 
@@ -296,18 +343,18 @@ impl DEAP {
     /// * `sink` - The sink to send messages to.
     /// * `ot_send` - The OT sender.
     #[allow(clippy::too_many_arguments)]
-    pub async fn execute_verify<T, OTS>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn execute_verify<Ctx, OTS>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         circ: Arc<Circuit>,
         inputs: &[ValueRef],
         outputs: &[ValueRef],
-        sink: &mut T,
-        ot_send: &OTS,
+        ot_send: &mut OTS,
     ) -> Result<(), DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        OTS: OTSendEncoding,
+        Ctx: Context,
+        OTS: OTSendEncoding<Ctx> + Send,
     {
         if matches!(self.role, Role::Leader) {
             return Err(DEAPError::RoleError(
@@ -320,12 +367,12 @@ impl DEAP {
         // The verifier only acts as the generator for ZKPs instead of
         // dual-execution.
         self.gen
-            .setup_assigned_values(id, &assigned_values, sink, ot_send)
+            .setup_assigned_values(ctx, &assigned_values, ot_send)
             .map_err(DEAPError::from)
             .await?;
 
         self.gen
-            .generate(circ.clone(), inputs, outputs, sink, false)
+            .generate(ctx, circ.clone(), inputs, outputs, false)
             .map_err(DEAPError::from)
             .await?;
 
@@ -333,12 +380,15 @@ impl DEAP {
     }
 
     /// Sends a commitment to the provided values, proving them to the follower upon finalization.
-    pub async fn defer_prove<S: Sink<GarbleMessage, Error = std::io::Error> + Unpin>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn defer_prove<Ctx>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut S,
-    ) -> Result<(), DEAPError> {
+    ) -> Result<(), DEAPError>
+    where
+        Ctx: Context,
+    {
         let encoded_values = self.ev.get_encodings(values)?;
 
         let encoding_digest = encoded_values.hash();
@@ -346,10 +396,11 @@ impl DEAP {
 
         // Store output proof decommitment until finalization
         self.state()
+            .log(ctx.id())
             .proof_decommitments
-            .insert(id.to_string(), decommitment);
+            .push(decommitment);
 
-        sink.send(GarbleMessage::HashCommitment(commitment)).await?;
+        ctx.io_mut().send(commitment).await?;
 
         Ok(())
     }
@@ -366,13 +417,16 @@ impl DEAP {
     /// * `values` - The values to receive a commitment to
     /// * `expected_values` - The expected values which will be verified against the commitment
     /// * `stream` - The stream to receive messages from
-    pub async fn defer_verify<S: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn defer_verify<Ctx>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
         expected_values: &[Value],
-        stream: &mut S,
-    ) -> Result<(), DEAPError> {
+    ) -> Result<(), DEAPError>
+    where
+        Ctx: Context,
+    {
         let encoded_values = self.gen.get_encodings(values)?;
 
         let expected_values = expected_values
@@ -383,12 +437,13 @@ impl DEAP {
 
         let expected_digest = expected_values.hash();
 
-        let commitment = expect_msg_or_err!(stream, GarbleMessage::HashCommitment)?;
+        let commitment: Hash = ctx.io_mut().expect_next().await?;
 
         // Store commitment to proof until finalization
         self.state()
+            .log(ctx.id())
             .proof_commitments
-            .insert(id.to_string(), (expected_digest, commitment));
+            .push((expected_digest, commitment));
 
         Ok(())
     }
@@ -409,16 +464,14 @@ impl DEAP {
     /// * `values` - The values to decode
     /// * `sink` - The sink to send messages to.
     /// * `stream` - The stream to receive messages from.
-    pub async fn decode<T, U>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn decode<Ctx>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
     ) -> Result<Vec<Value>, DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
+        Ctx: Context,
     {
         let full = values
             .iter()
@@ -439,10 +492,24 @@ impl DEAP {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Decode concurrently.
-        let (_, purported_values) = futures::try_join!(
-            self.gen.decode(values, sink).map_err(DEAPError::from),
-            self.ev.decode(values, stream).map_err(DEAPError::from),
-        )?;
+        let purported_values = match self.role {
+            Role::Leader => {
+                let (_, purported_values) = try_join!(
+                    ctx,
+                    self.gen.decode(ctx, values).map_err(DEAPError::from),
+                    self.ev.decode(ctx, values).map_err(DEAPError::from)
+                )??;
+                purported_values
+            }
+            Role::Follower => {
+                let (purported_values, _) = try_join!(
+                    ctx,
+                    self.ev.decode(ctx, values).map_err(DEAPError::from),
+                    self.gen.decode(ctx, values).map_err(DEAPError::from)
+                )??;
+                purported_values
+            }
+        };
 
         let eq_check = EqualityCheck::new(
             &full,
@@ -460,14 +527,15 @@ impl DEAP {
 
                 // Store equality check decommitment until finalization
                 self.state()
+                    .log(ctx.id())
                     .eq_decommitments
-                    .insert(id.to_string(), decommitment);
+                    .push(decommitment);
 
                 // Send commitment to equality check to follower
-                sink.send(GarbleMessage::HashCommitment(commit)).await?;
+                ctx.io_mut().send(commit).await?;
 
                 // Receive the active encoded outputs from the follower
-                let active = expect_msg_or_err!(stream, GarbleMessage::ActiveValues)?;
+                let active: Vec<_> = ctx.io_mut().expect_next().await?;
 
                 // Authenticate and decode values
                 active
@@ -478,15 +546,16 @@ impl DEAP {
             }
             Role::Follower => {
                 // Receive equality check commitment from leader
-                let commit = expect_msg_or_err!(stream, GarbleMessage::HashCommitment)?;
+                let commit: Hash = ctx.io_mut().expect_next().await?;
 
                 // Store equality check commitment until finalization
                 self.state()
+                    .log(ctx.id())
                     .eq_commitments
-                    .insert(id.to_string(), (eq_check, commit));
+                    .push((eq_check, commit));
 
                 // Send active encoded values to leader
-                sink.send(GarbleMessage::ActiveValues(active)).await?;
+                ctx.io_mut().send(active).await?;
 
                 // Assume purported values are correct until finalization
                 purported_values
@@ -496,21 +565,20 @@ impl DEAP {
         Ok(output)
     }
 
-    pub(crate) async fn decode_private<T, U, OTS, OTR>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub(crate) async fn decode_private<Ctx, OTS, OTR>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
-        ot_send: &OTS,
-        ot_recv: &OTR,
+        ot_send: &mut OTS,
+        ot_recv: &mut OTR,
     ) -> Result<Vec<Value>, DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OTS: OTSendEncoding,
-        OTR: OTReceiveEncoding,
+        Ctx: Context,
+        OTS: OTSendEncoding<Ctx> + Send,
+        OTR: OTReceiveEncoding<Ctx> + Send,
     {
+        let id = self.state().log(ctx.id()).operation_counter.next();
         let (((otp_refs, otp_typs), otp_values), mask_refs): (((Vec<_>, Vec<_>), Vec<_>), Vec<_>) = {
             let mut state = self.state();
 
@@ -538,13 +606,11 @@ impl DEAP {
             .cloned()
             .collect::<Vec<_>>();
 
-        self.execute(
-            id, circ, &inputs, &mask_refs, sink, stream, ot_send, ot_recv,
-        )
-        .await?;
+        self.execute(ctx, circ, &inputs, &mask_refs, ot_send, ot_recv)
+            .await?;
 
         // Decode masked values
-        let masked_values = self.decode(id, &mask_refs, sink, stream).await?;
+        let masked_values = self.decode(ctx, &mask_refs).await?;
 
         // Remove OTPs, returning plaintext values
         Ok(masked_values
@@ -554,21 +620,20 @@ impl DEAP {
             .collect())
     }
 
-    pub(crate) async fn decode_blind<T, U, OTS, OTR>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub(crate) async fn decode_blind<Ctx, OTS, OTR>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
-        ot_send: &OTS,
-        ot_recv: &OTR,
+        ot_send: &mut OTS,
+        ot_recv: &mut OTR,
     ) -> Result<(), DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OTS: OTSendEncoding,
-        OTR: OTReceiveEncoding,
+        Ctx: Context,
+        OTS: OTSendEncoding<Ctx> + Send,
+        OTR: OTReceiveEncoding<Ctx> + Send,
     {
+        let id = self.state().log(ctx.id()).operation_counter.next();
         let ((otp_refs, otp_typs), mask_refs): ((Vec<_>, Vec<_>), Vec<_>) = {
             let mut state = self.state();
 
@@ -594,32 +659,29 @@ impl DEAP {
             .cloned()
             .collect::<Vec<_>>();
 
-        self.execute(
-            id, circ, &inputs, &mask_refs, sink, stream, ot_send, ot_recv,
-        )
-        .await?;
+        self.execute(ctx, circ, &inputs, &mask_refs, ot_send, ot_recv)
+            .await?;
 
         // Discard masked values
-        _ = self.decode(id, &mask_refs, sink, stream).await?;
+        _ = self.decode(ctx, &mask_refs).await?;
 
         Ok(())
     }
 
-    pub(crate) async fn decode_shared<T, U, OTS, OTR>(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub(crate) async fn decode_shared<Ctx, OTS, OTR>(
         &self,
-        id: &str,
+        ctx: &mut Ctx,
         values: &[ValueRef],
-        sink: &mut T,
-        stream: &mut U,
-        ot_send: &OTS,
-        ot_recv: &OTR,
+        ot_send: &mut OTS,
+        ot_recv: &mut OTR,
     ) -> Result<Vec<Value>, DEAPError>
     where
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OTS: OTSendEncoding,
-        OTR: OTReceiveEncoding,
+        Ctx: Context,
+        OTS: OTSendEncoding<Ctx> + Send,
+        OTR: OTReceiveEncoding<Ctx> + Send,
     {
+        let id = self.state().log(ctx.id()).operation_counter.next();
         #[allow(clippy::type_complexity)]
         let ((((otp_0_refs, otp_1_refs), otp_typs), otp_values), mask_refs): (
             (((Vec<_>, Vec<_>), Vec<_>), Vec<_>),
@@ -666,13 +728,11 @@ impl DEAP {
             .cloned()
             .collect::<Vec<_>>();
 
-        self.execute(
-            id, circ, &inputs, &mask_refs, sink, stream, ot_send, ot_recv,
-        )
-        .await?;
+        self.execute(ctx, circ, &inputs, &mask_refs, ot_send, ot_recv)
+            .await?;
 
         // Decode masked values
-        let masked_values = self.decode(id, &mask_refs, sink, stream).await?;
+        let masked_values = self.decode(ctx, &mask_refs).await?;
 
         match self.role {
             Role::Leader => {
@@ -711,16 +771,16 @@ impl DEAP {
     ///
     /// - `channel` - The channel to communicate with the other party
     /// - `ot` - The OT verifier to use
-    pub async fn finalize<
-        T: Sink<GarbleMessage, Error = std::io::Error> + Unpin,
-        U: Stream<Item = Result<GarbleMessage, std::io::Error>> + Unpin,
-        OT: OTVerifyEncoding,
-    >(
+    #[tracing::instrument(fields(role = %self.role, thread = %ctx.id()), skip_all)]
+    pub async fn finalize<Ctx, OT>(
         &mut self,
-        sink: &mut T,
-        stream: &mut U,
-        ot: &OT,
-    ) -> Result<Option<[u8; 32]>, DEAPError> {
+        ctx: &mut Ctx,
+        ot: &mut OT,
+    ) -> Result<Option<[u8; 32]>, DEAPError>
+    where
+        Ctx: Context,
+        OT: OTVerifyEncoding<Ctx>,
+    {
         if self.finalized {
             return Err(FinalizationError::AlreadyFinalized)?;
         } else {
@@ -737,52 +797,35 @@ impl DEAP {
         match self.role {
             Role::Leader => {
                 // Receive the encoder seed from the follower.
-                let encoder_seed = expect_msg_or_err!(stream, GarbleMessage::EncoderSeed)?;
-
-                let encoder_seed: [u8; 32] = encoder_seed
-                    .try_into()
-                    .map_err(|_| FinalizationError::InvalidEncoderSeed)?;
+                let encoder_seed: [u8; 32] = ctx.io_mut().expect_next().await?;
 
                 // Verify all oblivious transfers, garbled circuits and decodings
                 // sent by the follower.
-                self.ev.verify(encoder_seed, ot).await?;
+                self.ev.verify(ctx, encoder_seed, ot).await?;
 
-                // Reveal the equality check decommitments to the follower.
-                sink.send(GarbleMessage::EqualityCheckDecommitments(
-                    eq_decommitments
-                        .into_iter()
-                        .map(|(_, decommitment)| decommitment)
-                        .collect(),
-                ))
-                .await?;
-
-                // Reveal the proof decommitments to the follower.
-                sink.send(GarbleMessage::ProofDecommitments(
-                    proof_decommitments
-                        .into_iter()
-                        .map(|(_, decommitment)| decommitment)
-                        .collect(),
-                ))
-                .await?;
+                // Reveal the equality checks and proofs to the follower.
+                ctx.io_mut().feed(eq_decommitments).await?;
+                ctx.io_mut().send(proof_decommitments).await?;
 
                 Ok(Some(encoder_seed))
             }
             Role::Follower => {
-                let encoder_seed = self.gen.seed();
+                let encoder_seed: [u8; 32] = self
+                    .gen
+                    .seed()
+                    .try_into()
+                    .expect("encoder seed is 32 bytes");
 
-                sink.send(GarbleMessage::EncoderSeed(encoder_seed.to_vec()))
-                    .await?;
+                ctx.io_mut().send(encoder_seed).await?;
 
-                // Receive the equality check decommitments from the leader.
-                let eq_decommitments =
-                    expect_msg_or_err!(stream, GarbleMessage::EqualityCheckDecommitments)?;
-
-                // Receive the proof decommitments from the leader.
-                let proof_decommitments =
-                    expect_msg_or_err!(stream, GarbleMessage::ProofDecommitments)?;
+                // Receive the equality checks and proofs from the leader.
+                let eq_decommitments: Vec<Decommitment<EqualityCheck>> =
+                    ctx.io_mut().expect_next().await?;
+                let proof_decommitments: Vec<Decommitment<Hash>> =
+                    ctx.io_mut().expect_next().await?;
 
                 // Verify all equality checks.
-                for (decommitment, (_, (expected_check, commitment))) in
+                for (decommitment, (expected_check, commitment)) in
                     eq_decommitments.iter().zip(eq_commitments.iter())
                 {
                     decommitment
@@ -795,7 +838,7 @@ impl DEAP {
                 }
 
                 // Verify all proofs.
-                for (decommitment, (_, (expected_digest, commitment))) in
+                for (decommitment, (expected_digest, commitment)) in
                     proof_decommitments.iter().zip(proof_commitments.iter())
                 {
                     decommitment
@@ -819,6 +862,10 @@ impl DEAP {
 }
 
 impl State {
+    fn log(&mut self, id: &ThreadId) -> &mut ThreadLog {
+        self.logs.entry(id.clone()).or_default()
+    }
+
     pub(crate) fn new_private_otp(&mut self, id: &str, value_ref: &ValueRef) -> (ValueRef, Value) {
         let typ = self.memory.get_value_type(value_ref);
         let value = Value::random(&mut thread_rng(), &typ);
@@ -857,40 +904,35 @@ impl State {
 
     /// Drain the states to be finalized.
     fn finalize_state(&mut self) -> FinalizedState {
-        let (
-            mut eq_decommitments,
-            mut eq_commitments,
-            mut proof_decommitments,
-            mut proof_commitments,
-        ) = {
-            (
-                self.eq_decommitments.drain().collect::<Vec<_>>(),
-                self.eq_commitments.drain().collect::<Vec<_>>(),
-                self.proof_decommitments.drain().collect::<Vec<_>>(),
-                self.proof_commitments.drain().collect::<Vec<_>>(),
-            )
-        };
+        let mut logs = mem::take(&mut self.logs).into_iter().collect::<Vec<_>>();
+        logs.sort_by_cached_key(|(id, _)| id.clone());
 
-        // Sort the decommitments and commitments by id
-        eq_decommitments.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-        eq_commitments.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-        proof_decommitments.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-        proof_commitments.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        logs.into_iter()
+            .fold(FinalizedState::default(), |mut state, (_, log)| {
+                let ThreadLog {
+                    eq_commitments,
+                    eq_decommitments,
+                    proof_commitments,
+                    proof_decommitments,
+                    ..
+                } = log;
 
-        FinalizedState {
-            eq_decommitments,
-            eq_commitments,
-            proof_decommitments,
-            proof_commitments,
-        }
+                state.eq_commitments.extend(eq_commitments);
+                state.eq_decommitments.extend(eq_decommitments);
+                state.proof_commitments.extend(proof_commitments);
+                state.proof_decommitments.extend(proof_decommitments);
+
+                state
+            })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use mpz_circuits::{circuits::AES128, ops::WrappingAdd, CircuitBuilder};
-    use mpz_ot::ideal::ideal_ot_shared_pair;
-    use utils_aio::duplex::MemoryDuplex;
+    use mpz_common::executor::test_st_executor;
+    use mpz_core::Block;
+    use mpz_ot::ideal::ot::ideal_ot;
 
     use crate::Memory;
 
@@ -911,9 +953,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_deap() {
-        let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        let (mut leader_ot_send, mut follower_ot_recv) = ideal_ot();
+        let (mut follower_ot_send, mut leader_ot_recv) = ideal_ot();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -922,8 +964,6 @@ mod tests {
         let msg = [69u8; 16];
 
         let leader_fut = {
-            let (mut sink, mut stream) = leader_channel.split();
-
             let key_ref = leader.new_private_input::<[u8; 16]>("key").unwrap();
             let msg_ref = leader.new_blind_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = leader.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -933,25 +973,20 @@ mod tests {
             async move {
                 leader
                     .execute(
-                        "test",
+                        &mut ctx_a,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
-                let outputs = leader
-                    .decode("test", &[ciphertext_ref], &mut sink, &mut stream)
-                    .await
-                    .unwrap();
+                let outputs = leader.decode(&mut ctx_a, &[ciphertext_ref]).await.unwrap();
 
                 leader
-                    .finalize(&mut sink, &mut stream, &leader_ot_recv)
+                    .finalize(&mut ctx_a, &mut leader_ot_recv)
                     .await
                     .unwrap();
 
@@ -960,8 +995,6 @@ mod tests {
         };
 
         let follower_fut = {
-            let (mut sink, mut stream) = follower_channel.split();
-
             let key_ref = follower.new_blind_input::<[u8; 16]>("key").unwrap();
             let msg_ref = follower.new_private_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = follower.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -971,25 +1004,23 @@ mod tests {
             async move {
                 follower
                     .execute(
-                        "test",
+                        &mut ctx_b,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 let outputs = follower
-                    .decode("test", &[ciphertext_ref], &mut sink, &mut stream)
+                    .decode(&mut ctx_b, &[ciphertext_ref])
                     .await
                     .unwrap();
 
                 follower
-                    .finalize(&mut sink, &mut stream, &follower_ot_recv)
+                    .finalize(&mut ctx_b, &mut follower_ot_recv)
                     .await
                     .unwrap();
 
@@ -1004,9 +1035,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_deap_load() {
-        let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        let (mut leader_ot_send, mut follower_ot_recv) = ideal_ot();
+        let (mut follower_ot_send, mut leader_ot_recv) = ideal_ot();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1015,8 +1046,6 @@ mod tests {
         let msg = [69u8; 16];
 
         let leader_fut = {
-            let (mut sink, mut stream) = leader_channel.split();
-
             let key_ref = leader.new_private_input::<[u8; 16]>("key").unwrap();
             let msg_ref = leader.new_blind_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = leader.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -1024,11 +1053,10 @@ mod tests {
             async move {
                 leader
                     .load(
+                        &mut ctx_a,
                         AES128.clone(),
                         &[key_ref.clone(), msg_ref.clone()],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
                     )
                     .await
                     .unwrap();
@@ -1037,25 +1065,20 @@ mod tests {
 
                 leader
                     .execute(
-                        "test",
+                        &mut ctx_a,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
-                let outputs = leader
-                    .decode("test", &[ciphertext_ref], &mut sink, &mut stream)
-                    .await
-                    .unwrap();
+                let outputs = leader.decode(&mut ctx_a, &[ciphertext_ref]).await.unwrap();
 
                 leader
-                    .finalize(&mut sink, &mut stream, &leader_ot_recv)
+                    .finalize(&mut ctx_a, &mut leader_ot_recv)
                     .await
                     .unwrap();
 
@@ -1064,8 +1087,6 @@ mod tests {
         };
 
         let follower_fut = {
-            let (mut sink, mut stream) = follower_channel.split();
-
             let key_ref = follower.new_blind_input::<[u8; 16]>("key").unwrap();
             let msg_ref = follower.new_private_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = follower.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -1073,11 +1094,10 @@ mod tests {
             async move {
                 follower
                     .load(
+                        &mut ctx_b,
                         AES128.clone(),
                         &[key_ref.clone(), msg_ref.clone()],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
                     )
                     .await
                     .unwrap();
@@ -1086,25 +1106,23 @@ mod tests {
 
                 follower
                     .execute(
-                        "test",
+                        &mut ctx_b,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 let outputs = follower
-                    .decode("test", &[ciphertext_ref], &mut sink, &mut stream)
+                    .decode(&mut ctx_b, &[ciphertext_ref])
                     .await
                     .unwrap();
 
                 follower
-                    .finalize(&mut sink, &mut stream, &follower_ot_recv)
+                    .finalize(&mut ctx_b, &mut follower_ot_recv)
                     .await
                     .unwrap();
 
@@ -1119,9 +1137,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_deap_decode_private() {
-        let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
+        tracing_subscriber::fmt::init();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        let (mut leader_ot_send, mut follower_ot_recv) = ideal_ot();
+        let (mut follower_ot_send, mut leader_ot_recv) = ideal_ot();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1133,7 +1152,6 @@ mod tests {
         let c: Value = (a + b).into();
 
         let leader_fut = {
-            let (mut sink, mut stream) = leader_channel.split();
             let circ = circ.clone();
             let a_ref = leader.new_private_input::<u8>("a").unwrap();
             let b_ref = leader.new_blind_input::<u8>("b").unwrap();
@@ -1144,32 +1162,28 @@ mod tests {
             async move {
                 leader
                     .execute(
-                        "test",
+                        &mut ctx_a,
                         circ,
                         &[a_ref, b_ref],
                         &[c_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 let outputs = leader
                     .decode_private(
-                        "test",
+                        &mut ctx_a,
                         &[c_ref],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 leader
-                    .finalize(&mut sink, &mut stream, &leader_ot_recv)
+                    .finalize(&mut ctx_a, &mut leader_ot_recv)
                     .await
                     .unwrap();
 
@@ -1178,8 +1192,6 @@ mod tests {
         };
 
         let follower_fut = {
-            let (mut sink, mut stream) = follower_channel.split();
-
             let a_ref = follower.new_blind_input::<u8>("a").unwrap();
             let b_ref = follower.new_private_input::<u8>("b").unwrap();
             let c_ref = follower.new_output::<u8>("c").unwrap();
@@ -1189,34 +1201,27 @@ mod tests {
             async move {
                 follower
                     .execute(
-                        "test",
+                        &mut ctx_b,
                         circ.clone(),
                         &[a_ref, b_ref],
                         &[c_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
-                    .await
-                    .unwrap();
+                    .await?;
 
                 follower
                     .decode_blind(
-                        "test",
+                        &mut ctx_b,
                         &[c_ref],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
-                    .await
-                    .unwrap();
+                    .await?;
 
-                follower
-                    .finalize(&mut sink, &mut stream, &follower_ot_recv)
-                    .await
-                    .unwrap();
+                follower.finalize(&mut ctx_b, &mut follower_ot_recv).await?;
+
+                Ok::<_, DEAPError>(())
             }
         };
 
@@ -1227,9 +1232,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_deap_decode_shared() {
-        let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (leader_ot_send, follower_ot_recv) = ideal_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        let (mut leader_ot_send, mut follower_ot_recv) = ideal_ot();
+        let (mut follower_ot_send, mut leader_ot_recv) = ideal_ot();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
@@ -1241,7 +1246,6 @@ mod tests {
         let c = a + b;
 
         let leader_fut = {
-            let (mut sink, mut stream) = leader_channel.split();
             let circ = circ.clone();
             let a_ref = leader.new_private_input::<u8>("a").unwrap();
             let b_ref = leader.new_blind_input::<u8>("b").unwrap();
@@ -1252,32 +1256,28 @@ mod tests {
             async move {
                 leader
                     .execute(
-                        "test",
+                        &mut ctx_a,
                         circ,
                         &[a_ref, b_ref],
                         &[c_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 let outputs = leader
                     .decode_shared(
-                        "test",
+                        &mut ctx_a,
                         &[c_ref],
-                        &mut sink,
-                        &mut stream,
-                        &leader_ot_send,
-                        &leader_ot_recv,
+                        &mut leader_ot_send,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 leader
-                    .finalize(&mut sink, &mut stream, &leader_ot_recv)
+                    .finalize(&mut ctx_a, &mut leader_ot_recv)
                     .await
                     .unwrap();
 
@@ -1286,8 +1286,6 @@ mod tests {
         };
 
         let follower_fut = {
-            let (mut sink, mut stream) = follower_channel.split();
-
             let a_ref = follower.new_blind_input::<u8>("a").unwrap();
             let b_ref = follower.new_private_input::<u8>("b").unwrap();
             let c_ref = follower.new_output::<u8>("c").unwrap();
@@ -1297,32 +1295,28 @@ mod tests {
             async move {
                 follower
                     .execute(
-                        "test",
+                        &mut ctx_b,
                         circ.clone(),
                         &[a_ref, b_ref],
                         &[c_ref.clone()],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 let outputs = follower
                     .decode_shared(
-                        "test",
+                        &mut ctx_b,
                         &[c_ref],
-                        &mut sink,
-                        &mut stream,
-                        &follower_ot_send,
-                        &follower_ot_recv,
+                        &mut follower_ot_send,
+                        &mut follower_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 follower
-                    .finalize(&mut sink, &mut stream, &follower_ot_recv)
+                    .finalize(&mut ctx_b, &mut follower_ot_recv)
                     .await
                     .unwrap();
 
@@ -1365,15 +1359,14 @@ mod tests {
     }
 
     async fn run_zk(key: [u8; 16], msg: [u8; 16], expected_ciphertext: [u8; 16]) {
-        let (leader_channel, follower_channel) = MemoryDuplex::<GarbleMessage>::new();
-        let (_, follower_ot_recv) = ideal_ot_shared_pair();
-        let (follower_ot_send, leader_ot_recv) = ideal_ot_shared_pair();
+        let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+        let (_, mut follower_ot_recv) = ideal_ot::<[Block; 2], _>();
+        let (mut follower_ot_send, mut leader_ot_recv) = ideal_ot();
 
         let mut leader = DEAP::new(Role::Leader, [42u8; 32]);
         let mut follower = DEAP::new(Role::Follower, [69u8; 32]);
 
         let leader_fut = {
-            let (mut sink, mut stream) = leader_channel.split();
             let key_ref = leader.new_private_input::<[u8; 16]>("key").unwrap();
             let msg_ref = leader.new_blind_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = leader.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -1383,30 +1376,28 @@ mod tests {
             async move {
                 leader
                     .execute_prove(
-                        "test0",
+                        &mut ctx_a,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut stream,
-                        &leader_ot_recv,
+                        &mut leader_ot_recv,
                     )
                     .await
                     .unwrap();
 
                 leader
-                    .defer_prove("test1", &[ciphertext_ref], &mut sink)
+                    .defer_prove(&mut ctx_a, &[ciphertext_ref])
                     .await
                     .unwrap();
 
                 leader
-                    .finalize(&mut sink, &mut stream, &leader_ot_recv)
+                    .finalize(&mut ctx_a, &mut leader_ot_recv)
                     .await
                     .unwrap();
             }
         };
 
         let follower_fut = {
-            let (mut sink, mut stream) = follower_channel.split();
             let key_ref = follower.new_blind_input::<[u8; 16]>("key").unwrap();
             let msg_ref = follower.new_private_input::<[u8; 16]>("msg").unwrap();
             let ciphertext_ref = follower.new_output::<[u8; 16]>("ciphertext").unwrap();
@@ -1416,28 +1407,22 @@ mod tests {
             async move {
                 follower
                     .execute_verify(
-                        "test0",
+                        &mut ctx_b,
                         AES128.clone(),
                         &[key_ref, msg_ref],
                         &[ciphertext_ref.clone()],
-                        &mut sink,
-                        &follower_ot_send,
+                        &mut follower_ot_send,
                     )
                     .await
                     .unwrap();
 
                 follower
-                    .defer_verify(
-                        "test1",
-                        &[ciphertext_ref],
-                        &[expected_ciphertext.into()],
-                        &mut stream,
-                    )
+                    .defer_verify(&mut ctx_b, &[ciphertext_ref], &[expected_ciphertext.into()])
                     .await
                     .unwrap();
 
                 follower
-                    .finalize(&mut sink, &mut stream, &follower_ot_recv)
+                    .finalize(&mut ctx_b, &mut follower_ot_recv)
                     .await
                     .unwrap();
             }

--- a/crates/mpz-garble/src/protocol/deap/vm.rs
+++ b/crates/mpz-garble/src/protocol/deap/vm.rs
@@ -97,7 +97,7 @@ where
 {
     /// Finalizes the DEAP instance.
     ///
-    /// If this instance is the leader this function returns the follower's
+    /// If this instance is the leader, this function returns the follower's
     /// encoder seed.
     pub async fn finalize(&mut self) -> Result<Option<[u8; 32]>, DEAPError> {
         match mem::replace(&mut self.state, State::Finalized) {

--- a/crates/mpz-garble/src/protocol/deap/vm.rs
+++ b/crates/mpz-garble/src/protocol/deap/vm.rs
@@ -1,28 +1,24 @@
 use std::{
-    collections::HashSet,
+    mem,
     sync::{Arc, Weak},
 };
 
 use async_trait::async_trait;
-use futures::{
-    stream::{SplitSink, SplitStream},
-    StreamExt, TryFutureExt,
-};
+use futures::TryFutureExt;
 
 use mpz_circuits::{
     types::{Value, ValueType},
     Circuit,
 };
-use mpz_garble_core::{encoding_state::Active, msg::GarbleMessage, EncodedValue};
-use utils::id::NestedId;
-use utils_aio::{duplex::Duplex, mux::MuxChannel};
+use mpz_common::Context;
+use mpz_garble_core::{encoding_state::Active, EncodedValue};
 
 use crate::{
     config::{Role, Visibility},
     ot::{VerifiableOTReceiveEncoding, VerifiableOTSendEncoding},
     value::ValueRef,
     Decode, DecodeError, DecodePrivate, Execute, ExecutionError, Load, LoadError, Memory,
-    MemoryError, Prove, ProveError, Thread, Verify, VerifyError, Vm, VmError,
+    MemoryError, Prove, ProveError, Thread, Verify, VerifyError,
 };
 
 use super::{
@@ -30,218 +26,135 @@ use super::{
     DEAPError, DEAP,
 };
 
-type ChannelFactory = Box<dyn MuxChannel<GarbleMessage> + Send + 'static>;
-type GarbleChannel = Box<dyn Duplex<GarbleMessage>>;
-
-/// A DEAP Vm.
-pub struct DEAPVm<OTS, OTR> {
-    /// The id of the vm.
-    id: NestedId,
-    /// The role of the vm.
-    role: Role,
-    /// Channel factory used to create new channels for new threads.
-    channel_factory: ChannelFactory,
-    /// The OT sender.
-    ot_send: Arc<OTS>,
-    /// The OT receiver.
-    ot_recv: Arc<OTR>,
-    /// The duplex channel sink to the peer.
-    sink: SplitSink<GarbleChannel, GarbleMessage>,
-    /// The duplex channel stream from the peer.
-    stream: SplitStream<GarbleChannel>,
-    /// The DEAP instance.
-    ///
-    /// The DEAPVm is the only owner of a strong reference to the instance,
-    /// and unwraps it during finalization.
-    deap: Option<Arc<DEAP>>,
-    /// The set of threads spawned by this vm.
-    threads: HashSet<NestedId>,
-    /// Whether the instance has been finalized.
-    finalized: bool,
+#[derive(Debug)]
+enum State {
+    Main(Arc<DEAP>),
+    Child(Weak<DEAP>),
+    Finalized,
 }
 
-impl<OTS, OTR> DEAPVm<OTS, OTR>
-where
-    OTS: VerifiableOTSendEncoding,
-    OTR: VerifiableOTReceiveEncoding,
-{
-    /// Create a new DEAP Vm.
-    pub fn new(
-        id: &str,
-        role: Role,
-        encoder_seed: [u8; 32],
-        channel: GarbleChannel,
-        channel_factory: ChannelFactory,
-        ot_send: OTS,
-        ot_recv: OTR,
-    ) -> Self {
-        let (sink, stream) = channel.split();
-        Self {
-            id: NestedId::new(id),
-            role,
-            channel_factory,
-            ot_send: Arc::new(ot_send),
-            ot_recv: Arc::new(ot_recv),
-            sink,
-            stream,
-            deap: Some(Arc::new(DEAP::new(role, encoder_seed))),
-            threads: HashSet::default(),
-            finalized: false,
+impl State {
+    fn get(&self) -> Arc<DEAP> {
+        match self {
+            State::Main(deap) => deap.clone(),
+            State::Child(deap) => deap.upgrade().expect("instance should not be dropped"),
+            State::Finalized => panic!("instance is finalized"),
         }
     }
 
+    fn is_finalized(&self) -> bool {
+        matches!(self, State::Finalized)
+    }
+}
+
+/// A DEAP thread.
+#[derive(Debug)]
+pub struct DEAPThread<Ctx, OTS, OTR> {
+    /// The thread context.
+    ctx: Ctx,
+    /// OT sender.
+    ot_send: OTS,
+    /// OT receiver.
+    ot_recv: OTR,
+    state: State,
+}
+
+impl<Ctx, OTS, OTR> DEAPThread<Ctx, OTS, OTR> {
+    /// Creates a new DEAP instance.
+    pub fn new(role: Role, encoder_seed: [u8; 32], ctx: Ctx, ot_send: OTS, ot_recv: OTR) -> Self {
+        Self {
+            ctx,
+            ot_send,
+            ot_recv,
+            state: State::Main(Arc::new(DEAP::new(role, encoder_seed))),
+        }
+    }
+
+    /// Creates a new DEAP thread.
+    pub fn new_thread(&self, ctx: Ctx, ot_send: OTS, ot_recv: OTR) -> Result<Self, DEAPError> {
+        match &self.state {
+            State::Main(state) => Ok(Self {
+                ctx,
+                ot_send,
+                ot_recv,
+                state: State::Child(Arc::downgrade(state)),
+            }),
+            State::Child(state) => Ok(Self {
+                ctx,
+                ot_send,
+                ot_recv,
+                state: State::Child(state.clone()),
+            }),
+            State::Finalized => Err(FinalizationError::AlreadyFinalized.into()),
+        }
+    }
+}
+
+impl<Ctx, OTS, OTR> DEAPThread<Ctx, OTS, OTR>
+where
+    Ctx: Context,
+    OTR: VerifiableOTReceiveEncoding<Ctx>,
+{
     /// Finalizes the DEAP instance.
     ///
     /// If this instance is the leader this function returns the follower's
     /// encoder seed.
     pub async fn finalize(&mut self) -> Result<Option<[u8; 32]>, DEAPError> {
-        if self.finalized {
-            return Err(FinalizationError::AlreadyFinalized)?;
-        } else {
-            self.finalized = true;
-        }
-
-        let mut instance =
-            Arc::try_unwrap(self.deap.take().expect("instance set until finalization"))
-                .expect("vm should have only strong reference");
-
-        instance
-            .finalize(&mut self.sink, &mut self.stream, &*self.ot_recv)
-            .await
-    }
-}
-
-#[async_trait]
-impl<OTS, OTR> Vm for DEAPVm<OTS, OTR>
-where
-    OTS: VerifiableOTSendEncoding + Clone + Send + Sync + 'static,
-    OTR: VerifiableOTReceiveEncoding + Clone + Send + Sync + 'static,
-{
-    type Thread = DEAPThread<OTS, OTR>;
-
-    async fn new_thread(&mut self, id: &str) -> Result<DEAPThread<OTS, OTR>, VmError> {
-        if self.finalized {
-            return Err(VmError::Shutdown);
-        }
-
-        let thread_id = self.id.append_string(id);
-
-        if self.threads.contains(&thread_id) {
-            return Err(VmError::ThreadAlreadyExists(thread_id.to_string()));
-        }
-
-        let channel = self
-            .channel_factory
-            .get_channel(&thread_id.to_string())
-            .await?;
-
-        Ok(DEAPThread::new(
-            thread_id,
-            self.role,
-            channel,
-            Arc::downgrade(self.deap.as_ref().expect("instance set until finalization")),
-            self.ot_send.clone(),
-            self.ot_recv.clone(),
-        ))
-    }
-}
-
-/// A DEAP thread.
-pub struct DEAPThread<OTS, OTR> {
-    /// The thread id.
-    _id: NestedId,
-    /// The DEAP role of the VM.
-    _role: Role,
-    /// The current operation id.
-    op_id: NestedId,
-    /// Reference to the DEAP instance.
-    deap: Weak<DEAP>,
-    /// OT sender.
-    ot_send: Arc<OTS>,
-    /// OT receiver.
-    ot_recv: Arc<OTR>,
-    /// The duplex channel sink to the peer.
-    sink: SplitSink<GarbleChannel, GarbleMessage>,
-    /// The duplex channel stream from the peer.
-    stream: SplitStream<GarbleChannel>,
-}
-
-impl<OTS, OTR> DEAPThread<OTS, OTR> {
-    fn deap(&self) -> Arc<DEAP> {
-        self.deap.upgrade().expect("instance should not be dropped")
-    }
-}
-
-impl<OTS, OTR> DEAPThread<OTS, OTR>
-where
-    OTS: VerifiableOTSendEncoding,
-    OTR: VerifiableOTReceiveEncoding,
-{
-    fn new(
-        id: NestedId,
-        role: Role,
-        channel: GarbleChannel,
-        deap: Weak<DEAP>,
-        ot_send: Arc<OTS>,
-        ot_recv: Arc<OTR>,
-    ) -> Self {
-        let (sink, stream) = channel.split();
-        let op_id = id.append_counter();
-        Self {
-            _id: id,
-            _role: role,
-            op_id,
-            deap,
-            ot_send,
-            ot_recv,
-            sink,
-            stream,
+        match mem::replace(&mut self.state, State::Finalized) {
+            State::Main(deap) => {
+                let mut deap =
+                    Arc::try_unwrap(deap).expect("state should have only strong reference");
+                deap.finalize(&mut self.ctx, &mut self.ot_recv).await
+            }
+            State::Child(_) => Err(FinalizationError::NotMainThread.into()),
+            State::Finalized => return Err(FinalizationError::AlreadyFinalized.into()),
         }
     }
 }
 
-impl<OTS, OTR> Thread for DEAPThread<OTS, OTR> {}
+impl<Ctx, OTS, OTR> Thread for DEAPThread<Ctx, OTS, OTR> {}
 
-impl<OTS, OTR> Memory for DEAPThread<OTS, OTR> {
+impl<Ctx, OTS, OTR> Memory for DEAPThread<Ctx, OTS, OTR> {
     fn new_input_with_type(
         &self,
         id: &str,
         typ: ValueType,
         visibility: Visibility,
     ) -> Result<ValueRef, MemoryError> {
-        self.deap().new_input_with_type(id, typ, visibility)
+        self.state.get().new_input_with_type(id, typ, visibility)
     }
 
     fn new_output_with_type(&self, id: &str, typ: ValueType) -> Result<ValueRef, MemoryError> {
-        self.deap().new_output_with_type(id, typ)
+        self.state.get().new_output_with_type(id, typ)
     }
 
     fn assign(&self, value_ref: &ValueRef, value: impl Into<Value>) -> Result<(), MemoryError> {
-        self.deap().assign(value_ref, value)
+        self.state.get().assign(value_ref, value)
     }
 
     fn assign_by_id(&self, id: &str, value: impl Into<Value>) -> Result<(), MemoryError> {
-        self.deap().assign_by_id(id, value)
+        self.state.get().assign_by_id(id, value)
     }
 
     fn get_value(&self, id: &str) -> Option<ValueRef> {
-        self.deap().get_value(id)
+        self.state.get().get_value(id)
     }
 
     fn get_value_type(&self, value_ref: &ValueRef) -> ValueType {
-        self.deap().get_value_type(value_ref)
+        self.state.get().get_value_type(value_ref)
     }
 
     fn get_value_type_by_id(&self, id: &str) -> Option<ValueType> {
-        self.deap().get_value_type_by_id(id)
+        self.state.get().get_value_type_by_id(id)
     }
 }
 
 #[async_trait]
-impl<OTS, OTR> Load for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> Load for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn load(
         &mut self,
@@ -249,18 +162,20 @@ where
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), LoadError> {
-        self.deap()
-            .load(circ, inputs, outputs, &mut self.sink, &mut self.stream)
+        self.state
+            .get()
+            .load(&mut self.ctx, circ, inputs, outputs)
             .map_err(LoadError::from)
             .await
     }
 }
 
 #[async_trait]
-impl<OTS, OTR> Execute for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> Execute for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn execute(
         &mut self,
@@ -268,16 +183,15 @@ where
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), ExecutionError> {
-        self.deap()
+        self.state
+            .get()
             .execute(
-                &self.op_id.increment_in_place().to_string(),
+                &mut self.ctx,
                 circ,
                 inputs,
                 outputs,
-                &mut self.sink,
-                &mut self.stream,
-                &*self.ot_send,
-                &*self.ot_recv,
+                &mut self.ot_send,
+                &mut self.ot_recv,
             )
             .map_err(ExecutionError::from)
             .await
@@ -285,10 +199,11 @@ where
 }
 
 #[async_trait]
-impl<OTS, OTR> Prove for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> Prove for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn execute_prove(
         &mut self,
@@ -296,36 +211,28 @@ where
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), ProveError> {
-        self.deap()
-            .execute_prove(
-                &self.op_id.increment_in_place().to_string(),
-                circ,
-                inputs,
-                outputs,
-                &mut self.stream,
-                &*self.ot_recv,
-            )
+        self.state
+            .get()
+            .execute_prove(&mut self.ctx, circ, inputs, outputs, &mut self.ot_recv)
             .map_err(ProveError::from)
             .await
     }
 
     async fn prove(&mut self, values: &[ValueRef]) -> Result<(), ProveError> {
-        self.deap()
-            .defer_prove(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                &mut self.sink,
-            )
+        self.state
+            .get()
+            .defer_prove(&mut self.ctx, values)
             .map_err(ProveError::from)
             .await
     }
 }
 
 #[async_trait]
-impl<OTS, OTR> Verify for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> Verify for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn execute_verify(
         &mut self,
@@ -333,15 +240,9 @@ where
         inputs: &[ValueRef],
         outputs: &[ValueRef],
     ) -> Result<(), VerifyError> {
-        self.deap()
-            .execute_verify(
-                &self.op_id.increment_in_place().to_string(),
-                circ,
-                inputs,
-                outputs,
-                &mut self.sink,
-                &*self.ot_send,
-            )
+        self.state
+            .get()
+            .execute_verify(&mut self.ctx, circ, inputs, outputs, &mut self.ot_send)
             .map_err(VerifyError::from)
             .await
     }
@@ -351,81 +252,57 @@ where
         values: &[ValueRef],
         expected_values: &[Value],
     ) -> Result<(), VerifyError> {
-        self.deap()
-            .defer_verify(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                expected_values,
-                &mut self.stream,
-            )
+        self.state
+            .get()
+            .defer_verify(&mut self.ctx, values, expected_values)
             .map_err(VerifyError::from)
             .await
     }
 }
 
 #[async_trait]
-impl<OTS, OTR> Decode for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> Decode for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn decode(&mut self, values: &[ValueRef]) -> Result<Vec<Value>, DecodeError> {
-        self.deap()
-            .decode(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                &mut self.sink,
-                &mut self.stream,
-            )
+        self.state
+            .get()
+            .decode(&mut self.ctx, values)
             .map_err(DecodeError::from)
             .await
     }
 }
 
 #[async_trait]
-impl<OTS, OTR> DecodePrivate for DEAPThread<OTS, OTR>
+impl<Ctx, OTS, OTR> DecodePrivate for DEAPThread<Ctx, OTS, OTR>
 where
-    OTS: VerifiableOTSendEncoding + Send + Sync,
-    OTR: VerifiableOTReceiveEncoding + Send + Sync,
+    Ctx: Context,
+    OTS: VerifiableOTSendEncoding<Ctx> + Send + Sync,
+    OTR: VerifiableOTReceiveEncoding<Ctx> + Send + Sync,
 {
     async fn decode_private(&mut self, values: &[ValueRef]) -> Result<Vec<Value>, DecodeError> {
-        self.deap()
-            .decode_private(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                &mut self.sink,
-                &mut self.stream,
-                &*self.ot_send,
-                &*self.ot_recv,
-            )
+        self.state
+            .get()
+            .decode_private(&mut self.ctx, values, &mut self.ot_send, &mut self.ot_recv)
             .map_err(DecodeError::from)
             .await
     }
 
     async fn decode_blind(&mut self, values: &[ValueRef]) -> Result<(), DecodeError> {
-        self.deap()
-            .decode_blind(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                &mut self.sink,
-                &mut self.stream,
-                &*self.ot_send,
-                &*self.ot_recv,
-            )
+        self.state
+            .get()
+            .decode_blind(&mut self.ctx, values, &mut self.ot_send, &mut self.ot_recv)
             .map_err(DecodeError::from)
             .await
     }
 
     async fn decode_shared(&mut self, values: &[ValueRef]) -> Result<Vec<Value>, DecodeError> {
-        self.deap()
-            .decode_shared(
-                &self.op_id.increment_in_place().to_string(),
-                values,
-                &mut self.sink,
-                &mut self.stream,
-                &*self.ot_send,
-                &*self.ot_recv,
-            )
+        self.state
+            .get()
+            .decode_shared(&mut self.ctx, values, &mut self.ot_send, &mut self.ot_recv)
             .map_err(DecodeError::from)
             .await
     }
@@ -444,16 +321,16 @@ pub trait PeerEncodings {
     ) -> Result<Vec<EncodedValue<Active>>, PeerEncodingsError>;
 }
 
-impl<OTS, OTR> PeerEncodings for DEAPVm<OTS, OTR> {
+impl<Ctx, OTS, OTR> PeerEncodings for DEAPThread<Ctx, OTS, OTR> {
     fn get_peer_encodings(
         &self,
         value_ids: &[&str],
     ) -> Result<Vec<EncodedValue<Active>>, PeerEncodingsError> {
-        if self.finalized {
+        if self.state.is_finalized() {
             return Err(PeerEncodingsError::AlreadyFinalized);
         }
 
-        let deap = self.deap.as_ref().expect("instance set until finalization");
+        let deap = self.state.get();
 
         value_ids
             .iter()
@@ -481,39 +358,22 @@ mod tests {
 
     use crate::protocol::deap::mock::create_mock_deap_vm;
 
-    use core::{future::Future, pin::Pin};
-    use mpz_ot::ideal::{IdealSharedOTReceiver, IdealSharedOTSender};
-    use rstest::{fixture, rstest};
-
-    // Leader and follower VMs in a set up state and the futures which need to be awaited
-    // to trigger circuit execution.
-    struct VmFixture {
-        leader_vm: DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
-        leader_fut: Pin<Box<dyn Future<Output = Vec<Value>>>>,
-        follower_vm: DEAPVm<IdealSharedOTSender, IdealSharedOTReceiver>,
-        follower_fut: Pin<Box<dyn Future<Output = Vec<Value>>>>,
-    }
-
-    // Sets up leader and follower VMs.
-    #[fixture]
-    async fn set_up_vms() -> VmFixture {
-        let (mut leader_vm, mut follower_vm) = create_mock_deap_vm("test_vm").await;
-
-        let mut leader_thread = leader_vm.new_thread("test_thread").await.unwrap();
-        let mut follower_thread = follower_vm.new_thread("test_thread").await.unwrap();
+    #[tokio::test]
+    async fn test_vm() {
+        let (mut leader_vm, mut follower_vm) = create_mock_deap_vm();
 
         let key = [42u8; 16];
         let msg = [69u8; 16];
 
         let leader_fut = {
-            let key_ref = leader_thread.new_private_input::<[u8; 16]>("key").unwrap();
-            let msg_ref = leader_thread.new_blind_input::<[u8; 16]>("msg").unwrap();
-            let ciphertext_ref = leader_thread.new_output::<[u8; 16]>("ciphertext").unwrap();
+            let key_ref = leader_vm.new_private_input::<[u8; 16]>("key").unwrap();
+            let msg_ref = leader_vm.new_blind_input::<[u8; 16]>("msg").unwrap();
+            let ciphertext_ref = leader_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
 
-            leader_thread.assign(&key_ref, key).unwrap();
+            leader_vm.assign(&key_ref, key).unwrap();
 
-            async move {
-                leader_thread
+            async {
+                leader_vm
                     .execute(
                         AES128.clone(),
                         &[key_ref, msg_ref],
@@ -522,23 +382,19 @@ mod tests {
                     .await
                     .unwrap();
 
-                leader_thread.decode(&[ciphertext_ref]).await.unwrap()
+                leader_vm.decode(&[ciphertext_ref]).await.unwrap()
             }
         };
 
         let follower_fut = {
-            let key_ref = follower_thread.new_blind_input::<[u8; 16]>("key").unwrap();
-            let msg_ref = follower_thread
-                .new_private_input::<[u8; 16]>("msg")
-                .unwrap();
-            let ciphertext_ref = follower_thread
-                .new_output::<[u8; 16]>("ciphertext")
-                .unwrap();
+            let key_ref = follower_vm.new_blind_input::<[u8; 16]>("key").unwrap();
+            let msg_ref = follower_vm.new_private_input::<[u8; 16]>("msg").unwrap();
+            let ciphertext_ref = follower_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
 
-            follower_thread.assign(&msg_ref, msg).unwrap();
+            follower_vm.assign(&msg_ref, msg).unwrap();
 
-            async move {
-                follower_thread
+            async {
+                follower_vm
                     .execute(
                         AES128.clone(),
                         &[key_ref, msg_ref],
@@ -547,27 +403,9 @@ mod tests {
                     .await
                     .unwrap();
 
-                follower_thread.decode(&[ciphertext_ref]).await.unwrap()
+                follower_vm.decode(&[ciphertext_ref]).await.unwrap()
             }
         };
-
-        VmFixture {
-            leader_vm,
-            leader_fut: Box::pin(leader_fut),
-            follower_vm,
-            follower_fut: Box::pin(follower_fut),
-        }
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_vm(set_up_vms: impl Future<Output = VmFixture>) {
-        let VmFixture {
-            mut leader_vm,
-            leader_fut,
-            mut follower_vm,
-            follower_fut,
-        } = set_up_vms.await;
 
         let (leader_result, follower_result) = futures::join!(leader_fut, follower_fut);
 
@@ -580,19 +418,58 @@ mod tests {
         follower_result.unwrap();
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn test_peer_encodings(set_up_vms: impl Future<Output = VmFixture>) {
-        let VmFixture {
-            mut leader_vm,
-            leader_fut,
-            mut follower_vm,
-            follower_fut,
-        } = set_up_vms.await;
+    async fn test_peer_encodings() {
+        let (mut leader_vm, mut follower_vm) = create_mock_deap_vm();
 
-        // Encodings are not yet available because the circuit hasn't yet been executed
-        let err = leader_vm.get_peer_encodings(&["msg"]).unwrap_err();
-        assert!(matches!(err, PeerEncodingsError::EncodingNotAvailable(_)));
+        let key = [42u8; 16];
+        let msg = [69u8; 16];
+
+        let leader_fut = {
+            let key_ref = leader_vm.new_private_input::<[u8; 16]>("key").unwrap();
+            let msg_ref = leader_vm.new_blind_input::<[u8; 16]>("msg").unwrap();
+            let ciphertext_ref = leader_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
+
+            leader_vm.assign(&key_ref, key).unwrap();
+
+            // Encodings are not yet available because the circuit hasn't yet been executed
+            let err = leader_vm.get_peer_encodings(&["msg"]).unwrap_err();
+            assert!(matches!(err, PeerEncodingsError::EncodingNotAvailable(_)));
+
+            async {
+                leader_vm
+                    .execute(
+                        AES128.clone(),
+                        &[key_ref, msg_ref],
+                        &[ciphertext_ref.clone()],
+                    )
+                    .await
+                    .unwrap();
+
+                leader_vm.decode(&[ciphertext_ref]).await.unwrap()
+            }
+        };
+
+        let follower_fut = {
+            let key_ref = follower_vm.new_blind_input::<[u8; 16]>("key").unwrap();
+            let msg_ref = follower_vm.new_private_input::<[u8; 16]>("msg").unwrap();
+            let ciphertext_ref = follower_vm.new_output::<[u8; 16]>("ciphertext").unwrap();
+
+            follower_vm.assign(&msg_ref, msg).unwrap();
+
+            async {
+                follower_vm
+                    .execute(
+                        AES128.clone(),
+                        &[key_ref, msg_ref],
+                        &[ciphertext_ref.clone()],
+                    )
+                    .await
+                    .unwrap();
+
+                follower_vm.decode(&[ciphertext_ref]).await.unwrap()
+            }
+        };
 
         // Execute the circuits
         _ = futures::join!(leader_fut, follower_fut);

--- a/crates/mpz-garble/tests/offline-garble.rs
+++ b/crates/mpz-garble/tests/offline-garble.rs
@@ -1,14 +1,13 @@
 use mpz_circuits::{circuits::AES128, types::StaticValueType};
-use mpz_garble_core::msg::GarbleMessage;
-use mpz_ot::ideal::ideal_ot_shared_pair;
-use utils_aio::duplex::MemoryDuplex;
+use mpz_common::executor::test_st_executor;
+use mpz_ot::ideal::ot::ideal_ot;
 
 use mpz_garble::{config::Visibility, Evaluator, Generator, GeneratorConfigBuilder, ValueMemory};
 
 #[tokio::test]
 async fn test_offline_garble() {
-    let (mut gen_channel, mut ev_channel) = MemoryDuplex::<GarbleMessage>::new();
-    let (ot_send, ot_recv) = ideal_ot_shared_pair();
+    let (mut ctx_a, mut ctx_b) = test_st_executor(8);
+    let (mut ot_send, mut ot_recv) = ideal_ot();
 
     let gen = Generator::new(
         GeneratorConfigBuilder::default().build().unwrap(),
@@ -40,10 +39,10 @@ async fn test_offline_garble() {
         gen.generate_input_encoding(&msg_ref, &msg_typ);
 
         gen.generate(
+            &mut ctx_a,
             AES128.clone(),
             &[key_ref.clone(), msg_ref.clone()],
             &[ciphertext_ref.clone()],
-            &mut gen_channel,
             false,
         )
         .await
@@ -52,10 +51,9 @@ async fn test_offline_garble() {
         memory.assign(&key_ref, key.into()).unwrap();
 
         gen.setup_assigned_values(
-            "test",
+            &mut ctx_a,
             &memory.drain_assigned(&[key_ref.clone(), msg_ref.clone()]),
-            &mut gen_channel,
-            &ot_send,
+            &mut ot_send,
         )
         .await
         .unwrap();
@@ -77,10 +75,10 @@ async fn test_offline_garble() {
             .unwrap();
 
         ev.receive_garbled_circuit(
+            &mut ctx_b,
             AES128.clone(),
             &[key_ref.clone(), msg_ref.clone()],
             &[ciphertext_ref.clone()],
-            &mut ev_channel,
         )
         .await
         .unwrap();
@@ -88,20 +86,19 @@ async fn test_offline_garble() {
         memory.assign(&msg_ref, msg.into()).unwrap();
 
         ev.setup_assigned_values(
-            "test",
+            &mut ctx_b,
             &memory.drain_assigned(&[key_ref.clone(), msg_ref.clone()]),
-            &mut ev_channel,
-            &ot_recv,
+            &mut ot_recv,
         )
         .await
         .unwrap();
 
         _ = ev
             .evaluate(
+                &mut ctx_b,
                 AES128.clone(),
                 &[key_ref.clone(), msg_ref.clone()],
                 &[ciphertext_ref.clone()],
-                &mut ev_channel,
             )
             .await
             .unwrap();

--- a/crates/mpz-ot/src/ideal/ot.rs
+++ b/crates/mpz-ot/src/ideal/ot.rs
@@ -8,11 +8,11 @@ use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
     Context,
 };
-use mpz_ot_core::ideal::ot::IdealOT;
+use mpz_ot_core::{ideal::ot::IdealOT, TransferId};
 
 use crate::{
-    CommittedOTReceiver, OTError, OTReceiver, OTReceiverOutput, OTSender, OTSenderOutput, OTSetup,
-    VerifiableOTSender,
+    CommittedOTReceiver, CommittedOTSender, OTError, OTReceiver, OTReceiverOutput, OTSender,
+    OTSenderOutput, OTSetup, VerifiableOTReceiver, VerifiableOTSender,
 };
 
 fn ot<T: Copy + Send + Sync + 'static>(
@@ -62,6 +62,15 @@ impl<Ctx: Context, T: Copy + Send + Sync + 'static> OTSender<Ctx, [T; 2]>
 }
 
 #[async_trait]
+impl<Ctx: Context, T: Copy + Send + Sync + 'static> CommittedOTSender<Ctx, [T; 2]>
+    for IdealOTSender<[T; 2]>
+{
+    async fn reveal(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl<Ctx: Context, T: Copy + Send + Sync + 'static> VerifiableOTSender<Ctx, bool, [T; 2]>
     for IdealOTSender<[T; 2]>
 {
@@ -103,5 +112,19 @@ impl<Ctx: Context, T: Copy + Send + Sync + 'static> CommittedOTReceiver<Ctx, boo
 {
     async fn reveal_choices(&mut self, ctx: &mut Ctx) -> Result<(), OTError> {
         Ok(self.0.call(ctx, (), verify).await)
+    }
+}
+
+#[async_trait]
+impl<Ctx: Context, U: Copy + Send + Sync + 'static, V> VerifiableOTReceiver<Ctx, bool, U, V>
+    for IdealOTReceiver<U>
+{
+    async fn verify(
+        &mut self,
+        _ctx: &mut Ctx,
+        _id: TransferId,
+        _msgs: &[V],
+    ) -> Result<(), OTError> {
+        Ok(())
     }
 }

--- a/crates/mpz-ot/src/lib.rs
+++ b/crates/mpz-ot/src/lib.rs
@@ -200,11 +200,7 @@ where
 /// An oblivious transfer sender that is committed to its messages and can reveal them
 /// to the receiver to verify them.
 #[async_trait]
-pub trait CommittedOTSender<Ctx, T>: OTSender<Ctx, T>
-where
-    Ctx: Context,
-    T: Send + Sync,
-{
+pub trait CommittedOTSender<Ctx, T>: OTSender<Ctx, T> {
     /// Reveals all messages sent to the receiver.
     ///
     /// # Warning
@@ -246,13 +242,7 @@ pub trait CommittedOTReceiver<Ctx, T, U>: OTReceiver<Ctx, T, U> {
 
 /// An oblivious transfer receiver that can verify the sender's messages.
 #[async_trait]
-pub trait VerifiableOTReceiver<Ctx, T, U, V>: OTReceiver<Ctx, T, U>
-where
-    Ctx: Context,
-    T: Send + Sync,
-    U: Send + Sync,
-    V: Send + Sync,
-{
+pub trait VerifiableOTReceiver<Ctx, T, U, V>: OTReceiver<Ctx, T, U> {
     /// Verifies purported messages sent by the sender.
     ///
     /// # Arguments


### PR DESCRIPTION
This PR refactors `mpz-garble` to accomodate the breaking changes from #112 .

# Changes
- Use new `Context` abstraction.
- Incorporate changes from #140 
- Remove `DEAPVm` type and just use `DEAPThread`