### PR TITLE
feat(common): try_join variants

### DIFF
--- a/crates/mpz-common/src/context.rs
+++ b/crates/mpz-common/src/context.rs
@@ -160,6 +160,59 @@ impl Context {
             }
         }
     }
+
+    /// Same as [`Context::try_join`], but with three closures.
+    pub async fn try_join3<'a, A, B, C, RA, RB, RC, E>(
+        &'a mut self,
+        a: A,
+        b: B,
+        c: C,
+    ) -> Result<Result<(RA, RB, RC), E>, ContextError>
+    where
+        A: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RA, E>> + Send + 'static,
+        B: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RB, E>> + Send + 'static,
+        C: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RC, E>> + Send + 'static,
+        RA: Send + 'static,
+        RB: Send + 'static,
+        RC: Send + 'static,
+        E: Send + 'static,
+    {
+        match &mut self.mode {
+            Mode::St => Ok(st::try_join3(self, a, b, c).await),
+            Mode::Mt { threads } => {
+                let threads = threads.get(3).await?;
+                mt::try_join3(threads, a, b, c).await
+            }
+        }
+    }
+
+    /// Same as [`Context::try_join`], but with four closures.
+    pub async fn try_join4<'a, A, B, C, D, RA, RB, RC, RD, E>(
+        &'a mut self,
+        a: A,
+        b: B,
+        c: C,
+        d: D,
+    ) -> Result<Result<(RA, RB, RC, RD), E>, ContextError>
+    where
+        A: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RA, E>> + Send + 'static,
+        B: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RB, E>> + Send + 'static,
+        C: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RC, E>> + Send + 'static,
+        D: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<RD, E>> + Send + 'static,
+        RA: Send + 'static,
+        RB: Send + 'static,
+        RC: Send + 'static,
+        RD: Send + 'static,
+        E: Send + 'static,
+    {
+        match &mut self.mode {
+            Mode::St => Ok(st::try_join4(self, a, b, c, d).await),
+            Mode::Mt { threads } => {
+                let threads = threads.get(4).await?;
+                mt::try_join4(threads, a, b, c, d).await
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/mpz-common/src/context/mt.rs
+++ b/crates/mpz-common/src/context/mt.rs
@@ -247,3 +247,125 @@ where
 
     Ok(Ok((ra, rb)))
 }
+
+pub(crate) async fn try_join3<'a, A, B, C, RA, RB, RC, E>(
+    threads: &[Handle],
+    a: A,
+    b: B,
+    c: C,
+) -> Result<Result<(RA, RB, RC), E>, ContextError>
+where
+    A: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RA, E>> + Send + 'static,
+    B: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RB, E>> + Send + 'static,
+    C: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RC, E>> + Send + 'static,
+    RA: Send + 'static,
+    RB: Send + 'static,
+    RC: Send + 'static,
+    E: Send + 'static,
+{
+    assert_eq!(threads.len(), 3, "expecting exactly three threads");
+
+    let mut a = threads[0].send_with_return(|ctx| a(ctx).block_on())?.fuse();
+    let mut b = threads[1].send_with_return(|ctx| b(ctx).block_on())?.fuse();
+    let mut c = threads[2].send_with_return(|ctx| c(ctx).block_on())?.fuse();
+
+    let mut ra = None;
+    let mut rb = None;
+    let mut rc = None;
+    loop {
+        futures::select! {
+            output = a => {
+                match output? {
+                    Ok(output) => ra = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            },
+            output = b => {
+                match output? {
+                    Ok(output) => rb = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            }
+            output = c => {
+                match output? {
+                    Ok(output) => rc = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            }
+            complete => break,
+        }
+    }
+
+    let ra = ra.expect("a future should have resolved");
+    let rb = rb.expect("b future should have resolved");
+    let rc = rc.expect("c future should have resolved");
+
+    Ok(Ok((ra, rb, rc)))
+}
+
+pub(crate) async fn try_join4<'a, A, B, C, D, RA, RB, RC, RD, E>(
+    threads: &[Handle],
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+) -> Result<Result<(RA, RB, RC, RD), E>, ContextError>
+where
+    A: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RA, E>> + Send + 'static,
+    B: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RB, E>> + Send + 'static,
+    C: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RC, E>> + Send + 'static,
+    D: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RD, E>> + Send + 'static,
+    RA: Send + 'static,
+    RB: Send + 'static,
+    RC: Send + 'static,
+    RD: Send + 'static,
+    E: Send + 'static,
+{
+    assert_eq!(threads.len(), 4, "expecting exactly four threads");
+
+    let mut a = threads[0].send_with_return(|ctx| a(ctx).block_on())?.fuse();
+    let mut b = threads[1].send_with_return(|ctx| b(ctx).block_on())?.fuse();
+    let mut c = threads[2].send_with_return(|ctx| c(ctx).block_on())?.fuse();
+    let mut d = threads[3].send_with_return(|ctx| d(ctx).block_on())?.fuse();
+
+    let mut ra = None;
+    let mut rb = None;
+    let mut rc = None;
+    let mut rd = None;
+    loop {
+        futures::select! {
+            output = a => {
+                match output? {
+                    Ok(output) => ra = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            },
+            output = b => {
+                match output? {
+                    Ok(output) => rb = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            }
+            output = c => {
+                match output? {
+                    Ok(output) => rc = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            }
+            output = d => {
+                match output? {
+                    Ok(output) => rd = Some(output),
+                    Err(error) => return Ok(Err(error)),
+                }
+            }
+            complete => break,
+        }
+    }
+
+    let ra = ra.expect("a future should have resolved");
+    let rb = rb.expect("b future should have resolved");
+    let rc = rc.expect("c future should have resolved");
+    let rd = rd.expect("d future should have resolved");
+
+    Ok(Ok((ra, rb, rc, rd)))
+}

--- a/crates/mpz-common/src/context/st.rs
+++ b/crates/mpz-common/src/context/st.rs
@@ -36,3 +36,40 @@ where
     let b = b(ctx).await?;
     Ok((a, b))
 }
+
+pub(crate) async fn try_join3<'a, A, B, C, RA, RB, RC, E>(
+    ctx: &'a mut Context,
+    a: A,
+    b: B,
+    c: C,
+) -> Result<(RA, RB, RC), E>
+where
+    A: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RA, E>>,
+    B: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RB, E>>,
+    C: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RC, E>>,
+{
+    let a = a(ctx).await?;
+    let b = b(ctx).await?;
+    let c = c(ctx).await?;
+    Ok((a, b, c))
+}
+
+pub(crate) async fn try_join4<'a, A, B, C, D, RA, RB, RC, RD, E>(
+    ctx: &'a mut Context,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+) -> Result<(RA, RB, RC, RD), E>
+where
+    A: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RA, E>>,
+    B: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RB, E>>,
+    C: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RC, E>>,
+    D: for<'b> FnOnce(&'b mut Context) -> ScopedBoxFuture<'a, 'b, Result<RD, E>>,
+{
+    let a = a(ctx).await?;
+    let b = b(ctx).await?;
+    let c = c(ctx).await?;
+    let d = d(ctx).await?;
+    Ok((a, b, c, d))
+}


### PR DESCRIPTION
This PR provides more `try_join` variants for 3 and 4 closures, similarly to the `futures` crate. This may not survive longer term as part of the API but it's needed now. In the future we probably want to figure out a join scope abstraction.