### PR TITLE
refactor(common): replace Output associated type with generic

### DIFF
--- a/crates/mpz-ole-core/src/role.rs
+++ b/crates/mpz-ole-core/src/role.rs
@@ -16,7 +16,7 @@ pub trait ROLESender<F> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = ROLESenderOutput<F>>;
+    type Future: Output<ROLESenderOutput<F>>;
 
     /// Allocates `count` ROLE for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -45,7 +45,7 @@ pub trait ROLEReceiver<F> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = ROLEReceiverOutput<F>>;
+    type Future: Output<ROLEReceiverOutput<F>>;
 
     /// Allocates `count` ROLE for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;

--- a/crates/mpz-ot-core/src/cot.rs
+++ b/crates/mpz-ot-core/src/cot.rs
@@ -22,7 +22,7 @@ pub trait COTSender<T> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = COTSenderOutput>;
+    type Future: Output<COTSenderOutput>;
 
     /// Allocates `count` COTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -55,7 +55,7 @@ pub trait COTReceiver<T, U> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = COTReceiverOutput<U>>;
+    type Future: Output<COTReceiverOutput<U>>;
 
     /// Allocates `count` COTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;

--- a/crates/mpz-ot-core/src/ot.rs
+++ b/crates/mpz-ot-core/src/ot.rs
@@ -16,7 +16,7 @@ pub trait OTSender<T> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = OTSenderOutput>;
+    type Future: Output<OTSenderOutput>;
 
     /// Allocates `count` OTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -43,7 +43,7 @@ pub trait OTReceiver<T, U> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = OTReceiverOutput<U>>;
+    type Future: Output<OTReceiverOutput<U>>;
 
     /// Allocates `count` OTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;

--- a/crates/mpz-ot-core/src/rcot.rs
+++ b/crates/mpz-ot-core/src/rcot.rs
@@ -18,7 +18,7 @@ pub trait RCOTSender<T> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = RCOTSenderOutput<T>>;
+    type Future: Output<RCOTSenderOutput<T>>;
 
     /// Allocates `count` RCOTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -60,7 +60,7 @@ pub trait RCOTReceiver<T, U> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = RCOTReceiverOutput<T, U>>;
+    type Future: Output<RCOTReceiverOutput<T, U>>;
 
     /// Allocates `count` RCOTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;

--- a/crates/mpz-ot-core/src/rot.rs
+++ b/crates/mpz-ot-core/src/rot.rs
@@ -24,7 +24,7 @@ pub trait ROTSender<T> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = ROTSenderOutput<T>>;
+    type Future: Output<ROTSenderOutput<T>>;
 
     /// Allocates `count` ROTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -63,7 +63,7 @@ pub trait ROTReceiver<T, U> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = ROTReceiverOutput<T, U>>;
+    type Future: Output<ROTReceiverOutput<T, U>>;
 
     /// Allocates `count` ROTs for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;

--- a/crates/mpz-ot-core/src/rot/any.rs
+++ b/crates/mpz-ot-core/src/rot/any.rs
@@ -38,7 +38,11 @@ where
     Standard: Distribution<U>,
 {
     type Error = T::Error;
-    type Future = Map<T::Future, fn(ROTSenderOutput<[Block; 2]>) -> ROTSenderOutput<[U; 2]>>;
+    type Future = Map<
+        T::Future,
+        ROTSenderOutput<[Block; 2]>,
+        fn(ROTSenderOutput<[Block; 2]>) -> ROTSenderOutput<[U; 2]>,
+    >;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
         self.rot.alloc(count)
@@ -110,7 +114,11 @@ where
     Standard: Distribution<U>,
 {
     type Error = T::Error;
-    type Future = Map<T::Future, fn(ROTReceiverOutput<bool, Block>) -> ROTReceiverOutput<bool, U>>;
+    type Future = Map<
+        T::Future,
+        ROTReceiverOutput<bool, Block>,
+        fn(ROTReceiverOutput<bool, Block>) -> ROTReceiverOutput<bool, U>,
+    >;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
         self.rot.alloc(count)

--- a/crates/mpz-ot-core/src/rot/randomize.rs
+++ b/crates/mpz-ot-core/src/rot/randomize.rs
@@ -46,7 +46,7 @@ where
     T: RCOTSender<Block>,
 {
     type Error = T::Error;
-    type Future = Map<T::Future, FnSender>;
+    type Future = Map<T::Future, RCOTSenderOutput<Block>, FnSender>;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
         self.rcot.alloc(count)
@@ -137,8 +137,11 @@ where
     T: RCOTReceiver<bool, Block>,
 {
     type Error = T::Error;
-    type Future =
-        Map<T::Future, fn(RCOTReceiverOutput<bool, Block>) -> ROTReceiverOutput<bool, Block>>;
+    type Future = Map<
+        T::Future,
+        RCOTReceiverOutput<bool, Block>,
+        fn(RCOTReceiverOutput<bool, Block>) -> ROTReceiverOutput<bool, Block>,
+    >;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
         self.rcot.alloc(count)

--- a/crates/mpz-share-conversion-core/src/lib.rs
+++ b/crates/mpz-share-conversion-core/src/lib.rs
@@ -31,7 +31,7 @@ pub trait AdditiveToMultiplicative<F> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = A2MOutput<F>>;
+    type Future: Output<A2MOutput<F>>;
 
     /// Allocates `count` A2M for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;
@@ -52,7 +52,7 @@ pub trait MultiplicativeToAdditive<F> {
     /// Error type.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Future type.
-    type Future: Output<Ok = M2AOutput<F>>;
+    type Future: Output<M2AOutput<F>>;
 
     /// Allocates `count` M2A for preprocessing.
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error>;


### PR DESCRIPTION
This PR replaces the `Output` trait `Ok` type with a generic. I ran into an issue trying to box and output and forgot that it forces you to fully qualify associated types in Self bounds. So to box it you'd have to do something like `Box<dyn Output<Ok = T, Output = Result<T, Canceled>>` because of the `Self: Future<..>` bound