### PR TITLE
fix(mpz-garble): add thread id to otp ids

### DIFF
--- a/crates/mpz-garble/src/protocol/deap/mod.rs
+++ b/crates/mpz-garble/src/protocol/deap/mod.rs
@@ -673,9 +673,10 @@ impl DEAP {
                 .enumerate()
                 .map(|(idx, value)| {
                     let (otp_ref, otp_value) =
-                        state.new_private_otp(&format!("{id}/{idx}/otp"), value);
+                        state.new_private_otp(&format!("{}/{id}/{idx}/otp", ctx.id()), value);
                     let otp_typ = otp_value.value_type();
-                    let mask_ref = state.new_output_mask(&format!("{id}/{idx}/mask"), value);
+                    let mask_ref =
+                        state.new_output_mask(&format!("{}/{id}/{idx}/mask", ctx.id()), value);
                     self.gen.generate_input_encoding(&otp_ref, &otp_typ);
                     (((otp_ref, otp_typ), otp_value), mask_ref)
                 })
@@ -727,8 +728,10 @@ impl DEAP {
                 .iter()
                 .enumerate()
                 .map(|(idx, value)| {
-                    let (otp_ref, otp_typ) = state.new_blind_otp(&format!("{id}/{idx}/otp"), value);
-                    let mask_ref = state.new_output_mask(&format!("{id}/{idx}/mask"), value);
+                    let (otp_ref, otp_typ) =
+                        state.new_blind_otp(&format!("{}/{id}/{idx}/otp", ctx.id()), value);
+                    let mask_ref =
+                        state.new_output_mask(&format!("{}/{id}/{idx}/mask", ctx.id()), value);
                     self.gen.generate_input_encoding(&otp_ref, &otp_typ);
                     ((otp_ref, otp_typ), mask_ref)
                 })
@@ -781,21 +784,22 @@ impl DEAP {
                 .map(|(idx, value)| {
                     let (otp_0_ref, otp_1_ref, otp_value, otp_typ) = match self.role {
                         Role::Leader => {
-                            let (otp_0_ref, otp_value) =
-                                state.new_private_otp(&format!("{id}/{idx}/otp_0"), value);
-                            let (otp_1_ref, otp_typ) =
-                                state.new_blind_otp(&format!("{id}/{idx}/otp_1"), value);
+                            let (otp_0_ref, otp_value) = state
+                                .new_private_otp(&format!("{}/{id}/{idx}/otp_0", ctx.id()), value);
+                            let (otp_1_ref, otp_typ) = state
+                                .new_blind_otp(&format!("{}/{id}/{idx}/otp_1", ctx.id()), value);
                             (otp_0_ref, otp_1_ref, otp_value, otp_typ)
                         }
                         Role::Follower => {
-                            let (otp_0_ref, otp_typ) =
-                                state.new_blind_otp(&format!("{id}/{idx}/otp_0"), value);
-                            let (otp_1_ref, otp_value) =
-                                state.new_private_otp(&format!("{id}/{idx}/otp_1"), value);
+                            let (otp_0_ref, otp_typ) = state
+                                .new_blind_otp(&format!("{}/{id}/{idx}/otp_0", ctx.id()), value);
+                            let (otp_1_ref, otp_value) = state
+                                .new_private_otp(&format!("{}/{id}/{idx}/otp_1", ctx.id()), value);
                             (otp_0_ref, otp_1_ref, otp_value, otp_typ)
                         }
                     };
-                    let mask_ref = state.new_output_mask(&format!("{id}/{idx}/mask"), value);
+                    let mask_ref =
+                        state.new_output_mask(&format!("{}/{id}/{idx}/mask", ctx.id()), value);
                     self.gen.generate_input_encoding(&otp_0_ref, &otp_typ);
                     self.gen.generate_input_encoding(&otp_1_ref, &otp_typ);
                     ((((otp_0_ref, otp_1_ref), otp_typ), otp_value), mask_ref)

--- a/crates/mpz-ot/src/kos/shared_receiver.rs
+++ b/crates/mpz-ot/src/kos/shared_receiver.rs
@@ -117,17 +117,12 @@ where
 
     async fn verify(
         &mut self,
-        ctx: &mut Ctx,
+        _ctx: &mut Ctx,
         id: TransferId,
         msgs: &[[Block; 2]],
     ) -> Result<(), OTError> {
         let record = {
-            let mut inner = self.inner.lock(ctx).await?;
-
-            // Verify delta if we haven't yet.
-            if inner.state().is_extension() {
-                inner.verify_delta(ctx).await?;
-            }
+            let inner = self.inner.blocking_lock_unsync();
 
             let receiver = inner.state().try_as_verify().map_err(ReceiverError::from)?;
 


### PR DESCRIPTION
This PR fixes a bug which causes duplicate OTP names because the thread id is not included.