### PR TITLE
fix(share-conversion): broken features

### DIFF
--- a/crates/mpz-share-conversion/Cargo.toml
+++ b/crates/mpz-share-conversion/Cargo.toml
@@ -11,7 +11,7 @@ name = "mpz_share_conversion"
 
 [features]
 default = []
-test-utils = ["mpz-share-conversion-core/test-utils", "mpz-common/executor", "mpz-common/test-utils", "dep:tokio"]
+test-utils = ["mpz-share-conversion-core/test-utils"]
 
 [dependencies]
 mpz-core = { workspace = true }
@@ -24,23 +24,15 @@ thiserror.workspace = true
 async-trait.workspace = true
 serio.workspace = true
 rand.workspace = true
-tokio = { workspace = true, optional = true, features = [
-    "net",
-    "macros",
-    "rt",
-    "rt-multi-thread",
-] }
 
 [dev-dependencies]
 mpz-share-conversion-core = { workspace = true, features = ["test-utils"] }
 mpz-ole = { workspace = true, features = ["test-utils"] }
 mpz-common = { workspace = true, features = ["executor", "test-utils"] }
 mpz-core.workspace = true
-
 tokio = { workspace = true, features = [
     "net",
     "macros",
     "rt",
     "rt-multi-thread",
 ] }
-

--- a/crates/mpz-share-conversion/Cargo.toml
+++ b/crates/mpz-share-conversion/Cargo.toml
@@ -11,7 +11,7 @@ name = "mpz_share_conversion"
 
 [features]
 default = []
-test-utils = ["mpz-share-conversion-core/test-utils"]
+test-utils = ["mpz-share-conversion-core/test-utils", "mpz-common/executor", "mpz-common/test-utils", "dep:tokio"]
 
 [dependencies]
 mpz-core = { workspace = true }
@@ -24,15 +24,23 @@ thiserror.workspace = true
 async-trait.workspace = true
 serio.workspace = true
 rand.workspace = true
+tokio = { workspace = true, optional = true, features = [
+    "net",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
 
 [dev-dependencies]
 mpz-share-conversion-core = { workspace = true, features = ["test-utils"] }
 mpz-ole = { workspace = true, features = ["test-utils"] }
 mpz-common = { workspace = true, features = ["executor", "test-utils"] }
 mpz-core.workspace = true
+
 tokio = { workspace = true, features = [
     "net",
     "macros",
     "rt",
     "rt-multi-thread",
 ] }
+

--- a/crates/mpz-share-conversion/src/ideal.rs
+++ b/crates/mpz-share-conversion/src/ideal.rs
@@ -1,3 +1,5 @@
+//! Ideal functionalities.
+
 use crate::{AdditiveToMultiplicative, MultiplicativeToAdditive};
 use async_trait::async_trait;
 use mpz_common::Flush;

--- a/crates/mpz-share-conversion/src/lib.rs
+++ b/crates/mpz-share-conversion/src/lib.rs
@@ -9,7 +9,7 @@
 pub mod ideal;
 mod receiver;
 mod sender;
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(test)]
 pub mod test;
 
 pub use mpz_share_conversion_core::{

--- a/crates/mpz-share-conversion/src/lib.rs
+++ b/crates/mpz-share-conversion/src/lib.rs
@@ -10,7 +10,7 @@ pub mod ideal;
 mod receiver;
 mod sender;
 #[cfg(test)]
-pub mod test;
+mod test;
 
 pub use mpz_share_conversion_core::{
     A2MOutput, AdditiveToMultiplicative, M2AOutput, MultiplicativeToAdditive, ShareConvert,

--- a/crates/mpz-share-conversion/src/test.rs
+++ b/crates/mpz-share-conversion/src/test.rs
@@ -12,7 +12,7 @@ use mpz_share_conversion_core::{
 use rand::{rngs::StdRng, SeedableRng};
 
 /// Test share conversion.
-pub async fn test_share_convert<S, R, F>(mut sender: S, mut receiver: R, cycles: usize)
+pub(crate) async fn test_share_convert<S, R, F>(mut sender: S, mut receiver: R, cycles: usize)
 where
     S: ShareConvert<F> + Flush<TestSTExecutor>,
     R: ShareConvert<F> + Flush<TestSTExecutor>,


### PR DESCRIPTION
Fix dependencies for `mpz-share-conversion` so that all features compile.