### PR TITLE
(fix) ferret lpn parameter selector

### DIFF
--- a/crates/mpz-ot-core/src/ferret/config.rs
+++ b/crates/mpz-ot-core/src/ferret/config.rs
@@ -104,7 +104,7 @@ fn default_parameter_selector(ty: LpnType, available: usize, additional: usize) 
     // *Assumes the parameters are in ascending order.*
     for param in params {
         let cost = iteration_cost(ty, *param);
-        let net = param.t - cost;
+        let net = param.n - cost;
         // If we don't have enough available we select the smallest parameters
         // immediately.
         if available <= cost || net >= additional {


### PR DESCRIPTION
Discovered a bug when I ran tlsn's `attestation_prove` example in debug mode
```
thread '<unnamed>' panicked at /Users/yuroitaki/.cargo/git/checkouts/mpz-585819f1a9027d2e/68d0571/crates/mpz-ot-core/src/ferret/config.rs:107:19:
attempt to subtract with overflow
```
(P/S: in release mode there is no issue)

@sinui0 pointed out that this should be the fix — tested and all worked with the fix.