### PR TITLE
Ferret tests2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,4 +72,4 @@ jobs:
         run: cargo +nightly fmt --check --all
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo +nightly clippy --all-targets --all-features

--- a/crates/mpz-core/src/ggm.rs
+++ b/crates/mpz-core/src/ggm.rs
@@ -77,7 +77,8 @@ impl<'a> GgmTree<'a> {
     /// * `idx` - Index of the missing leaf.
     /// * `leaves` - Leaves of the tree.
     pub fn new_partial(depth: usize, sums: &[Block], idx: usize, leaves: &'a mut [Block]) -> Self {
-        assert!(idx < 1 << depth, "index out of bounds");
+        assert_eq!(leaves.len(), 1 << depth, "invalid length of leaves");
+        assert!(idx < leaves.len(), "index out of bounds");
         assert_eq!(sums.len(), depth, "invalid length of sums");
 
         let mut buf = vec![Block::ZERO; (1 << depth) - 1];

--- a/crates/mpz-core/src/ggm.rs
+++ b/crates/mpz-core/src/ggm.rs
@@ -191,7 +191,7 @@ mod tests {
 
         GgmTree::new_from_seed(depth, seed, &mut leaves);
 
-        assert_ne!(leaves, vec![Block::ZERO; 1 << depth]);
+        assert!(leaves.iter().all(|leaf| *leaf != Block::ZERO));
     }
 
     #[test]

--- a/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
@@ -271,13 +271,11 @@ mod tests {
         //Corrupt an index.
         idxs[idx_count - 1] = idxs[idx_count - 2];
 
-        assert_eq!(
+        assert!(matches!(
             MPCOTReceiver::new(rng.gen(), LpnType::Regular)
                 .start_extend(&idxs, interval_len * idx_count)
-                .unwrap_err()
-                .0
-                .to_string(),
-            ErrorRepr::NotRegular.to_string()
-        );
+                .unwrap_err(),
+            MPCOTReceiverError(ErrorRepr::NotRegular)
+        ));
     }
 }

--- a/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
@@ -252,3 +252,32 @@ pub(crate) mod state {
 }
 
 use state::{Extension, Initialized};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+
+    #[test]
+    fn test_indices_not_regular() {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let interval_len = 8;
+        let idx_count = 4;
+        let mut idxs: Vec<_> = (0..idx_count)
+            .map(|i| rng.gen_range(interval_len * i..interval_len * (i + 1)))
+            .collect();
+
+        //Corrupt an index.
+        idxs[idx_count - 1] = idxs[idx_count - 2];
+
+        assert_eq!(
+            MPCOTReceiver::new(rng.gen(), LpnType::Regular)
+                .start_extend(&idxs, interval_len * idx_count)
+                .unwrap_err()
+                .0
+                .to_string(),
+            ErrorRepr::NotRegular.to_string()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a missing assert on a fn input and improves the tests.


This PR is a copy of https://github.com/privacy-scaling-explorations/mpz/pull/247 with feedback applied.
That PR's diff got messy due to changing the base branch.