### PR TITLE
Refactor: optimize gate branching

### DIFF
--- a/crates/mpz-core/src/block.rs
+++ b/crates/mpz-core/src/block.rs
@@ -9,7 +9,7 @@ use rand::{distributions::Standard, prelude::Distribution, CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 
 /// A block of 128 bits
-#[repr(transparent)]
+#[repr(C, align(16))]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, Pod, Zeroable)]
 pub struct Block([u8; 16]);
 

--- a/crates/mpz-garble-core/src/encoding/mod.rs
+++ b/crates/mpz-garble-core/src/encoding/mod.rs
@@ -272,6 +272,7 @@ impl<const N: usize, S: LabelState> Index<usize> for Labels<N, S> {
 }
 
 /// Encoded bit label.
+#[repr(transparent)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Label(Block);
 

--- a/crates/mpz-garble-core/src/generator.rs
+++ b/crates/mpz-garble-core/src/generator.rs
@@ -255,27 +255,31 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(gate) = self.gates.next() {
+        // Cache the labels slice locally for faster access
+        let labels = &mut self.labels;
+        let gates = &mut self.gates;
+
+        while let Some(gate) = gates.next() {
             match gate {
                 Gate::Xor {
                     x: node_x,
                     y: node_y,
                     z: node_z,
                 } => {
-                    let x_0 = self.labels[node_x.id()];
-                    let y_0 = self.labels[node_y.id()];
-                    self.labels[node_z.id()] = x_0 ^ y_0;
+                    let x_0 = labels[node_x.id()];
+                    let y_0 = labels[node_y.id()];
+                    labels[node_z.id()] = x_0 ^ y_0;
                 }
                 Gate::And {
                     x: node_x,
                     y: node_y,
                     z: node_z,
                 } => {
-                    let x_0 = self.labels[node_x.id()];
-                    let y_0 = self.labels[node_y.id()];
+                    let x_0 = labels[node_x.id()];
+                    let y_0 = labels[node_y.id()];
                     let (z_0, encrypted_gate) =
                         and_gate(self.cipher, &x_0, &y_0, &self.delta, self.gid);
-                    self.labels[node_z.id()] = z_0;
+                    labels[node_z.id()] = z_0;
 
                     self.gid += 2;
                     self.counter += 1;
@@ -298,8 +302,8 @@ where
                     x: node_x,
                     z: node_z,
                 } => {
-                    let x_0 = self.labels[node_x.id()];
-                    self.labels[node_z.id()] = x_0 ^ self.delta;
+                    let x_0 = labels[node_x.id()];
+                    labels[node_z.id()] = x_0 ^ self.delta;
                 }
             }
         }

--- a/crates/mpz-garble-core/src/generator.rs
+++ b/crates/mpz-garble-core/src/generator.rs
@@ -261,25 +261,17 @@ where
 
         while let Some(gate) = gates.next() {
             match gate {
-                Gate::Xor {
-                    x: node_x,
-                    y: node_y,
-                    z: node_z,
-                } => {
-                    let x_0 = labels[node_x.id()];
-                    let y_0 = labels[node_y.id()];
-                    labels[node_z.id()] = x_0 ^ y_0;
+                Gate::Xor { x, y, z, } => {
+                    let x_0 = labels[x.id()];
+                    let y_0 = labels[y.id()];
+                    labels[z.id()] = x_0 ^ y_0;
                 }
-                Gate::And {
-                    x: node_x,
-                    y: node_y,
-                    z: node_z,
-                } => {
-                    let x_0 = labels[node_x.id()];
-                    let y_0 = labels[node_y.id()];
+                Gate::And { x, y, z, } => {
+                    let x_0 = labels[x.id()];
+                    let y_0 = labels[y.id()];
                     let (z_0, encrypted_gate) =
                         and_gate(self.cipher, &x_0, &y_0, &self.delta, self.gid);
-                    labels[node_z.id()] = z_0;
+                    labels[z.id()] = z_0;
 
                     self.gid += 2;
                     self.counter += 1;
@@ -298,12 +290,10 @@ where
 
                     return Some(encrypted_gate);
                 }
-                Gate::Inv {
-                    x: node_x,
-                    z: node_z,
-                } => {
-                    let x_0 = labels[node_x.id()];
-                    labels[node_z.id()] = x_0 ^ self.delta;
+                Gate::Inv { x,
+                    z, } => {
+                    let x_0 = labels[x.id()];
+                    labels[z.id()] = x_0 ^ self.delta;
                 }
             }
         }


### PR DESCRIPTION
## Related Issue
- #142 

## Implementation
**Adjusted struct field types to ensure 16-byte memory alignment and C-compatibility on frequently accessed fields.**
- crates/mpz-core/src/block.rs
- crates/mpz-garble-core/src/encoding/mod.rs
```Rust
#[repr(C, align(16))]

pub struct Block([u8; 16]);
```

**Move frequently accessed struct fields outside the loop.**
- crates/mpz-garble-core/src/generator.rs
- crates/mpz-garble-core/src/evaluator.rs
```Rust
let labels = &mut self.labels;
let gates = &mut self.gates;
while let Some(gate) = gates.next() {
    match gate {
        Gate::Xor { x, y, z, } => {
            let x_label = labels[x.id()];
            let y_label = labels[y.id()];
            labels[z.id()] = x_label ^ y_label;
```

**Omitted field name shadowing.**
- crates/mpz-garble-core/src/generator.rs
- crates/mpz-garble-core/src/evaluator.rs
```Rust
Gate::Xor { x, y, z, } => {
```

## Result
Garbling: Approximately 6-9% speed improvement
Evaluation: No significant change

![image](https://github.com/user-attachments/assets/8946ade9-c02a-4b93-89ea-bd282fa8ddda)

garble/aes128
![image](https://github.com/user-attachments/assets/a38c3e83-0cd5-4274-b9b4-75f6aa470956)

garble/aes128_batched
![image](https://github.com/user-attachments/assets/0d789f4b-791d-4a01-a6a0-177357aaa4c9)

garble/aes128_with_hash
![image](https://github.com/user-attachments/assets/8d6b215c-6cbe-4947-be98-3ecd3ca8a4c1)

evaluate/aes128
![image](https://github.com/user-attachments/assets/f34fad79-1a16-446b-b2d7-75dcf5eb988e)

## 