### PR TITLE
Mpz zk misc attempt2

### DIFF
--- a/crates/mpz-memory-core/src/correlated/keys.rs
+++ b/crates/mpz-memory-core/src/correlated/keys.rs
@@ -152,6 +152,7 @@ pub struct KeyStore {
     delta: Delta,
     /// Key for public 1 MAC.
     public_one: Key,
+    /// Keys used for either OT or for transfering MACs directly.
     used: RangeSet,
 }
 
@@ -160,6 +161,7 @@ impl KeyStore {
     #[inline]
     pub fn new(delta: Delta) -> Self {
         let mut public_one = Key(MAC_ONE ^ delta.as_block());
+        // By definition, LSB(public_one) == 0. We set it here again for expliciteness.
         public_one.0.set_lsb(false);
         Self {
             keys: Store::default(),

--- a/crates/mpz-zk-core/src/store.rs
+++ b/crates/mpz-zk-core/src/store.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::view::FlushView;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(try_from = "validation::ProverFlushUnchecked")]
 pub struct ProverFlush {
     view: FlushView,
     adjust: BitVec,
@@ -20,6 +21,48 @@ pub struct ProverFlush {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VerifierFlush {
     view: FlushView,
+}
+
+mod validation {
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    pub(super) struct ProverFlushUnchecked {
+        view: FlushView,
+        adjust: BitVec,
+        mac_proof: Option<(BitVec, Hash)>,
+    }
+
+    impl TryFrom<ProverFlushUnchecked> for ProverFlush {
+        type Error = String;
+
+        fn try_from(value: ProverFlushUnchecked) -> Result<Self, Self::Error> {
+            let ProverFlushUnchecked {
+                view,
+                adjust,
+                mac_proof,
+            } = value;
+
+            if view.commit.len() != adjust.len() {
+                return Err("prover sent flush with invalid number of adjustment bits".to_string());
+            }
+
+            let mac_proof_bits = match mac_proof {
+                Some(ref proof) => proof.0.len(),
+                None => 0,
+            };
+
+            if view.prove.len() != mac_proof_bits {
+                return Err("prover sent flush with invalid number of mac proof bits".to_string());
+            }
+
+            Ok(ProverFlush {
+                view,
+                adjust,
+                mac_proof,
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mpz-zk-core/src/view.rs
+++ b/crates/mpz-zk-core/src/view.rs
@@ -245,8 +245,8 @@ impl View {
 
         self.decode.all |= &undecoded;
 
-        let input = range.intersection(&self.input.all);
-        let output = range.intersection(&self.output.all);
+        let input = undecoded.intersection(&self.input.all);
+        let output = undecoded.intersection(&self.output.all);
 
         let provable_input = match self.role {
             Role::Prover => input.intersection(self.vis.private()),

--- a/crates/mpz-zk/src/prover.rs
+++ b/crates/mpz-zk/src/prover.rs
@@ -269,7 +269,9 @@ where
         Ok(())
     }
 
-    fn mark_blind_raw(&mut self, slice: Slice) -> VmResult<()> {
-        self.store.mark_blind_raw(slice).map_err(VmError::view)
+    fn mark_blind_raw(&mut self, _slice: Slice) -> VmResult<()> {
+        Err(VmError::view(
+            "marking as blind is not allowed for zk prover",
+        ))
     }
 }

--- a/crates/mpz-zk/src/verifier.rs
+++ b/crates/mpz-zk/src/verifier.rs
@@ -249,8 +249,10 @@ where
         self.store.mark_public_raw(slice).map_err(VmError::view)
     }
 
-    fn mark_private_raw(&mut self, slice: Slice) -> VmResult<()> {
-        self.store.mark_private_raw(slice).map_err(VmError::view)
+    fn mark_private_raw(&mut self, _slice: Slice) -> VmResult<()> {
+        Err(VmError::view(
+            "marking as private is not allowed for zk verifier",
+        ))
     }
 
     fn mark_blind_raw(&mut self, slice: Slice) -> VmResult<()> {


### PR DESCRIPTION
This PR is a copy of https://github.com/privacy-scaling-explorations/mpz/pull/261, I simply cherry-picked the commits with no changes.
It was needed because gh did something wrong when I changed 261's base dev->alpha.3 (lesson learned!)

Original description:


This PR adds some fixes around the zk code:
    improve comments
    do not allow decoding already decoded values
    disables marking the inputs as blind/private for prover/verifier resp
    add validation to the prover's flush msg

