### PR TITLE
refactor(mpz-ot): add accept_reveal for verifiable ot

### DIFF
--- a/crates/mpz-ot/src/ideal/ot.rs
+++ b/crates/mpz-ot/src/ideal/ot.rs
@@ -151,6 +151,10 @@ impl<Ctx: Context, T: Copy + Send + Sync + 'static> CommittedOTReceiver<Ctx, boo
 impl<Ctx: Context, U: Copy + Send + Sync + 'static, V> VerifiableOTReceiver<Ctx, bool, U, V>
     for IdealOTReceiver<U>
 {
+    async fn accept_reveal(&mut self, _ctx: &mut Ctx) -> Result<(), OTError> {
+        Ok(())
+    }
+
     async fn verify(
         &mut self,
         _ctx: &mut Ctx,

--- a/crates/mpz-ot/src/kos/mod.rs
+++ b/crates/mpz-ot/src/kos/mod.rs
@@ -45,8 +45,8 @@ mod tests {
 
     use crate::{
         ideal::ot::{ideal_ot, IdealOTReceiver, IdealOTSender},
-        OTError, OTReceiver, OTSender, OTSetup, RandomOTReceiver, RandomOTSender,
-        VerifiableOTReceiver,
+        CommittedOTSender, OTError, OTReceiver, OTSender, OTSetup, RandomOTReceiver,
+        RandomOTSender, VerifiableOTReceiver,
     };
 
     #[fixture]
@@ -215,12 +215,15 @@ mod tests {
         assert_eq!(output_receiver.msgs, expected);
 
         tokio::try_join!(
-            sender.reveal(&mut ctx_sender).map_err(OTError::from),
-            receiver
-                .verify(&mut ctx_receiver, output_receiver.id, &data)
-                .map_err(OTError::from)
+            CommittedOTSender::reveal(&mut sender, &mut ctx_sender),
+            receiver.accept_reveal(&mut ctx_receiver)
         )
         .unwrap();
+
+        receiver
+            .verify(&mut ctx_receiver, output_receiver.id, &data)
+            .await
+            .unwrap();
     }
 
     #[rstest]

--- a/crates/mpz-ot/src/kos/receiver.rs
+++ b/crates/mpz-ot/src/kos/receiver.rs
@@ -363,17 +363,16 @@ where
     Ctx: Context,
     BaseOT: VerifiableOTSender<Ctx, bool, [Block; 2]> + Send,
 {
+    async fn accept_reveal(&mut self, ctx: &mut Ctx) -> Result<(), OTError> {
+        self.verify_delta(ctx).await.map_err(OTError::from)
+    }
+
     async fn verify(
         &mut self,
-        ctx: &mut Ctx,
+        _ctx: &mut Ctx,
         id: TransferId,
         msgs: &[[Block; 2]],
     ) -> Result<(), OTError> {
-        // Verify delta if we haven't yet.
-        if self.state.is_extension() {
-            self.verify_delta(ctx).await?;
-        }
-
         let receiver = self.state.try_as_verify().map_err(ReceiverError::from)?;
 
         let record = receiver.remove_record(id).map_err(ReceiverError::from)?;

--- a/crates/mpz-ot/src/kos/shared_receiver.rs
+++ b/crates/mpz-ot/src/kos/shared_receiver.rs
@@ -111,6 +111,10 @@ where
     Ctx: Context,
     BaseOT: VerifiableOTSender<Ctx, bool, [Block; 2]> + Send,
 {
+    async fn accept_reveal(&mut self, ctx: &mut Ctx) -> Result<(), OTError> {
+        self.inner.lock(ctx).await?.accept_reveal(ctx).await
+    }
+
     async fn verify(
         &mut self,
         ctx: &mut Ctx,

--- a/crates/mpz-ot/src/lib.rs
+++ b/crates/mpz-ot/src/lib.rs
@@ -224,6 +224,13 @@ pub trait CommittedOTReceiver<Ctx, T, U>: OTReceiver<Ctx, T, U> {
 /// An oblivious transfer receiver that can verify the sender's messages.
 #[async_trait]
 pub trait VerifiableOTReceiver<Ctx, T, U, V>: OTReceiver<Ctx, T, U> {
+    /// Accepts revealed secrets from the sender which are requried to verify previous messages.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The thread context.
+    async fn accept_reveal(&mut self, ctx: &mut Ctx) -> Result<(), OTError>;
+
     /// Verifies purported messages sent by the sender.
     ///
     /// # Arguments


### PR DESCRIPTION
This PR adds a method for synchronizing the reveal step for verifiable OT.