### PR TITLE
add Lpn estimator

### DIFF
--- a/crates/mpz-core/Cargo.toml
+++ b/crates/mpz-core/Cargo.toml
@@ -28,6 +28,7 @@ itybity.workspace = true
 opaque-debug.workspace = true
 bcs = "0.1.5"
 rand_core = "0.6.4"
+rug = "1.24.1"
 bytemuck = { workspace = true, features = ["derive"] }
 generic-array.workspace = true
 rayon = { workspace = true, optional = true }

--- a/crates/mpz-core/examples/lpn_estimator.rs
+++ b/crates/mpz-core/examples/lpn_estimator.rs
@@ -30,4 +30,36 @@ fn main() {
     println!("lpn_regular_1<<18_15336_760 security:\t {} bits", sec5);
     println!("lpn_regular_1<<20_32771_1419 security:\t {} bits", sec6);
     println!("lpn_regular_1<<22_67440_2735 security:\t {} bits", sec7);
+
+    let sec1 = LpnEstimator::security_dual_for_binary(1 << 10, 1 << 12, 44);
+    let sec2 = LpnEstimator::security_dual_for_binary(1 << 12, 1 << 14, 39);
+    let sec3 = LpnEstimator::security_dual_for_binary(1 << 14, 1 << 16, 34);
+    let sec4 = LpnEstimator::security_dual_for_binary(1 << 16, 1 << 18, 32);
+    let sec5 = LpnEstimator::security_dual_for_binary(1 << 18, 1 << 20, 31);
+    let sec6 = LpnEstimator::security_dual_for_binary(1 << 20, 1 << 22, 30);
+    let sec7 = LpnEstimator::security_dual_for_binary(1 << 22, 1 << 24, 29);
+
+    println!("dual_lpn_1<<10_1<<12_44 security:\t {} bits", sec1);
+    println!("dual_lpn_1<<12_1<<14_39 security:\t {} bits", sec2);
+    println!("dual_lpn_1<<14_1<<16_34 security:\t {} bits", sec3);
+    println!("dual_lpn_1<<16_1<<18_32 security:\t {} bits", sec4);
+    println!("dual_lpn_1<<18_1<<20_31 security:\t {} bits", sec5);
+    println!("dual_lpn_1<<20_1<<22_30 security:\t {} bits", sec6);
+    println!("dual_lpn_1<<22_1<<24_29 security:\t {} bits", sec7);
+
+    let sec1 = LpnEstimator::security_dual_for_binary_regular(1 << 10, 1 << 12, 44);
+    let sec2 = LpnEstimator::security_dual_for_binary_regular(1 << 12, 1 << 14, 39);
+    let sec3 = LpnEstimator::security_dual_for_binary_regular(1 << 14, 1 << 16, 34);
+    let sec4 = LpnEstimator::security_dual_for_binary_regular(1 << 16, 1 << 18, 32);
+    let sec5 = LpnEstimator::security_dual_for_binary_regular(1 << 18, 1 << 20, 31);
+    let sec6 = LpnEstimator::security_dual_for_binary_regular(1 << 20, 1 << 22, 30);
+    let sec7 = LpnEstimator::security_dual_for_binary_regular(1 << 22, 1 << 24, 29);
+
+    println!("dual_lpn_regular_1<<10_1<<12_44 security:\t {} bits", sec1);
+    println!("dual_lpn_regular_1<<12_1<<14_39 security:\t {} bits", sec2);
+    println!("dual_lpn_regular_1<<14_1<<16_34 security:\t {} bits", sec3);
+    println!("dual_lpn_regular_1<<16_1<<18_32 security:\t {} bits", sec4);
+    println!("dual_lpn_regular_1<<18_1<<20_31 security:\t {} bits", sec5);
+    println!("dual_lpn_regular_1<<20_1<<22_30 security:\t {} bits", sec6);
+    println!("dual_lpn_regular_1<<22_1<<24_29 security:\t {} bits", sec7);
 }

--- a/crates/mpz-core/examples/lpn_estimator.rs
+++ b/crates/mpz-core/examples/lpn_estimator.rs
@@ -2,6 +2,10 @@ use mpz_core::LpnEstimator;
 
 
 fn main(){
-    let sec = LpnEstimator::security_for_binary_regular(1<<10, 652, 57);
+    // let sec = LpnEstimator::security_for_binary(1 << 10, 652, 57);
+    // let sec = LpnEstimator::security_for_binary(1 << 12, 1589, 98);
+    let sec = LpnEstimator::security_for_binary(1 << 14, 3482, 198);
+    // let sec = LpnEstimator::security_for_binary(1 << 16, 7391, 389);
+    // let sec = LpnEstimator::security_for_binary(1 << 22, 67440, 2735);
     println!("security: {} bits", sec);
 }

--- a/crates/mpz-core/examples/lpn_estimator.rs
+++ b/crates/mpz-core/examples/lpn_estimator.rs
@@ -1,11 +1,33 @@
 use mpz_core::LpnEstimator;
 
+fn main() {
+    let sec1 = LpnEstimator::security_for_binary(1 << 10, 652, 57);
+    let sec2 = LpnEstimator::security_for_binary(1 << 12, 1589, 98);
+    let sec3 = LpnEstimator::security_for_binary(1 << 14, 3482, 198);
+    let sec4 = LpnEstimator::security_for_binary(1 << 16, 7391, 389);
+    let sec5 = LpnEstimator::security_for_binary(1 << 18, 15336, 760);
+    let sec6 = LpnEstimator::security_for_binary(1 << 20, 32771, 1419);
+    let sec7 = LpnEstimator::security_for_binary(1 << 22, 67440, 2735);
+    println!("lpn_1<<10_652_57 security:\t {} bits", sec1);
+    println!("lpn_1<<12_1589_98 security:\t {} bits", sec2);
+    println!("lpn_1<<14_3482_198 security:\t {} bits", sec3);
+    println!("lpn_1<<16_7391_389 security:\t {} bits", sec4);
+    println!("lpn_1<<18_15336_760 security:\t {} bits", sec5);
+    println!("lpn_1<<20_32771_1419 security:\t {} bits", sec6);
+    println!("lpn_1<<22_67440_2735 security:\t {} bits", sec7);
 
-fn main(){
-    // let sec = LpnEstimator::security_for_binary(1 << 10, 652, 57);
-    // let sec = LpnEstimator::security_for_binary(1 << 12, 1589, 98);
-    let sec = LpnEstimator::security_for_binary(1 << 14, 3482, 198);
-    // let sec = LpnEstimator::security_for_binary(1 << 16, 7391, 389);
-    // let sec = LpnEstimator::security_for_binary(1 << 22, 67440, 2735);
-    println!("security: {} bits", sec);
+    let sec1 = LpnEstimator::security_for_binary_regular(1 << 10, 652, 57);
+    let sec2 = LpnEstimator::security_for_binary_regular(1 << 12, 1589, 98);
+    let sec3 = LpnEstimator::security_for_binary_regular(1 << 14, 3482, 198);
+    let sec4 = LpnEstimator::security_for_binary_regular(1 << 16, 7391, 389);
+    let sec5 = LpnEstimator::security_for_binary_regular(1 << 18, 15336, 760);
+    let sec6 = LpnEstimator::security_for_binary_regular(1 << 20, 32771, 1419);
+    let sec7 = LpnEstimator::security_for_binary_regular(1 << 22, 67440, 2735);
+    println!("lpn_regular_1<<10_652_57 security:\t {} bits", sec1);
+    println!("lpn_regular_1<<12_1589_98 security:\t {} bits", sec2);
+    println!("lpn_regular_1<<14_3482_198 security:\t {} bits", sec3);
+    println!("lpn_regular_1<<16_7391_389 security:\t {} bits", sec4);
+    println!("lpn_regular_1<<18_15336_760 security:\t {} bits", sec5);
+    println!("lpn_regular_1<<20_32771_1419 security:\t {} bits", sec6);
+    println!("lpn_regular_1<<22_67440_2735 security:\t {} bits", sec7);
 }

--- a/crates/mpz-core/examples/lpn_estimator.rs
+++ b/crates/mpz-core/examples/lpn_estimator.rs
@@ -2,6 +2,10 @@ use mpz_core::LpnEstimator;
 
 
 fn main(){
-    let sec = LpnEstimator::security_for_binary_regular(1<<10, 652, 57);
+    let sec = LpnEstimator::security_for_binary(1 << 10, 652, 57);
+    // let sec = LpnEstimator::security_for_binary(1 << 12, 1589, 98);
+    // let sec = LpnEstimator::security_for_binary(1 << 14, 3482, 198);
+    // let sec = LpnEstimator::security_for_binary(1 << 16, 7391, 389);
+    // let sec = LpnEstimator::security_for_binary(1 << 22, 67440, 2735);    
     println!("security: {} bits", sec);
 }

--- a/crates/mpz-core/examples/lpn_estimator.rs
+++ b/crates/mpz-core/examples/lpn_estimator.rs
@@ -1,0 +1,7 @@
+use mpz_core::LpnEstimator;
+
+
+fn main(){
+    let sec = LpnEstimator::security_for_binary_regular(1<<10, 652, 57);
+    println!("security: {} bits", sec);
+}

--- a/crates/mpz-core/src/lib.rs
+++ b/crates/mpz-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commit;
 pub mod ggm_tree;
 pub mod hash;
 pub mod lpn;
+pub mod lpn_estimator;
 pub mod prg;
 pub mod prp;
 pub mod serialize;
@@ -15,6 +16,7 @@ pub mod tkprp;
 pub mod utils;
 
 pub use block::{Block, BlockSerialize};
+pub use lpn_estimator::*;
 
 /// A protocol with a message type.
 pub trait ProtocolMessage {

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -577,6 +577,36 @@ impl LpnEstimator {
         }
         cost_agb.min(cost_others)
     }
+
+    /// The security of the parameters for dual lpn in binary field.
+    /// See Sec 5.1 in this [paper](https://eprint.iacr.org/2022/712.pdf)
+    /// # Arguments.
+    ///
+    /// * `rank` - The rank of the matrix, i.e., the output length.
+    /// * `n` - The number of samples.
+    /// * `t` - The Hamming weight of the error.
+    ///
+    /// NOTE: Run it in the release mode.
+    #[inline]
+    pub fn security_dual_for_binary(rank: u64, n: u64, t: u64) -> f64 {
+        let k = n - rank;
+        Self::security_for_binary(n, k, t)
+    }
+
+    /// The security of the parameters for regular dual lpn in binary field.
+    /// See Sec 5.1 in this [paper](https://eprint.iacr.org/2022/712.pdf)
+    /// # Arguments.
+    ///
+    /// * `rank` - The rank of the matrix, i.e., the output length.
+    /// * `n` - The number of samples.
+    /// * `t` - The Hamming weight of the error.
+    ///
+    /// NOTE: Run it in the release mode.
+    #[inline]
+    pub fn security_dual_for_binary_regular(rank: u64, n: u64, t: u64) -> f64 {
+        let k = n - rank;
+        Self::security_for_binary_regular(n, k, t)
+    }
 }
 
 mod tests {

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -1,0 +1,128 @@
+//! An estimator to analyse the security of different LPN parameters.
+//! The implementation is according to https://eprint.iacr.org/2022/712.pdf.
+
+use rug::{ops::Pow, Float};
+
+// The precision for security analysis.
+const PRECISION: u32 = 200;
+
+// The highest security level in our analysis.
+const HIGHEST_SECURITY: usize = 256;
+
+/// Define the struct of LPN estimator.
+pub struct LpnEstimator;
+
+impl LpnEstimator {
+    // Compute the combination number of n choose m.
+    fn cal_comb(n: usize, m: usize) -> Float {
+        assert!(n >= m);
+
+        let mut res = Float::with_val(PRECISION, 1);
+
+        let range = std::cmp::min(m, n - m);
+        for i in 0..range {
+            res *= Float::with_val(PRECISION, (n - i) as f64)
+                / Float::with_val(PRECISION, (range - i) as f64);
+        }
+
+        res
+    }
+
+    /// Compute the bit security under the Pooled Gauss attack, see page 37 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    pub fn security_under_pooled_gauss_binary(n: usize, k: usize, t: usize) -> f64 {
+        let log_guess_prob = Self::cal_comb(n - k, t).log2() - Self::cal_comb(n, t).log2();
+
+        let matrix_inversion_cost = (std::cmp::min(n - k, k) as f64).powf(2.8);
+
+        matrix_inversion_cost.log2() - log_guess_prob.to_f64()
+    }
+
+    // Compute the fomulas inside the min function of Therem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    fn sub_sd_isd_binary(n: usize, k: usize, t: usize, l: usize, p: usize) -> f64 {
+        let l_zero = Self::cal_comb((k + l) / 2 + 1, p / 2);
+
+        let log_l_zero = l_zero.clone().log2();
+        let log_s: Float = 2 * log_l_zero.clone() - l;
+
+        // If it has enough security, just break.
+        if log_l_zero > HIGHEST_SECURITY || log_s > HIGHEST_SECURITY {
+            return HIGHEST_SECURITY as f64;
+        }
+
+        // Computes s = 1 << log_s.
+        let s = Float::with_val(PRECISION, 2).pow(log_s.clone());
+
+        // Compute T_Gauss + 2 * L0 * N + 2 * |S| * N
+        let mut cost = Float::with_val(PRECISION, (n - k - l) * (n - k))
+            / Float::with_val(PRECISION, f64::log2((n - k - l) as f64));
+
+        cost += 2 * l_zero + 2 * s;
+        cost *= n;
+
+        // Compute log P(p,l).
+        let mut log_p = Self::cal_comb(n - k - l, t - p).log2() - Self::cal_comb(n, t).log2();
+
+        log_p += l + log_s;
+
+        (cost.log2() - log_p).to_f64()
+    }
+
+    // Minimize sub_SD_ISD_binary when fix p.
+    fn min_sub_sd_isd_binary_with_fixed_p(n: usize, k: usize, t: usize, p: usize) -> f64 {
+        let mut start = 1;
+        let mut end = n - k;
+
+        let t_start = Self::sub_sd_isd_binary(n, k, t, start, p);
+        let mut res = t_start;
+
+        while end - start > 30 {
+            let mid_left = (end - start) / 3 + start;
+            let mid_right = end - (end - start) / 3;
+
+            let left = Self::sub_sd_isd_binary(n, k, t, mid_left, p);
+            let right = Self::sub_sd_isd_binary(n, k, t, mid_right, p);
+
+            if left > right {
+                start = mid_left;
+                res = right;
+            } else {
+                end = mid_right;
+                res = left;
+            }
+        }
+
+        for l in start..=end {
+            let t = Self::sub_sd_isd_binary(n, k, t, l, p);
+            if t <= res {
+                res = t;
+            }
+        }
+
+        res
+    }
+
+    /// The security of the lpn parameters under SD_ISD attack for binary field. See Therem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    pub fn security_under_sd_isd_binary(n: usize, k: usize, t: usize) -> f64 {
+        let mut res = Self::sub_sd_isd_binary(n, k, t, 0, 0);
+
+        for p in 0..t / 2 {
+            let min = Self::min_sub_sd_isd_binary_with_fixed_p(n, k, t, p);
+            if min <= res {
+                res = min;
+            }
+            if min > res + 30.0 {
+                break;
+            }
+        }
+
+        res
+    }
+}
+
+mod tests {
+    #[test]
+    fn security_test() {
+        let security = crate::LpnEstimator::security_under_sd_isd_binary(1 << 14, 3482, 198);
+        println!("{:?}", security);
+    }
+}

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -450,16 +450,9 @@ impl LpnEstimator {
 
         let d2_left = a1 + b1 + a1 * b1 + a2 + b2 + c2;
         let d2_right = (a1 + b1) * minus_c1 + minus_c1;
-        // let d2 = a1 + b1 + a1 * b1 + a2 + b2 + c2 - (a1 + b1) * minus_c1 - minus_c1;
 
         let d3_left = b1 * c2 + b3 + a1 * (b2 + c2) + a2 * b1 + a3;
         let d3_right = minus_c3 + b2 * minus_c1 + a1 * b1 * minus_c1 + a2 * minus_c1;
-
-        // let d3 = b1 * c2 + b3 + a1 * (b2 + c2) + a2 * b1 + a3
-        //     - minus_c3
-        //     - b2 * minus_c1
-        //     - a1 * b1 * minus_c1
-        //     - a2 * minus_c1;
 
         let d4_left =
             c4 + b2 * c2 + b4 + a1 * (b1 * c2 + b2 + b3) + a2 * (b2 + c2 + b1) + a3 * b1 + a4;
@@ -470,23 +463,12 @@ impl LpnEstimator {
             + a2 * b1 * minus_c1
             + a1 * minus_c3;
 
-        // let d4 = c4 + b2 * c2 + b4 + a1 * (b1 * c2 + b2 + b3) + a2 * (b2 + c2 + b1) + a3 * b1 + a4
-        //     - b1 * minus_c3
-        //     - b3 * minus_c1
-        //     - a3 * minus_c1
-        //     - a1 * b2 * minus_c1
-        //     - a2 * b1 * minus_c1
-        //     - a1 * minus_c3;
-
-        // if d2 < 1 {
         if d2_left <= d2_right {
             return 2.0;
         }
-        // if d3 < 1 {
         if d3_left <= d3_right {
             return 3.0;
         }
-        // if d4 < 1 {
         if d4_left <= d4_right {
             return 4.0;
         }
@@ -535,14 +517,14 @@ impl LpnEstimator {
 
         let d = Self::cost_agb_binary(n, k, t, f as u64, mu as u64);
 
-        let mut cost = a1.clone() + b1.clone() + a1.clone() * b1.clone() + a2.clone() + b2.clone();
+        let mut cost = a1 + b1 + a1 * b1 + a2 + b2;
         if d == 2.0 {
             cost += 0;
         } else if d == 3.0 {
             let d3 = b3 + a1 * b2 + a2 * b1 + a3;
             cost += d3;
         } else if d == 4.0 {
-            let d3 = b3.clone() + a1.clone() * b2.clone() + a2.clone() * b1.clone() + a3.clone();
+            let d3 = b3 + a1 * b2 + a2 * b1 + a3;
             let d4 = b4 + a1 * b3 + a2 * b2 + a3 * b1 + a4;
             cost += d3 + d4;
         } else {

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -4,11 +4,6 @@
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-use rug::{ops::Pow, Float};
-
-// The precision for security analysis.
-const PRECISION: u32 = 200;
-
 // The highest security level.
 const HIGHEST_SECURITY: usize = 256;
 
@@ -17,17 +12,14 @@ pub struct LpnEstimator;
 
 impl LpnEstimator {
     // Compute the combination number of n choose m.
-    fn cal_comb(n: usize, m: usize) -> Float {
+    fn cal_comb(n: u64, m: u64) -> f64 {
         assert!(n >= m);
 
-        let mut res = Float::with_val(PRECISION, 1);
-
+        let mut res = 1.0;
         let range = std::cmp::min(m, n - m);
         for i in 0..range {
-            res *= Float::with_val(PRECISION, (n - i) as f64)
-                / Float::with_val(PRECISION, (range - i) as f64);
+            res *= (n - i) as f64 / (range - i) as f64;
         }
-
         res
     }
 
@@ -40,43 +32,54 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_under_pooled_gauss(n: usize, k: usize, t: usize) -> f64 {
+    pub fn security_under_pooled_gauss(n: u64, k: u64, t: u64) -> f64 {
         let log_guess_prob = Self::cal_comb(n - k, t).log2() - Self::cal_comb(n, t).log2();
 
         let matrix_inversion_cost = (std::cmp::min(n - k, k) as f64).powf(2.8);
 
-        matrix_inversion_cost.log2() - log_guess_prob.to_f64()
+        matrix_inversion_cost.log2() - log_guess_prob
     }
 
     // Compute the fomulas inside the min function of Theorem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
-    fn sub_sd_isd_binary(n: usize, k: usize, t: usize, l: usize, p: usize) -> f64 {
+    fn sub_sd_isd_binary(n: u64, k: u64, t: u64, l: u64, p: u64) -> f64 {
         let l_zero = Self::cal_comb((k + l) / 2 + 1, p / 2);
+        let log_l_zero = l_zero.log2();
+        let log_s = 2.0 * log_l_zero - (l as f64);
 
-        let log_l_zero = l_zero.clone().log2();
-        let log_s: Float = 2 * log_l_zero.clone() - l;
+        // Quick break, the cost should be larger than log_l_zero and log_s.
+        if log_l_zero > HIGHEST_SECURITY as f64 || log_s > HIGHEST_SECURITY as f64 {
+            return HIGHEST_SECURITY as f64;
+        }
 
         // Computes s = 1 << log_s.
-        let s = Float::with_val(PRECISION, 2).pow(log_s.clone());
+        let s = 2.0_f64.powf(log_s);
+
+        if n - k - l < 1 {
+            return u32::MAX as f64;
+        }
 
         // Compute T_Gauss + 2 * L0 * N + 2 * |S| * N
-        let mut cost = Float::with_val(PRECISION, (n - k - l) * (n - k))
-            / Float::with_val(PRECISION, f64::log2((n - k - l) as f64));
-
-        cost += 2 * l_zero + 2 * s;
-        cost *= n;
+        let mut cost = ((n - k - l) * (n - k)) as f64 / ((n - k - l) as f64).log2();
+        cost += 2.0 * l_zero + 2.0 * s;
+        cost *= n as f64;
 
         // Compute log P(p,l).
         let mut log_p = Self::cal_comb(n - k - l, t - p).log2() - Self::cal_comb(n, t).log2();
 
-        log_p += l + log_s;
+        log_p += l as f64 + log_s;
 
-        (cost.log2() - log_p).to_f64()
+        // Quick break, the probability should be smaller than 1.
+        if log_p >= 0.0 {
+            return HIGHEST_SECURITY as f64;
+        }
+
+        cost.log2() - log_p
     }
 
     // Minimize sub_sd_isd_binary when fix p.
-    fn min_sub_sd_isd_binary_with_fixed_p(n: usize, k: usize, t: usize, p: usize) -> f64 {
+    fn min_sub_sd_isd_binary_with_fixed_p(n: u64, k: u64, t: u64, p: u64) -> f64 {
         let mut start = 1;
-        let mut end = n - k;
+        let mut end = n - k - 8;
 
         let t_start = Self::sub_sd_isd_binary(n, k, t, start, p);
         let mut res = t_start;
@@ -97,7 +100,13 @@ impl LpnEstimator {
             }
         }
 
-        for l in start..=end {
+        if start < 10 {
+            start = 0;
+        } else {
+            start = start - 10;
+        }
+
+        for l in start..=end + 10 {
             let t = Self::sub_sd_isd_binary(n, k, t, l, p);
             if t <= res {
                 res = t;
@@ -116,13 +125,16 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_under_sd_isd_binary(n: usize, k: usize, t: usize) -> f64 {
+    pub fn security_under_sd_isd_binary(n: u64, k: u64, t: u64) -> f64 {
         let mut res = Self::sub_sd_isd_binary(n, k, t, 0, 0);
 
         for p in 0..t / 2 {
             let min = Self::min_sub_sd_isd_binary_with_fixed_p(n, k, t, p);
             if min <= res {
                 res = min;
+            }
+            if min > res + 30.0 {
+                break;
             }
         }
         res
@@ -131,15 +143,15 @@ impl LpnEstimator {
     // Compute the fomulas inside the min function of Theorem 16 in this [paper](https://eprint.iacr.org/2022/712.pdf).
     #[allow(clippy::too_many_arguments)]
     fn sub_bjmm_isd_binary(
-        n: usize,
-        k: usize,
-        t: usize,
-        p2: usize,
-        l: usize,
-        e1: usize,
-        e2: usize,
-        r1: usize,
-        r2: usize,
+        n: u64,
+        k: u64,
+        t: u64,
+        p2: u64,
+        l: u64,
+        e1: u64,
+        e2: u64,
+        r1: u64,
+        r2: u64,
         local_min: f64,
     ) -> f64 {
         assert!(p2 >= e2);
@@ -149,24 +161,24 @@ impl LpnEstimator {
 
         let s3 = Self::cal_comb((k + l) / 2 + 1, p2 / 2);
 
-        let log_s3 = s3.clone().log2();
-        let log_c3: Float = s3.clone().log2() * 2 - r2;
-        let c3 = Float::with_val(PRECISION, 2).pow(log_c3.clone());
+        let log_s3 = s3.log2();
+        let log_c3 = s3.log2() * 2.0 - r2 as f64;
+        let c3 = 2.0_f64.powf(log_c3);
 
-        let log_c2: Float = log_c3.clone() * 2 - r1;
-        let c2 = Float::with_val(PRECISION, 2).pow(log_c2.clone());
+        let log_c2 = log_c3 * 2.0 - r1 as f64;
+        let c2 = 2.0_f64.powf(log_c2);
 
         assert!(k + l >= p2);
         assert!(p2 >= e2);
         let log_mu2 = Self::cal_comb(p2, e2).log2() + Self::cal_comb(k + l - p2, p2 - e2).log2()
             - Self::cal_comb(k + l, p2).log2();
 
-        let log_s1_left = log_mu2 + log_c2.clone();
-        let log_s1_right = Self::cal_comb(k + l, p1).log2() - (r1 + r2);
-        let log_s1 = log_s1_left.min(&log_s1_right);
+        let log_s1_left = log_mu2 + log_c2;
+        let log_s1_right = Self::cal_comb(k + l, p1).log2() - (r1 + r2) as f64;
+        let log_s1 = log_s1_left.min(log_s1_right);
 
-        let log_c1: Float = log_s1 * 2 - l + r1 + r2;
-        let c1 = Float::with_val(PRECISION, 2).pow(log_c1.clone());
+        let log_c1 = log_s1 * 2.0 - (l - r1 - r2) as f64;
+        let c1 = 2.0_f64.powf(log_c1);
 
         assert!(k + l >= p1);
         assert!(p1 >= e1);
@@ -174,45 +186,37 @@ impl LpnEstimator {
             - Self::cal_comb(k + l, p1).log2();
 
         let log_s_left = log_mu1 + log_c1;
-        let log_s_right = Self::cal_comb(k + l, p).log2() - l;
+        let log_s_right = Self::cal_comb(k + l, p).log2() - l as f64;
 
-        let log_s = log_s_left.clone().min(&log_s_right);
+        let log_s = log_s_left.min(log_s_right);
 
         // Quick break
-        if (log_s3.to_f64() > local_min) || (log_c3.to_f64() > local_min) || (log_c2 > local_min) {
+        if (log_s3 > local_min) || (log_c3 > local_min) || (log_c2 > local_min) {
             return HIGHEST_SECURITY as f64;
         }
 
         // Compute T_Gauss + (8*S3 + 4*C3 + 2*C2 + 2*C1) * N
-        let mut cost = Float::with_val(PRECISION, (n - k - l) * (n - k))
-            / Float::with_val(PRECISION, f64::log2((n - k - l) as f64));
-
-        cost += 8 * s3 + 4 * c3 + 2 * c2 + 2 * c1;
-        cost *= n;
+        let mut cost = ((n - k - l) * (n - k)) as f64 / ((n - k - l) as f64).log2();
+        cost += 8.0 * s3 + 4.0 * c3 + 2.0 * c2 + 2.0 * c1;
+        cost *= n as f64;
 
         // Compute log P(p,l).
         assert!(n >= k + l);
         assert!(t >= p);
         let mut log_p = Self::cal_comb(n - k - l, t - p).log2() - Self::cal_comb(n, t).log2();
 
-        log_p += l + log_s;
+        log_p += l as f64 + log_s;
 
         // Quick break, the probability should be smaller than 1.
-        if log_p >= 0 {
+        if log_p >= 0.0 {
             return HIGHEST_SECURITY as f64;
         }
 
-        (cost.log2() - log_p).to_f64()
+        cost.log2() - log_p
     }
 
     // Minimize sub_bjmm_isd_binary with fixed p2 and l.
-    fn min_sub_bjmm_isd_binary_with_fixed_p2_and_l(
-        n: usize,
-        k: usize,
-        t: usize,
-        p2: usize,
-        l: usize,
-    ) -> f64 {
+    fn min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n: u64, k: u64, t: u64, p2: u64, l: u64) -> f64 {
         let mut local_min = HIGHEST_SECURITY as f64;
         // Try all possible values of e2.
         for e2 in 0..p2 {
@@ -234,15 +238,15 @@ impl LpnEstimator {
                     + Self::cal_comb(k + l - p2, p2 - e2).log2()
                     - Self::cal_comb(k + l, p2).log2();
 
-                let r2: Float = log_mu2 + 4 * (Self::cal_comb((k + l) / 2, p2 / 2).log2())
+                let r2 = log_mu2 + 4.0 * (Self::cal_comb((k + l) / 2, p2 / 2).log2())
                     - Self::cal_comb(k + l, p1).log2();
 
-                let r2: usize = if r2 <= 0 {
+                let r2 = if r2 <= 0.0 {
                     0
-                } else if r2 >= l {
+                } else if r2 as u64 >= l {
                     l - 1
                 } else {
-                    r2.to_f64() as usize
+                    r2 as u64
                 };
 
                 // Also use the equation of mu_1 in Proposition 1.
@@ -251,13 +255,13 @@ impl LpnEstimator {
                     + Self::cal_comb(k + l, p1).log2()
                     - Self::cal_comb(k + l, p).log2();
 
-                let r1 = r - r2;
-                let r1 = if r1 <= 0 {
+                let r1 = r - r2 as f64;
+                let r1 = if r1 <= 0.0 {
                     0
-                } else if (r1.clone() + r2) >= l {
+                } else if (r1 as u64 + r2) >= l {
                     l - r2 - 1
                 } else {
-                    r1.to_f64() as usize
+                    r1 as u64
                 };
 
                 let middle = Self::sub_bjmm_isd_binary(n, k, t, p2, l, e1, e2, r1, r2, local_min);
@@ -271,7 +275,7 @@ impl LpnEstimator {
     }
 
     // Minimize sub_bjmm_isd_binary with fixed p2.
-    fn min_sub_bjmm_isd_binary_with_fixed_p2(n: usize, k: usize, t: usize, p2: usize) -> f64 {
+    fn min_sub_bjmm_isd_binary_with_fixed_p2(n: u64, k: u64, t: u64, p2: u64) -> f64 {
         let mut start = 1;
         let mut end = (n - k - 2) / 8;
 
@@ -293,7 +297,12 @@ impl LpnEstimator {
             }
         }
 
-        for l in (start + 1)..(end + 5) {
+        if start < 5 {
+            start = 0;
+        } else {
+            start = start - 5;
+        }
+        for l in start..end + 5 {
             let min_middle = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, l);
             if min_middle < min_cost {
                 min_cost = min_middle;
@@ -311,13 +320,16 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_under_bjmm_isd_binary(n: usize, k: usize, t: usize) -> f64 {
+    pub fn security_under_bjmm_isd_binary(n: u64, k: u64, t: u64) -> f64 {
         let mut res = Self::min_sub_bjmm_isd_binary_with_fixed_p2(n, k, t, 0);
 
-        for p2 in 1..t {
+        for p2 in (0..t).step_by(2) {
             let min = Self::min_sub_bjmm_isd_binary_with_fixed_p2(n, k, t, p2);
             if min < res {
                 res = min;
+            }
+            if min > res + 8.0 {
+                break;
             }
         }
         res
@@ -332,13 +344,12 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_under_sd_binary(n: usize, k: usize, t: usize) -> f64 {
-        let cost = Float::with_val(PRECISION, n - t + 1) / Float::with_val(PRECISION, n - k - t);
+    pub fn security_under_sd_binary(n: u64, k: u64, t: u64) -> f64 {
+        let cost = (n - t + 1) as f64 / (n - k - t) as f64;
 
-        let cost = cost.log2() * 2 * t + 2;
+        let cost = cost.log2() * 2.0 * t as f64 + 2 as f64;
 
-        let cost: Float = Float::with_val(PRECISION, k + 1).log2() + cost;
-        cost.to_f64()
+        ((k + 1) as f64).log2() + cost
     }
 
     /// The security of the lpn parameters under SD 2.0 attack for binary field. See The equation with in page 39 in this [paper](https://eprint.iacr.org/2022/712.pdf).
@@ -350,8 +361,8 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_under_sd2_binary(n: usize, k: usize, t: usize) -> f64 {
-        let s = Self::security_under_pooled_gauss(n, k, t) as usize;
+    pub fn security_under_sd2_binary(n: u64, k: u64, t: u64) -> f64 {
+        let s = Self::security_under_pooled_gauss(n, k, t) as u64;
         Self::security_under_sd_binary(n, k - s, t)
     }
 
@@ -363,8 +374,8 @@ impl LpnEstimator {
     /// * `t` - The Hamming weight of the error.
     ///
     /// NOTE: Run it in the release mode.
-    pub fn security_for_binary(n: usize, k: usize, t: usize) -> f64 {
-        let funcs: Vec<fn(usize, usize, usize) -> f64> = vec![
+    pub fn security_for_binary(n: u64, k: u64, t: u64) -> f64 {
+        let funcs: Vec<fn(u64, u64, u64) -> f64> = vec![
             Self::security_under_pooled_gauss,
             Self::security_under_sd_binary,
             Self::security_under_sd2_binary,
@@ -382,203 +393,205 @@ impl LpnEstimator {
 
         let res: Vec<f64> = iter.map(|&func| func(n, k, t)).collect();
 
-        res.into_iter()
-            .min_by(|a, b| a.partial_cmp(b).unwrap())
-            .expect("Some error in finding min")
-    }
-
-    // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
-    fn cost_agb_binary(n: usize, k: usize, t: usize, f: usize, mu: usize) -> f64 {
-        let f = Float::with_val(PRECISION, f);
-        let mu = Float::with_val(PRECISION, mu);
-        let beta = Float::with_val(PRECISION, n / t);
-
-        let beta_minus_mu_minus_one: Float = beta.clone() - mu - 1;
-
-        let a1 = beta_minus_mu_minus_one.clone() * f.clone();
-        let a2: Float = beta_minus_mu_minus_one.clone().pow(2) * f.clone() * (f.clone() - 1) / 2;
-        let a3: Float =
-            beta_minus_mu_minus_one.clone().pow(3) * f.clone() * (f.clone() - 1) * (f.clone() - 2)
-                / 6;
-        let a4 = beta_minus_mu_minus_one.pow(4)
-            * f.clone()
-            * (f.clone() - 1)
-            * (f.clone() - 2)
-            * (f.clone() - 3)
-            / 24;
-
-        let beta_minus_one: Float = beta - 1;
-        let t_minus_f = Float::with_val(PRECISION, t - f);
-
-        let b1 = beta_minus_one.clone() * t_minus_f.clone();
-        let b2: Float =
-            beta_minus_one.clone().pow(2) * t_minus_f.clone() * (t_minus_f.clone() - 1) / 2;
-        let b3: Float = beta_minus_one.clone().pow(3)
-            * t_minus_f.clone()
-            * (t_minus_f.clone() - 1)
-            * (t_minus_f.clone() - 2)
-            / 6;
-        let b4 = beta_minus_one.pow(4)
-            * t_minus_f.clone()
-            * (t_minus_f.clone() - 1)
-            * (t_minus_f.clone() - 2)
-            * (t_minus_f - 3)
-            / 24;
-
-        let c1 = -Self::cal_comb(n - k - 1, 1);
-        let c2 = Self::cal_comb(n - k, 2);
-        let c3 = -Self::cal_comb(n - k + 1, 3);
-        let c4 = Self::cal_comb(n - k + 2, 4);
-
-        let d2 = a1.clone()
-            + b1.clone()
-            + c1.clone()
-            + a1.clone() * b1.clone()
-            + a1.clone() * c1.clone()
-            + b1.clone() * c1.clone()
-            + a2.clone()
-            + b2.clone()
-            + c2.clone();
-
-        let d3 = c3.clone()
-            + b1.clone() * c2.clone()
-            + b2.clone() * c1.clone()
-            + b3.clone()
-            + a1.clone() * (b1.clone() * c1.clone() + b2.clone() + c2.clone())
-            + a2.clone() * (b1.clone() + c1.clone())
-            + a3.clone();
-
-        let d4 = c4
-            + b1.clone() * c3.clone()
-            + b2.clone() * c2.clone()
-            + b3.clone() * c1.clone()
-            + b4
-            + a1 * (b1.clone() * c2.clone() + b2.clone() * c1.clone() + b3 + c3)
-            + a2 * (b2 + c2 + b1.clone() * c1.clone())
-            + a3 * (b1 + c1)
-            + a4;
-
-        if d2 < 1 {
-            return 2.0;
-        }
-        if d3 < 1 {
-            return 3.0;
-        }
-        if d4 < 1 {
-            return 4.0;
-        }
+        // res.into_iter()
+        //     .min_by(|a, b| a.partial_cmp(b).unwrap())
+        //     .expect("Some error in finding min")
+        println!("res: {:?}", res);
         0.0
     }
 
-    // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
-    fn sub_agb_binary(n: usize, k: usize, t: usize, f: usize, mu: usize) -> f64 {
-        let mu_copy = mu;
-        let beta_copy = n / t;
-        let f_copy = f;
-        let f = Float::with_val(PRECISION, f);
-        let mu = Float::with_val(PRECISION, mu);
-        let beta = Float::with_val(PRECISION, n / t);
+    // // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
+    // fn cost_agb_binary(n: usize, k: usize, t: usize, f: usize, mu: usize) -> f64 {
+    //     let f = Float::with_val(PRECISION, f);
+    //     let mu = Float::with_val(PRECISION, mu);
+    //     let beta = Float::with_val(PRECISION, n / t);
 
-        let beta_minus_mu_minus_one: Float = beta.clone() - mu - 1;
+    //     let beta_minus_mu_minus_one: Float = beta.clone() - mu - 1;
 
-        let a1 = beta_minus_mu_minus_one.clone() * f.clone();
-        let a2: Float = beta_minus_mu_minus_one.clone().pow(2) * f.clone() * (f.clone() - 1) / 2;
-        let a3: Float =
-            beta_minus_mu_minus_one.clone().pow(3) * f.clone() * (f.clone() - 1) * (f.clone() - 2)
-                / 6;
-        let a4 = beta_minus_mu_minus_one.pow(4)
-            * f.clone()
-            * (f.clone() - 1)
-            * (f.clone() - 2)
-            * (f.clone() - 3)
-            / 24;
+    //     let a1 = beta_minus_mu_minus_one.clone() * f.clone();
+    //     let a2: Float = beta_minus_mu_minus_one.clone().pow(2) * f.clone() * (f.clone() - 1) / 2;
+    //     let a3: Float =
+    //         beta_minus_mu_minus_one.clone().pow(3) * f.clone() * (f.clone() - 1) * (f.clone() - 2)
+    //             / 6;
+    //     let a4 = beta_minus_mu_minus_one.pow(4)
+    //         * f.clone()
+    //         * (f.clone() - 1)
+    //         * (f.clone() - 2)
+    //         * (f.clone() - 3)
+    //         / 24;
 
-        let beta_minus_one: Float = beta - 1;
-        let t_minus_f: Float = Float::with_val(PRECISION, t - f);
+    //     let beta_minus_one: Float = beta - 1;
+    //     let t_minus_f = Float::with_val(PRECISION, t - f);
 
-        let b1 = beta_minus_one.clone() * t_minus_f.clone();
-        let b2: Float =
-            beta_minus_one.clone().pow(2) * t_minus_f.clone() * (t_minus_f.clone() - 1) / 2;
-        let b3: Float = beta_minus_one.clone().pow(3)
-            * t_minus_f.clone()
-            * (t_minus_f.clone() - 1)
-            * (t_minus_f.clone() - 2)
-            / 6;
-        let b4 = beta_minus_one.pow(4)
-            * t_minus_f.clone()
-            * (t_minus_f.clone() - 1)
-            * (t_minus_f.clone() - 2)
-            * (t_minus_f - 3)
-            / 24;
+    //     let b1 = beta_minus_one.clone() * t_minus_f.clone();
+    //     let b2: Float =
+    //         beta_minus_one.clone().pow(2) * t_minus_f.clone() * (t_minus_f.clone() - 1) / 2;
+    //     let b3: Float = beta_minus_one.clone().pow(3)
+    //         * t_minus_f.clone()
+    //         * (t_minus_f.clone() - 1)
+    //         * (t_minus_f.clone() - 2)
+    //         / 6;
+    //     let b4 = beta_minus_one.pow(4)
+    //         * t_minus_f.clone()
+    //         * (t_minus_f.clone() - 1)
+    //         * (t_minus_f.clone() - 2)
+    //         * (t_minus_f - 3)
+    //         / 24;
 
-        let d = Self::cost_agb_binary(n, k, t, f_copy, mu_copy);
-        let mut cost = a1.clone() + b1.clone() + a1.clone() * b1.clone() + a2.clone() + b2.clone();
-        if d == 2.0 {
-            cost += 0;
-        } else if d == 3.0 {
-            let d3 = b3 + a1 * b2 + a2 * b1 + a3;
-            cost += d3;
-        } else if d == 4.0 {
-            let d3 = b3.clone() + a1.clone() * b2.clone() + a2.clone() * b1.clone() + a3.clone();
-            let d4 = b4 + a1 * b3 + a2 * b2 + a3 * b1 + a4;
-            cost += d3 + d4;
-        } else {
-            return u32::MAX as f64;
-        }
+    //     let c1 = -Self::cal_comb(n - k - 1, 1);
+    //     let c2 = Self::cal_comb(n - k, 2);
+    //     let c3 = -Self::cal_comb(n - k + 1, 3);
+    //     let c4 = Self::cal_comb(n - k + 2, 4);
 
-        let res: Float = 2 * cost.log2()
-            + Float::with_val(PRECISION, 3 * (k + 1 - f_copy * mu_copy)).log2()
-            - f_copy
-                * Float::with_val(PRECISION, 1.0 - (mu_copy as f64) / (beta_copy as f64)).log2();
+    //     let d2 = a1.clone()
+    //         + b1.clone()
+    //         + c1.clone()
+    //         + a1.clone() * b1.clone()
+    //         + a1.clone() * c1.clone()
+    //         + b1.clone() * c1.clone()
+    //         + a2.clone()
+    //         + b2.clone()
+    //         + c2.clone();
 
-        res.to_f64()
-    }
+    //     let d3 = c3.clone()
+    //         + b1.clone() * c2.clone()
+    //         + b2.clone() * c1.clone()
+    //         + b3.clone()
+    //         + a1.clone() * (b1.clone() * c1.clone() + b2.clone() + c2.clone())
+    //         + a2.clone() * (b1.clone() + c1.clone())
+    //         + a3.clone();
 
-    // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
-    fn security_under_agb_binary(n: usize, k: usize, t: usize) -> f64 {
-        let mut res = u32::MAX as f64;
-        for f in 0..t {
-            for mu in 0..n / t {
-                if f * mu < k + 1 {
-                    let cost = Self::sub_agb_binary(n, k, t, f, mu);
-                    if res > cost {
-                        res = cost;
-                    }
-                }
-            }
-        }
-        res
-    }
+    //     let d4 = c4
+    //         + b1.clone() * c3.clone()
+    //         + b2.clone() * c2.clone()
+    //         + b3.clone() * c1.clone()
+    //         + b4
+    //         + a1 * (b1.clone() * c2.clone() + b2.clone() * c1.clone() + b3 + c3)
+    //         + a2 * (b2 + c2 + b1.clone() * c1.clone())
+    //         + a3 * (b1 + c1)
+    //         + a4;
 
-    /// The security of the regular lpn parameters for binary field.
-    /// See Sec 5.1 in this [paper](https://eprint.iacr.org/2022/712.pdf)
-    /// # Arguments.
-    ///
-    /// * `n` - The number of samples.
-    /// * `k` - The length of the secret.
-    /// * `t` - The Hamming weight of the error.
-    ///
-    /// NOTE: Run it in the release mode.
-    pub fn security_for_binary_regular(n: usize, k: usize, t: usize) -> f64 {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "rayon")]{
-                let (cost_agb, cost_others) = rayon::join(
-                    || Self::security_under_agb_binary(n, k, t),
-                    || Self::security_for_binary(n - t, k - t, t),
-                );
-            }else{
-                let cost_agb = Self::security_under_agb_binary(n, k, t);
-                let cost_others = Self::security_for_binary(n-t, k-t, t);
-            }
-        }
-        cost_agb.min(cost_others)
-    }
+    //     if d2 < 1 {
+    //         return 2.0;
+    //     }
+    //     if d3 < 1 {
+    //         return 3.0;
+    //     }
+    //     if d4 < 1 {
+    //         return 4.0;
+    //     }
+    //     0.0
+    // }
+
+    // // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
+    // fn sub_agb_binary(n: usize, k: usize, t: usize, f: usize, mu: usize) -> f64 {
+    //     let mu_copy = mu;
+    //     let beta_copy = n / t;
+    //     let f_copy = f;
+    //     let f = Float::with_val(PRECISION, f);
+    //     let mu = Float::with_val(PRECISION, mu);
+    //     let beta = Float::with_val(PRECISION, n / t);
+
+    //     let beta_minus_mu_minus_one: Float = beta.clone() - mu - 1;
+
+    //     let a1 = beta_minus_mu_minus_one.clone() * f.clone();
+    //     let a2: Float = beta_minus_mu_minus_one.clone().pow(2) * f.clone() * (f.clone() - 1) / 2;
+    //     let a3: Float =
+    //         beta_minus_mu_minus_one.clone().pow(3) * f.clone() * (f.clone() - 1) * (f.clone() - 2)
+    //             / 6;
+    //     let a4 = beta_minus_mu_minus_one.pow(4)
+    //         * f.clone()
+    //         * (f.clone() - 1)
+    //         * (f.clone() - 2)
+    //         * (f.clone() - 3)
+    //         / 24;
+
+    //     let beta_minus_one: Float = beta - 1;
+    //     let t_minus_f: Float = Float::with_val(PRECISION, t - f);
+
+    //     let b1 = beta_minus_one.clone() * t_minus_f.clone();
+    //     let b2: Float =
+    //         beta_minus_one.clone().pow(2) * t_minus_f.clone() * (t_minus_f.clone() - 1) / 2;
+    //     let b3: Float = beta_minus_one.clone().pow(3)
+    //         * t_minus_f.clone()
+    //         * (t_minus_f.clone() - 1)
+    //         * (t_minus_f.clone() - 2)
+    //         / 6;
+    //     let b4 = beta_minus_one.pow(4)
+    //         * t_minus_f.clone()
+    //         * (t_minus_f.clone() - 1)
+    //         * (t_minus_f.clone() - 2)
+    //         * (t_minus_f - 3)
+    //         / 24;
+
+    //     let d = Self::cost_agb_binary(n, k, t, f_copy, mu_copy);
+    //     let mut cost = a1.clone() + b1.clone() + a1.clone() * b1.clone() + a2.clone() + b2.clone();
+    //     if d == 2.0 {
+    //         cost += 0;
+    //     } else if d == 3.0 {
+    //         let d3 = b3 + a1 * b2 + a2 * b1 + a3;
+    //         cost += d3;
+    //     } else if d == 4.0 {
+    //         let d3 = b3.clone() + a1.clone() * b2.clone() + a2.clone() * b1.clone() + a3.clone();
+    //         let d4 = b4 + a1 * b3 + a2 * b2 + a3 * b1 + a4;
+    //         cost += d3 + d4;
+    //     } else {
+    //         return u32::MAX as f64;
+    //     }
+
+    //     let res: Float = 2 * cost.log2()
+    //         + Float::with_val(PRECISION, 3 * (k + 1 - f_copy * mu_copy)).log2()
+    //         - f_copy
+    //             * Float::with_val(PRECISION, 1.0 - (mu_copy as f64) / (beta_copy as f64)).log2();
+
+    //     res.to_f64()
+    // }
+
+    // // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)
+    // fn security_under_agb_binary(n: usize, k: usize, t: usize) -> f64 {
+    //     let mut res = u32::MAX as f64;
+    //     for f in 0..t {
+    //         for mu in 0..n / t {
+    //             if f * mu < k + 1 {
+    //                 let cost = Self::sub_agb_binary(n, k, t, f, mu);
+    //                 if res > cost {
+    //                     res = cost;
+    //                 }
+    //             }
+    //         }
+    //     }
+    //     res
+    // }
+
+    // /// The security of the regular lpn parameters for binary field.
+    // /// See Sec 5.1 in this [paper](https://eprint.iacr.org/2022/712.pdf)
+    // /// # Arguments.
+    // ///
+    // /// * `n` - The number of samples.
+    // /// * `k` - The length of the secret.
+    // /// * `t` - The Hamming weight of the error.
+    // ///
+    // /// NOTE: Run it in the release mode.
+    // pub fn security_for_binary_regular(n: usize, k: usize, t: usize) -> f64 {
+    //     cfg_if::cfg_if! {
+    //         if #[cfg(feature = "rayon")]{
+    //             let (cost_agb, cost_others) = rayon::join(
+    //                 || Self::security_under_agb_binary(n, k, t),
+    //                 || Self::security_for_binary(n - t, k - t, t),
+    //             );
+    //         }else{
+    //             let cost_agb = Self::security_under_agb_binary(n, k, t);
+    //             let cost_others = Self::security_for_binary(n-t, k-t, t);
+    //         }
+    //     }
+    //     cost_agb.min(cost_others)
+    // }
 }
 
 mod tests {
     #[test]
     fn security_test() {
-        let security = crate::LpnEstimator::security_for_binary_regular(1 << 10, 652, 57);
+        let security = crate::LpnEstimator::security_for_binary(1 << 22, 67440, 2735);
         println!("{:?}", security);
     }
 }

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -411,49 +411,83 @@ impl LpnEstimator {
 
         let beta_minus_mu_minus_one = beta - mu - 1;
 
-        let a1 = beta_minus_mu_minus_one * f;
-        let a2 = beta_minus_mu_minus_one.pow(2) * f * (f - 1) / 2;
-        let a3 = beta_minus_mu_minus_one.pow(3) * f * (f - 1) * (f - 2) / 6;
-        let a4 = beta_minus_mu_minus_one.pow(4) * f * (f - 1) * (f - 2) * (f - 3) / 24;
+        let mut a1 = 0;
+        let mut a2 = 0;
+        let mut a3 = 0;
+        let mut a4 = 0;
+
+        if f >= 3 {
+            a1 = beta_minus_mu_minus_one * f;
+            a2 = beta_minus_mu_minus_one.pow(2) * f * (f - 1) / 2;
+            a3 = beta_minus_mu_minus_one.pow(3) * f * (f - 1) * (f - 2) / 6;
+            a4 = beta_minus_mu_minus_one.pow(4) * f * (f - 1) * (f - 2) * (f - 3) / 24;
+        }
 
         let beta_minus_one = beta - 1;
         let t_minus_f = t as u128 - f;
 
-        let b1 = beta_minus_one * t_minus_f;
-        let b2 = beta_minus_one.pow(2) * t_minus_f * (t_minus_f - 1) / 2;
-        let b3 = beta_minus_one.pow(3) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) / 6;
-        let b4 =
-            beta_minus_one.pow(4) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) * (t_minus_f - 3)
+        let mut b1 = 0;
+        let mut b2 = 0;
+        let mut b3 = 0;
+        let mut b4 = 0;
+
+        if t_minus_f >= 3 {
+            b1 = beta_minus_one * t_minus_f;
+            b2 = beta_minus_one.pow(2) * t_minus_f * (t_minus_f - 1) / 2;
+            b3 = beta_minus_one.pow(3) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) / 6;
+            b4 = beta_minus_one.pow(4)
+                * t_minus_f
+                * (t_minus_f - 1)
+                * (t_minus_f - 2)
+                * (t_minus_f - 3)
                 / 24;
+        }
 
         let minus_c1 = n - k - 1;
         let c2 = (n - k) * (n - k - 1) / 2;
         let minus_c3 = (n - k + 1) * (n - k) * (n - k - 1) / 6;
         let c4 = (n - k + 2) * (n - k + 1) * (n - k) * (n - k - 1) / 24;
 
-        let d2 = a1 + b1 + a1 * b1 + a2 + b2 + c2 - (a1 + b1) * minus_c1 - minus_c1;
+        let d2_left = a1 + b1 + a1 * b1 + a2 + b2 + c2;
+        let d2_right = (a1 + b1) * minus_c1 + minus_c1;
+        // let d2 = a1 + b1 + a1 * b1 + a2 + b2 + c2 - (a1 + b1) * minus_c1 - minus_c1;
 
-        let d3 = b1 * c2 + b3 + a1 * (b2 + c2) + a2 * b1 + a3
-            - minus_c3
-            - b2 * minus_c1
-            - a1 * b1 * minus_c1
-            - a2 * minus_c1;
+        let d3_left = b1 * c2 + b3 + a1 * (b2 + c2) + a2 * b1 + a3;
+        let d3_right = minus_c3 + b2 * minus_c1 + a1 * b1 * minus_c1 + a2 * minus_c1;
 
-        let d4 = c4 + b2 * c2 + b4 + a1 * (b1 * c2 + b2 + b3) + a2 * (b2 + c2 + b1) + a3 * b1 + a4
-            - b1 * minus_c3
-            - b3 * minus_c1
-            - a3 * minus_c1
-            - a1 * b2 * minus_c1
-            - a2 * b1 * minus_c1
-            - a1 * minus_c3;
+        // let d3 = b1 * c2 + b3 + a1 * (b2 + c2) + a2 * b1 + a3
+        //     - minus_c3
+        //     - b2 * minus_c1
+        //     - a1 * b1 * minus_c1
+        //     - a2 * minus_c1;
 
-        if d2 < 1 {
+        let d4_left =
+            c4 + b2 * c2 + b4 + a1 * (b1 * c2 + b2 + b3) + a2 * (b2 + c2 + b1) + a3 * b1 + a4;
+        let d4_right = b1 * minus_c3
+            + b3 * minus_c1
+            + a3 * minus_c1
+            + a1 * b2 * minus_c1
+            + a2 * b1 * minus_c1
+            + a1 * minus_c3;
+
+        // let d4 = c4 + b2 * c2 + b4 + a1 * (b1 * c2 + b2 + b3) + a2 * (b2 + c2 + b1) + a3 * b1 + a4
+        //     - b1 * minus_c3
+        //     - b3 * minus_c1
+        //     - a3 * minus_c1
+        //     - a1 * b2 * minus_c1
+        //     - a2 * b1 * minus_c1
+        //     - a1 * minus_c3;
+
+        // if d2 < 1 {
+        if d2_left <= d2_right {
             return 2.0;
         }
-        if d3 < 1 {
+        // if d3 < 1 {
+        if d3_left <= d3_right {
             return 3.0;
         }
-        if d4 < 1 {
+        // if d4 < 1 {
+        if d4_left <= d4_right {
             return 4.0;
         }
         0.0
@@ -467,20 +501,37 @@ impl LpnEstimator {
 
         let beta_minus_mu_minus_one = beta - mu - 1;
 
-        let a1 = beta_minus_mu_minus_one * f;
-        let a2 = beta_minus_mu_minus_one.pow(2) * f * (f - 1) / 2;
-        let a3 = beta_minus_mu_minus_one.pow(3) * f * (f - 1) * (f - 2) / 6;
-        let a4 = beta_minus_mu_minus_one.pow(4) * f * (f - 1) * (f - 2) * (f - 3) / 24;
+        let mut a1 = 0;
+        let mut a2 = 0;
+        let mut a3 = 0;
+        let mut a4 = 0;
+
+        if f >= 3 {
+            a1 = beta_minus_mu_minus_one * f;
+            a2 = beta_minus_mu_minus_one.pow(2) * f * (f - 1) / 2;
+            a3 = beta_minus_mu_minus_one.pow(3) * f * (f - 1) * (f - 2) / 6;
+            a4 = beta_minus_mu_minus_one.pow(4) * f * (f - 1) * (f - 2) * (f - 3) / 24;
+        }
 
         let beta_minus_one = beta - 1;
         let t_minus_f = t as u128 - f;
 
-        let b1 = beta_minus_one * t_minus_f;
-        let b2 = beta_minus_one.pow(2) * t_minus_f * (t_minus_f - 1) / 2;
-        let b3 = beta_minus_one.pow(3) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) / 6;
-        let b4 =
-            beta_minus_one.pow(4) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) * (t_minus_f - 3)
+        let mut b1 = 0;
+        let mut b2 = 0;
+        let mut b3 = 0;
+        let mut b4 = 0;
+
+        if t_minus_f >= 3 {
+            b1 = beta_minus_one * t_minus_f;
+            b2 = beta_minus_one.pow(2) * t_minus_f * (t_minus_f - 1) / 2;
+            b3 = beta_minus_one.pow(3) * t_minus_f * (t_minus_f - 1) * (t_minus_f - 2) / 6;
+            b4 = beta_minus_one.pow(4)
+                * t_minus_f
+                * (t_minus_f - 1)
+                * (t_minus_f - 2)
+                * (t_minus_f - 3)
                 / 24;
+        }
 
         let d = Self::cost_agb_binary(n, k, t, f as u64, mu as u64);
 
@@ -549,7 +600,9 @@ impl LpnEstimator {
 mod tests {
     #[test]
     fn security_test() {
-        let security = crate::LpnEstimator::security_for_binary_regular(1 << 22, 67440, 2735);
-        println!("{:?}", security);
+        let sec = crate::LpnEstimator::security_for_binary(1 << 10, 652, 57);
+        let sec_reg = crate::LpnEstimator::security_for_binary_regular(1 << 10, 652, 57);
+        assert!(sec < 95.0);
+        assert!(sec_reg < 90.0);
     }
 }

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -6,7 +6,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rug::Float;
 
 // The precision.
-const PRECISION: u32 = 200;
+const PRECISION: u32 = 64;
 
 // The highest security level.
 const HIGHEST_SECURITY: usize = 256;
@@ -531,11 +531,11 @@ impl LpnEstimator {
             return HIGHEST_SECURITY as f64;
         }
 
-        let res: Float = 2 * Float::with_val(PRECISION, cost).log2()
-            + Float::with_val(PRECISION, 3 * (k + 1 - f as u64 * mu as u64)).log2()
-            - f * Float::with_val(PRECISION, 1.0 - (mu as f64) / (beta as f64)).log2();
+        let mut res = 2.0 * Float::with_val(PRECISION, cost).log2().to_f64();
+        res += ((3 * (k + 1 - f as u64 * mu as u64)) as f64).log2();
+        res -= (f as f64) * (1.0 - (mu as f64) / (beta as f64)).log2();
 
-        res.to_f64()
+        res
     }
 
     // Attack in the [paper](https://eprint.iacr.org/2023/176.pdf)

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -6,7 +6,7 @@ use rug::{ops::Pow, Float};
 // The precision for security analysis.
 const PRECISION: u32 = 200;
 
-// The highest security level in our analysis.
+// The highest security level.
 const HIGHEST_SECURITY: usize = 256;
 
 /// Define the struct of LPN estimator.
@@ -28,8 +28,14 @@ impl LpnEstimator {
         res
     }
 
-    /// Compute the bit security under the Pooled Gauss attack, see page 37 in this [paper](https://eprint.iacr.org/2022/712.pdf).
-    pub fn security_under_pooled_gauss_binary(n: usize, k: usize, t: usize) -> f64 {
+    /// Compute the bit security under the Pooled Gauss attack, see page 37 in this [paper](https://eprint.iacr.org/2022/712.pdf). Note that it is the same for binary and larger fields.
+    ///
+    /// # Arguments.
+    ///
+    /// * `n` - The number of samples.
+    /// * `k` - The length of the secret.
+    /// * `t` - The Hammin weight of the error.
+    pub fn security_under_pooled_gauss(n: usize, k: usize, t: usize) -> f64 {
         let log_guess_prob = Self::cal_comb(n - k, t).log2() - Self::cal_comb(n, t).log2();
 
         let matrix_inversion_cost = (std::cmp::min(n - k, k) as f64).powf(2.8);
@@ -37,17 +43,12 @@ impl LpnEstimator {
         matrix_inversion_cost.log2() - log_guess_prob.to_f64()
     }
 
-    // Compute the fomulas inside the min function of Therem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    // Compute the fomulas inside the min function of Theorem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
     fn sub_sd_isd_binary(n: usize, k: usize, t: usize, l: usize, p: usize) -> f64 {
         let l_zero = Self::cal_comb((k + l) / 2 + 1, p / 2);
 
         let log_l_zero = l_zero.clone().log2();
         let log_s: Float = 2 * log_l_zero.clone() - l;
-
-        // If it has enough security, just break.
-        if log_l_zero > HIGHEST_SECURITY || log_s > HIGHEST_SECURITY {
-            return HIGHEST_SECURITY as f64;
-        }
 
         // Computes s = 1 << log_s.
         let s = Float::with_val(PRECISION, 2).pow(log_s.clone());
@@ -67,7 +68,7 @@ impl LpnEstimator {
         (cost.log2() - log_p).to_f64()
     }
 
-    // Minimize sub_SD_ISD_binary when fix p.
+    // Minimize sub_sd_isd_binary when fix p.
     fn min_sub_sd_isd_binary_with_fixed_p(n: usize, k: usize, t: usize, p: usize) -> f64 {
         let mut start = 1;
         let mut end = n - k;
@@ -102,6 +103,12 @@ impl LpnEstimator {
     }
 
     /// The security of the lpn parameters under SD_ISD attack for binary field. See Therem 14 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    ///
+    /// # Arguments.
+    ///
+    /// * `n` - The number of samples.
+    /// * `k` - The length of the secret.
+    /// * `t` - The Hammin weight of the error.
     pub fn security_under_sd_isd_binary(n: usize, k: usize, t: usize) -> f64 {
         let mut res = Self::sub_sd_isd_binary(n, k, t, 0, 0);
 
@@ -110,11 +117,199 @@ impl LpnEstimator {
             if min <= res {
                 res = min;
             }
-            if min > res + 30.0 {
-                break;
+        }
+        res
+    }
+
+    // Compute the fomulas inside the min function of Theorem 16 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    fn sub_bjmm_isd_binary(
+        n: usize,
+        k: usize,
+        t: usize,
+        p2: usize,
+        l: usize,
+        e1: usize,
+        e2: usize,
+        r1: usize,
+        r2: usize,
+        local_min: f64,
+    ) -> f64 {
+        assert!(p2 >= e2);
+        let p1 = 2 * (p2 - e2);
+        assert!(p1 >= e1);
+        let p = 2 * (p1 - e1);
+
+        let s3 = Self::cal_comb((k + l) / 2 + 1, p2 / 2);
+
+        let log_s3 = s3.clone().log2();
+        let log_c3: Float = s3.clone().log2() * 2 - r2;
+        let c3 = Float::with_val(PRECISION, 2).pow(log_c3.clone());
+
+        let log_c2: Float = log_c3.clone() * 2 - r1;
+        let c2 = Float::with_val(PRECISION, 2).pow(log_c2.clone());
+
+        assert!(k + l >= p2);
+        assert!(p2 >= e2);
+        let log_mu2 = Self::cal_comb(p2, e2).log2() + Self::cal_comb(k + l - p2, p2 - e2).log2()
+            - Self::cal_comb(k + l, p2).log2();
+
+        let log_s1_left = log_mu2 + log_c2.clone();
+        let log_s1_right = Self::cal_comb(k + l, p1).log2() - (r1 + r2);
+        let log_s1 = log_s1_left.min(&log_s1_right);
+
+        let log_c1: Float = log_s1 * 2 - l + r1 + r2;
+        let c1 = Float::with_val(PRECISION, 2).pow(log_c1.clone());
+
+        assert!(k + l >= p1);
+        assert!(p1 >= e1);
+        let log_mu1 = Self::cal_comb(p1, e1).log2() + Self::cal_comb(k + l - p1, p1 - e1).log2()
+            - Self::cal_comb(k + l, p1).log2();
+
+        let log_s_left = log_mu1 + log_c1;
+        let log_s_right = Self::cal_comb(k + l, p).log2() - l;
+
+        let log_s = log_s_left.clone().min(&log_s_right);
+
+        // Quick break
+        if (log_s3.to_f64() > local_min) || (log_c3.to_f64() > local_min) || (log_c2 > local_min) {
+            return HIGHEST_SECURITY as f64;
+        }
+
+        // Compute T_Gauss + (8*S3 + 4*C3 + 2*C2 + 2*C1) * N
+        let mut cost = Float::with_val(PRECISION, (n - k - l) * (n - k))
+            / Float::with_val(PRECISION, f64::log2((n - k - l) as f64));
+
+        cost += 8 * s3 + 4 * c3 + 2 * c2 + 2 * c1;
+        cost *= n;
+
+        // Compute log P(p,l).
+        assert!(n >= k + l);
+        assert!(t >= p);
+        let mut log_p = Self::cal_comb(n - k - l, t - p).log2() - Self::cal_comb(n, t).log2();
+
+        log_p += l + log_s;
+
+        // Quick break, the probability should be smaller than 1.
+        if log_p >= 0 {
+            return HIGHEST_SECURITY as f64;
+        }
+
+        (cost.log2() - log_p).to_f64()
+    }
+
+    // Minimize sub_bjmm_isd_binary with fixed p2 and l.
+    fn min_sub_bjmm_isd_binary_with_fixed_p2_and_l(
+        n: usize,
+        k: usize,
+        t: usize,
+        p2: usize,
+        l: usize,
+    ) -> f64 {
+        let mut local_min = HIGHEST_SECURITY as f64;
+        // Try all possible values of e2.
+        for e2 in 0..p2 {
+            let p1 = 2 * (p2 - e2);
+
+            let e1_start = if p1 <= (t / 2) { 0 } else { p1 - t / 2 };
+
+            // Try all possible values of e1.
+            for e1 in e1_start..p1 {
+                let p = 2 * (p1 - e1);
+
+                // The following part is according to Equation (6), Page 11 in this [paper](https://eprint.iacr.org/2013/162.pdf).
+                assert!(k + l >= p2);
+                assert!(k + l >= p1);
+                assert!(p2 >= e2);
+                assert!(p1 >= e1);
+                // Proposition 1 in this [paper](https://eprint.iacr.org/2013/162.pdf).
+                let log_mu2 = Self::cal_comb(p2, e2).log2()
+                    + Self::cal_comb(k + l - p2, p2 - e2).log2()
+                    - Self::cal_comb(k + l, p2).log2();
+
+                let r2: Float = log_mu2 + 4 * (Self::cal_comb((k + l) / 2, p2 / 2).log2())
+                    - Self::cal_comb(k + l, p1).log2();
+
+                let r2: usize = if r2 <= 0 {
+                    0
+                } else if r2 >= l {
+                    l - 1
+                } else {
+                    r2.to_f64() as usize
+                };
+
+                // Also use the equation of mu_1 in Proposition 1.
+                let r = Self::cal_comb(p1, e1).log2()
+                    + Self::cal_comb(k + l - p1, p1 - e1).log2()
+                    + Self::cal_comb(k + l, p1).log2()
+                    - Self::cal_comb(k + l, p).log2();
+
+                let r1 = r - r2;
+                let r1 = if r1 <= 0 {
+                    0
+                } else if (r1.clone() + r2) >= l {
+                    l - r2 - 1
+                } else {
+                    r1.to_f64() as usize
+                };
+
+                let middle = Self::sub_bjmm_isd_binary(n, k, t, p2, l, e1, e2, r1, r2, local_min);
+
+                if middle < local_min {
+                    local_min = middle;
+                }
+            }
+        }
+        local_min
+    }
+
+    // Minimize sub_bjmm_isd_binary with fixed p2.
+    fn min_sub_bjmm_isd_binary_with_fixed_p2(n: usize, k: usize, t: usize, p2: usize) -> f64 {
+        let mut start = 1;
+        let mut end = (n - k - 2) / 8;
+
+        let mut min_cost = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, start);
+
+        while end - start > 10 {
+            let left = (end - start) / 3 + start;
+            let right = end - (end - start) / 3;
+
+            let min_left = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, left);
+            let min_right = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, right);
+
+            if min_left > min_right {
+                start = left;
+                min_cost = min_right;
+            } else {
+                end = right;
+                min_cost = min_left;
             }
         }
 
+        for l in (start + 1)..(end + 5) {
+            let min_middle = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, l);
+            if min_middle < min_cost {
+                min_cost = min_middle;
+            }
+        }
+        min_cost
+    }
+
+    /// The security of the lpn parameters under BJMM_ISD attack for binary field. See Therem 16 in this [paper](https://eprint.iacr.org/2022/712.pdf).
+    ///
+    /// # Arguments.
+    ///
+    /// * `n` - The number of samples.
+    /// * `k` - The length of the secret.
+    /// * `t` - The Hammin weight of the error.
+    pub fn security_under_bjmm_isd_binary(n: usize, k: usize, t: usize) -> f64 {
+        let mut res = Self::min_sub_bjmm_isd_binary_with_fixed_p2(n, k, t, 0);
+
+        for p2 in 1..t {
+            let min = Self::min_sub_bjmm_isd_binary_with_fixed_p2(n, k, t, p2);
+            if min < res {
+                res = min;
+            }
+        }
         res
     }
 }
@@ -122,7 +317,7 @@ impl LpnEstimator {
 mod tests {
     #[test]
     fn security_test() {
-        let security = crate::LpnEstimator::security_under_sd_isd_binary(1 << 14, 3482, 198);
+        let security = crate::LpnEstimator::security_under_bjmm_isd_binary(1 << 10, 100, 10);
         println!("{:?}", security);
     }
 }

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -103,7 +103,7 @@ impl LpnEstimator {
         if start < 10 {
             start = 0;
         } else {
-            start = start - 10;
+            start -= 10;
         }
 
         for l in start..=end + 10 {
@@ -303,7 +303,7 @@ impl LpnEstimator {
         if start < 5 {
             start = 0;
         } else {
-            start = start - 5;
+            start -= 5;
         }
         for l in start..end + 5 {
             let min_middle = Self::min_sub_bjmm_isd_binary_with_fixed_p2_and_l(n, k, t, p2, l);
@@ -349,7 +349,7 @@ impl LpnEstimator {
     pub fn security_under_sd_binary(n: u64, k: u64, t: u64) -> f64 {
         let cost = (n - t + 1) as f64 / (n - k - t) as f64;
 
-        let cost = cost.log2() * 2.0 * t as f64 + 2 as f64;
+        let cost = cost.log2() * 2.0 * t as f64 + 2.0;
 
         ((k + 1) as f64).log2() + cost
     }
@@ -407,7 +407,7 @@ impl LpnEstimator {
         let t = t as u128;
         let f = f as u128;
         let mu = mu as u128;
-        let beta = (n / t) as u128;
+        let beta = n / t;
 
         let beta_minus_mu_minus_one = beta - mu - 1;
 
@@ -424,7 +424,7 @@ impl LpnEstimator {
         }
 
         let beta_minus_one = beta - 1;
-        let t_minus_f = t as u128 - f;
+        let t_minus_f = t - f;
 
         let mut b1 = 0;
         let mut b2 = 0;

--- a/crates/mpz-core/src/lpn_estimator.rs
+++ b/crates/mpz-core/src/lpn_estimator.rs
@@ -614,7 +614,12 @@ mod tests {
     fn security_test() {
         let sec = crate::LpnEstimator::security_for_binary(1 << 10, 652, 57);
         let sec_reg = crate::LpnEstimator::security_for_binary_regular(1 << 10, 652, 57);
+        let dual_sec = crate::LpnEstimator::security_dual_for_binary(1 << 10, 1 << 12, 44);
+        let dual_sec_reg =
+            crate::LpnEstimator::security_dual_for_binary_regular(1 << 10, 1 << 12, 44);
         assert!(sec < 95.0);
         assert!(sec_reg < 90.0);
+        assert!(dual_sec < 98.0);
+        assert!(dual_sec_reg < 97.0);
     }
 }


### PR DESCRIPTION
This PR contains:
1. A security estimator for LPN in binary field.
2. A security estimator for Dual LPN in binary field.
More work still need to do to implement a "smart" way to choose the "best" parameters according to the number of COTs needed when using Ferret. This will be done later.