### PR TITLE
feat(common): limit message size

### DIFF
--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -9,7 +9,10 @@ use bytes::{Bytes, BytesMut};
 use futures::{AsyncRead, AsyncWrite};
 use pin_project_lite::pin_project;
 use serio::{Framed, Sink, Stream, channel::MemoryDuplex, codec::Bincode};
-use tokio_util::{codec::LengthDelimitedCodec, compat::FuturesAsyncReadCompatExt as _};
+use tokio_util::{
+    codec::{Framed as TokioFramed, LengthDelimitedCodec},
+    compat::FuturesAsyncReadCompatExt as _,
+};
 
 trait Duplex:
     futures::Stream<Item = Result<BytesMut, std::io::Error>>
@@ -21,6 +24,83 @@ impl<T> Duplex for T where
     T: futures::Stream<Item = Result<BytesMut, std::io::Error>>
         + futures::Sink<Bytes, Error = std::io::Error>
 {
+}
+
+trait DuplexFrameLimited<T, U> {
+    /// Sets a new maximum frame length and returns a [`WithFrameLimit`].
+    ///
+    /// # Arguments
+    ///
+    /// * `max_frame_len` - The new maximum frame length in bytes.
+    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> WithFrameLimit<'_, T>;
+}
+
+impl<T, U> DuplexFrameLimited<T, U> for Framed<TokioFramed<T, LengthDelimitedCodec>, U> {
+    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> WithFrameLimit<'_, T> {
+        let old_frame_limit = self.inner().codec().max_frame_length();
+        self.inner_mut()
+            .codec_mut()
+            .set_max_frame_length(max_frame_len);
+
+        WithFrameLimit {
+            old_frame_limit,
+            framed: self.inner_mut(),
+        }
+    }
+}
+
+pin_project! {
+    /// Wrapper around [`Framed`] to temporarily set a new maximum frame length.
+    pub struct WithFrameLimit<'a, T> {
+        old_frame_limit: usize,
+        #[pin]
+        framed: &'a mut TokioFramed<T, LengthDelimitedCodec>,
+    }
+
+    impl<'a, T> PinnedDrop for WithFrameLimit<'a, T> {
+        fn drop(this: Pin<&mut Self>) {
+            let frame_limit = this.old_frame_limit;
+            this.project()
+                .framed
+                .codec_mut()
+                .set_max_frame_length(frame_limit);
+        }
+    }
+}
+
+impl<T> futures::Stream for WithFrameLimit<'_, T>
+where
+    TokioFramed<T, LengthDelimitedCodec>:
+        futures::Stream<Item = Result<BytesMut, std::io::Error>> + Unpin,
+{
+    type Item = Result<BytesMut, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().framed.poll_next(cx)
+    }
+}
+
+impl<T> futures::Sink<Bytes> for WithFrameLimit<'_, T>
+where
+    TokioFramed<T, LengthDelimitedCodec>: futures::Sink<Bytes, Error = std::io::Error> + Unpin,
+{
+    type Error = std::io::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().framed.poll_ready(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
+        self.project().framed.start_send(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().framed.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().framed.poll_close(cx)
+    }
 }
 
 pin_project! {

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -75,7 +75,7 @@ pin_project! {
     }
 }
 
-impl<'a> WithLimit<'a> {
+impl WithLimit<'_> {
     #[cfg(test)]
     fn frame_limit(&self) -> Option<usize> {
         self.io.frame_limit()

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -15,7 +15,7 @@ use tokio_util::{
 };
 
 /// A trait for Sink and Stream functionality.
-pub trait Duplex:
+trait Duplex:
     futures::Stream<Item = Result<BytesMut, std::io::Error>>
     + futures::Sink<Bytes, Error = std::io::Error>
 {
@@ -27,83 +27,85 @@ impl<T> Duplex for T where
 {
 }
 
-trait DuplexFrameLimited: Duplex {
-    /// Sets a new maximum frame length and returns a [`WithFrameLimit`].
+trait FrameLimit {
+    /// Sets a new maximum frame length.
     ///
     /// # Arguments
     ///
-    /// * `max_frame_len` - The new maximum frame length in bytes.
-    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_>;
+    /// * `frame_limit` - The new maximum frame length in bytes.
+    fn set_frame_limit(&mut self, frame_limit: usize);
+
+    /// Returns the current frame limit, if available.
+    fn frame_limit(&self) -> Option<usize>;
 }
 
-impl<T> DuplexFrameLimited for TokioFramed<Compat<T>, LengthDelimitedCodec>
-where
-    T: AsyncRead + AsyncWrite + Unpin,
-{
-    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_> {
-        let old_frame_limit = self.codec().max_frame_length();
-        self.codec_mut().set_max_frame_length(max_frame_len);
+impl<T> FrameLimit for TokioFramed<Compat<T>, LengthDelimitedCodec> {
+    fn set_frame_limit(&mut self, frame_limit: usize) {
+        self.codec_mut().set_max_frame_length(frame_limit);
+    }
 
-        let limited = WithFrameLimit {
-            old_frame_limit,
-            framed: self,
-        };
-
-        Box::new(limited)
+    fn frame_limit(&self) -> Option<usize> {
+        let limit = self.codec().max_frame_length();
+        Some(limit)
     }
 }
+
+trait DuplexFrameLimited: Duplex + FrameLimit {}
+
+impl<T> DuplexFrameLimited for T where T: Duplex + FrameLimit {}
 
 pin_project! {
-    /// Wrapper around [`Framed`] to temporarily set a new maximum frame length.
-    pub struct WithFrameLimit<'a, T> {
-        old_frame_limit: usize,
+    /// Wrapper around [`Io`] to temporarily set a frame limit.
+    pub struct WithLimit<'a> {
+        old_limit: Option<usize>,
         #[pin]
-        framed: &'a mut TokioFramed<T, LengthDelimitedCodec>,
+        io: &'a mut Io,
     }
 
-    impl<'a, T> PinnedDrop for WithFrameLimit<'a, T> {
-        fn drop(this: Pin<&mut Self>) {
-            let frame_limit = this.old_frame_limit;
-            this.project()
-                .framed
-                .codec_mut()
-                .set_max_frame_length(frame_limit);
+    impl<'a> PinnedDrop for WithLimit<'a> {
+        fn drop(mut this: Pin<&mut Self>) {
+            let Some(old_limit) = this.old_limit else {
+                return;
+            };
+            let Inner::Transport { ref mut framed } = this.io.inner else {
+                return;
+            };
+            framed.inner_mut().set_frame_limit(old_limit);
         }
     }
 }
 
-impl<T> futures::Stream for WithFrameLimit<'_, T>
-where
-    TokioFramed<T, LengthDelimitedCodec>:
-        futures::Stream<Item = Result<BytesMut, std::io::Error>> + Unpin,
-{
-    type Item = Result<BytesMut, std::io::Error>;
+impl Stream for WithLimit<'_> {
+    type Error = std::io::Error;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.project().framed.poll_next(cx)
+    fn poll_next<Item: serio::Deserialize>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Item, Self::Error>>> {
+        self.project().io.poll_next(cx)
     }
 }
 
-impl<T> futures::Sink<Bytes> for WithFrameLimit<'_, T>
-where
-    TokioFramed<T, LengthDelimitedCodec>: futures::Sink<Bytes, Error = std::io::Error> + Unpin,
-{
+impl Sink for WithLimit<'_> {
     type Error = std::io::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().framed.poll_ready(cx)
+        self.project().io.poll_ready(cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Bytes) -> Result<(), Self::Error> {
-        self.project().framed.start_send(item)
+    fn start_send<Item: serio::Serialize>(
+        self: Pin<&mut Self>,
+        item: Item,
+    ) -> Result<(), Self::Error> {
+        self.project().io.start_send(item)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().framed.poll_flush(cx)
+        self.project().io.poll_flush(cx)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().framed.poll_close(cx)
+        self.project().io.poll_close(cx)
     }
 }
 
@@ -128,15 +130,24 @@ impl Io {
         }
     }
 
-    /// Sets a new maximum frame length and returns a [`WithFrameLimit`].
+    /// Returns a frame limited Io.
     ///
     /// # Arguments
     ///
-    /// * `max_frame_len` - The new maximum frame length in bytes.
-    pub fn with_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_> {
-        match &mut self.inner {
-            Inner::Transport { framed } => framed.inner_mut().with_max_frame_limit(max_frame_len),
-            Inner::Memory { channel } => Box::new(self),
+    /// * `frame_limit` - The new maximum frame length in bytes.
+    pub fn with_limit(&mut self, frame_limit: usize) -> WithLimit<'_> {
+        let old_limit = match &self.inner {
+            Inner::Transport { framed } => framed.inner().frame_limit(),
+            Inner::Memory { channel: _ } => None,
+        };
+
+        if let Inner::Transport { ref mut framed } = self.inner {
+            framed.inner_mut().set_frame_limit(frame_limit);
+        };
+
+        WithLimit {
+            old_limit,
+            io: self,
         }
     }
 

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -18,15 +18,6 @@ trait Duplex:
     futures::Stream<Item = Result<BytesMut, std::io::Error>>
     + futures::Sink<Bytes, Error = std::io::Error>
 {
-}
-
-impl<T> Duplex for T where
-    T: futures::Stream<Item = Result<BytesMut, std::io::Error>>
-        + futures::Sink<Bytes, Error = std::io::Error>
-{
-}
-
-trait FrameLimit {
     /// Sets a new maximum frame length.
     ///
     /// # Arguments
@@ -34,24 +25,22 @@ trait FrameLimit {
     /// * `frame_limit` - The new maximum frame length in bytes.
     fn set_frame_limit(&mut self, frame_limit: usize);
 
-    /// Returns the current frame limit, if available.
-    fn frame_limit(&self) -> Option<usize>;
+    /// Returns the current frame limit.
+    fn frame_limit(&self) -> usize;
 }
 
-impl<T> FrameLimit for TokioFramed<Compat<T>, LengthDelimitedCodec> {
+impl<T> Duplex for TokioFramed<Compat<T>, LengthDelimitedCodec>
+where
+    T: AsyncRead + AsyncWrite,
+{
     fn set_frame_limit(&mut self, frame_limit: usize) {
         self.codec_mut().set_max_frame_length(frame_limit);
     }
 
-    fn frame_limit(&self) -> Option<usize> {
-        let limit = self.codec().max_frame_length();
-        Some(limit)
+    fn frame_limit(&self) -> usize {
+        self.codec().max_frame_length()
     }
 }
-
-trait DuplexFrameLimited: Duplex + FrameLimit {}
-
-impl<T> DuplexFrameLimited for T where T: Duplex + FrameLimit {}
 
 pin_project! {
     /// Wrapper around [`Io`] to temporarily set a frame limit.
@@ -63,13 +52,13 @@ pin_project! {
 
     impl<'a> PinnedDrop for WithLimit<'a> {
         fn drop(mut this: Pin<&mut Self>) {
-            let Some(old_limit) = this.old_limit else {
-                return;
-            };
-            let Inner::Transport { ref mut framed } = this.io.inner else {
-                return;
-            };
-            framed.inner_mut().set_frame_limit(old_limit);
+            let old_limit = this
+                .old_limit
+                .expect("old limit is always set for transport variant");
+
+            if let Inner::Transport { framed } = &mut this.io.inner {
+                framed.inner_mut().set_frame_limit(old_limit);
+            }
         }
     }
 }
@@ -142,13 +131,13 @@ impl Io {
     ///
     /// * `frame_limit` - The new maximum frame length in bytes.
     pub fn with_limit(&mut self, frame_limit: usize) -> WithLimit<'_> {
-        let old_limit = match &self.inner {
-            Inner::Transport { framed } => framed.inner().frame_limit(),
+        let old_limit = match &mut self.inner {
+            Inner::Transport { framed } => {
+                let old_limit = framed.inner().frame_limit();
+                framed.inner_mut().set_frame_limit(frame_limit);
+                Some(old_limit)
+            }
             Inner::Memory { channel: _ } => None,
-        };
-
-        if let Inner::Transport { ref mut framed } = self.inner {
-            framed.inner_mut().set_frame_limit(frame_limit);
         };
 
         WithLimit {
@@ -167,7 +156,7 @@ impl Io {
     #[cfg(test)]
     fn frame_limit(&self) -> Option<usize> {
         match &self.inner {
-            Inner::Transport { framed } => framed.inner().frame_limit(),
+            Inner::Transport { framed } => Some(framed.inner().frame_limit()),
             Inner::Memory { channel: _ } => None,
         }
     }
@@ -177,7 +166,7 @@ pin_project! {
     #[project = InnerProj]
     enum Inner {
         /// I/O over a framed bytes transport.
-        Transport { #[pin] framed: Framed<Box<dyn DuplexFrameLimited + Send + Sync + Unpin>, Bincode> },
+        Transport { #[pin] framed: Framed<Box<dyn Duplex + Send + Sync + Unpin>, Bincode> },
         /// I/O over a memory channel.
         Memory { #[pin] channel: MemoryDuplex }
     }

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -75,6 +75,13 @@ pin_project! {
     }
 }
 
+impl<'a> WithLimit<'a> {
+    #[cfg(test)]
+    fn frame_limit(&self) -> Option<usize> {
+        self.io.frame_limit()
+    }
+}
+
 impl Stream for WithLimit<'_> {
     type Error = std::io::Error;
 
@@ -157,6 +164,14 @@ impl Io {
             inner: Inner::Memory { channel: duplex },
         }
     }
+
+    #[cfg(test)]
+    fn frame_limit(&self) -> Option<usize> {
+        match &self.inner {
+            Inner::Transport { framed } => framed.inner().frame_limit(),
+            Inner::Memory { channel: _ } => None,
+        }
+    }
 }
 
 pin_project! {
@@ -231,5 +246,33 @@ impl Stream for Io {
             Inner::Transport { framed } => framed.size_hint(),
             Inner::Memory { channel } => channel.size_hint(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Io;
+    use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    #[test]
+    fn test_frame_limit() {
+        let (a, b) = tokio::io::duplex(1024);
+
+        let mut a = Io::from_io(a.compat());
+        let mut b = Io::from_io(b.compat());
+
+        let old_limit = a.frame_limit().unwrap();
+        let new_limit = 2 * old_limit;
+
+        {
+            let a = a.with_limit(new_limit);
+            let b = b.with_limit(new_limit);
+
+            assert_eq!(a.frame_limit().unwrap(), new_limit);
+            assert_eq!(b.frame_limit().unwrap(), new_limit);
+        }
+
+        assert_eq!(a.frame_limit().unwrap(), old_limit);
+        assert_eq!(b.frame_limit().unwrap(), old_limit);
     }
 }

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -14,7 +14,6 @@ use tokio_util::{
     compat::{Compat, FuturesAsyncReadCompatExt as _},
 };
 
-/// A trait for Sink and Stream functionality.
 trait Duplex:
     futures::Stream<Item = Result<BytesMut, std::io::Error>>
     + futures::Sink<Bytes, Error = std::io::Error>
@@ -137,7 +136,7 @@ impl Io {
         }
     }
 
-    /// Returns a frame limited Io.
+    /// Adjusts the frame limit temporarily and returns a [`WithLimit`].
     ///
     /// # Arguments
     ///

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -52,11 +52,8 @@ pin_project! {
 
     impl<'a> PinnedDrop for WithLimit<'a> {
         fn drop(mut this: Pin<&mut Self>) {
-            let old_limit = this
-                .old_limit
-                .expect("old limit is always set for transport variant");
-
-            if let Inner::Transport { framed } = &mut this.io.inner {
+            if let (Some(old_limit), Inner::Transport { framed }) = (this.old_limit, &mut this.io.inner)
+            {
                 framed.inner_mut().set_frame_limit(old_limit);
             }
         }

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -11,10 +11,11 @@ use pin_project_lite::pin_project;
 use serio::{Framed, Sink, Stream, channel::MemoryDuplex, codec::Bincode};
 use tokio_util::{
     codec::{Framed as TokioFramed, LengthDelimitedCodec},
-    compat::FuturesAsyncReadCompatExt as _,
+    compat::{Compat, FuturesAsyncReadCompatExt as _},
 };
 
-trait Duplex:
+/// A trait for Sink and Stream functionality.
+pub trait Duplex:
     futures::Stream<Item = Result<BytesMut, std::io::Error>>
     + futures::Sink<Bytes, Error = std::io::Error>
 {
@@ -26,26 +27,29 @@ impl<T> Duplex for T where
 {
 }
 
-trait DuplexFrameLimited<T, U> {
+trait DuplexFrameLimited: Duplex {
     /// Sets a new maximum frame length and returns a [`WithFrameLimit`].
     ///
     /// # Arguments
     ///
     /// * `max_frame_len` - The new maximum frame length in bytes.
-    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> WithFrameLimit<'_, T>;
+    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_>;
 }
 
-impl<T, U> DuplexFrameLimited<T, U> for Framed<TokioFramed<T, LengthDelimitedCodec>, U> {
-    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> WithFrameLimit<'_, T> {
-        let old_frame_limit = self.inner().codec().max_frame_length();
-        self.inner_mut()
-            .codec_mut()
-            .set_max_frame_length(max_frame_len);
+impl<T> DuplexFrameLimited for TokioFramed<Compat<T>, LengthDelimitedCodec>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    fn with_max_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_> {
+        let old_frame_limit = self.codec().max_frame_length();
+        self.codec_mut().set_max_frame_length(max_frame_len);
 
-        WithFrameLimit {
+        let limited = WithFrameLimit {
             old_frame_limit,
-            framed: self.inner_mut(),
-        }
+            framed: self,
+        };
+
+        Box::new(limited)
     }
 }
 
@@ -124,6 +128,18 @@ impl Io {
         }
     }
 
+    /// Sets a new maximum frame length and returns a [`WithFrameLimit`].
+    ///
+    /// # Arguments
+    ///
+    /// * `max_frame_len` - The new maximum frame length in bytes.
+    pub fn with_frame_limit(&mut self, max_frame_len: usize) -> Box<dyn Duplex + '_> {
+        match &mut self.inner {
+            Inner::Transport { framed } => framed.inner_mut().with_max_frame_limit(max_frame_len),
+            Inner::Memory { channel } => Box::new(self),
+        }
+    }
+
     #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn from_channel(duplex: MemoryDuplex) -> Self {
         Self {
@@ -136,7 +152,7 @@ pin_project! {
     #[project = InnerProj]
     enum Inner {
         /// I/O over a framed bytes transport.
-        Transport { #[pin] framed: Framed<Box<dyn Duplex + Send + Sync + Unpin>, Bincode> },
+        Transport { #[pin] framed: Framed<Box<dyn DuplexFrameLimited + Send + Sync + Unpin>, Bincode> },
         /// I/O over a memory channel.
         Memory { #[pin] channel: MemoryDuplex }
     }


### PR DESCRIPTION
This PR adds a way to temporarily adjust the maximum frame size of `Io`.