### PR TITLE
fix: zero allocation guards

### DIFF
--- a/crates/ot/src/rcot/shared/receiver.rs
+++ b/crates/ot/src/rcot/shared/receiver.rs
@@ -133,6 +133,10 @@ where
     type Future = MaybeDone<RCOTReceiverOutput<U, V>>;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
+        if count == 0 {
+            return Ok(());
+        }
+
         let mut state = self.state.lock().unwrap();
 
         state.alloc += count;

--- a/crates/ot/src/rcot/shared/sender.rs
+++ b/crates/ot/src/rcot/shared/sender.rs
@@ -130,6 +130,10 @@ where
     type Future = MaybeDone<RCOTSenderOutput<U>>;
 
     fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
+        if count == 0 {
+            return Ok(());
+        }
+
         let mut state = self.state.lock().unwrap();
 
         state.alloc += count;

--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -211,13 +211,15 @@ where
         let output = self.store.alloc_output(call.circ().outputs().len());
 
         let mut count = call.circ().and_count();
+        if count > 0 {
+            // If the callstack is empty, we allocate more for the consistency check.
+            if self.callstack.is_empty() {
+                count += 128
+            }
 
-        // If the callstack is empty, we allocate more for the consistency check.
-        if self.callstack.is_empty() {
-            count += 128
+            self.ot.alloc(count).map_err(VmError::execute)?;
         }
 
-        self.ot.alloc(count).map_err(VmError::execute)?;
         self.callstack.push((call, output));
 
         Ok(output)

--- a/crates/zk/src/verifier.rs
+++ b/crates/zk/src/verifier.rs
@@ -199,13 +199,15 @@ where
         let output = self.store.alloc_output(call.circ().outputs().len());
 
         let mut count = call.circ().and_count();
+        if count > 0 {
+            // If the callstack is empty, we allocate more for the consistency check.
+            if self.callstack.is_empty() {
+                count += 128
+            }
 
-        // If the callstack is empty, we allocate more for the consistency check.
-        if self.callstack.is_empty() {
-            count += 128
+            self.ot.alloc(count).map_err(VmError::execute)?;
         }
 
-        self.ot.alloc(count).map_err(VmError::execute)?;
         self.callstack.push((call, output));
 
         Ok(output)


### PR DESCRIPTION
This PR introduces some guards to
1. Prevent the ZK VM from trying to allocate OTs if the count it is asking for is 0
2. Preventing the shared RCOT implementation from inserting an empty internal buffer if this does happen