### PR TITLE
refactor: odds and ends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ mpz-zk = { path = "crates/mpz-zk" }
 clmul = { path = "crates/clmul" }
 matrix-transpose = { path = "crates/matrix-transpose" }
 
-tlsn-utils = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "43995c5" }
+tlsn-utils = { git = "https://github.com/tlsnotary/tlsn-utils", branch = "dev" }
 
 # rand
 rand_chacha = "0.3"

--- a/crates/mpz-garble-core/src/store/evaluator.rs
+++ b/crates/mpz-garble-core/src/store/evaluator.rs
@@ -325,10 +325,7 @@ impl<COT> Memory<Binary> for EvaluatorStore<COT> {
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.data_store
-            .try_get(slice)
-            .map(|data| Some(data.to_bitvec()))
-            .map_err(Error::from)
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {

--- a/crates/mpz-garble-core/src/store/generator.rs
+++ b/crates/mpz-garble-core/src/store/generator.rs
@@ -260,10 +260,7 @@ impl<COT> Memory<Binary> for GeneratorStore<COT> {
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.data_store
-            .try_get(slice)
-            .map(|data| Some(data.to_bitvec()))
-            .map_err(Error::from)
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {

--- a/crates/mpz-garble-core/src/view.rs
+++ b/crates/mpz-garble-core/src/view.rs
@@ -311,7 +311,10 @@ impl View {
         // Decode evaluator inputs if they are ready.
         self.flush.decode |= view.ot.intersection(&self.decode.all);
         // Decode outputs if they are ready.
-        self.flush.decode |= view.decode_info.intersection(&self.output.complete);
+        self.flush.decode |= view
+            .decode_info
+            .intersection(&self.output.complete)
+            .difference(&self.decode.complete);
     }
 }
 

--- a/crates/mpz-memory-core/src/store.rs
+++ b/crates/mpz-memory-core/src/store.rs
@@ -160,6 +160,16 @@ impl BitStore {
 
     /// Returns a slice if it is set.
     #[inline]
+    pub fn get(&self, slice: Slice) -> Option<&BitSlice> {
+        if slice.to_range().is_subset(&self.set) {
+            Some(&self.bits[slice])
+        } else {
+            None
+        }
+    }
+
+    /// Returns a slice if it is set, otherwise returns an error.
+    #[inline]
     pub fn try_get(&self, slice: Slice) -> Result<&BitSlice> {
         if slice.to_range().is_subset(&self.set) {
             Ok(&self.bits[slice])

--- a/crates/mpz-ot/src/rcot/shared/receiver.rs
+++ b/crates/mpz-ot/src/rcot/shared/receiver.rs
@@ -153,6 +153,10 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        if !self.wants_flush() {
+            return Ok(());
+        }
+
         self.barrier.wait().await;
 
         if self.is_leader() {

--- a/crates/mpz-ot/src/rcot/shared/sender.rs
+++ b/crates/mpz-ot/src/rcot/shared/sender.rs
@@ -151,6 +151,10 @@ where
     }
 
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        if !self.wants_flush() {
+            return Ok(());
+        }
+
         self.barrier.wait().await;
 
         if self.is_leader() {

--- a/crates/mpz-zk-core/src/store/prover.rs
+++ b/crates/mpz-zk-core/src/store/prover.rs
@@ -226,10 +226,7 @@ impl Memory<Binary> for ProverStore {
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.data_store
-            .try_get(slice)
-            .map(|data| Some(data.to_bitvec()))
-            .map_err(Error::from)
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {

--- a/crates/mpz-zk-core/src/store/verifier.rs
+++ b/crates/mpz-zk-core/src/store/verifier.rs
@@ -204,10 +204,7 @@ impl Memory<Binary> for VerifierStore {
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.data_store
-            .try_get(slice)
-            .map(|data| Some(data.to_bitvec()))
-            .map_err(Error::from)
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {


### PR DESCRIPTION
This PR makes a couple small changes:

1. Switches `tlsn-utils` to `dev`
2. Fixes getter impl on VMs to return `None` instead of an error.
3. Fixes a bug in the garble memory implementation which caused duplicate encoding operations.