### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/crates/clmul/LICENSE-MIT
+++ b/crates/clmul/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 RustCrypto Developers
+Copyright (c) 2025 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Updated the copyright year from 2019 to 2025 in the LICENSE file