### PR TITLE
fix: SPCOT count inconsistency between platforms in Ferret Uniform LPN mode

### DIFF
--- a/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
@@ -80,6 +80,8 @@ impl MPCOTReceiver<state::Initialized> {
                         let (_, pos) = buckets.get(x.value as usize)[x.hash_idx as usize];
                         idxs.push(pos);
                     } else {
+                        // Acc.to p.10 "if T[j] is empty ... then the receiver's input p_j can
+                        // point to this extra cell".
                         idxs.push(bucket_length);
                     }
                     

--- a/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
@@ -1,4 +1,5 @@
 use std::array::from_fn;
+use super::utils::padded_log2_and_length;
 
 use mpz_core::{aes::AesEncryptor, lpn::LpnType, prg::Prg, utils::slices_from_lengths, Block};
 use rand_core::SeedableRng;
@@ -73,22 +74,17 @@ impl MPCOTReceiver<state::Initialized> {
                 let mut spcot_lengths = vec![];
                 for (item, bucket_length) in cuckoo.iter().zip(buckets.iter_buckets()) {
                     // pad to power of 2.
-                    let power_of_two = (bucket_length + 1)
-                        .checked_next_power_of_two()
-                        .expect("bucket length should be less than usize::MAX / 2 - 1");
+                    let (log2_len, padded_len) = crate::utils::padded_log2_and_length(bucket_length);
 
                     if let Some(x) = item {
                         let (_, pos) = buckets.get(x.value as usize)[x.hash_idx as usize];
-
                         idxs.push(pos);
                     } else {
-                        // Acc.to p.10 "if T[j] is empty ... then the receiver's input p_j can
-                        // point to this extra cell".
                         idxs.push(bucket_length);
                     }
-
-                    spcot_log2_lengths.push(power_of_two.ilog2() as usize);
-                    spcot_lengths.push(power_of_two);
+                    
+                    spcot_log2_lengths.push(log2_len);
+                    spcot_lengths.push(padded_len);                    
                 }
 
                 (

--- a/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/receiver.rs
@@ -74,7 +74,7 @@ impl MPCOTReceiver<state::Initialized> {
                 let mut spcot_lengths = vec![];
                 for (item, bucket_length) in cuckoo.iter().zip(buckets.iter_buckets()) {
                     // pad to power of 2.
-                    let (log2_len, padded_len) = crate::utils::padded_log2_and_length(bucket_length);
+                    let (log2_len, padded_len) = padded_log2_and_length(bucket_length);
 
                     if let Some(x) = item {
                         let (_, pos) = buckets.get(x.value as usize)[x.hash_idx as usize];

--- a/crates/mpz-ot-core/src/ferret/mpcot/sender.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/sender.rs
@@ -1,4 +1,5 @@
 use std::array::from_fn;
+use super::utils::padded_log2_and_length;
 
 use mpz_core::{aes::AesEncryptor, lpn::LpnType, prg::Prg, utils::slices_from_lengths, Block};
 use rand_core::SeedableRng;
@@ -69,15 +70,11 @@ impl MPCOTSender<Initialized> {
                 // bucket.
                 let mut bs = vec![];
                 let mut spcot_lengths = vec![];
-                for len in buckets.iter_buckets() {
-                    let power_of_two = (len + 1)
-                        .checked_next_power_of_two()
-                        .expect("bucket length should be less than usize::MAX / 2 - 1");
-
-                    bs.push(power_of_two.ilog2() as usize);
-                    spcot_lengths.push(power_of_two);
+                for bucket_len in buckets.iter_buckets() {
+                    let (log2_len, padded_len) = padded_log2_and_length(bucket_len);
+                    bs.push(log2_len);
+                    spcot_lengths.push(padded_len);
                 }
-
                 (
                     Extension::Uniform {
                         len,

--- a/crates/mpz-ot-core/src/ferret/mpcot/utils.rs
+++ b/crates/mpz-ot-core/src/ferret/mpcot/utils.rs
@@ -1,0 +1,5 @@
+/// Pads `n` to next power of two and returns (log2, length)
+pub fn padded_log2_and_length(n: usize) -> (usize, usize) {
+    let pow2 = (n + 1).checked_next_power_of_two().unwrap();
+    (pow2.ilog2() as usize, pow2)
+}


### PR DESCRIPTION
Replace platform-dependent `checked_next_power_of_two()` with a deterministic algorithm to ensure consistent SPCOT lengths across WASM and x86 platforms.