### PR TITLE
Add Memory trait for Encodings

### DIFF
--- a/crates/mpz-memory-core/src/encoding/key.rs
+++ b/crates/mpz-memory-core/src/encoding/key.rs
@@ -1,0 +1,30 @@
+use mpz_core::Block;
+
+use crate::{encoding::Encoding, FromRaw, Ptr, Repr, Slice, StaticSize, ToRaw};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyEncoding(Ptr);
+
+impl Repr<Encoding> for KeyEncoding {
+    type Clear = Block;
+}
+
+impl<const N: usize> StaticSize<Encoding> for [KeyEncoding; N] {
+    const SIZE: usize = 128 * N;
+}
+
+impl StaticSize<Encoding> for KeyEncoding {
+    const SIZE: usize = 128;
+}
+
+impl FromRaw<Encoding> for KeyEncoding {
+    fn from_raw(slice: Slice) -> Self {
+        Self(slice.ptr)
+    }
+}
+
+impl ToRaw for KeyEncoding {
+    fn to_raw(&self) -> Slice {
+        Slice::new_unchecked(self.0, Self::SIZE)
+    }
+}

--- a/crates/mpz-memory-core/src/encoding/mac.rs
+++ b/crates/mpz-memory-core/src/encoding/mac.rs
@@ -1,0 +1,30 @@
+use mpz_core::Block;
+
+use crate::{encoding::Encoding, FromRaw, Ptr, Repr, Slice, StaticSize, ToRaw};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacEncoding(Ptr);
+
+impl Repr<Encoding> for MacEncoding {
+    type Clear = Block;
+}
+
+impl<const N: usize> StaticSize<Encoding> for [MacEncoding; N] {
+    const SIZE: usize = 128 * N;
+}
+
+impl StaticSize<Encoding> for MacEncoding {
+    const SIZE: usize = 128;
+}
+
+impl FromRaw<Encoding> for MacEncoding {
+    fn from_raw(slice: Slice) -> Self {
+        Self(slice.ptr)
+    }
+}
+
+impl ToRaw for MacEncoding {
+    fn to_raw(&self) -> Slice {
+        Slice::new_unchecked(self.0, Self::SIZE)
+    }
+}

--- a/crates/mpz-memory-core/src/encoding/mod.rs
+++ b/crates/mpz-memory-core/src/encoding/mod.rs
@@ -1,0 +1,56 @@
+use itybity::{FromBitIterator, IntoBitIterator, IntoBits};
+use mpz_core::{bitvec::BitVec, Block};
+
+use crate::{ClearValue, MemoryType, StaticSize};
+
+mod key;
+mod mac;
+
+pub use key::KeyEncoding;
+pub use mac::MacEncoding;
+
+pub struct Encoding;
+
+impl MemoryType for Encoding {
+    type Raw = BitVec;
+}
+
+impl StaticSize<Encoding> for Block {
+    const SIZE: usize = 128;
+}
+
+impl<const N: usize> StaticSize<Encoding> for [Block; N] {
+    const SIZE: usize = 128 * N;
+}
+
+impl ClearValue<Encoding> for Block {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(self.into_iter_lsb0())
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        debug_assert_eq!(value.len(), Self::SIZE);
+        Self::from_lsb0_iter(value.iter().by_vals())
+    }
+}
+
+impl<const N: usize> ClearValue<Encoding> for [Block; N] {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(self.into_iter_lsb0())
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        debug_assert_eq!(value.len(), Self::SIZE * N);
+        Self::from_lsb0_iter(value.iter().by_vals())
+    }
+}
+
+impl ClearValue<Encoding> for Vec<Block> {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(self.into_iter_lsb0())
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        Self::from_lsb0_iter(value.iter().by_vals())
+    }
+}

--- a/crates/mpz-memory-core/src/lib.rs
+++ b/crates/mpz-memory-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod binary;
 pub mod correlated;
 mod decode;
+pub mod encoding;
 pub mod store;
 pub mod view;
 

--- a/crates/mpz-zk-core/src/store/prover.rs
+++ b/crates/mpz-zk-core/src/store/prover.rs
@@ -261,6 +261,74 @@ impl ViewTrait<Binary> for ProverStore {
     }
 }
 
+impl Memory<Encoding> for ProverStore {
+    type Error = Error;
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.view.alloc_input(size);
+        self.mac_store.alloc(size);
+        self.mask_store.alloc(size);
+        let slice = self.data_store.alloc(size);
+
+        Ok(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        // For public data, set MACs.
+        let public = slice.to_range() & self.view.visibility().public();
+        for range in public.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+
+            let data = self.data_store.try_get(slice)?;
+            self.mac_store.try_set_public(slice, data)?;
+        }
+
+        Ok(())
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        let (fut, mut op) = DecodeFuture::new(slice);
+
+        // If data is already decoded, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        self.view.decode(slice.to_range())?;
+
+        Ok(fut)
+    }
+}
+
+impl ViewTrait<Encoding> for ProverStore {
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct ProverStoreError(#[from] ErrorRepr);

--- a/crates/mpz-zk-core/src/store/prover.rs
+++ b/crates/mpz-zk-core/src/store/prover.rs
@@ -2,6 +2,7 @@ use mpz_core::bitvec::{BitSlice, BitVec};
 use mpz_memory_core::{
     binary::Binary,
     correlated::{Mac, MacStore, MacStoreError},
+    encoding::Encoding,
     store::{BitStore, StoreError},
     DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
 };

--- a/crates/mpz-zk-core/src/store/verifier.rs
+++ b/crates/mpz-zk-core/src/store/verifier.rs
@@ -2,6 +2,7 @@ use mpz_core::bitvec::BitVec;
 use mpz_memory_core::{
     binary::Binary,
     correlated::{Delta, Key, KeyStore, KeyStoreError},
+    encoding::Encoding,
     store::{BitStore, StoreError},
     DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
 };

--- a/crates/mpz-zk-core/src/store/verifier.rs
+++ b/crates/mpz-zk-core/src/store/verifier.rs
@@ -239,6 +239,73 @@ impl ViewTrait<Binary> for VerifierStore {
     }
 }
 
+impl Memory<Encoding> for VerifierStore {
+    type Error = Error;
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.view.alloc_input(size);
+        self.key_store.alloc(size);
+        let slice = self.data_store.alloc(size);
+
+        Ok(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        // For public data, set keys.
+        let public = slice.to_range() & self.view.visibility().public();
+        for range in public.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+
+            let data = self.data_store.try_get(slice)?;
+            self.key_store.try_set_public(slice, data)?;
+        }
+
+        Ok(())
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        let (fut, mut op) = DecodeFuture::new(slice);
+
+        // If data is already decoded, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        self.view.decode(slice.to_range())?;
+
+        Ok(fut)
+    }
+}
+
+impl ViewTrait<Encoding> for VerifierStore {
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("verifier store error: {0}")]
 pub struct VerifierStoreError(#[from] ErrorRepr);

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -3,7 +3,9 @@ use mpz_common::{scoped_futures::ScopedFutureExt, Context, Flush};
 use mpz_core::{bitvec::BitVec, Block};
 use mpz_ot::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
-    memory::{binary::Binary, correlated::Mac, DecodeFuture, Memory, Slice, View},
+    memory::{
+        binary::Binary, correlated::Mac, encoding::Encoding, DecodeFuture, Memory, Slice, View,
+    },
     Call, Callable, Execute, Result, VmError,
 };
 use mpz_zk_core::{store::ProverStore, Prover as Core};
@@ -234,6 +236,56 @@ where
 }
 
 impl<OT> View<Binary> for Prover<OT>
+where
+    OT: RCOTReceiver<bool, Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_public_raw(slice).map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_private_raw(slice).map_err(VmError::view)?;
+
+        self.ot.alloc(slice.len()).map_err(VmError::view)?;
+
+        Ok(())
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_blind_raw(slice).map_err(VmError::view)
+    }
+}
+
+impl<OT> Memory<Encoding> for Prover<OT>
+where
+    OT: RCOTReceiver<bool, Block>,
+{
+    type Error = VmError;
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store.alloc_raw(size).map_err(VmError::memory)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.store.assign_raw(slice, data).map_err(VmError::memory)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.commit_raw(slice).map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store.get_raw(slice).map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store.decode_raw(slice).map_err(VmError::memory)
+    }
+}
+
+impl<OT> View<Encoding> for Prover<OT>
 where
     OT: RCOTReceiver<bool, Block>,
 {

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -215,23 +215,24 @@ where
     type Error = VmError;
 
     fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
-        self.store.alloc_raw(size).map_err(VmError::memory)
+        <ProverStore as Memory<Binary>>::alloc_raw(&mut self.store, size).map_err(VmError::memory)
     }
 
     fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
-        self.store.assign_raw(slice, data).map_err(VmError::memory)
+        <ProverStore as Memory<Binary>>::assign_raw(&mut self.store, slice, data)
+            .map_err(VmError::memory)
     }
 
     fn commit_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.commit_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Binary>>::commit_raw(&mut self.store, slice).map_err(VmError::memory)
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.store.get_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Binary>>::get_raw(&self.store, slice).map_err(VmError::memory)
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
-        self.store.decode_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Binary>>::decode_raw(&mut self.store, slice).map_err(VmError::memory)
     }
 }
 
@@ -242,11 +243,13 @@ where
     type Error = VmError;
 
     fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_public_raw(slice).map_err(VmError::view)
+        <ProverStore as View<Binary>>::mark_public_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_private_raw(slice).map_err(VmError::view)?;
+        <ProverStore as View<Binary>>::mark_private_raw(&mut self.store, slice)
+            .map_err(VmError::view)?;
 
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
@@ -254,7 +257,7 @@ where
     }
 
     fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_blind_raw(slice).map_err(VmError::view)
+        <ProverStore as View<Binary>>::mark_blind_raw(&mut self.store, slice).map_err(VmError::view)
     }
 }
 
@@ -265,23 +268,26 @@ where
     type Error = VmError;
 
     fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
-        self.store.alloc_raw(size).map_err(VmError::memory)
+        <ProverStore as Memory<Encoding>>::alloc_raw(&mut self.store, size).map_err(VmError::memory)
     }
 
     fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
-        self.store.assign_raw(slice, data).map_err(VmError::memory)
+        <ProverStore as Memory<Encoding>>::assign_raw(&mut self.store, slice, data)
+            .map_err(VmError::memory)
     }
 
     fn commit_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.commit_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Encoding>>::commit_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.store.get_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Encoding>>::get_raw(&self.store, slice).map_err(VmError::memory)
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
-        self.store.decode_raw(slice).map_err(VmError::memory)
+        <ProverStore as Memory<Encoding>>::decode_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 }
 
@@ -292,11 +298,13 @@ where
     type Error = VmError;
 
     fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_public_raw(slice).map_err(VmError::view)
+        <ProverStore as View<Encoding>>::mark_public_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_private_raw(slice).map_err(VmError::view)?;
+        <ProverStore as View<Encoding>>::mark_private_raw(&mut self.store, slice)
+            .map_err(VmError::view)?;
 
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
@@ -304,6 +312,7 @@ where
     }
 
     fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_blind_raw(slice).map_err(VmError::view)
+        <ProverStore as View<Encoding>>::mark_blind_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 }

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -201,23 +201,26 @@ where
     type Error = VmError;
 
     fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
-        self.store.alloc_raw(size).map_err(VmError::memory)
+        <VerifierStore as Memory<Binary>>::alloc_raw(&mut self.store, size).map_err(VmError::memory)
     }
 
     fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
-        self.store.assign_raw(slice, data).map_err(VmError::memory)
+        <VerifierStore as Memory<Binary>>::assign_raw(&mut self.store, slice, data)
+            .map_err(VmError::memory)
     }
 
     fn commit_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.commit_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Binary>>::commit_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.store.get_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Binary>>::get_raw(&self.store, slice).map_err(VmError::memory)
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
-        self.store.decode_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Binary>>::decode_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 }
 
@@ -228,15 +231,19 @@ where
     type Error = VmError;
 
     fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_public_raw(slice).map_err(VmError::view)
+        <VerifierStore as View<Binary>>::mark_public_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_private_raw(slice).map_err(VmError::view)
+        <VerifierStore as View<Binary>>::mark_private_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_blind_raw(slice).map_err(VmError::view)?;
+        <VerifierStore as View<Binary>>::mark_blind_raw(&mut self.store, slice)
+            .map_err(VmError::view)?;
+
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
         Ok(())
@@ -250,23 +257,27 @@ where
     type Error = VmError;
 
     fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
-        self.store.alloc_raw(size).map_err(VmError::memory)
+        <VerifierStore as Memory<Encoding>>::alloc_raw(&mut self.store, size)
+            .map_err(VmError::memory)
     }
 
     fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
-        self.store.assign_raw(slice, data).map_err(VmError::memory)
+        <VerifierStore as Memory<Encoding>>::assign_raw(&mut self.store, slice, data)
+            .map_err(VmError::memory)
     }
 
     fn commit_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.commit_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Encoding>>::commit_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 
     fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
-        self.store.get_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Encoding>>::get_raw(&self.store, slice).map_err(VmError::memory)
     }
 
     fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
-        self.store.decode_raw(slice).map_err(VmError::memory)
+        <VerifierStore as Memory<Encoding>>::decode_raw(&mut self.store, slice)
+            .map_err(VmError::memory)
     }
 }
 
@@ -277,15 +288,19 @@ where
     type Error = VmError;
 
     fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_public_raw(slice).map_err(VmError::view)
+        <VerifierStore as View<Encoding>>::mark_public_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_private_raw(slice).map_err(VmError::view)
+        <VerifierStore as View<Encoding>>::mark_private_raw(&mut self.store, slice)
+            .map_err(VmError::view)
     }
 
     fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
-        self.store.mark_blind_raw(slice).map_err(VmError::view)?;
+        <VerifierStore as View<Encoding>>::mark_blind_raw(&mut self.store, slice)
+            .map_err(VmError::view)?;
+
         self.ot.alloc(slice.len()).map_err(VmError::view)?;
 
         Ok(())

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -6,6 +6,7 @@ use mpz_vm_core::{
     memory::{
         binary::Binary,
         correlated::{Delta, Key},
+        encoding::Encoding,
         DecodeFuture, Memory, Slice, View,
     },
     Call, Callable, Execute, Result, VmError,
@@ -221,6 +222,55 @@ where
 }
 
 impl<OT> View<Binary> for Verifier<OT>
+where
+    OT: RCOTSender<Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_public_raw(slice).map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_private_raw(slice).map_err(VmError::view)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.mark_blind_raw(slice).map_err(VmError::view)?;
+        self.ot.alloc(slice.len()).map_err(VmError::view)?;
+
+        Ok(())
+    }
+}
+
+impl<OT> Memory<Encoding> for Verifier<OT>
+where
+    OT: RCOTSender<Block>,
+{
+    type Error = VmError;
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store.alloc_raw(size).map_err(VmError::memory)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.store.assign_raw(slice, data).map_err(VmError::memory)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store.commit_raw(slice).map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store.get_raw(slice).map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store.decode_raw(slice).map_err(VmError::memory)
+    }
+}
+
+impl<OT> View<Encoding> for Verifier<OT>
 where
     OT: RCOTSender<Block>,
 {


### PR DESCRIPTION
This PR implements the `Memory` trait to deal with raw encodings.