### PR TITLE
Fix deadlock for garble-vm

### DIFF
--- a/crates/mpz-garble-core/src/view.rs
+++ b/crates/mpz-garble-core/src/view.rs
@@ -207,10 +207,6 @@ impl View {
 
         self.output.preprocessed |= &range;
         self.output.complete |= &range;
-
-        // If we want to use the output as input for another circuit
-        self.input.complete |= &range;
-
         // If marked for decoding, transfer decode info.
         self.flush.decode_info |= range.intersection(&self.decode.all) - &self.decode.decode_info;
         // If decoding info transferred, prove MACs.
@@ -220,7 +216,7 @@ impl View {
     }
 
     pub(crate) fn is_committed(&self, range: Range) -> bool {
-        range.is_subset(&self.input.complete)
+        range.is_subset(&self.input.complete) || range.is_subset(&self.output.complete)
     }
 
     pub(crate) fn commit(&mut self, range: Range) -> Result<()> {

--- a/crates/mpz-garble-core/src/view.rs
+++ b/crates/mpz-garble-core/src/view.rs
@@ -207,6 +207,10 @@ impl View {
 
         self.output.preprocessed |= &range;
         self.output.complete |= &range;
+
+        // If we want to use the output as input for another circuit
+        self.input.complete |= &range;
+
         // If marked for decoding, transfer decode info.
         self.flush.decode_info |= range.intersection(&self.decode.all) - &self.decode.decode_info;
         // If decoding info transferred, prove MACs.

--- a/crates/mpz-garble/src/protocol/semihonest/evaluator.rs
+++ b/crates/mpz-garble/src/protocol/semihonest/evaluator.rs
@@ -57,6 +57,7 @@ impl<COT> Evaluator<COT> {
                     idx_outputs |= output.to_range();
                     true
                 } else {
+                    idx_outputs |= output.to_range();
                     false
                 }
             })


### PR DESCRIPTION
This PR fixes the VM hanging, when circuit output ranges are used as input ranges for a new circuit. **The change fixes the curently hanging tests of the prf and cipher crates of tlsnotary.**

When a circuit is executed the input range corresponding to the output range of the circuit output is not marked as `complete`. This leads to `is_committed` returning false and the circuit never being executed.

**Questions**
1) Do we also need to touch `assigned` or `all` of `InputView`? Anything else which needs to be adapted for consistency?
2) Is this change compatible with the overall picture, because I get the idea that so far inputs and outputs are treated entirely different.