### PR TITLE
Fix CO15 mismatched length issue

### DIFF
--- a/crates/mpz-ot-core/src/chou_orlandi/error.rs
+++ b/crates/mpz-ot-core/src/chou_orlandi/error.rs
@@ -1,7 +1,7 @@
 use crate::TransferId;
 use serde::{Deserialize, Serialize};
 
-/// A KOS abort error.
+/// A Chou-Orlandi abort error.
 #[derive(Debug, Clone, Copy, thiserror::Error, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum AbortError {

--- a/crates/mpz-ot-core/src/chou_orlandi/error.rs
+++ b/crates/mpz-ot-core/src/chou_orlandi/error.rs
@@ -1,4 +1,13 @@
 use crate::TransferId;
+use serde::{Deserialize, Serialize};
+
+/// A KOS abort error.
+#[derive(Debug, Clone, Copy, thiserror::Error, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum AbortError {
+    #[error("mismatched OT batch lengths: expected {expected}, actual {actual}")]
+    MismatchedLengths { expected: usize, actual: usize },
+}
 
 /// Errors that can occur when using the CO15 sender.
 #[derive(Debug, thiserror::Error)]

--- a/crates/mpz-ot-core/src/chou_orlandi/mod.rs
+++ b/crates/mpz-ot-core/src/chou_orlandi/mod.rs
@@ -10,7 +10,7 @@ pub use config::{
     ReceiverConfig, ReceiverConfigBuilder, ReceiverConfigBuilderError, SenderConfig,
     SenderConfigBuilder, SenderConfigBuilderError,
 };
-pub use error::{ReceiverError, SenderError, SenderVerifyError};
+pub use error::{AbortError, ReceiverError, SenderError, SenderVerifyError};
 pub use receiver::{state as receiver_state, Receiver};
 pub use sender::{state as sender_state, Sender};
 

--- a/crates/mpz-ot/src/chou_orlandi/error.rs
+++ b/crates/mpz-ot/src/chou_orlandi/error.rs
@@ -1,3 +1,5 @@
+use mpz_ot_core::chou_orlandi::AbortError;
+
 use crate::OTError;
 
 /// A Chou-Orlandi sender error.
@@ -14,6 +16,8 @@ pub enum SenderError {
     CointossError(#[from] mpz_cointoss::CointossError),
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
+    #[error(transparent)]
+    AbortError(#[from] AbortError),
 }
 
 impl From<SenderError> for OTError {
@@ -45,6 +49,8 @@ pub enum ReceiverError {
     CointossError(#[from] mpz_cointoss::CointossError),
     #[error("invalid configuration: {0}")]
     InvalidConfig(String),
+    #[error(transparent)]
+    AbortError(#[from] AbortError),
 }
 
 impl From<ReceiverError> for OTError {

--- a/crates/mpz-ot/src/chou_orlandi/mod.rs
+++ b/crates/mpz-ot/src/chou_orlandi/mod.rs
@@ -138,7 +138,7 @@ mod tests {
         )
         .await;
 
-        // Remove an element from the data.
+        // Remove an element from the array of messages.
         data.pop();
 
         let result = tokio::try_join!(


### PR DESCRIPTION
This PR adds a new serializable `AbortError` type meant to be sent between players to signal an abort during the protocol. In this case, an abort can be sent by the Sender if the `ReceiverPayload` length does not match their locally requested OT batch size. 

Generally speaking, it may make sense to consider generalizing the use of `AbortError` as for example, a local error by an OT protocol is currently only propagated locally and not to the other player. 