### PR TITLE
test(mpz-common): test mt executor concurrency

### DIFF
--- a/crates/mpz-common/src/executor/mod.rs
+++ b/crates/mpz-common/src/executor/mod.rs
@@ -27,7 +27,7 @@ mod test_utils {
     /// Test multi-threaded executor.
     pub type TestMTExecutor = MTExecutor<TestFramedMux>;
 
-    /// Creates a pair of multi-threaded executors with yamux I/O channels.
+    /// Creates a pair of multi-threaded executors with multiplexed I/O channels.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
This PR adds a test for the multi-threaded executor, ensuring futures are polled concurrently.