### PR TITLE
refactor: KOS and preprocessing traits

### DIFF
--- a/crates/mpz-common/src/lib.rs
+++ b/crates/mpz-common/src/lib.rs
@@ -23,11 +23,28 @@ pub mod ideal;
 #[cfg(feature = "sync")]
 pub mod sync;
 
+use async_trait::async_trait;
 pub use context::{Context, ContextError};
 pub use id::{Counter, ThreadId};
 
 // Re-export scoped-futures for use with the callback-like API in `Context`.
 pub use scoped_futures;
+
+/// Allocates capacity from a functionality in the pre-processing model.
+pub trait Allocate {
+    /// Allocates `count` capacity.
+    fn alloc(&mut self, count: usize);
+}
+
+/// A functionality in the pre-processing model.
+#[async_trait]
+pub trait Preprocess<Ctx>: Allocate {
+    /// Error type.
+    type Error;
+
+    /// Preprocesses the functionality.
+    async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), Self::Error>;
+}
 
 /// A convenience macro for creating a closure which returns a scoped future.
 ///

--- a/crates/mpz-common/src/lib.rs
+++ b/crates/mpz-common/src/lib.rs
@@ -40,7 +40,7 @@ pub trait Allocate {
 #[async_trait]
 pub trait Preprocess<Ctx>: Allocate {
     /// Error type.
-    type Error;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Preprocesses the functionality.
     async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), Self::Error>;

--- a/crates/mpz-ole-core/src/lib.rs
+++ b/crates/mpz-ole-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod msg;
 mod receiver;
 mod sender;
 
-pub use receiver::OLEReceiver;
+pub use receiver::{BatchReceiverAdjust, OLEReceiver};
 pub use sender::{BatchSenderAdjust, OLESender};
 use serde::{Deserialize, Serialize};
 

--- a/crates/mpz-ole/src/ideal.rs
+++ b/crates/mpz-ole/src/ideal.rs
@@ -4,7 +4,7 @@ use crate::{OLEError, OLEReceiver, OLESender};
 use async_trait::async_trait;
 use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
-    Context,
+    Allocate, Context, Preprocess,
 };
 use mpz_fields::Field;
 use rand::thread_rng;
@@ -34,6 +34,32 @@ fn ole<F: Field>(_: &mut (), alice_input: Vec<F>, bob_input: Vec<F>) -> (Vec<F>,
         .collect();
 
     (alice_output, bob_output)
+}
+
+impl Allocate for IdealOLESender {
+    fn alloc(&mut self, _: usize) {}
+}
+
+impl Allocate for IdealOLEReceiver {
+    fn alloc(&mut self, _: usize) {}
+}
+
+#[async_trait]
+impl<Ctx: Context> Preprocess<Ctx> for IdealOLESender {
+    type Error = OLEError;
+
+    async fn preprocess(&mut self, _: &mut Ctx) -> Result<(), OLEError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<Ctx: Context> Preprocess<Ctx> for IdealOLEReceiver {
+    type Error = OLEError;
+
+    async fn preprocess(&mut self, _: &mut Ctx) -> Result<(), OLEError> {
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/crates/mpz-ole/src/lib.rs
+++ b/crates/mpz-ole/src/lib.rs
@@ -82,6 +82,7 @@ impl OLEError {
 impl Display for OLEError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
+            OLEErrorKind::Context => write!(f, "Context Error"),
             OLEErrorKind::OT => write!(f, "OT Error"),
             OLEErrorKind::IO => write!(f, "IO Error"),
             OLEErrorKind::Core => write!(f, "OLE Core Error"),
@@ -99,11 +100,24 @@ impl Display for OLEError {
 
 #[derive(Debug)]
 pub(crate) enum OLEErrorKind {
+    Context,
     OT,
     IO,
     Core,
     Field,
     InsufficientOLEs,
+}
+
+impl From<mpz_common::ContextError> for OLEError {
+    fn from(value: mpz_common::ContextError) -> Self {
+        Self::new(OLEErrorKind::Context, value)
+    }
+}
+
+impl From<mpz_common::sync::MutexError> for OLEError {
+    fn from(value: mpz_common::sync::MutexError) -> Self {
+        Self::new(OLEErrorKind::Context, value)
+    }
 }
 
 impl From<OTError> for OLEError {

--- a/crates/mpz-ole/src/rot/mod.rs
+++ b/crates/mpz-ole/src/rot/mod.rs
@@ -12,7 +12,7 @@ mod tests {
         rot::{OLEReceiver, OLESender},
         OLEReceiver as _, OLESender as _,
     };
-    use mpz_common::executor::test_st_executor;
+    use mpz_common::{executor::test_st_executor, Allocate, Preprocess};
     use mpz_core::{prg::Prg, Block};
     use mpz_fields::{p256::P256, UniformRand};
     use mpz_ot::ideal::rot::ideal_rot;
@@ -33,9 +33,12 @@ mod tests {
 
         let (mut ctx_sender, mut ctx_receiver) = test_st_executor(10);
 
+        ole_sender.alloc(count);
+        ole_receiver.alloc(count);
+
         tokio::try_join!(
-            ole_sender.preprocess(&mut ctx_sender, count),
-            ole_receiver.preprocess(&mut ctx_receiver, count)
+            ole_sender.preprocess(&mut ctx_sender),
+            ole_receiver.preprocess(&mut ctx_receiver)
         )
         .unwrap();
 

--- a/crates/mpz-ole/src/rot/sender.rs
+++ b/crates/mpz-ole/src/rot/sender.rs
@@ -1,19 +1,20 @@
+use std::mem;
+
 use crate::{OLEError, OLEErrorKind, OLESender as OLESend};
 use async_trait::async_trait;
-use mpz_common::Context;
+use mpz_common::{Allocate, Context, Preprocess};
 use mpz_fields::Field;
-use mpz_ole_core::msg::BatchAdjust;
-use mpz_ole_core::OLESender as OLECoreSender;
-use mpz_ot::RandomOTSender;
+use mpz_ole_core::{msg::BatchAdjust, BatchSenderAdjust, OLESender as OLECoreSender};
+use mpz_ot::{OTError, RandomOTSender};
 use rand::thread_rng;
-use serio::stream::IoStreamExt;
-use serio::SinkExt;
-use serio::{Deserialize, Serialize};
+use serio::{stream::IoStreamExt, Deserialize, Serialize, SinkExt};
 
 /// OLE sender.
+#[derive(Debug)]
 pub struct OLESender<T, F> {
     rot_sender: T,
     core: OLECoreSender<F>,
+    alloc: usize,
 }
 
 impl<T, F> OLESender<T, F>
@@ -25,27 +26,52 @@ where
         Self {
             rot_sender,
             core: OLECoreSender::default(),
+            alloc: 0,
         }
+    }
+
+    pub(crate) fn adjust(
+        &mut self,
+        inputs: Vec<F>,
+    ) -> Result<(BatchSenderAdjust<F>, BatchAdjust<F>), OLEError> {
+        let len = inputs.len();
+        self.core.adjust(inputs).ok_or_else(|| {
+            OLEError::new(
+                OLEErrorKind::InsufficientOLEs,
+                format!("{} < {}", self.core.cache_size(), len),
+            )
+        })
     }
 }
 
-impl<T, F> OLESender<T, F>
+impl<T, F> Allocate for OLESender<T, F>
 where
+    T: Allocate,
+    F: Field,
+{
+    fn alloc(&mut self, count: usize) {
+        self.rot_sender.alloc(count * F::BIT_SIZE);
+        self.alloc += count;
+    }
+}
+
+#[async_trait]
+impl<Ctx, T, F> Preprocess<Ctx> for OLESender<T, F>
+where
+    Ctx: Context,
+    T: Allocate + Preprocess<Ctx, Error = OTError> + RandomOTSender<Ctx, [F; 2]> + Send,
     F: Field + Serialize + Deserialize,
 {
-    /// Preprocesses OLEs.
-    ///
-    /// # Arguments
-    ///
-    /// * `count` - The number of OLEs to preprocess.
-    pub async fn preprocess<Ctx: Context>(
-        &mut self,
-        ctx: &mut Ctx,
-        count: usize,
-    ) -> Result<(), OLEError>
-    where
-        T: RandomOTSender<Ctx, [F; 2]> + Send,
-    {
+    type Error = OLEError;
+
+    async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), OLEError> {
+        let count = mem::take(&mut self.alloc);
+        if count == 0 {
+            return Ok(());
+        }
+
+        self.rot_sender.preprocess(ctx).await?;
+
         let random = {
             let mut rng = thread_rng();
             (0..count).map(|_| F::rand(&mut rng)).collect()
@@ -72,14 +98,8 @@ where
     F: Field + Serialize + Deserialize,
 {
     async fn send(&mut self, ctx: &mut Ctx, a_k: Vec<F>) -> Result<Vec<F>, OLEError> {
-        let len_requested = a_k.len();
+        let (sender_adjust, adjust) = self.adjust(a_k)?;
 
-        let (sender_adjust, adjust) = self.core.adjust(a_k).ok_or_else(|| {
-            OLEError::new(
-                OLEErrorKind::InsufficientOLEs,
-                format!("{} < {}", self.core.cache_size(), len_requested),
-            )
-        })?;
         let channel = ctx.io_mut();
         channel.send(adjust).await?;
         let adjust = channel.expect_next::<BatchAdjust<F>>().await?;

--- a/crates/mpz-ot/src/ideal/cot.rs
+++ b/crates/mpz-ot/src/ideal/cot.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
-    Context,
+    Allocate, Context, Preprocess,
 };
 use mpz_core::Block;
 use mpz_ot_core::{
@@ -59,6 +59,22 @@ where
     }
 }
 
+impl Allocate for IdealCOTSender {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx> Preprocess<Ctx> for IdealCOTSender
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl<Ctx: Context> COTSender<Ctx, Block> for IdealCOTSender {
     async fn send_correlated(
@@ -91,6 +107,22 @@ where
     Ctx: Context,
 {
     async fn setup(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
+impl Allocate for IdealCOTReceiver {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx> Preprocess<Ctx> for IdealCOTReceiver
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
         Ok(())
     }
 }

--- a/crates/mpz-ot/src/ideal/ot.rs
+++ b/crates/mpz-ot/src/ideal/ot.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 
 use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
-    Context,
+    Allocate, Context, Preprocess,
 };
 use mpz_ot_core::{ideal::ot::IdealOT, TransferId};
 
@@ -52,6 +52,22 @@ where
     }
 }
 
+impl<T> Allocate for IdealOTSender<T> {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx, T> Preprocess<Ctx> for IdealOTSender<T>
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl<Ctx: Context, T: Copy + Send + Sync + 'static> OTSender<Ctx, [T; 2]>
     for IdealOTSender<[T; 2]>
@@ -89,6 +105,22 @@ where
     Ctx: Context,
 {
     async fn setup(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
+impl<T> Allocate for IdealOTReceiver<T> {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx, T> Preprocess<Ctx> for IdealOTReceiver<T>
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
         Ok(())
     }
 }

--- a/crates/mpz-ot/src/ideal/rot.rs
+++ b/crates/mpz-ot/src/ideal/rot.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
-    Context,
+    Allocate, Context, Preprocess,
 };
 use mpz_ot_core::{ideal::rot::IdealROT, ROTReceiverOutput, ROTSenderOutput};
 use rand::distributions::{Distribution, Standard};
@@ -44,6 +44,22 @@ where
     }
 }
 
+impl Allocate for IdealROTSender {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx> Preprocess<Ctx> for IdealROTSender
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl<T: Copy + Send + 'static, Ctx: Context> RandomOTSender<Ctx, [T; 2]> for IdealROTSender
 where
@@ -68,6 +84,22 @@ where
     Ctx: Context,
 {
     async fn setup(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+}
+
+impl Allocate for IdealROTReceiver {
+    fn alloc(&mut self, _count: usize) {}
+}
+
+#[async_trait]
+impl<Ctx> Preprocess<Ctx> for IdealROTReceiver
+where
+    Ctx: Context,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
         Ok(())
     }
 }

--- a/crates/mpz-ot/src/kos/receiver.rs
+++ b/crates/mpz-ot/src/kos/receiver.rs
@@ -1,8 +1,10 @@
+use std::mem;
+
 use async_trait::async_trait;
 use futures::TryFutureExt as _;
 use itybity::{FromBitIterator, IntoBitIterator};
 use mpz_cointoss as cointoss;
-use mpz_common::{try_join, Context};
+use mpz_common::{try_join, Allocate, Context, Preprocess};
 use mpz_core::{prg::Prg, Block};
 use mpz_ot_core::{
     kos::{
@@ -14,8 +16,11 @@ use mpz_ot_core::{
 };
 
 use enum_try_as_inner::EnumTryAsInner;
-use rand::{thread_rng, Rng};
-use rand_core::{RngCore, SeedableRng};
+use rand::{
+    distributions::{Distribution, Standard},
+    thread_rng, Rng,
+};
+use rand_core::SeedableRng;
 use serio::{stream::IoStreamExt as _, SinkExt as _};
 use utils_aio::non_blocking_backend::{Backend, NonBlockingBackend};
 
@@ -39,7 +44,7 @@ pub(crate) enum State {
 pub struct Receiver<BaseOT> {
     state: State,
     base: BaseOT,
-
+    alloc: usize,
     cointoss_receiver: Option<cointoss::Receiver<cointoss::receiver_state::Received>>,
 }
 
@@ -56,6 +61,7 @@ where
         Self {
             state: State::Initialized(Box::new(ReceiverCore::new(config))),
             base,
+            alloc: 0,
             cointoss_receiver: None,
         }
     }
@@ -214,6 +220,34 @@ where
     }
 }
 
+impl<BaseOT> Allocate for Receiver<BaseOT> {
+    fn alloc(&mut self, count: usize) {
+        self.alloc += count;
+    }
+}
+
+#[async_trait]
+impl<Ctx, BaseOT> Preprocess<Ctx> for Receiver<BaseOT>
+where
+    Ctx: Context,
+    BaseOT: OTSetup<Ctx> + OTSender<Ctx, [Block; 2]> + Send,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), OTError> {
+        if self.state.is_initialized() {
+            self.setup(ctx).await?;
+        }
+
+        let count = mem::take(&mut self.alloc);
+        if count == 0 {
+            return Ok(());
+        }
+
+        self.extend(ctx, count).await.map_err(OTError::from)
+    }
+}
+
 #[async_trait]
 impl<Ctx, BaseOT> OTReceiver<Ctx, bool, Block> for Receiver<BaseOT>
 where
@@ -256,16 +290,17 @@ where
 }
 
 #[async_trait]
-impl<Ctx, BaseOT> RandomOTReceiver<Ctx, bool, Block> for Receiver<BaseOT>
+impl<Ctx, T, BaseOT> RandomOTReceiver<Ctx, bool, T> for Receiver<BaseOT>
 where
     Ctx: Context,
+    Standard: Distribution<T>,
     BaseOT: Send,
 {
     async fn receive_random(
         &mut self,
         _ctx: &mut Ctx,
         count: usize,
-    ) -> Result<ROTReceiverOutput<bool, Block>, OTError> {
+    ) -> Result<ROTReceiverOutput<bool, T>, OTError> {
         let receiver = self
             .state
             .try_as_extension_mut()
@@ -273,7 +308,9 @@ where
 
         let keys = receiver.keys(count).map_err(ReceiverError::from)?;
         let id = keys.id();
-        let (choices, msgs) = keys.take_choices_and_keys();
+        let (choices, keys) = keys.take_choices_and_keys();
+
+        let msgs = keys.into_iter().map(|k| Prg::from_seed(k).gen()).collect();
 
         Ok(ROTReceiverOutput { id, choices, msgs })
     }
@@ -317,40 +354,6 @@ where
         .await?;
 
         Ok(OTReceiverOutput { id, msgs: received })
-    }
-}
-
-#[async_trait]
-impl<Ctx, const N: usize, BaseOT> RandomOTReceiver<Ctx, bool, [u8; N]> for Receiver<BaseOT>
-where
-    Ctx: Context,
-    BaseOT: Send,
-{
-    async fn receive_random(
-        &mut self,
-        _ctx: &mut Ctx,
-        count: usize,
-    ) -> Result<ROTReceiverOutput<bool, [u8; N]>, OTError> {
-        let receiver = self
-            .state
-            .try_as_extension_mut()
-            .map_err(ReceiverError::from)?;
-
-        let keys = receiver.keys(count).map_err(ReceiverError::from)?;
-        let id = keys.id();
-
-        let (choices, random_outputs) = keys.take_choices_and_keys();
-        let msgs = random_outputs
-            .into_iter()
-            .map(|block| {
-                let mut prg = Prg::from_seed(block);
-                let mut out = [0_u8; N];
-                prg.fill_bytes(&mut out);
-                out
-            })
-            .collect();
-
-        Ok(ROTReceiverOutput { id, choices, msgs })
     }
 }
 

--- a/crates/mpz-ot/src/kos/shared_sender.rs
+++ b/crates/mpz-ot/src/kos/shared_sender.rs
@@ -2,20 +2,29 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use mpz_common::{sync::AsyncMutex, Context};
+use mpz_common::{sync::AsyncMutex, Allocate, Context, Preprocess};
 use mpz_core::Block;
+use rand::distributions::{Distribution, Standard};
 use serio::{stream::IoStreamExt as _, SinkExt as _};
 
 use crate::{
     kos::{Sender, SenderError},
-    CommittedOTReceiver, CommittedOTSender, OTError, OTReceiver, OTSender, OTSenderOutput,
+    CommittedOTReceiver, CommittedOTSender, OTError, OTReceiver, OTSender, OTSenderOutput, OTSetup,
     ROTSenderOutput, RandomOTSender,
 };
 
 /// A shared KOS sender.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SharedSender<BaseOT> {
     inner: Arc<AsyncMutex<Sender<BaseOT>>>,
+}
+
+impl<BaseOT> Clone for SharedSender<BaseOT> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<BaseOT> SharedSender<BaseOT> {
@@ -25,6 +34,25 @@ impl<BaseOT> SharedSender<BaseOT> {
             // KOS sender is always the follower.
             inner: Arc::new(AsyncMutex::new_follower(sender)),
         }
+    }
+}
+
+impl<BaseOT> Allocate for SharedSender<BaseOT> {
+    fn alloc(&mut self, count: usize) {
+        self.inner.blocking_lock_unsync().alloc(count);
+    }
+}
+
+#[async_trait]
+impl<Ctx, BaseOT> Preprocess<Ctx> for SharedSender<BaseOT>
+where
+    Ctx: Context,
+    BaseOT: OTSetup<Ctx> + OTReceiver<Ctx, bool, Block> + Send + 'static,
+{
+    type Error = OTError;
+
+    async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), OTError> {
+        self.inner.lock(ctx).await?.preprocess(ctx).await
     }
 }
 
@@ -57,16 +85,17 @@ where
 }
 
 #[async_trait]
-impl<Ctx, BaseOT> RandomOTSender<Ctx, [Block; 2]> for SharedSender<BaseOT>
+impl<Ctx, T, BaseOT> RandomOTSender<Ctx, [T; 2]> for SharedSender<BaseOT>
 where
     Ctx: Context,
-    BaseOT: OTReceiver<Ctx, bool, Block> + Send + 'static,
+    Standard: Distribution<T>,
+    BaseOT: Send,
 {
     async fn send_random(
         &mut self,
         ctx: &mut Ctx,
         count: usize,
-    ) -> Result<ROTSenderOutput<[Block; 2]>, OTError> {
+    ) -> Result<ROTSenderOutput<[T; 2]>, OTError> {
         self.inner.lock(ctx).await?.send_random(ctx, count).await
     }
 }

--- a/crates/mpz-ot/src/lib.rs
+++ b/crates/mpz-ot/src/lib.rs
@@ -15,7 +15,6 @@ pub mod ideal;
 pub mod kos;
 
 use async_trait::async_trait;
-use mpz_common::Context;
 
 pub use mpz_ot_core::{
     COTReceiverOutput, COTSenderOutput, OTReceiverOutput, OTSenderOutput, RCOTReceiverOutput,
@@ -40,10 +39,7 @@ pub enum OTError {
 
 /// An oblivious transfer protocol that needs to perform a one-time setup.
 #[async_trait]
-pub trait OTSetup<Ctx>
-where
-    Ctx: Context,
-{
+pub trait OTSetup<Ctx> {
     /// Runs any one-time setup for the protocol.
     ///
     /// # Arguments
@@ -134,12 +130,7 @@ pub trait OTReceiver<Ctx, T, U> {
 
 /// A correlated oblivious transfer receiver.
 #[async_trait]
-pub trait COTReceiver<Ctx, T, U>
-where
-    Ctx: Context,
-    T: Send + Sync,
-    U: Send + Sync,
-{
+pub trait COTReceiver<Ctx, T, U> {
     /// Obliviously receives correlated messages from the sender.
     ///
     /// # Arguments
@@ -155,12 +146,7 @@ where
 
 /// A random OT receiver.
 #[async_trait]
-pub trait RandomOTReceiver<Ctx, T, U>
-where
-    Ctx: Context,
-    T: Send + Sync,
-    U: Send + Sync,
-{
+pub trait RandomOTReceiver<Ctx, T, U> {
     /// Outputs the choice bits and the corresponding messages.
     ///
     /// # Arguments
@@ -176,12 +162,7 @@ where
 
 /// A random correlated oblivious transfer receiver.
 #[async_trait]
-pub trait RandomCOTReceiver<Ctx, T, U>
-where
-    Ctx: Context,
-    T: Send + Sync,
-    U: Send + Sync,
-{
+pub trait RandomCOTReceiver<Ctx, T, U> {
     /// Obliviously receives correlated messages with random choices.
     ///
     /// Returns a tuple of the choices and the messages, respectively.

--- a/crates/mpz-share-conversion/src/ideal.rs
+++ b/crates/mpz-share-conversion/src/ideal.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use mpz_common::{
     ideal::{ideal_f2p, Alice, Bob},
-    Context,
+    Allocate, Context, Preprocess,
 };
 use mpz_fields::Field;
 use mpz_share_conversion_core::ideal::{IdealA2M, IdealM2A};
@@ -26,6 +26,22 @@ enum Role {
 /// An ideal share converter.
 #[derive(Debug)]
 pub struct IdealShareConverter(Role);
+
+impl Allocate for IdealShareConverter {
+    fn alloc(&mut self, _: usize) {}
+}
+
+#[async_trait]
+impl<Ctx> Preprocess<Ctx> for IdealShareConverter
+where
+    Ctx: Context,
+{
+    type Error = ShareConversionError;
+
+    async fn preprocess(&mut self, _ctx: &mut Ctx) -> Result<(), ShareConversionError> {
+        Ok(())
+    }
+}
 
 #[async_trait]
 impl<Ctx: Context, F: Field> AdditiveToMultiplicative<Ctx, F> for IdealShareConverter {

--- a/crates/mpz-share-conversion/src/receiver.rs
+++ b/crates/mpz-share-conversion/src/receiver.rs
@@ -11,14 +11,14 @@ use std::marker::PhantomData;
 #[derive(Debug)]
 pub struct ShareConversionReceiver<T, F> {
     ole_receiver: T,
-    phantom: PhantomData<F>,
+    _pd: PhantomData<F>,
 }
 
 impl<T: Clone, F> Clone for ShareConversionReceiver<T, F> {
     fn clone(&self) -> Self {
         Self {
             ole_receiver: self.ole_receiver.clone(),
-            phantom: PhantomData,
+            _pd: PhantomData,
         }
     }
 }
@@ -28,7 +28,7 @@ impl<T, F> ShareConversionReceiver<T, F> {
     pub fn new(ole_receiver: T) -> Self {
         Self {
             ole_receiver,
-            phantom: PhantomData,
+            _pd: PhantomData,
         }
     }
 }

--- a/crates/mpz-share-conversion/src/sender.rs
+++ b/crates/mpz-share-conversion/src/sender.rs
@@ -1,17 +1,27 @@
 use crate::{AdditiveToMultiplicative, MultiplicativeToAdditive, ShareConversionError};
 use async_trait::async_trait;
-use mpz_common::Context;
+use mpz_common::{Allocate, Context, Preprocess};
 use mpz_fields::Field;
-use mpz_ole::OLESender;
+use mpz_ole::{OLEError, OLESender};
 use mpz_share_conversion_core::{a2m_convert_sender, m2a_convert, msgs::Masks};
 use rand::thread_rng;
 use serio::{Deserialize, Serialize, SinkExt};
 use std::marker::PhantomData;
 
 /// Sender for share conversion.
+#[derive(Debug)]
 pub struct ShareConversionSender<T, F> {
     ole_sender: T,
-    phantom: PhantomData<F>,
+    _pd: PhantomData<F>,
+}
+
+impl<T: Clone, F> Clone for ShareConversionSender<T, F> {
+    fn clone(&self) -> Self {
+        Self {
+            ole_sender: self.ole_sender.clone(),
+            _pd: PhantomData,
+        }
+    }
 }
 
 impl<T, F> ShareConversionSender<T, F> {
@@ -19,8 +29,35 @@ impl<T, F> ShareConversionSender<T, F> {
     pub fn new(ole_sender: T) -> Self {
         Self {
             ole_sender,
-            phantom: PhantomData,
+            _pd: PhantomData,
         }
+    }
+}
+
+impl<F, T> Allocate for ShareConversionSender<T, F>
+where
+    T: Allocate,
+    F: Field,
+{
+    fn alloc(&mut self, count: usize) {
+        self.ole_sender.alloc(count);
+    }
+}
+
+#[async_trait]
+impl<Ctx, F, T> Preprocess<Ctx> for ShareConversionSender<T, F>
+where
+    T: Preprocess<Ctx, Error = OLEError> + Send,
+    F: Field + Serialize + Deserialize,
+    Ctx: Context,
+{
+    type Error = ShareConversionError;
+
+    async fn preprocess(&mut self, ctx: &mut Ctx) -> Result<(), ShareConversionError> {
+        self.ole_sender
+            .preprocess(ctx)
+            .await
+            .map_err(ShareConversionError::from)
     }
 }
 


### PR DESCRIPTION
This PR adds traits for the preprocessing model and also updates KOS to implement random OT for any `Standard: Distribution<T>` type.

`Allocate` trait rationale
---

It is difficult to properly model preprocessing in the case where a functionality is shared by multiple others. One approach would be to update the `preprocess` function so that it has a `count` argument then use some sort of async `Barrier` for synchronization. That approach doesn't work in the case where multiplexing isn't available (only 1 context).

The approach I settled on was to decouple reserving capacity step from execution of the preprocessing. The implemented model is 2 steps:

1. A functionality is injected as a sub-protocol into other protocols. Those protocols themselves implement `Allocate`, which allocate what they need from the sub-protocol. This process does not requires synchronization.
2. Once all protocols have allocated what they need, `Preprocess` is called which actually executes the preprocessing all batched together.

Modeling it this way works for both cases where a functionality is "shared" or owned directly by another protocol.

Side note: Once we have SoftSpoken which can be extended multiple times, we should be able to just share the base OT and perform OT extensions in parallel instead of this batching. This will remove the need for shared state synchronization and be more performant in terms of latency and compute.