### PR TITLE
fix: Use Cargo Clippy to avoid the `gen` reserved keyword

### DIFF
--- a/crates/clmul/benches/clmul.rs
+++ b/crates/clmul/benches/clmul.rs
@@ -6,8 +6,8 @@ use rand_chacha::ChaCha12Rng;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rng = ChaCha12Rng::seed_from_u64(0);
-    let a: [u8; 16] = rng.gen();
-    let b: [u8; 16] = rng.gen();
+    let a: [u8; 16] = rng.r#gen();
+    let b: [u8; 16] = rng.r#gen();
     let a = Clmul::new(&a);
     let b = Clmul::new(&b);
 

--- a/crates/clmul/src/lib.rs
+++ b/crates/clmul/src/lib.rs
@@ -78,8 +78,8 @@ mod tests {
         use soft64::Clmul as s64;
 
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
-        let a: [u8; 16] = rng.gen();
-        let b: [u8; 16] = rng.gen();
+        let a: [u8; 16] = rng.r#gen();
+        let b: [u8; 16] = rng.r#gen();
 
         let (r64_0, r64_1) = s64::new(&a).clmul(s64::new(&b));
         let (r32_0, r32_1) = s32::new(&a).clmul(s32::new(&b));

--- a/crates/matrix-transpose/benches/transpose.rs
+++ b/crates/matrix-transpose/benches/transpose.rs
@@ -8,7 +8,7 @@ where
     Standard: Distribution<T>,
 {
     let mut rng = thread_rng();
-    (0..elements).map(|_| rng.gen::<T>()).collect()
+    (0..elements).map(|_| rng.r#gen::<T>()).collect()
 }
 
 #[inline]

--- a/crates/matrix-transpose/src/lib.rs
+++ b/crates/matrix-transpose/src/lib.rs
@@ -82,7 +82,7 @@ mod tests {
         Standard: Distribution<T>,
     {
         let mut rng = thread_rng();
-        (0..elements).map(|_| rng.gen::<T>()).collect()
+        (0..elements).map(|_| rng.r#gen::<T>()).collect()
     }
 
     fn transpose_naive(data: &[u8], row_width: usize) -> Vec<u8> {

--- a/crates/mpz-circuits/src/types.rs
+++ b/crates/mpz-circuits/src/types.rs
@@ -552,12 +552,12 @@ impl Value {
     /// Creates a new value using the provided rng.
     pub fn random<R: Rng>(rng: &mut R, ty: &ValueType) -> Self {
         match ty {
-            ValueType::Bit => Value::Bit(rng.gen()),
-            ValueType::U8 => Value::U8(rng.gen()),
-            ValueType::U16 => Value::U16(rng.gen()),
-            ValueType::U32 => Value::U32(rng.gen()),
-            ValueType::U64 => Value::U64(rng.gen()),
-            ValueType::U128 => Value::U128(rng.gen()),
+            ValueType::Bit => Value::Bit(rng.r#gen()),
+            ValueType::U8 => Value::U8(rng.r#gen()),
+            ValueType::U16 => Value::U16(rng.r#gen()),
+            ValueType::U32 => Value::U32(rng.r#gen()),
+            ValueType::U64 => Value::U64(rng.r#gen()),
+            ValueType::U128 => Value::U128(rng.r#gen()),
             ValueType::Array(ty, len) => Value::Array(
                 (0..*len)
                     .map(|_| Value::random(rng, ty))

--- a/crates/mpz-core/benches/ggm.rs
+++ b/crates/mpz-core/benches/ggm.rs
@@ -11,7 +11,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut k1 = vec![Block::ZERO; depth];
         let seed = rand::random::<Block>();
         bench.iter(|| {
-            black_box(ggm.gen(
+            black_box(ggm.r#gen(
                 black_box(seed),
                 black_box(&mut tree),
                 black_box(&mut k0),

--- a/crates/mpz-core/src/block.rs
+++ b/crates/mpz-core/src/block.rs
@@ -40,19 +40,19 @@ impl Block {
     /// Generate a random block using the provided RNG
     #[inline]
     pub fn random<R: Rng + CryptoRng + ?Sized>(rng: &mut R) -> Self {
-        Self::new(rng.gen())
+        Self::new(rng.r#gen())
     }
 
     /// Generate a random array of blocks using the provided RNG
     #[inline]
     pub fn random_array<const N: usize, R: Rng + CryptoRng>(rng: &mut R) -> [Self; N] {
-        std::array::from_fn(|_| rng.gen::<[u8; 16]>().into())
+        std::array::from_fn(|_| rng.r#gen::<[u8; 16]>().into())
     }
 
     /// Generate a random vector of blocks using the provided RNG
     #[inline]
     pub fn random_vec<R: Rng + CryptoRng + ?Sized>(rng: &mut R, n: usize) -> Vec<Self> {
-        (0..n).map(|_| rng.gen::<[u8; 16]>().into()).collect()
+        (0..n).map(|_| rng.r#gen::<[u8; 16]>().into()).collect()
     }
 
     /// Carry-less multiplication of two blocks, without the reduction step.
@@ -286,7 +286,7 @@ impl BitAndAssign for Block {
 
 impl Distribution<Block> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Block {
-        Block::new(rng.gen())
+        Block::new(rng.r#gen())
     }
 }
 
@@ -367,9 +367,9 @@ mod tests {
         let mut c = (Block::ZERO, Block::ZERO);
         let mut d = Block::ZERO;
         for i in 0..SIZE {
-            let r: [u8; 16] = rng.gen();
+            let r: [u8; 16] = rng.r#gen();
             a.push(Block::from(r));
-            let r: [u8; 16] = rng.gen();
+            let r: [u8; 16] = rng.r#gen();
             b.push(Block::from(r));
 
             let z = a[i].clmul(b[i]);
@@ -389,7 +389,7 @@ mod tests {
         use rand::{Rng, SeedableRng};
         use rand_chacha::ChaCha12Rng;
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
-        let mut x: [u8; 16] = rng.gen();
+        let mut x: [u8; 16] = rng.r#gen();
         let bx = Block::sigma(Block::from(x));
         let (xl, xr) = x.split_at_mut(8);
 

--- a/crates/mpz-core/src/commit.rs
+++ b/crates/mpz-core/src/commit.rs
@@ -23,7 +23,7 @@ pub struct Nonce([u8; 32]);
 impl Nonce {
     /// Creates a random 32 byte nonce
     fn random() -> Self {
-        Self(thread_rng().gen())
+        Self(thread_rng().r#gen())
     }
 }
 

--- a/crates/mpz-core/src/ggm_tree.rs
+++ b/crates/mpz-core/src/ggm_tree.rs
@@ -27,7 +27,7 @@ impl GgmTree {
     /// * `k0` - XORs of all the left-node values in each level, with size `depth`.
     /// * `k1`- XORs of all the right-node values in each level, with size `depth`.
     // This implementation is adapted from EMP Toolkit.
-    pub fn gen(&self, seed: Block, tree: &mut [Block], k0: &mut [Block], k1: &mut [Block]) {
+    pub fn r#gen(&self, seed: Block, tree: &mut [Block], k0: &mut [Block], k1: &mut [Block]) {
         assert_eq!(tree.len(), 1 << (self.depth));
         assert_eq!(k0.len(), self.depth);
         assert_eq!(k1.len(), self.depth);
@@ -150,7 +150,7 @@ fn ggm_test() {
 
     let ggm = GgmTree::new(depth);
 
-    ggm.gen(Block::ZERO, &mut tree, &mut k0, &mut k1);
+    ggm.r#gen(Block::ZERO, &mut tree, &mut k0, &mut k1);
 
     for i in 0..depth {
         if alpha[i] {

--- a/crates/mpz-core/src/prg.rs
+++ b/crates/mpz-core/src/prg.rs
@@ -142,7 +142,7 @@ impl Prg {
     /// Generate a random bool value.
     #[inline(always)]
     pub fn random_bool(&mut self) -> bool {
-        self.gen()
+        self.r#gen()
     }
 
     /// Fill a bool slice with random bool values.
@@ -154,7 +154,7 @@ impl Prg {
     /// Generate a random byte value.
     #[inline(always)]
     pub fn random_byte(&mut self) -> u8 {
-        self.gen()
+        self.r#gen()
     }
 
     /// Fill a byte slice with random values.
@@ -166,7 +166,7 @@ impl Prg {
     /// Generate a random block.
     #[inline(always)]
     pub fn random_block(&mut self) -> Block {
-        self.gen()
+        self.r#gen()
     }
 
     /// Fill a block slice with random block values.

--- a/crates/mpz-fields/benches/inverse_gf2_128.rs
+++ b/crates/mpz-fields/benches/inverse_gf2_128.rs
@@ -5,7 +5,7 @@ use rand::{Rng, SeedableRng};
 
 fn bench_gf2_128_inverse(c: &mut Criterion) {
     let mut rng = Prg::from_seed(Block::ZERO);
-    let a: Gf2_128 = rng.gen();
+    let a: Gf2_128 = rng.r#gen();
 
     c.bench_function("inverse", move |bench| {
         bench.iter(|| {

--- a/crates/mpz-fields/src/p256.rs
+++ b/crates/mpz-fields/src/p256.rs
@@ -192,7 +192,7 @@ mod tests {
         let mut rng = Prg::from_seed(Block::ZERO);
 
         for _ in 0..32 {
-            let a = P256(rng.gen());
+            let a = P256(rng.r#gen());
             let bytes: [u8; 32] = a.into();
             let b = P256::try_from(bytes).unwrap();
 

--- a/crates/mpz-garble-core/benches/garble.rs
+++ b/crates/mpz-garble-core/benches/garble.rs
@@ -18,9 +18,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     gb_group.bench_function("aes128", |b| {
-        let mut gen = Generator::default();
+        let mut r#gen = Generator::default();
         b.iter(|| {
-            let mut gen_iter = gen
+            let mut gen_iter = r#gen
                 .generate(&AES128, encoder.delta(), full_inputs.clone())
                 .unwrap();
 
@@ -31,9 +31,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     gb_group.bench_function("aes128_batched", |b| {
-        let mut gen = Generator::default();
+        let mut r#gen = Generator::default();
         b.iter(|| {
-            let mut gen_iter = gen
+            let mut gen_iter = r#gen
                 .generate_batched(&AES128, encoder.delta(), full_inputs.clone())
                 .unwrap();
 
@@ -44,9 +44,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     gb_group.bench_function("aes128_with_hash", |b| {
-        let mut gen = Generator::default();
+        let mut r#gen = Generator::default();
         b.iter(|| {
-            let mut gen_iter = gen
+            let mut gen_iter = r#gen
                 .generate(&AES128, encoder.delta(), full_inputs.clone())
                 .unwrap();
 
@@ -63,8 +63,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut ev_group = c.benchmark_group("evaluate");
 
     ev_group.bench_function("aes128", |b| {
-        let mut gen = Generator::default();
-        let mut gen_iter = gen
+        let mut r#gen = Generator::default();
+        let mut gen_iter = r#gen
             .generate(&AES128, encoder.delta(), full_inputs.clone())
             .unwrap();
         let gates: Vec<_> = gen_iter.by_ref().collect();

--- a/crates/mpz-garble-core/src/encoding/encoder.rs
+++ b/crates/mpz-garble-core/src/encoding/encoder.rs
@@ -42,7 +42,7 @@ pub struct ChaChaEncoder {
 
 impl Default for ChaChaEncoder {
     fn default() -> Self {
-        Self::new(OsRng.gen())
+        Self::new(OsRng.r#gen())
     }
 }
 

--- a/crates/mpz-garble-core/src/encoding/ops.rs
+++ b/crates/mpz-garble-core/src/encoding/ops.rs
@@ -168,8 +168,8 @@ mod tests {
     {
         let mut rng = ChaCha12Rng::from_seed([0u8; 32]);
 
-        let a: T = rng.gen();
-        let b: T = rng.gen();
+        let a: T = rng.r#gen();
+        let b: T = rng.r#gen();
 
         let a_full: EncodedValue<_> = encoder.encode_by_type(0, &T::value_type());
         let b_full: EncodedValue<_> = encoder.encode_by_type(1, &T::value_type());
@@ -200,8 +200,8 @@ mod tests {
     {
         let mut rng = ChaCha12Rng::from_seed([0u8; 32]);
 
-        let a: [T; 16] = rng.gen();
-        let b: [T; 16] = rng.gen();
+        let a: [T; 16] = rng.r#gen();
+        let b: [T; 16] = rng.r#gen();
 
         let a_full: EncodedValue<_> = encoder.encode_by_type(0, &<[T; 16]>::value_type());
         let b_full: EncodedValue<_> = encoder.encode_by_type(1, &<[T; 16]>::value_type());

--- a/crates/mpz-garble-core/src/encoding/value.rs
+++ b/crates/mpz-garble-core/src/encoding/value.rs
@@ -817,7 +817,7 @@ mod tests {
     {
         let mut rng = ChaCha12Rng::from_seed([0u8; 32]);
 
-        let value: T = rng.gen();
+        let value: T = rng.r#gen();
 
         let encoded: EncodedValue<_> = encoder.encode_by_type(0, &T::value_type());
         let decoding = encoded.decoding();

--- a/crates/mpz-garble-core/src/generator.rs
+++ b/crates/mpz-garble-core/src/generator.rs
@@ -378,8 +378,8 @@ mod tests {
             .map(|input| encoder.encode_by_type(0, &input.value_type()))
             .collect();
 
-        let mut gen = Generator::default();
-        let mut gate_iter = gen.generate(&AES128, encoder.delta(), inputs).unwrap();
+        let mut r#gen = Generator::default();
+        let mut gate_iter = r#gen.generate(&AES128, encoder.delta(), inputs).unwrap();
 
         let enc_gates: Vec<EncryptedGate> = gate_iter.by_ref().collect();
 
@@ -408,8 +408,8 @@ mod tests {
             .map(|input| encoder.encode_by_type(0, &input.value_type()))
             .collect();
 
-        let mut gen = Generator::default();
-        let mut gate_iter = gen
+        let mut r#gen = Generator::default();
+        let mut gate_iter = r#gen
             .generate_batched(&circ, encoder.delta(), inputs)
             .unwrap();
 

--- a/crates/mpz-garble-core/src/lib.rs
+++ b/crates/mpz-garble-core/src/lib.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_and_gate() {
-        use crate::{evaluator as ev, generator as gen};
+        use crate::{evaluator as ev, generator as r#gen};
 
         let mut rng = ChaCha12Rng::seed_from_u64(0);
         let cipher = &(*FIXED_KEY_AES);
@@ -106,7 +106,7 @@ mod tests {
         let y_1 = y_0 ^ delta;
         let gid: usize = 1;
 
-        let (z_0, encrypted_gate) = gen::and_gate(cipher, &x_0, &y_0, &delta, gid);
+        let (z_0, encrypted_gate) = r#gen::and_gate(cipher, &x_0, &y_0, &delta, gid);
         let z_1 = z_0 ^ delta;
 
         assert_eq!(ev::and_gate(cipher, &x_0, &y_0, &encrypted_gate, gid), z_0);
@@ -140,10 +140,10 @@ mod tests {
             full_inputs[1].clone().select(msg).unwrap(),
         ];
 
-        let mut gen = Generator::default();
+        let mut r#gen = Generator::default();
         let mut ev = Evaluator::default();
 
-        let mut gen_iter = gen
+        let mut gen_iter = r#gen
             .generate_batched(&AES128, encoder.delta(), full_inputs)
             .unwrap();
         let mut ev_consumer = ev.evaluate_batched(&AES128, active_inputs).unwrap();
@@ -192,7 +192,7 @@ mod tests {
         let circ = builder.build().unwrap();
         assert_eq!(circ.and_count(), 0);
 
-        let mut gen = Generator::default();
+        let mut r#gen = Generator::default();
         let mut ev = Evaluator::default();
 
         let a = 1u8;
@@ -209,7 +209,7 @@ mod tests {
             full_inputs[1].clone().select(b).unwrap(),
         ];
 
-        let mut gen_iter = gen
+        let mut gen_iter = r#gen
             .generate_batched(&circ, encoder.delta(), full_inputs)
             .unwrap();
         let mut ev_consumer = ev.evaluate_batched(&circ, active_inputs).unwrap();

--- a/crates/mpz-garble/src/generator/mod.rs
+++ b/crates/mpz-garble/src/generator/mod.rs
@@ -311,8 +311,8 @@ impl Generator {
         } = ctx
             .blocking(scoped!(move |ctx| async move {
                 let _enter = span.enter();
-                let mut gen = GeneratorCore::default();
-                let mut gen_iter = gen.generate_batched(&circ, delta, inputs)?;
+                let mut r#gen = GeneratorCore::default();
+                let mut gen_iter = r#gen.generate_batched(&circ, delta, inputs)?;
                 let io = ctx.io_mut();
 
                 if hash {

--- a/crates/mpz-garble/src/protocol/deap/memory.rs
+++ b/crates/mpz-garble/src/protocol/deap/memory.rs
@@ -12,7 +12,7 @@ impl Memory for DEAP {
         visibility: Visibility,
     ) -> Result<ValueRef, MemoryError> {
         let value_ref = self.state().memory.new_input(id, typ.clone(), visibility)?;
-        self.gen.generate_input_encoding(&value_ref, &typ);
+        self.r#gen.generate_input_encoding(&value_ref, &typ);
         Ok(value_ref)
     }
 

--- a/crates/mpz-garble/tests/offline-garble.rs
+++ b/crates/mpz-garble/tests/offline-garble.rs
@@ -9,7 +9,7 @@ async fn test_offline_garble() {
     let (mut ctx_a, mut ctx_b) = test_st_executor(8);
     let (mut ot_send, mut ot_recv) = ideal_ot();
 
-    let gen = Generator::new(
+    let r#gen = Generator::new(
         GeneratorConfigBuilder::default().build().unwrap(),
         [0u8; 32],
     );
@@ -35,10 +35,10 @@ async fn test_offline_garble() {
             .new_output("ciphertext", ciphertext_typ.clone())
             .unwrap();
 
-        gen.generate_input_encoding(&key_ref, &key_typ);
-        gen.generate_input_encoding(&msg_ref, &msg_typ);
+        r#gen.generate_input_encoding(&key_ref, &key_typ);
+        r#gen.generate_input_encoding(&msg_ref, &msg_typ);
 
-        gen.generate(
+        r#gen.generate(
             &mut ctx_a,
             AES128.clone(),
             &[key_ref.clone(), msg_ref.clone()],
@@ -50,7 +50,7 @@ async fn test_offline_garble() {
 
         memory.assign(&key_ref, key.into()).unwrap();
 
-        gen.setup_assigned_values(
+        r#gen.setup_assigned_values(
             &mut ctx_a,
             &memory.drain_assigned(&[key_ref.clone(), msg_ref.clone()]),
             &mut ot_send,
@@ -58,7 +58,7 @@ async fn test_offline_garble() {
         .await
         .unwrap();
 
-        gen.get_encoding(&ciphertext_ref).unwrap()
+        r#gen.get_encoding(&ciphertext_ref).unwrap()
     };
 
     let ev_fut = async {

--- a/crates/mpz-garble/tests/semihonest.rs
+++ b/crates/mpz-garble/tests/semihonest.rs
@@ -9,7 +9,7 @@ async fn test_semi_honest() {
     let (mut ctx_a, mut ctx_b) = test_st_executor(8);
     let (mut ot_send, mut ot_recv) = ideal_ot();
 
-    let gen = Generator::new(
+    let r#gen = Generator::new(
         GeneratorConfigBuilder::default().build().unwrap(),
         [0u8; 32],
     );
@@ -37,10 +37,10 @@ async fn test_semi_honest() {
 
         memory.assign(&key_ref, key.into()).unwrap();
 
-        gen.generate_input_encoding(&key_ref, &key_typ);
-        gen.generate_input_encoding(&msg_ref, &msg_typ);
+        r#gen.generate_input_encoding(&key_ref, &key_typ);
+        r#gen.generate_input_encoding(&msg_ref, &msg_typ);
 
-        gen.setup_assigned_values(
+        r#gen.setup_assigned_values(
             &mut ctx_a,
             &memory.drain_assigned(&[key_ref.clone(), msg_ref.clone()]),
             &mut ot_send,
@@ -48,7 +48,7 @@ async fn test_semi_honest() {
         .await
         .unwrap();
 
-        gen.generate(
+        r#gen.generate(
             &mut ctx_a,
             AES128.clone(),
             &[key_ref.clone(), msg_ref.clone()],
@@ -58,7 +58,7 @@ async fn test_semi_honest() {
         .await
         .unwrap();
 
-        gen.get_encoding(&ciphertext_ref).unwrap()
+        r#gen.get_encoding(&ciphertext_ref).unwrap()
     };
 
     let ev_fut = async {

--- a/crates/mpz-ot-core/benches/ot.rs
+++ b/crates/mpz-ot-core/benches/ot.rs
@@ -40,7 +40,7 @@ fn kos(c: &mut Criterion) {
             let delta = Block::random(&mut rng);
             let chi_seed = Block::random(&mut rng);
 
-            let receiver_seeds: [[Block; 2]; 128] = std::array::from_fn(|_| [rng.gen(), rng.gen()]);
+            let receiver_seeds: [[Block; 2]; 128] = std::array::from_fn(|_| [rng.r#gen(), rng.r#gen()]);
             let sender_seeds: [Block; 128] = delta
                 .iter_lsb0()
                 .zip(receiver_seeds)

--- a/crates/mpz-ot-core/src/chou_orlandi/mod.rs
+++ b/crates/mpz-ot-core/src/chou_orlandi/mod.rs
@@ -51,14 +51,14 @@ mod tests {
     #[fixture]
     fn choices() -> Vec<bool> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
-        (0..128).map(|_| rng.gen()).collect()
+        (0..128).map(|_| rng.r#gen()).collect()
     }
 
     #[fixture]
     fn data() -> Vec<[Block; 2]> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
         (0..128)
-            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .map(|_| [rng.r#gen::<[u8; 16]>().into(), rng.r#gen::<[u8; 16]>().into()])
             .collect()
     }
 

--- a/crates/mpz-ot-core/src/ferret/spcot/sender.rs
+++ b/crates/mpz-ot-core/src/ferret/spcot/sender.rs
@@ -93,7 +93,7 @@ impl Sender<state::Extension> {
         let mut k0 = vec![Block::ZERO; h];
         let mut k1 = vec![Block::ZERO; h];
         let mut tree = vec![Block::ZERO; 1 << h];
-        ggm_tree.gen(s, &mut tree, &mut k0, &mut k1);
+        ggm_tree.r#gen(s, &mut tree, &mut k0, &mut k1);
 
         // Stores the tree, i.e., the possible output of sender.
         self.state.unchecked_vs.extend_from_slice(&tree);

--- a/crates/mpz-ot-core/src/ideal/cot.rs
+++ b/crates/mpz-ot-core/src/ideal/cot.rs
@@ -125,7 +125,7 @@ impl IdealCOT {
 impl Default for IdealCOT {
     fn default() -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        Self::new(rng.gen(), rng.gen())
+        Self::new(rng.r#gen(), rng.r#gen())
     }
 }
 

--- a/crates/mpz-ot-core/src/ideal/mpcot.rs
+++ b/crates/mpz-ot-core/src/ideal/mpcot.rs
@@ -69,7 +69,7 @@ impl IdealMpcot {
 impl Default for IdealMpcot {
     fn default() -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        IdealMpcot::new(rng.gen(), rng.gen())
+        IdealMpcot::new(rng.r#gen(), rng.r#gen())
     }
 }
 

--- a/crates/mpz-ot-core/src/ideal/ot.rs
+++ b/crates/mpz-ot-core/src/ideal/ot.rs
@@ -75,7 +75,7 @@ mod tests {
         let mut choices = vec![false; 100];
         rng.fill(&mut choices[..]);
 
-        let msgs: Vec<[Block; 2]> = (0..100).map(|_| [rng.gen(), rng.gen()]).collect();
+        let msgs: Vec<[Block; 2]> = (0..100).map(|_| [rng.r#gen(), rng.r#gen()]).collect();
 
         let (OTSenderOutput { .. }, OTReceiverOutput { msgs: chosen, .. }) =
             IdealOT::default().chosen(choices.clone(), msgs.clone());

--- a/crates/mpz-ot-core/src/ideal/rot.rs
+++ b/crates/mpz-ot-core/src/ideal/rot.rs
@@ -119,7 +119,7 @@ impl IdealROT {
 impl Default for IdealROT {
     fn default() -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        Self::new(rng.gen())
+        Self::new(rng.r#gen())
     }
 }
 

--- a/crates/mpz-ot-core/src/kos/mod.rs
+++ b/crates/mpz-ot-core/src/kos/mod.rs
@@ -57,27 +57,27 @@ mod tests {
     #[fixture]
     fn choices() -> Vec<bool> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
-        (0..128).map(|_| rng.gen()).collect()
+        (0..128).map(|_| rng.r#gen()).collect()
     }
 
     #[fixture]
     fn data() -> Vec<[Block; 2]> {
         let mut rng = ChaCha12Rng::seed_from_u64(1);
         (0..128)
-            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .map(|_| [rng.r#gen::<[u8; 16]>().into(), rng.r#gen::<[u8; 16]>().into()])
             .collect()
     }
 
     #[fixture]
     fn delta() -> Block {
         let mut rng = ChaCha12Rng::seed_from_u64(2);
-        rng.gen::<[u8; 16]>().into()
+        rng.r#gen::<[u8; 16]>().into()
     }
 
     #[fixture]
     fn receiver_seeds() -> [[Block; 2]; CSP] {
         let mut rng = ChaCha12Rng::seed_from_u64(3);
-        std::array::from_fn(|_| [rng.gen(), rng.gen()])
+        std::array::from_fn(|_| [rng.r#gen(), rng.r#gen()])
     }
 
     #[fixture]
@@ -94,7 +94,7 @@ mod tests {
     #[fixture]
     fn chi_seed() -> Block {
         let mut rng = ChaCha12Rng::seed_from_u64(4);
-        rng.gen::<[u8; 16]>().into()
+        rng.r#gen::<[u8; 16]>().into()
     }
 
     #[fixture]

--- a/crates/mpz-ot-core/src/kos/receiver.rs
+++ b/crates/mpz-ot-core/src/kos/receiver.rs
@@ -153,7 +153,7 @@ impl Receiver<state::Extension> {
         let mut rng = thread_rng();
         // x₁,...,xₗ bits in Figure 3, step 1.
         let choices = (0..row_width)
-            .flat_map(|_| rng.gen::<u8>().into_iter_lsb0())
+            .flat_map(|_| rng.r#gen::<u8>().into_iter_lsb0())
             .collect::<Vec<_>>();
 
         // 𝐱ⁱ in Figure 3. Note that it is the same for all i = 1,...,k.

--- a/crates/mpz-ot-core/src/kos/sender.rs
+++ b/crates/mpz-ot-core/src/kos/sender.rs
@@ -217,7 +217,7 @@ impl Sender<state::Extension> {
         // Figure 7, "Check correlation", point 1.
         // Sample random weights for the consistency check.
         let chis = (0..unchecked_qs.len())
-            .map(|_| rng.gen())
+            .map(|_| rng.r#gen())
             .collect::<Vec<_>>();
 
         // Figure 7, "Check correlation", point 3.
@@ -397,7 +397,7 @@ impl SenderKeys {
 
         // Generate a random IV which is used for all messages.
         // This is safe because every message is encrypted with a different key.
-        let iv: [u8; 16] = rand::thread_rng().gen();
+        let iv: [u8; 16] = rand::thread_rng().r#gen();
 
         // If we have derandomization, use it to correct the receiver's choices, else we use
         // default

--- a/crates/mpz-ot/src/chou_orlandi/mod.rs
+++ b/crates/mpz-ot/src/chou_orlandi/mod.rs
@@ -66,14 +66,14 @@ mod tests {
     #[fixture]
     fn choices() -> Vec<bool> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
-        (0..128).map(|_| rng.gen()).collect()
+        (0..128).map(|_| rng.r#gen()).collect()
     }
 
     #[fixture]
     fn data() -> Vec<[Block; 2]> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
         (0..128)
-            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .map(|_| [rng.r#gen::<[u8; 16]>().into(), rng.r#gen::<[u8; 16]>().into()])
             .collect()
     }
 

--- a/crates/mpz-ot/src/chou_orlandi/receiver.rs
+++ b/crates/mpz-ot/src/chou_orlandi/receiver.rs
@@ -98,7 +98,7 @@ impl<Ctx: Context> OTSetup<Ctx> for Receiver {
                 ))?;
             }
 
-            let cointoss_seed = thread_rng().gen();
+            let cointoss_seed = thread_rng().r#gen();
             let (seeds, cointoss_sender) = cointoss::Sender::new(vec![cointoss_seed])
                 .commit(ctx)
                 .await
@@ -117,7 +117,7 @@ impl<Ctx: Context> OTSetup<Ctx> for Receiver {
 
             stretched_seed
         } else {
-            seed.unwrap_or_else(|| thread_rng().gen())
+            seed.unwrap_or_else(|| thread_rng().r#gen())
         };
 
         let sender_setup = ctx.io_mut().expect_next().await?;

--- a/crates/mpz-ot/src/chou_orlandi/sender.rs
+++ b/crates/mpz-ot/src/chou_orlandi/sender.rs
@@ -80,7 +80,7 @@ impl<Ctx: Context> OTSetup<Ctx> for Sender {
 
         // If the receiver is committed, we run the cointoss protocol
         if sender.config().receiver_commit() {
-            let cointoss_seed = thread_rng().gen();
+            let cointoss_seed = thread_rng().r#gen();
             self.cointoss_receiver = Some(
                 cointoss::Receiver::new(vec![cointoss_seed])
                     .receive(ctx)

--- a/crates/mpz-ot/src/ideal/cot.rs
+++ b/crates/mpz-ot/src/ideal/cot.rs
@@ -166,7 +166,7 @@ mod tests {
         let delta = alice.0.get_mut().delta();
 
         let count = 10;
-        let choices = (0..count).map(|_| rng.gen()).collect::<Vec<bool>>();
+        let choices = (0..count).map(|_| rng.r#gen()).collect::<Vec<bool>>();
 
         let (
             COTSenderOutput {

--- a/crates/mpz-ot/src/kos/mod.rs
+++ b/crates/mpz-ot/src/kos/mod.rs
@@ -52,14 +52,14 @@ mod tests {
     #[fixture]
     fn choices() -> Vec<bool> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
-        (0..128).map(|_| rng.gen()).collect()
+        (0..128).map(|_| rng.r#gen()).collect()
     }
 
     #[fixture]
     fn data() -> Vec<[Block; 2]> {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
         (0..128)
-            .map(|_| [rng.gen::<[u8; 16]>().into(), rng.gen::<[u8; 16]>().into()])
+            .map(|_| [rng.r#gen::<[u8; 16]>().into(), rng.r#gen::<[u8; 16]>().into()])
             .collect()
     }
 

--- a/crates/mpz-ot/src/kos/receiver.rs
+++ b/crates/mpz-ot/src/kos/receiver.rs
@@ -116,7 +116,7 @@ where
         ctx.io_mut().flush().await?;
 
         // Sample chi_seed with coin-toss.
-        let seed = thread_rng().gen();
+        let seed = thread_rng().r#gen();
         let chi_seed = cointoss::cointoss_sender(ctx, vec![seed]).await?[0];
 
         // Compute consistency check.
@@ -193,7 +193,7 @@ where
 
         // If the sender is committed, we run a coin toss
         if ext_receiver.config().sender_commit() {
-            let cointoss_seed = thread_rng().gen();
+            let cointoss_seed = thread_rng().r#gen();
             let (cointoss_receiver, _) = try_join!(
                 ctx,
                 cointoss::Receiver::new(vec![cointoss_seed])
@@ -207,7 +207,7 @@ where
             self.base.setup(ctx).await?;
         }
 
-        let seeds: [[Block; 2]; CSP] = std::array::from_fn(|_| thread_rng().gen());
+        let seeds: [[Block; 2]; CSP] = std::array::from_fn(|_| thread_rng().r#gen());
 
         // Send seeds to sender
         self.base.send(ctx, &seeds).await?;
@@ -310,7 +310,7 @@ where
         let id = keys.id();
         let (choices, keys) = keys.take_choices_and_keys();
 
-        let msgs = keys.into_iter().map(|k| Prg::from_seed(k).gen()).collect();
+        let msgs = keys.into_iter().map(|k| Prg::from_seed(k).r#gen()).collect();
 
         Ok(ROTReceiverOutput { id, choices, msgs })
     }

--- a/crates/mpz-ot/src/kos/sender.rs
+++ b/crates/mpz-ot/src/kos/sender.rs
@@ -166,7 +166,7 @@ impl<BaseOT: Send> Sender<BaseOT> {
             Backend::spawn(move || ext_sender.extend(count, extend).map(|_| ext_sender)).await?;
 
         // Sample chi_seed with coin-toss.
-        let seed: Block = thread_rng().gen();
+        let seed: Block = thread_rng().r#gen();
         let chi_seed = cointoss::cointoss_receiver(ctx, vec![seed]).await?[0];
 
         // Receive the receiver's check.
@@ -229,7 +229,7 @@ where
 
         // If the sender is committed, we sample delta using a coin toss.
         let delta = if sender.config().sender_commit() {
-            let cointoss_seed = thread_rng().gen();
+            let cointoss_seed = thread_rng().r#gen();
 
             // Execute coin-toss protocol and base OT setup concurrently.
             let ((seeds, cointoss_sender), _) = try_join!(
@@ -387,7 +387,7 @@ where
                 let mut prg_0 = Prg::from_seed(k0);
                 let mut prg_1 = Prg::from_seed(k1);
 
-                [prg_0.gen::<T>(), prg_1.gen::<T>()]
+                [prg_0.r#gen::<T>(), prg_1.r#gen::<T>()]
             })
             .collect();
 


### PR DESCRIPTION
RUSTFLAGS="-D keyword_idents_2024" cargo clippy --fix fixes #180