### PR TITLE
fix: cross-platform bitvec bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ bincode = "1.3.3"
 bytes = "1"
 yamux = "0.10"
 bytemuck = { version = "1.13", features = ["derive"] }
-zerocopy = "0.8.20"
+zerocopy = "0.8"
 serio = { version = "0.2" }
 
 # io

--- a/crates/mpz-core/src/bitvec.rs
+++ b/crates/mpz-core/src/bitvec.rs
@@ -1,6 +1,6 @@
 //! Bit vectors.
 
 /// Bit vector.
-pub type BitVec<T = u32> = bitvec::vec::BitVec<T, bitvec::order::Lsb0>;
+pub type BitVec = bitvec::vec::BitVec<u32, bitvec::order::Lsb0>;
 /// Bit slice.
-pub type BitSlice<T = u32> = bitvec::slice::BitSlice<T, bitvec::order::Lsb0>;
+pub type BitSlice = bitvec::slice::BitSlice<u32, bitvec::order::Lsb0>;

--- a/crates/mpz-memory-core/src/correlated.rs
+++ b/crates/mpz-memory-core/src/correlated.rs
@@ -256,15 +256,13 @@ enum MacCommitmentErrorKind {
 
 #[cfg(test)]
 mod tests {
-    use mpz_core::prg::Prg;
+    use mpz_core::{bitvec::BitVec, prg::Prg};
     use mpz_ot_core::{cot::COTReceiverOutput, ideal::cot::IdealCOT};
     use rand::{rngs::StdRng, SeedableRng};
 
     use crate::Slice;
 
     use super::*;
-
-    type BitVec = mpz_core::bitvec::BitVec<u32>;
 
     #[test]
     fn test_correlated_store() {

--- a/crates/mpz-memory-core/src/correlated/macs.rs
+++ b/crates/mpz-memory-core/src/correlated/macs.rs
@@ -276,7 +276,7 @@ mod tests {
         let macs = vec![Mac::PUBLIC[0], Mac::PUBLIC[1]];
 
         let slice = store.alloc_with(&macs);
-        let data = BitVec::<u32>::from_iter([true, false]);
+        let data = BitVec::from_iter([true, false]);
 
         store.adjust(slice, &data).unwrap();
 

--- a/crates/mpz-ot-core/Cargo.toml
+++ b/crates/mpz-ot-core/Cargo.toml
@@ -41,6 +41,7 @@ bytemuck = { workspace = true, features = ["derive"] }
 enum-try-as-inner.workspace = true
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+zerocopy = { workspace = true }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/mpz-ot-core/src/cot/derandomize.rs
+++ b/crates/mpz-ot-core/src/cot/derandomize.rs
@@ -168,7 +168,7 @@ struct QueuedReceive {
 pub struct DerandCOTReceiver<T> {
     rcot: T,
     /// Choice bits from RCOT which need to be derandomized.
-    derandomize: BitVec<u8>,
+    derandomize: BitVec,
     queue: VecDeque<QueuedReceive>,
 }
 

--- a/crates/mpz-ot-core/src/ferret/spcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/spcot/receiver.rs
@@ -13,6 +13,7 @@ use mpz_core::{
     utils::{slices_from_lengths, slices_from_lengths_mut},
     Block,
 };
+use zerocopy::IntoBytes;
 
 use crate::{ferret::config::CSP, Derandomize};
 
@@ -89,7 +90,9 @@ impl SPCOTReceiver {
                 .map(|(b, m)| !b ^ m),
         );
 
-        self.transcript.update(flip.as_raw_slice());
+        let flip_len = flip.len();
+        self.transcript
+            .update(&flip.as_raw_slice().as_bytes()[..flip_len.div_ceil(8)]);
 
         Ok(Derandomize { flip })
     }

--- a/crates/mpz-ot-core/src/ferret/spcot/sender.rs
+++ b/crates/mpz-ot-core/src/ferret/spcot/sender.rs
@@ -8,6 +8,7 @@ use mpz_core::{
     aes::FIXED_KEY_AES, bitvec::BitVec, ggm::GgmTree, prg::Prg, utils::slices_from_lengths_mut,
     Block,
 };
+use zerocopy::IntoBytes;
 
 use crate::ferret::config::CSP;
 
@@ -58,7 +59,7 @@ impl SPCOTSender {
         rng: &mut R,
         log2_lengths: &[usize],
         keys: &[Block],
-        masks: &BitVec<u8>,
+        masks: &BitVec,
     ) -> Result<(&[Block], Vec<[Block; 2]>, Vec<Block>)> {
         let len_sum: usize = log2_lengths.iter().sum();
         if keys.len() != len_sum {
@@ -132,7 +133,9 @@ impl SPCOTSender {
             })
             .collect();
 
-        self.transcript.update(masks.as_raw_slice());
+        let masks_len = masks.len();
+        self.transcript
+            .update(&masks.as_raw_slice().as_bytes()[..masks_len.div_ceil(8)]);
         self.transcript.update(Block::array_as_flattened_bytes(&ms));
         self.transcript.update(Block::as_flattened_bytes(&sums));
         self.counter += len_sum as u128;
@@ -146,7 +149,7 @@ impl SPCOTSender {
     ///
     /// * `keys` - COT keys.
     /// * `masks` - Derandomized COT choice bits from the receiver.
-    pub(crate) fn check(&mut self, keys: &[Block], masks: &BitVec<u8>) -> Result<Hash> {
+    pub(crate) fn check(&mut self, keys: &[Block], masks: &BitVec) -> Result<Hash> {
         if keys.len() != CSP {
             return Err(ErrorRepr::KeyCount {
                 expected: CSP,

--- a/crates/mpz-ot-core/src/lib.rs
+++ b/crates/mpz-ot-core/src/lib.rs
@@ -68,5 +68,5 @@ impl TransferId {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Derandomize {
     /// Correction bits
-    pub flip: BitVec<u8>,
+    pub flip: BitVec,
 }

--- a/crates/mpz-zk-core/src/check.rs
+++ b/crates/mpz-zk-core/src/check.rs
@@ -9,6 +9,7 @@ use mpz_core::{
     Block,
 };
 use serde::{Deserialize, Serialize};
+use zerocopy::IntoBytes;
 
 use crate::vole::{vole_receiver, vole_sender};
 
@@ -31,7 +32,7 @@ pub(crate) struct Triple {
 #[derive(Debug, Default)]
 pub(crate) struct Check {
     triples: Vec<Triple>,
-    adjust: BitVec<u8>,
+    adjust: BitVec,
 }
 
 impl Check {
@@ -44,7 +45,7 @@ impl Check {
         idx
     }
 
-    pub(crate) fn write(&mut self, idx: usize, triples: &[Triple], adjust: &BitSlice<u8>) {
+    pub(crate) fn write(&mut self, idx: usize, triples: &[Triple], adjust: &BitSlice) {
         self.triples[idx..idx + triples.len()].copy_from_slice(triples);
         self.adjust[idx..idx + triples.len()].copy_from_bitslice(adjust);
     }
@@ -90,7 +91,8 @@ impl Check {
             (u, v)
         }
 
-        transcript.update(self.adjust.as_raw_slice());
+        let adjust_len = self.adjust.len();
+        transcript.update(&self.adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
 
         let chi = Block::try_from(&transcript.finalize().as_bytes()[..16])
             .expect("block should be 16 bytes");
@@ -152,7 +154,8 @@ impl Check {
             b.gfmul(chi)
         }
 
-        transcript.update(self.adjust.as_raw_slice());
+        let adjust_len = self.adjust.len();
+        transcript.update(&self.adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
 
         let chi = Block::try_from(&transcript.finalize().as_bytes()[..16])
             .expect("block should be 16 bytes");

--- a/crates/mpz-zk-core/src/prover.rs
+++ b/crates/mpz-zk-core/src/prover.rs
@@ -95,7 +95,7 @@ pub struct ProverExecute {
     circ: Arc<Circuit>,
     macs: Vec<Mac>,
     triples: Vec<Triple>,
-    adjust: BitVec<u8>,
+    adjust: BitVec,
     gate_masks: Vec<bool>,
     gate_macs: Vec<Mac>,
     check: Arc<Mutex<Check>>,
@@ -193,7 +193,7 @@ pub struct ProverIter<'a, I> {
     gate_macs: &'a [Mac],
     gates: I,
     triples: &'a mut Vec<Triple>,
-    adjust: &'a mut BitVec<u8>,
+    adjust: &'a mut BitVec,
     counter: &'a mut usize,
     and_count: usize,
 }

--- a/crates/mpz-zk-core/src/store/prover.rs
+++ b/crates/mpz-zk-core/src/store/prover.rs
@@ -125,7 +125,7 @@ impl ProverStore {
         self.pending = true;
 
         // Commit MACs.
-        let mut adjust: BitVec<u32> = BitVec::with_capacity(self.view.flush().commit.len());
+        let mut adjust: BitVec = BitVec::with_capacity(self.view.flush().commit.len());
         let mut i = 0;
         for range in self.view.flush().commit.iter_ranges() {
             let slice = Slice::from_range_unchecked(range);
@@ -140,7 +140,8 @@ impl ProverStore {
             i += slice.len();
         }
 
-        transcript.update(adjust.as_raw_slice().as_bytes());
+        let adjust_len = adjust.len();
+        transcript.update(&adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
 
         let mac_proof = if !self.view.flush().prove.is_empty() {
             Some(self.mac_store.prove(&self.view.flush().prove)?)

--- a/crates/mpz-zk-core/src/store/verifier.rs
+++ b/crates/mpz-zk-core/src/store/verifier.rs
@@ -143,7 +143,8 @@ impl VerifierStore {
             i += slice.len();
         }
 
-        transcript.update(adjust.as_raw_slice().as_bytes());
+        let adjust_len = adjust.len();
+        transcript.update(&adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
 
         // Verify MAC proofs.
         i = 0;

--- a/crates/mpz-zk-core/src/verifier.rs
+++ b/crates/mpz-zk-core/src/verifier.rs
@@ -93,7 +93,7 @@ pub struct VerifierExecute {
     keys: Vec<Key>,
     gate_keys: Vec<Key>,
     triples: Vec<Triple>,
-    adjust: BitVec<u8>,
+    adjust: BitVec,
     check: Arc<Mutex<Check>>,
     check_idx: usize,
 
@@ -194,7 +194,7 @@ pub struct VerifierConsumer<'a, I> {
     delta: Delta,
     gates: I,
     triples: &'a mut Vec<Triple>,
-    adjust: &'a mut BitVec<u8>,
+    adjust: &'a mut BitVec,
     counter: &'a mut usize,
     and_count: usize,
 }

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -160,8 +160,7 @@ where
                             let mut iter = execute.iter();
                             loop {
                                 // Stream the `adjust` bits to avoid buffering them in memory.
-                                let adjust: BitVec<u32> =
-                                    BitVec::from_iter(iter.by_ref().take(8000));
+                                let adjust: BitVec = BitVec::from_iter(iter.by_ref().take(8000));
 
                                 if !adjust.is_empty() {
                                     ctx.io_mut().send(adjust).await?;

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -153,7 +153,7 @@ where
                         async move {
                             let mut consumer = execute.consumer();
                             while consumer.wants_adjust() {
-                                let adjust: BitVec<u32> = ctx.io_mut().expect_next().await?;
+                                let adjust: BitVec = ctx.io_mut().expect_next().await?;
                                 for bit in adjust {
                                     consumer.next(bit);
                                 }


### PR DESCRIPTION
This PR fixes a cross-platform issue arising from `bitvec`. The author of that crate recommends using only `BitVec<u32>` to mitigate this. Additionally, there is some variance in the backing store between platforms which busts transcript hashing. I've modified that code to only include the slice corresponding to initialized data.