### PR TITLE
feat: shared RCOT

### DIFF
--- a/crates/mpz-ot-core/src/lib.rs
+++ b/crates/mpz-ot-core/src/lib.rs
@@ -54,7 +54,7 @@ impl TransferId {
     }
 
     /// Returns the current transfer ID, incrementing `self` in-place.
-    pub(crate) fn next(&mut self) -> Self {
+    pub fn next(&mut self) -> Self {
         let id = *self;
         self.0 += 1;
         id

--- a/crates/mpz-ot/Cargo.toml
+++ b/crates/mpz-ot/Cargo.toml
@@ -35,6 +35,7 @@ opaque-debug.workspace = true
 serde = { workspace = true, optional = true }
 serio.workspace = true
 cfg-if.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 mpz-common = { workspace = true, features = [

--- a/crates/mpz-ot/src/rcot.rs
+++ b/crates/mpz-ot/src/rcot.rs
@@ -1,3 +1,5 @@
 //! Random correlated OT.
 
+pub mod shared;
+
 pub use mpz_ot_core::rcot::{RCOTReceiver, RCOTReceiverOutput, RCOTSender, RCOTSenderOutput};

--- a/crates/mpz-ot/src/rcot/shared.rs
+++ b/crates/mpz-ot/src/rcot/shared.rs
@@ -1,0 +1,41 @@
+//! Shared RCOT.
+
+mod receiver;
+mod sender;
+
+pub use receiver::{SharedRCOTReceiver, SharedRCOTReceiverError};
+pub use sender::{SharedRCOTSender, SharedRCOTSenderError};
+
+#[cfg(test)]
+mod tests {
+    use mpz_core::Block;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use crate::{ideal::rcot::ideal_rcot, test::test_rcot};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_shared_rcot() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let n = 8;
+        let cycles = 4;
+
+        let (ideal_send, ideal_recv) = ideal_rcot(Block::random(&mut rng), Block::random(&mut rng));
+
+        let rcots: Vec<_> = SharedRCOTSender::new(n, ideal_send)
+            .zip(SharedRCOTReceiver::new(n, ideal_recv))
+            .collect();
+
+        assert_eq!(rcots.len(), 8);
+
+        let tasks: Vec<_> = rcots
+            .into_iter()
+            .map(|(send, recv)| tokio::spawn(test_rcot(send, recv, cycles)))
+            .collect();
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+    }
+}

--- a/crates/mpz-ot/src/rcot/shared/receiver.rs
+++ b/crates/mpz-ot/src/rcot/shared/receiver.rs
@@ -1,0 +1,227 @@
+use std::{
+    collections::VecDeque,
+    mem::take,
+    sync::{Arc, Mutex as StdMutex},
+};
+
+use async_trait::async_trait;
+use mpz_common::{
+    future::{new_output, MaybeDone, Sender},
+    Context, Flush,
+};
+use mpz_ot_core::{
+    rcot::{RCOTReceiver, RCOTReceiverOutput},
+    TransferId,
+};
+use tokio::sync::{Barrier, Mutex};
+
+#[derive(Debug)]
+struct State<U, V> {
+    allocs: Vec<usize>,
+    inputs: Vec<Vec<U>>,
+    macs: Vec<Vec<V>>,
+}
+
+impl<U, V> State<U, V> {
+    fn new(n: usize) -> Self {
+        Self {
+            allocs: vec![0; n],
+            inputs: (0..n).map(|_| Vec::new()).collect(),
+            macs: (0..n).map(|_| Vec::new()).collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Queued<U, V> {
+    count: usize,
+    sender: Sender<RCOTReceiverOutput<U, V>>,
+}
+
+/// Shared RCOT recver.
+#[derive(Debug)]
+pub struct SharedRCOTReceiver<T, U, V> {
+    id: usize,
+    transfer_id: TransferId,
+    inner: Arc<Mutex<T>>,
+    barrier: Arc<Barrier>,
+    state: Arc<StdMutex<State<U, V>>>,
+    inputs: Vec<U>,
+    macs: Vec<V>,
+    queue: VecDeque<Queued<U, V>>,
+}
+
+impl<T, U, V> SharedRCOTReceiver<T, U, V>
+where
+    T: RCOTReceiver<U, V>,
+    U: Copy + Send,
+    V: Copy + Send,
+{
+    /// Returns an iterator yielding `n` instances of `SharedRCOTReceiver`.
+    pub fn new(n: usize, inner: T) -> impl Iterator<Item = Self> {
+        let inner = Arc::new(Mutex::new(inner));
+        let barrier = Arc::new(Barrier::new(n));
+        let state = Arc::new(StdMutex::new(State::new(n)));
+
+        (0..n).map(move |id| Self {
+            id,
+            transfer_id: TransferId::default(),
+            inner: inner.clone(),
+            barrier: barrier.clone(),
+            state: state.clone(),
+            inputs: Vec::new(),
+            macs: Vec::new(),
+            queue: VecDeque::new(),
+        })
+    }
+
+    fn is_leader(&self) -> bool {
+        self.id == 0
+    }
+}
+
+impl<T, U, V> RCOTReceiver<U, V> for SharedRCOTReceiver<T, U, V>
+where
+    T: RCOTReceiver<U, V>,
+    U: Copy + Send,
+    V: Copy + Send,
+{
+    type Error = SharedRCOTReceiverError;
+    type Future = MaybeDone<RCOTReceiverOutput<U, V>>;
+
+    fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
+        self.state.lock().unwrap().allocs[self.id] += count;
+        Ok(())
+    }
+
+    fn available(&self) -> usize {
+        self.macs.len()
+    }
+
+    fn try_recv_rcot(&mut self, count: usize) -> Result<RCOTReceiverOutput<U, V>, Self::Error> {
+        if self.available() < count {
+            return Err(ErrorRepr::InsufficientSetup {
+                expected: count,
+                actual: self.available(),
+            }
+            .into());
+        }
+
+        let inputs = self.inputs.split_off(self.inputs.len() - count);
+        let macs = self.macs.split_off(self.macs.len() - count);
+
+        Ok(RCOTReceiverOutput {
+            id: self.transfer_id.next(),
+            choices: inputs,
+            msgs: macs,
+        })
+    }
+
+    fn queue_recv_rcot(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
+        if self.available() >= count {
+            let output = self.try_recv_rcot(count)?;
+            let (sender, recv) = new_output();
+            sender.send(output);
+
+            return Ok(recv);
+        } else {
+            let (sender, recv) = new_output();
+
+            self.queue.push_back(Queued { count, sender });
+
+            return Ok(recv);
+        }
+    }
+}
+
+#[async_trait]
+impl<T, U, V> Flush for SharedRCOTReceiver<T, U, V>
+where
+    T: RCOTReceiver<U, V> + Flush + Send,
+    U: Copy + Send,
+    V: Copy + Send,
+{
+    type Error = SharedRCOTReceiverError;
+
+    fn wants_flush(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .allocs
+            .iter()
+            .any(|&alloc| alloc > 0)
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        self.barrier.wait().await;
+
+        if self.is_leader() {
+            let mut inner = self.inner.lock().await;
+
+            {
+                let state = self.state.lock().unwrap();
+                for alloc in state.allocs.iter() {
+                    inner
+                        .alloc(*alloc)
+                        .map_err(SharedRCOTReceiverError::inner)?;
+                }
+            }
+
+            inner
+                .flush(ctx)
+                .await
+                .map_err(SharedRCOTReceiverError::inner)?;
+
+            let state = &mut (*self.state.lock().unwrap());
+            for (id, alloc) in state.allocs.iter_mut().enumerate() {
+                let alloc = take(alloc);
+                let output = inner
+                    .try_recv_rcot(alloc)
+                    .map_err(SharedRCOTReceiverError::inner)?;
+
+                state.inputs[id].extend_from_slice(&output.choices);
+                state.macs[id].extend_from_slice(&output.msgs);
+            }
+        }
+
+        self.barrier.wait().await;
+
+        {
+            let mut state = self.state.lock().unwrap();
+            self.inputs.extend_from_slice(&state.inputs[self.id]);
+            self.macs.extend_from_slice(&state.macs[self.id]);
+            state.inputs[self.id].clear();
+            state.macs[self.id].clear();
+        }
+
+        for queued in take(&mut self.queue) {
+            let output = self.try_recv_rcot(queued.count)?;
+            queued.sender.send(output);
+        }
+
+        Ok(())
+    }
+}
+
+/// Error for [`SharedRCOTReceiver`].
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct SharedRCOTReceiverError(#[from] ErrorRepr);
+
+impl SharedRCOTReceiverError {
+    fn inner<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Receiver(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("shared RCOT recver error: ")]
+enum ErrorRepr {
+    #[error("inner recver error: {0}")]
+    Receiver(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("insufficient RCOTs setup: expected {expected}, actual {actual}")]
+    InsufficientSetup { expected: usize, actual: usize },
+}

--- a/crates/mpz-ot/src/rcot/shared/receiver.rs
+++ b/crates/mpz-ot/src/rcot/shared/receiver.rs
@@ -153,8 +153,6 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
-        self.barrier.wait().await;
-
         if self.is_leader() {
             let mut inner = self.inner.lock().await;
 
@@ -173,10 +171,9 @@ where
                 .map_err(SharedRCOTReceiverError::inner)?;
 
             let state = &mut (*self.state.lock().unwrap());
-            for (id, alloc) in state.allocs.iter_mut().enumerate() {
-                let alloc = take(alloc);
+            for (id, alloc) in state.allocs.iter().enumerate() {
                 let output = inner
-                    .try_recv_rcot(alloc)
+                    .try_recv_rcot(*alloc)
                     .map_err(SharedRCOTReceiverError::inner)?;
 
                 state.inputs[id].extend_from_slice(&output.choices);
@@ -184,14 +181,13 @@ where
             }
         }
 
-        self.barrier.wait().await;
-
         {
             let mut state = self.state.lock().unwrap();
             self.inputs.extend_from_slice(&state.inputs[self.id]);
             self.macs.extend_from_slice(&state.macs[self.id]);
             state.inputs[self.id].clear();
             state.macs[self.id].clear();
+            state.allocs[self.id] = 0;
         }
 
         for queued in take(&mut self.queue) {

--- a/crates/mpz-ot/src/rcot/shared/receiver.rs
+++ b/crates/mpz-ot/src/rcot/shared/receiver.rs
@@ -218,9 +218,9 @@ impl SharedRCOTReceiverError {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("shared RCOT recver error: ")]
+#[error("shared RCOT receiver error: ")]
 enum ErrorRepr {
-    #[error("inner recver error: {0}")]
+    #[error("inner receiver error: {0}")]
     Receiver(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("insufficient RCOTs setup: expected {expected}, actual {actual}")]
     InsufficientSetup { expected: usize, actual: usize },

--- a/crates/mpz-ot/src/rcot/shared/receiver.rs
+++ b/crates/mpz-ot/src/rcot/shared/receiver.rs
@@ -153,6 +153,8 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        self.barrier.wait().await;
+
         if self.is_leader() {
             let mut inner = self.inner.lock().await;
 
@@ -171,9 +173,10 @@ where
                 .map_err(SharedRCOTReceiverError::inner)?;
 
             let state = &mut (*self.state.lock().unwrap());
-            for (id, alloc) in state.allocs.iter().enumerate() {
+            for (id, alloc) in state.allocs.iter_mut().enumerate() {
+                let alloc = take(alloc);
                 let output = inner
-                    .try_recv_rcot(*alloc)
+                    .try_recv_rcot(alloc)
                     .map_err(SharedRCOTReceiverError::inner)?;
 
                 state.inputs[id].extend_from_slice(&output.choices);
@@ -181,13 +184,14 @@ where
             }
         }
 
+        self.barrier.wait().await;
+
         {
             let mut state = self.state.lock().unwrap();
             self.inputs.extend_from_slice(&state.inputs[self.id]);
             self.macs.extend_from_slice(&state.macs[self.id]);
             state.inputs[self.id].clear();
             state.macs[self.id].clear();
-            state.allocs[self.id] = 0;
         }
 
         for queued in take(&mut self.queue) {

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -1,0 +1,220 @@
+use std::{
+    collections::VecDeque,
+    mem::take,
+    sync::{Arc, Mutex as StdMutex},
+};
+
+use async_trait::async_trait;
+use mpz_common::{
+    future::{new_output, MaybeDone, Sender},
+    Context, Flush,
+};
+use mpz_ot_core::{
+    rcot::{RCOTSender, RCOTSenderOutput},
+    TransferId,
+};
+use tokio::sync::{Barrier, Mutex};
+
+#[derive(Debug)]
+struct State<U> {
+    allocs: Vec<usize>,
+    keys: Vec<Vec<U>>,
+}
+
+impl<U> State<U> {
+    fn new(n: usize) -> Self {
+        Self {
+            allocs: vec![0; n],
+            keys: (0..n).map(|_| Vec::new()).collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Queued<U> {
+    count: usize,
+    sender: Sender<RCOTSenderOutput<U>>,
+}
+
+/// Shared RCOT sender.
+#[derive(Debug)]
+pub struct SharedRCOTSender<T, U> {
+    id: usize,
+    transfer_id: TransferId,
+    inner: Arc<Mutex<T>>,
+    barrier: Arc<Barrier>,
+    state: Arc<StdMutex<State<U>>>,
+    delta: U,
+    keys: Vec<U>,
+    queue: VecDeque<Queued<U>>,
+}
+
+impl<T, U> SharedRCOTSender<T, U>
+where
+    T: RCOTSender<U>,
+    U: Copy + Send,
+{
+    /// Returns an iterator yielding `n` instances of `SharedRCOTSender`.
+    pub fn new(n: usize, inner: T) -> impl Iterator<Item = Self> {
+        let delta = inner.delta();
+        let inner = Arc::new(Mutex::new(inner));
+        let barrier = Arc::new(Barrier::new(n));
+        let state = Arc::new(StdMutex::new(State::new(n)));
+
+        (0..n).map(move |id| Self {
+            id,
+            transfer_id: TransferId::default(),
+            inner: inner.clone(),
+            barrier: barrier.clone(),
+            state: state.clone(),
+            delta,
+            keys: Vec::new(),
+            queue: VecDeque::new(),
+        })
+    }
+
+    fn is_leader(&self) -> bool {
+        self.id == 0
+    }
+}
+
+impl<T, U> RCOTSender<U> for SharedRCOTSender<T, U>
+where
+    T: RCOTSender<U>,
+    U: Copy + Send,
+{
+    type Error = SharedRCOTSenderError;
+    type Future = MaybeDone<RCOTSenderOutput<U>>;
+
+    fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
+        self.state.lock().unwrap().allocs[self.id] += count;
+        Ok(())
+    }
+
+    fn available(&self) -> usize {
+        self.keys.len()
+    }
+
+    fn delta(&self) -> U {
+        self.delta
+    }
+
+    fn try_send_rcot(&mut self, count: usize) -> Result<RCOTSenderOutput<U>, Self::Error> {
+        if self.available() < count {
+            return Err(ErrorRepr::InsufficientSetup {
+                expected: count,
+                actual: self.available(),
+            }
+            .into());
+        }
+
+        let keys = self.keys.split_off(self.keys.len() - count);
+
+        Ok(RCOTSenderOutput {
+            id: self.transfer_id.next(),
+            keys,
+        })
+    }
+
+    fn queue_send_rcot(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
+        if self.available() >= count {
+            let output = self.try_send_rcot(count)?;
+            let (sender, recv) = new_output();
+            sender.send(output);
+
+            return Ok(recv);
+        } else {
+            let (sender, recv) = new_output();
+
+            self.queue.push_back(Queued { count, sender });
+
+            return Ok(recv);
+        }
+    }
+}
+
+#[async_trait]
+impl<T, U> Flush for SharedRCOTSender<T, U>
+where
+    T: RCOTSender<U> + Flush + Send,
+    U: Copy + Send,
+{
+    type Error = SharedRCOTSenderError;
+
+    fn wants_flush(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .allocs
+            .iter()
+            .any(|&alloc| alloc > 0)
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        self.barrier.wait().await;
+
+        if self.is_leader() {
+            let mut inner = self.inner.lock().await;
+
+            {
+                let state = self.state.lock().unwrap();
+                for alloc in state.allocs.iter() {
+                    inner.alloc(*alloc).map_err(SharedRCOTSenderError::inner)?;
+                }
+            }
+
+            inner
+                .flush(ctx)
+                .await
+                .map_err(SharedRCOTSenderError::inner)?;
+
+            let state = &mut (*self.state.lock().unwrap());
+            for (id, alloc) in state.allocs.iter_mut().enumerate() {
+                let alloc = take(alloc);
+                let keys = inner
+                    .try_send_rcot(alloc)
+                    .map_err(SharedRCOTSenderError::inner)?
+                    .keys;
+                state.keys[id].extend_from_slice(&keys);
+            }
+        }
+
+        self.barrier.wait().await;
+
+        {
+            let mut state = self.state.lock().unwrap();
+            self.keys.extend_from_slice(&state.keys[self.id]);
+            state.keys[self.id].clear();
+        }
+
+        for queued in take(&mut self.queue) {
+            let output = self.try_send_rcot(queued.count)?;
+            queued.sender.send(output);
+        }
+
+        Ok(())
+    }
+}
+
+/// Error for [`SharedRCOTSender`].
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct SharedRCOTSenderError(#[from] ErrorRepr);
+
+impl SharedRCOTSenderError {
+    fn inner<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Sender(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("shared RCOT sender error: ")]
+enum ErrorRepr {
+    #[error("inner sender error: {0}")]
+    Sender(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("insufficient RCOTs setup: expected {expected}, actual {actual}")]
+    InsufficientSetup { expected: usize, actual: usize },
+}

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -169,9 +169,10 @@ where
                 .map_err(SharedRCOTSenderError::inner)?;
 
             let state = &mut (*self.state.lock().unwrap());
-            for (id, alloc) in state.allocs.iter().enumerate() {
+            for (id, alloc) in state.allocs.iter_mut().enumerate() {
+                let alloc = take(alloc);
                 let keys = inner
-                    .try_send_rcot(*alloc)
+                    .try_send_rcot(alloc)
                     .map_err(SharedRCOTSenderError::inner)?
                     .keys;
                 state.keys[id].extend_from_slice(&keys);
@@ -184,7 +185,6 @@ where
             let mut state = self.state.lock().unwrap();
             self.keys.extend_from_slice(&state.keys[self.id]);
             state.keys[self.id].clear();
-            state.allocs[self.id] = 0;
         }
 
         for queued in take(&mut self.queue) {

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -151,6 +151,8 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        self.barrier.wait().await;
+
         if self.is_leader() {
             let mut inner = self.inner.lock().await;
 
@@ -175,6 +177,8 @@ where
                 state.keys[id].extend_from_slice(&keys);
             }
         }
+
+        self.barrier.wait().await;
 
         {
             let mut state = self.state.lock().unwrap();

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -167,10 +167,9 @@ where
                 .map_err(SharedRCOTSenderError::inner)?;
 
             let state = &mut (*self.state.lock().unwrap());
-            for (id, alloc) in state.allocs.iter_mut().enumerate() {
-                let alloc = take(alloc);
+            for (id, alloc) in state.allocs.iter().enumerate() {
                 let keys = inner
-                    .try_send_rcot(alloc)
+                    .try_send_rcot(*alloc)
                     .map_err(SharedRCOTSenderError::inner)?
                     .keys;
                 state.keys[id].extend_from_slice(&keys);
@@ -181,6 +180,7 @@ where
             let mut state = self.state.lock().unwrap();
             self.keys.extend_from_slice(&state.keys[self.id]);
             state.keys[self.id].clear();
+            state.allocs[self.id] = 0;
         }
 
         for queued in take(&mut self.queue) {

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -151,8 +151,6 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
-        self.barrier.wait().await;
-
         if self.is_leader() {
             let mut inner = self.inner.lock().await;
 
@@ -178,8 +176,6 @@ where
                 state.keys[id].extend_from_slice(&keys);
             }
         }
-
-        self.barrier.wait().await;
 
         {
             let mut state = self.state.lock().unwrap();


### PR DESCRIPTION
This PR provides a wrapper which supports sharing an RCOT instance across threads while maintaining synchronization between machines.

This is fairly hacky but for the moment sufficient for our needs.