### PR TITLE
refactor: add Callable trait and Vm supertrait

### DIFF
--- a/crates/mpz-garble/src/protocol/semihonest.rs
+++ b/crates/mpz-garble/src/protocol/semihonest.rs
@@ -10,12 +10,23 @@ pub use generator::{Generator, GeneratorError};
 mod tests {
     use mpz_circuits::circuits::AES128;
     use mpz_common::executor::test_st_executor;
-    use mpz_memory_core::{binary::U8, correlated::Delta, Array, MemoryExt, ViewExt};
-    use mpz_ot::ideal::cot::ideal_cot;
-    use mpz_vm_core::{Call, Execute, VmExt};
+    use mpz_memory_core::{
+        binary::{Binary, U8},
+        correlated::Delta,
+        Array, MemoryExt, ViewExt,
+    };
+    use mpz_ot::ideal::cot::{ideal_cot, IdealCOTReceiver, IdealCOTSender};
+    use mpz_vm_core::{Call, CallableExt, Execute, Vm};
     use rand::{rngs::StdRng, SeedableRng};
 
     use super::*;
+
+    #[test]
+    fn test_semihonest_is_vm() {
+        fn is_vm<T: Vm<Binary>>() {}
+        is_vm::<Generator<IdealCOTSender>>();
+        is_vm::<Evaluator<IdealCOTReceiver>>();
+    }
 
     #[tokio::test]
     async fn test_semihonest() {

--- a/crates/mpz-garble/src/protocol/semihonest/evaluator.rs
+++ b/crates/mpz-garble/src/protocol/semihonest/evaluator.rs
@@ -16,7 +16,7 @@ use mpz_core::{bitvec::BitVec, Block};
 use mpz_garble_core::{evaluate_garbled_circuits, EvaluatorOutput, GarbledCircuit};
 use mpz_memory_core::{binary::Binary, DecodeFuture, Memory, Slice, View};
 use mpz_ot::cot::COTReceiver;
-use mpz_vm_core::{Call, Execute, Vm};
+use mpz_vm_core::{Call, Callable, Execute};
 
 use crate::{
     evaluator::receive_garbled_circuit,
@@ -194,10 +194,13 @@ where
     }
 }
 
-impl<COT> Vm<Binary> for Evaluator<COT> {
+impl<COT> Callable<Binary> for Evaluator<COT> {
     type Error = Error;
 
-    fn call_raw(&mut self, call: Call) -> std::result::Result<Slice, <Self as Vm<Binary>>::Error> {
+    fn call_raw(
+        &mut self,
+        call: Call,
+    ) -> std::result::Result<Slice, <Self as Callable<Binary>>::Error> {
         let output = self
             .store
             .try_lock()

--- a/crates/mpz-garble/src/protocol/semihonest/generator.rs
+++ b/crates/mpz-garble/src/protocol/semihonest/generator.rs
@@ -12,7 +12,7 @@ use mpz_core::{bitvec::BitVec, Block};
 use mpz_garble_core::GeneratorOutput;
 use mpz_memory_core::{binary::Binary, correlated::Delta, DecodeFuture, Memory, Slice, View};
 use mpz_ot::cot::COTSender;
-use mpz_vm_core::{Call, Execute, Vm};
+use mpz_vm_core::{Call, Callable, Execute};
 
 use crate::store::{GeneratorStore, GeneratorStoreError};
 
@@ -149,7 +149,7 @@ where
     }
 }
 
-impl<COT> Vm<Binary> for Generator<COT> {
+impl<COT> Callable<Binary> for Generator<COT> {
     type Error = GeneratorError;
 
     fn call_raw(&mut self, call: Call) -> Result<Slice> {

--- a/crates/mpz-vm-core/src/lib.rs
+++ b/crates/mpz-vm-core/src/lib.rs
@@ -4,27 +4,46 @@ pub use call::{Call, CallBuilder, CallError};
 pub use mpz_memory_core as memory;
 
 pub mod prelude {
-    pub use crate::{Execute, VmExt};
+    pub use crate::{CallableExt, Execute};
     pub use mpz_memory_core::{Array, MemoryExt, Slice, ViewExt};
 }
 
 use async_trait::async_trait;
 
-use mpz_memory_core::{Memory, MemoryType, Repr, Slice};
+use mpz_memory_core::{Memory, MemoryType, Repr, Slice, View};
 
-/// Virtual machine.
-pub trait Vm<T: MemoryType>: Memory<T, Error = <Self as Vm<T>>::Error> {
+/// A virtual machine.
+pub trait Vm<T: MemoryType>:
+    Callable<T, Error = <Self as Vm<T>>::Error>
+    + Memory<T, Error = <Self as Vm<T>>::Error>
+    + View<T, Error = <Self as Vm<T>>::Error>
+{
+    /// Error type for the virtual machine.
+    type Error: std::error::Error + Send + Sync + 'static;
+}
+
+impl<T, U, E> Vm<U> for T
+where
+    T: ?Sized + Callable<U, Error = E> + Memory<U, Error = E> + View<U, Error = E>,
+    U: MemoryType,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type Error = E;
+}
+
+/// Interface for calling functions.
+pub trait Callable<T: MemoryType>: Memory<T, Error = <Self as Callable<T>>::Error> {
     /// Error type for calling functions.
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Calls a function, returning the output.
-    fn call_raw(&mut self, call: Call) -> Result<Slice, <Self as Vm<T>>::Error>;
+    fn call_raw(&mut self, call: Call) -> Result<Slice, <Self as Callable<T>>::Error>;
 }
 
-/// Extension trait for [`Vm`].
-pub trait VmExt<T: MemoryType>: Vm<T> {
+/// Extension trait for [`Callable`].
+pub trait CallableExt<T: MemoryType>: Callable<T> {
     /// Calls a function, returning the output.
-    fn call<R>(&mut self, call: Call) -> Result<R, <Self as Vm<T>>::Error>
+    fn call<R>(&mut self, call: Call) -> Result<R, <Self as Callable<T>>::Error>
     where
         R: Repr<T>,
     {
@@ -32,9 +51,9 @@ pub trait VmExt<T: MemoryType>: Vm<T> {
     }
 }
 
-impl<T, M> VmExt<M> for T
+impl<T, M> CallableExt<M> for T
 where
-    T: Vm<M>,
+    T: Callable<M>,
     M: MemoryType,
 {
 }

--- a/crates/mpz-zk/src/lib.rs
+++ b/crates/mpz-zk/src/lib.rs
@@ -8,15 +8,26 @@ pub use verifier::{Verifier, VerifierError};
 mod tests {
     use mpz_circuits::circuits::AES128;
     use mpz_common::executor::test_st_executor;
-    use mpz_ot::ideal::rcot::ideal_rcot;
+    use mpz_ot::ideal::rcot::{ideal_rcot, IdealRCOTReceiver, IdealRCOTSender};
     use mpz_vm_core::{
-        memory::{binary::U8, correlated::Delta, Array},
+        memory::{
+            binary::{Binary, U8},
+            correlated::Delta,
+            Array,
+        },
         prelude::*,
-        Call,
+        Call, Vm,
     };
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
     use super::*;
+
+    #[test]
+    fn test_zk_is_vm() {
+        fn is_vm<T: Vm<Binary>>() {}
+        is_vm::<Prover<IdealRCOTReceiver>>();
+        is_vm::<Verifier<IdealRCOTSender>>();
+    }
 
     #[tokio::test]
     async fn test_zk() {

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -4,7 +4,7 @@ use mpz_core::{bitvec::BitVec, Block};
 use mpz_ot::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
     memory::{binary::Binary, correlated::Mac, DecodeFuture, Memory, Slice, View},
-    Call, Execute, Vm,
+    Call, Execute, Callable,
 };
 use mpz_zk_core::{
     store::{ProverStore, ProverStoreError},
@@ -166,7 +166,7 @@ where
     }
 }
 
-impl<OT> Vm<Binary> for Prover<OT>
+impl<OT> Callable<Binary> for Prover<OT>
 where
     OT: RCOTReceiver<bool, Block>,
 {

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -8,7 +8,7 @@ use mpz_vm_core::{
         correlated::{Delta, Key},
         DecodeFuture, Memory, Slice, View,
     },
-    Call, Execute, Vm,
+    Call, Execute, Callable,
 };
 use mpz_zk_core::{
     store::{VerifierStore, VerifierStoreError},
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<OT> Vm<Binary> for Verifier<OT>
+impl<OT> Callable<Binary> for Verifier<OT>
 where
     OT: RCOTSender<Block>,
 {


### PR DESCRIPTION
This PR renames `Vm` to `Callable` and adds a `Vm` trait which is a supertrait of the others. This makes bounds cleaner in consuming code.