### PR TITLE
fix(mpz-common): flush io in syncer

### DIFF
--- a/crates/mpz-common/src/sync/async_syncer.rs
+++ b/crates/mpz-common/src/sync/async_syncer.rs
@@ -5,8 +5,8 @@ use std::{
     task::{ready, Context as StdContext, Poll, Waker},
 };
 
-use futures::{future::poll_fn, Future};
-use serio::{stream::IoStreamExt, IoDuplex};
+use futures::Future;
+use serio::{stream::IoStreamExt, IoDuplex, SinkExt};
 use tokio::sync::Mutex;
 
 use crate::sync::{SyncError, Ticket};
@@ -67,15 +67,11 @@ impl Leader {
     where
         Fut: Future,
     {
-        let mut io = Pin::new(io);
-        poll_fn(|cx| io.as_mut().poll_ready(cx)).await?;
-        let (output, tick) = {
-            let mut tick_lock = self.tick.lock().await;
-            let output = fut.await;
-            let tick = tick_lock.increment_in_place();
-            (output, tick)
-        };
-        io.start_send(tick)?;
+        let mut tick_lock = self.tick.lock().await;
+        io.send(tick_lock.increment_in_place()).await?;
+        let output = fut.await;
+        drop(tick_lock);
+
         Ok(output)
     }
 }

--- a/crates/mpz-common/src/sync/async_syncer.rs
+++ b/crates/mpz-common/src/sync/async_syncer.rs
@@ -5,7 +5,7 @@ use std::{
     task::{ready, Context as StdContext, Poll, Waker},
 };
 
-use futures::Future;
+use futures::{Future, FutureExt, TryFutureExt};
 use serio::{stream::IoStreamExt, IoDuplex, SinkExt};
 use tokio::sync::Mutex;
 
@@ -68,8 +68,11 @@ impl Leader {
         Fut: Future,
     {
         let mut tick_lock = self.tick.lock().await;
-        io.send(tick_lock.increment_in_place()).await?;
-        let output = fut.await;
+        let (_, output) = futures::try_join!(
+            io.send(tick_lock.increment_in_place())
+                .map_err(SyncError::from),
+            fut.map(Ok),
+        )?;
         drop(tick_lock);
 
         Ok(output)


### PR DESCRIPTION
This PR fixes a bug in the syncers. The leader *must* flush the io before returning, otherwise it deadlocks. Also, the leader should be sending the ticket *before* executing the function/future.