### PR TITLE
make from_io in Context public

### DIFF
--- a/crates/common/src/context.rs
+++ b/crates/common/src/context.rs
@@ -48,7 +48,12 @@ impl Context {
         }
     }
 
-    pub(crate) fn from_io(io: Io) -> Self {
+    /// Creates a new single-threaded context from an I/O channel.
+    ///
+    /// # Arguments
+    ///
+    /// * `io` - The I/O channel used by the context.
+    pub fn from_io(io: Io) -> Self {
         Self {
             id: ThreadId::default(),
             io,


### PR DESCRIPTION
While playing with `mpz` I needed to make 2 parties communicate over TCP and figured I needed to use Context::from_io which therefore needs to be public. See here: https://github.com/th4s/mpz-play/pull/1