### PR TITLE
fix(co15): error when payload is too small

### DIFF
--- a/crates/ot-core/src/chou_orlandi.rs
+++ b/crates/ot-core/src/chou_orlandi.rs
@@ -67,7 +67,7 @@ mod tests {
             .collect()
     }
 
-    fn setup() -> (Sender<sender_state::Setup>, Receiver<receiver_state::Setup>) {
+    pub(crate) fn setup() -> (Sender<sender_state::Setup>, Receiver<receiver_state::Setup>) {
         let sender = Sender::new_with_seed(SENDER_SEED);
         let receiver = Receiver::new_with_seed(RECEIVER_SEED);
 

--- a/crates/ot-core/src/chou_orlandi/error.rs
+++ b/crates/ot-core/src/chou_orlandi/error.rs
@@ -24,6 +24,8 @@ pub enum ReceiverError {
     IdMismatch(TransferId, TransferId),
     #[error("count mismatch: receiver expected {0} but sender sent {1}")]
     CountMismatch(usize, usize),
+    #[error("payload too small: receiver expected at least {0} but sender sent {1}")]
+    PayloadTooSmall(usize, usize),
 }
 
 /// Errors that can occur during verification of the receiver's choices.

--- a/crates/ot-core/src/chou_orlandi/error.rs
+++ b/crates/ot-core/src/chou_orlandi/error.rs
@@ -24,8 +24,6 @@ pub enum ReceiverError {
     IdMismatch(TransferId, TransferId),
     #[error("count mismatch: receiver expected {0} but sender sent {1}")]
     CountMismatch(usize, usize),
-    #[error("payload too small: receiver expected at least {0} but sender sent {1}")]
-    PayloadTooSmall(usize, usize),
 }
 
 /// Errors that can occur during verification of the receiver's choices.

--- a/crates/ot-core/src/chou_orlandi/receiver.rs
+++ b/crates/ot-core/src/chou_orlandi/receiver.rs
@@ -140,6 +140,11 @@ impl Receiver<state::Setup> {
                 payload.len(),
             ));
         }
+        // Check that all queued transfers can be processed.
+        let total_queued = self.queue.iter().map(|q| q.count).sum();
+        if total_queued > payload.len() {
+            return Err(ReceiverError::PayloadTooSmall(total_queued, payload.len()));
+        }
 
         let mut msgs =
             decryption_keys

--- a/crates/ot-core/src/chou_orlandi/receiver.rs
+++ b/crates/ot-core/src/chou_orlandi/receiver.rs
@@ -287,3 +287,33 @@ pub mod state {
 
     opaque_debug::implement!(Setup);
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        chou_orlandi::{ReceiverError, msgs::SenderPayload, tests::setup},
+        ot::OTReceiver,
+    };
+    use mpz_core::Block;
+
+    #[test]
+    fn test_receive_count_err() {
+        let (_, mut receiver) = setup();
+
+        _ = receiver.queue_recv_ot(&[true, false]).unwrap();
+
+        matches!(
+            receiver.receive(SenderPayload {
+                payload: vec![[Block::ZERO; 2]],
+            }),
+            Err(ReceiverError::CountMismatch(2, 1))
+        );
+
+        matches!(
+            receiver.receive(SenderPayload {
+                payload: vec![[Block::ZERO; 2]; 3],
+            }),
+            Err(ReceiverError::CountMismatch(2, 3))
+        );
+    }
+}

--- a/crates/ot-core/src/chou_orlandi/receiver.rs
+++ b/crates/ot-core/src/chou_orlandi/receiver.rs
@@ -134,16 +134,11 @@ impl Receiver<state::Setup> {
 
         // Check that the number of ciphertexts does not exceed the number of pending
         // keys
-        if payload.len() > decryption_keys.len() {
+        if payload.len() != decryption_keys.len() {
             return Err(ReceiverError::CountMismatch(
                 decryption_keys.len(),
                 payload.len(),
             ));
-        }
-        // Check that all queued transfers can be processed.
-        let total_queued = self.queue.iter().map(|q| q.count).sum();
-        if total_queued > payload.len() {
-            return Err(ReceiverError::PayloadTooSmall(total_queued, payload.len()));
         }
 
         let mut msgs =


### PR DESCRIPTION
This PR handles cases when co15 sender's payload is too small.

Closes https://github.com/privacy-scaling-explorations/mpz/issues/194