### PR TITLE
ci: add explicit +nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,4 +72,4 @@ jobs:
         run: cargo +nightly fmt --check --all
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo +nightly clippy --all-targets --all-features


### PR DESCRIPTION
Add +nightly to make it easier to copy paste failing commands from gh's actions page