### PR TITLE
Add `get_macs` and `get_keys` methods for ZK Prover/Verifier

### DIFF
--- a/crates/mpz-zk-core/src/prover.rs
+++ b/crates/mpz-zk-core/src/prover.rs
@@ -4,7 +4,10 @@ use mpz_circuits::{Circuit, Gate};
 use mpz_core::{bitvec::BitVec, Block};
 use mpz_memory_core::correlated::Mac;
 
-use crate::check::{Check, CheckError, Triple, UV};
+use crate::{
+    check::{Check, CheckError, Triple, UV},
+    store::ProverStoreError,
+};
 
 type Result<T> = core::result::Result<T, ProverError>;
 
@@ -261,10 +264,18 @@ enum ErrorRepr {
     Inprogress,
     #[error(transparent)]
     Check(CheckError),
+    #[error("cannot return encodings: {0}")]
+    Encodings(ProverStoreError),
 }
 
 impl From<CheckError> for ProverError {
     fn from(err: CheckError) -> Self {
         Self(ErrorRepr::Check(err))
+    }
+}
+
+impl From<ProverStoreError> for ProverError {
+    fn from(value: ProverStoreError) -> Self {
+        Self(ErrorRepr::Encodings(value))
     }
 }

--- a/crates/mpz-zk-core/src/prover.rs
+++ b/crates/mpz-zk-core/src/prover.rs
@@ -264,8 +264,8 @@ enum ErrorRepr {
     Inprogress,
     #[error(transparent)]
     Check(CheckError),
-    #[error("cannot return encodings: {0}")]
-    Encodings(ProverStoreError),
+    #[error("cannot return Macs: {0}")]
+    Macs(ProverStoreError),
 }
 
 impl From<CheckError> for ProverError {
@@ -276,6 +276,6 @@ impl From<CheckError> for ProverError {
 
 impl From<ProverStoreError> for ProverError {
     fn from(value: ProverStoreError) -> Self {
-        Self(ErrorRepr::Encodings(value))
+        Self(ErrorRepr::Macs(value))
     }
 }

--- a/crates/mpz-zk-core/src/verifier.rs
+++ b/crates/mpz-zk-core/src/verifier.rs
@@ -276,7 +276,7 @@ enum ErrorRepr {
     Inprogress,
     #[error(transparent)]
     Check(CheckError),
-    #[error("cannot return encodings: {0}")]
+    #[error("cannot return keys: {0}")]
     Keys(VerifierStoreError),
 }
 

--- a/crates/mpz-zk-core/src/verifier.rs
+++ b/crates/mpz-zk-core/src/verifier.rs
@@ -277,7 +277,7 @@ enum ErrorRepr {
     #[error(transparent)]
     Check(CheckError),
     #[error("cannot return encodings: {0}")]
-    Encodings(VerifierStoreError),
+    Keys(VerifierStoreError),
 }
 
 impl From<CheckError> for VerifierError {
@@ -288,6 +288,6 @@ impl From<CheckError> for VerifierError {
 
 impl From<VerifierStoreError> for VerifierError {
     fn from(value: VerifierStoreError) -> Self {
-        Self(ErrorRepr::Encodings(value))
+        Self(ErrorRepr::Keys(value))
     }
 }

--- a/crates/mpz-zk-core/src/verifier.rs
+++ b/crates/mpz-zk-core/src/verifier.rs
@@ -4,7 +4,10 @@ use mpz_circuits::{Circuit, Gate};
 use mpz_core::{bitvec::BitVec, Block};
 use mpz_memory_core::correlated::{Delta, Key};
 
-use crate::check::{Check, CheckError, Triple, UV};
+use crate::{
+    check::{Check, CheckError, Triple, UV},
+    store::VerifierStoreError,
+};
 
 type Result<T> = core::result::Result<T, VerifierError>;
 
@@ -273,10 +276,18 @@ enum ErrorRepr {
     Inprogress,
     #[error(transparent)]
     Check(CheckError),
+    #[error("cannot return encodings: {0}")]
+    Encodings(VerifierStoreError),
 }
 
 impl From<CheckError> for VerifierError {
     fn from(err: CheckError) -> Self {
         Self(ErrorRepr::Check(err))
+    }
+}
+
+impl From<VerifierStoreError> for VerifierError {
+    fn from(value: VerifierStoreError) -> Self {
+        Self(ErrorRepr::Encodings(value))
     }
 }

--- a/crates/mpz-zk/src/lib.rs
+++ b/crates/mpz-zk/src/lib.rs
@@ -7,9 +7,15 @@ pub use verifier::Verifier;
 use mpz_core::Block;
 use mpz_vm_core::prelude::Slice;
 
+/// Trait for operating on raw encodings.
 pub trait Encodings {
     type Error: Send + 'static + std::error::Error;
 
+    /// Returns encodings for the specified memory location.
+    ///
+    /// # Arguments
+    ///
+    /// * `slice` - The memory location.
     fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error>;
 }
 

--- a/crates/mpz-zk/src/lib.rs
+++ b/crates/mpz-zk/src/lib.rs
@@ -4,21 +4,6 @@ mod verifier;
 pub use prover::Prover;
 pub use verifier::Verifier;
 
-use mpz_core::Block;
-use mpz_vm_core::prelude::Slice;
-
-/// Trait for operating on raw encodings.
-pub trait Encodings {
-    type Error: Send + 'static + std::error::Error;
-
-    /// Returns encodings for the specified memory location.
-    ///
-    /// # Arguments
-    ///
-    /// * `slice` - The memory location.
-    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error>;
-}
-
 #[cfg(test)]
 mod tests {
     use mpz_circuits::circuits::AES128;

--- a/crates/mpz-zk/src/lib.rs
+++ b/crates/mpz-zk/src/lib.rs
@@ -4,6 +4,15 @@ mod verifier;
 pub use prover::Prover;
 pub use verifier::Verifier;
 
+use mpz_core::Block;
+use mpz_vm_core::prelude::Slice;
+
+pub trait Encodings {
+    type Error: Send + 'static + std::error::Error;
+
+    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error>;
+}
+
 #[cfg(test)]
 mod tests {
     use mpz_circuits::circuits::AES128;

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -3,9 +3,7 @@ use mpz_common::{scoped_futures::ScopedFutureExt, Context, Flush};
 use mpz_core::{bitvec::BitVec, Block};
 use mpz_ot::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
-    memory::{
-        binary::Binary, correlated::Mac, DecodeFuture, Memory, MemoryType, Repr, Slice, View,
-    },
+    memory::{binary::Binary, correlated::Mac, DecodeFuture, Memory, Repr, Slice, View},
     Call, Callable, Execute, Result as VmResult, VmError,
 };
 use mpz_zk_core::{store::ProverStore, Prover as Core, ProverError};
@@ -34,13 +32,12 @@ impl<OT> Prover<OT> {
     /// # Arguments
     ///
     /// * `value` - The value to return the MACs for.
-    pub fn get_macs<R, M>(&self, value: R) -> Result<Vec<Mac>, ProverError>
+    pub fn get_macs<R>(&self, value: R) -> Result<&[Mac], ProverError>
     where
-        R: Repr<M>,
-        M: MemoryType,
+        R: Repr<Binary>,
     {
         let slice = value.to_raw();
-        let macs = self.store.try_get_macs(slice)?.to_vec();
+        let macs = self.store.try_get_macs(slice)?;
 
         Ok(macs)
     }

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -4,11 +4,13 @@ use mpz_core::{bitvec::BitVec, Block};
 use mpz_ot::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
     memory::{binary::Binary, correlated::Mac, DecodeFuture, Memory, Slice, View},
-    Call, Callable, Execute, Result, VmError,
+    Call, Callable, Execute, Result as VmResult, VmError,
 };
-use mpz_zk_core::{store::ProverStore, Prover as Core};
+use mpz_zk_core::{store::ProverStore, Prover as Core, ProverError};
 use serio::{stream::IoStreamExt, SinkExt};
 use utils::filter_drain::FilterDrain;
+
+use crate::Encodings;
 
 #[derive(Debug)]
 pub struct Prover<OT> {
@@ -37,7 +39,7 @@ where
         self.ot.wants_flush() || self.store.wants_macs() || self.store.wants_flush()
     }
 
-    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+    async fn flush(&mut self, ctx: &mut Context) -> VmResult<()> {
         if self.ot.wants_flush() {
             self.ot.flush(ctx).await.map_err(VmError::execute)?;
         }
@@ -73,7 +75,7 @@ where
         false
     }
 
-    async fn preprocess(&mut self, _ctx: &mut Context) -> Result<()> {
+    async fn preprocess(&mut self, _ctx: &mut Context) -> VmResult<()> {
         Ok(())
     }
 
@@ -85,7 +87,7 @@ where
         })
     }
 
-    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+    async fn execute(&mut self, ctx: &mut Context) -> VmResult<()> {
         let mut prover = Core::default();
         while !self.callstack.is_empty() {
             let ready_calls: Vec<_> = self
@@ -159,7 +161,7 @@ where
                 .await
                 .map_err(VmError::execute)?
                 .into_iter()
-                .collect::<Result<Vec<_>>>()?;
+                .collect::<VmResult<Vec<_>>>()?;
 
             for (output, output_macs) in outputs {
                 self.store
@@ -189,7 +191,7 @@ impl<OT> Callable<Binary> for Prover<OT>
 where
     OT: RCOTReceiver<bool, Block>,
 {
-    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+    fn call_raw(&mut self, call: Call) -> VmResult<Slice> {
         let output = self.store.alloc_output(call.circ().output_len());
 
         let mut count = call.circ().and_count();
@@ -212,23 +214,23 @@ where
 {
     type Error = VmError;
 
-    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+    fn alloc_raw(&mut self, size: usize) -> VmResult<Slice> {
         self.store.alloc_raw(size).map_err(VmError::memory)
     }
 
-    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> VmResult<()> {
         self.store.assign_raw(slice, data).map_err(VmError::memory)
     }
 
-    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+    fn commit_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.commit_raw(slice).map_err(VmError::memory)
     }
 
-    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+    fn get_raw(&self, slice: Slice) -> VmResult<Option<BitVec>> {
         self.store.get_raw(slice).map_err(VmError::memory)
     }
 
-    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+    fn decode_raw(&mut self, slice: Slice) -> VmResult<DecodeFuture<BitVec>> {
         self.store.decode_raw(slice).map_err(VmError::memory)
     }
 }
@@ -239,11 +241,11 @@ where
 {
     type Error = VmError;
 
-    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_public_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_public_raw(slice).map_err(VmError::view)
     }
 
-    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_private_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_private_raw(slice).map_err(VmError::view)?;
 
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
@@ -251,7 +253,18 @@ where
         Ok(())
     }
 
-    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_blind_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_blind_raw(slice).map_err(VmError::view)
+    }
+}
+
+impl<OT> Encodings for Prover<OT> {
+    type Error = ProverError;
+
+    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error> {
+        let macs = self.store.try_get_macs(slice)?;
+        let macs = Mac::as_blocks(macs).to_vec();
+
+        Ok(macs)
     }
 }

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -3,14 +3,14 @@ use mpz_common::{scoped_futures::ScopedFutureExt, Context, Flush};
 use mpz_core::{bitvec::BitVec, Block};
 use mpz_ot::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
-    memory::{binary::Binary, correlated::Mac, DecodeFuture, Memory, Slice, View},
+    memory::{
+        binary::Binary, correlated::Mac, DecodeFuture, Memory, MemoryType, Repr, Slice, View,
+    },
     Call, Callable, Execute, Result as VmResult, VmError,
 };
 use mpz_zk_core::{store::ProverStore, Prover as Core, ProverError};
 use serio::{stream::IoStreamExt, SinkExt};
 use utils::filter_drain::FilterDrain;
-
-use crate::Encodings;
 
 #[derive(Debug)]
 pub struct Prover<OT> {
@@ -27,6 +27,22 @@ impl<OT> Prover<OT> {
             ot,
             callstack: Vec::default(),
         }
+    }
+
+    /// Returns the MACs.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The value to return the MACs for.
+    pub fn get_macs<R, M>(&self, value: R) -> Result<Vec<Mac>, ProverError>
+    where
+        R: Repr<M>,
+        M: MemoryType,
+    {
+        let slice = value.to_raw();
+        let macs = self.store.try_get_macs(slice)?.to_vec();
+
+        Ok(macs)
     }
 }
 
@@ -255,16 +271,5 @@ where
 
     fn mark_blind_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_blind_raw(slice).map_err(VmError::view)
-    }
-}
-
-impl<OT> Encodings for Prover<OT> {
-    type Error = ProverError;
-
-    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error> {
-        let macs = self.store.try_get_macs(slice)?;
-        let macs = Mac::as_blocks(macs).to_vec();
-
-        Ok(macs)
     }
 }

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -6,7 +6,7 @@ use mpz_vm_core::{
     memory::{
         binary::Binary,
         correlated::{Delta, Key},
-        DecodeFuture, Memory, MemoryType, Repr, Slice, View,
+        DecodeFuture, Memory, Repr, Slice, View,
     },
     Call, Callable, Execute, Result as VmResult, VmError,
 };
@@ -36,13 +36,12 @@ impl<OT> Verifier<OT> {
     /// # Arguments
     ///
     /// * `value` - The value to return the keys for.
-    pub fn get_keys<R, M>(&self, value: R) -> Result<Vec<Key>, VerifierError>
+    pub fn get_keys<R>(&self, value: R) -> Result<&[Key], VerifierError>
     where
-        R: Repr<M>,
-        M: MemoryType,
+        R: Repr<Binary>,
     {
         let slice = value.to_raw();
-        let keys = self.store.try_get_keys(slice)?.to_vec();
+        let keys = self.store.try_get_keys(slice)?;
 
         Ok(keys)
     }

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -6,15 +6,13 @@ use mpz_vm_core::{
     memory::{
         binary::Binary,
         correlated::{Delta, Key},
-        DecodeFuture, Memory, Slice, View,
+        DecodeFuture, Memory, MemoryType, Repr, Slice, View,
     },
     Call, Callable, Execute, Result as VmResult, VmError,
 };
 use mpz_zk_core::{store::VerifierStore, Verifier as Core, VerifierError};
 use serio::{stream::IoStreamExt, SinkExt};
 use utils::filter_drain::FilterDrain;
-
-use crate::Encodings;
 
 #[derive(Debug)]
 pub struct Verifier<OT> {
@@ -31,6 +29,22 @@ impl<OT> Verifier<OT> {
             ot,
             callstack: Vec::default(),
         }
+    }
+
+    /// Returns the keys.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The value to return the keys for.
+    pub fn get_keys<R, M>(&self, value: R) -> Result<Vec<Key>, VerifierError>
+    where
+        R: Repr<M>,
+        M: MemoryType,
+    {
+        let slice = value.to_raw();
+        let keys = self.store.try_get_keys(slice)?.to_vec();
+
+        Ok(keys)
     }
 }
 
@@ -241,16 +255,5 @@ where
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
         Ok(())
-    }
-}
-
-impl<OT> Encodings for Verifier<OT> {
-    type Error = VerifierError;
-
-    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error> {
-        let keys = self.store.try_get_keys(slice)?;
-        let keys = Key::as_blocks(keys).to_vec();
-
-        Ok(keys)
     }
 }

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -8,11 +8,13 @@ use mpz_vm_core::{
         correlated::{Delta, Key},
         DecodeFuture, Memory, Slice, View,
     },
-    Call, Callable, Execute, Result, VmError,
+    Call, Callable, Execute, Result as VmResult, VmError,
 };
-use mpz_zk_core::{store::VerifierStore, Verifier as Core};
+use mpz_zk_core::{store::VerifierStore, Verifier as Core, VerifierError};
 use serio::{stream::IoStreamExt, SinkExt};
 use utils::filter_drain::FilterDrain;
+
+use crate::Encodings;
 
 #[derive(Debug)]
 pub struct Verifier<OT> {
@@ -41,7 +43,7 @@ where
         self.ot.wants_flush() || self.store.wants_keys() || self.store.wants_flush()
     }
 
-    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+    async fn flush(&mut self, ctx: &mut Context) -> VmResult<()> {
         if self.ot.wants_flush() {
             self.ot.flush(ctx).await.map_err(VmError::execute)?;
         }
@@ -70,7 +72,7 @@ where
         false
     }
 
-    async fn preprocess(&mut self, _ctx: &mut Context) -> Result<()> {
+    async fn preprocess(&mut self, _ctx: &mut Context) -> VmResult<()> {
         Ok(())
     }
 
@@ -82,7 +84,7 @@ where
         })
     }
 
-    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+    async fn execute(&mut self, ctx: &mut Context) -> VmResult<()> {
         let mut verifier = Core::new(*self.store.delta());
         while !self.callstack.is_empty() {
             let ready_calls: Vec<_> = self
@@ -150,7 +152,7 @@ where
                 .await
                 .map_err(VmError::execute)?
                 .into_iter()
-                .collect::<Result<Vec<_>>>()?;
+                .collect::<VmResult<Vec<_>>>()?;
 
             for (output, output_keys) in outputs {
                 self.store
@@ -176,7 +178,7 @@ impl<OT> Callable<Binary> for Verifier<OT>
 where
     OT: RCOTSender<Block>,
 {
-    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+    fn call_raw(&mut self, call: Call) -> VmResult<Slice> {
         let output = self.store.alloc_output(call.circ().output_len());
 
         let mut count = call.circ().and_count();
@@ -199,23 +201,23 @@ where
 {
     type Error = VmError;
 
-    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+    fn alloc_raw(&mut self, size: usize) -> VmResult<Slice> {
         self.store.alloc_raw(size).map_err(VmError::memory)
     }
 
-    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> VmResult<()> {
         self.store.assign_raw(slice, data).map_err(VmError::memory)
     }
 
-    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+    fn commit_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.commit_raw(slice).map_err(VmError::memory)
     }
 
-    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+    fn get_raw(&self, slice: Slice) -> VmResult<Option<BitVec>> {
         self.store.get_raw(slice).map_err(VmError::memory)
     }
 
-    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+    fn decode_raw(&mut self, slice: Slice) -> VmResult<DecodeFuture<BitVec>> {
         self.store.decode_raw(slice).map_err(VmError::memory)
     }
 }
@@ -226,18 +228,29 @@ where
 {
     type Error = VmError;
 
-    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_public_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_public_raw(slice).map_err(VmError::view)
     }
 
-    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_private_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_private_raw(slice).map_err(VmError::view)
     }
 
-    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+    fn mark_blind_raw(&mut self, slice: Slice) -> VmResult<()> {
         self.store.mark_blind_raw(slice).map_err(VmError::view)?;
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
         Ok(())
+    }
+}
+
+impl<OT> Encodings for Verifier<OT> {
+    type Error = VerifierError;
+
+    fn get_encodings(&self, slice: Slice) -> Result<Vec<Block>, Self::Error> {
+        let keys = self.store.try_get_keys(slice)?;
+        let keys = Key::as_blocks(keys).to_vec();
+
+        Ok(keys)
     }
 }


### PR DESCRIPTION
~~This PR adds an `Encodings` trait to pull out macs and keys from the vm.~~
Add methods for getting keys and macs on ZK prover and verifier