### PR TITLE
Add authenticated garbling (rebased onto dev)

### DIFF
--- a/crates/core/src/block.rs
+++ b/crates/core/src/block.rs
@@ -142,6 +142,15 @@ impl Block {
         (self.0[0] & 1) == 1
     }
 
+    /// multiplies the block with a boolean
+    #[inline]
+    pub fn mul_bool(self, bit: bool) -> Self {
+        if bit {
+            self
+        } else {
+            Self::ZERO
+        }
+    }
     /// Let `x0` and `x1` be the lower and higher halves of `x`, respectively.
     /// This function compute ``sigma( x = x0 || x1 ) = x1 || (x0 xor x1)``.
     #[inline(always)]

--- a/crates/garble-core/src/auth_eval.rs
+++ b/crates/garble-core/src/auth_eval.rs
@@ -1,0 +1,728 @@
+use std::{fmt, ops::Range};
+use mpz_memory_core::correlated::{Mac, Delta, Key};
+
+use mpz_circuits::{
+    Circuit, CircuitError, Gate,
+};
+use mpz_core::{
+    aes::{FixedKeyAes, FIXED_KEY_AES},
+    Block,
+};
+
+use crate::{fpre::{AuthBitShare, AuthTripleShare}, circuit::{AuthHalfGate, AuthHalfGateBatch}, DEFAULT_BATCH_SIZE};
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+
+/// Errors that can occur during garbled circuit evaluation.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum AuthEvaluatorError {
+    #[error(transparent)]
+    CircuitError(#[from] CircuitError),
+    #[error("evaluator not finished")]
+    NotFinished,
+    #[error("MAC verification failed at gate {0}")]
+    MacCheckFailed(usize), 
+    #[error("expected {expected} auth bits, got {actual}")]
+    InvalidAuthBitCount { expected: usize, actual: usize },
+    #[error("expected {expected} derandomization bits, got {actual}")]
+    InvalidDerandCount { expected: usize, actual: usize },
+    #[error("expected {expected} input MACs, got {actual}")]
+    InvalidInputMacCount { expected: usize, actual: usize },
+    #[error("expected {expected} masked inputs, got {actual}")]
+    InvalidMaskedInputCount { expected: usize, actual: usize },
+    #[error("expected {expected} output MACs, got {actual}")]
+    InvalidOutputMacCount { expected: usize, actual: usize },
+}
+
+// hash helper
+fn h2d(a: Block, b: Block, cipher: &FixedKeyAes) -> Block {
+    let mut d = [a, a ^ b];
+    cipher.cr_many( &mut d);
+    d[0] = d[0] ^ d[1]; 
+    return d[0] ^ b;
+}
+
+// hash helper
+fn h2(a: Block, b: Block, cipher: &FixedKeyAes) -> Block {
+    let mut d = [a, b];
+    cipher.cr_many(&mut d);
+    d[0] = d[0] ^ d[1];
+    d[0] = d[0] ^ a;
+    return d[0] ^ b;
+}
+
+#[inline]
+pub(crate) fn and_gate(
+    lx: Block,
+    ly: Block,
+    sx: AuthBitShare,
+    sy: AuthBitShare,
+    sz: AuthBitShare,
+    ss: AuthBitShare,
+    encrypted_gate: AuthHalfGate,
+    za: bool,
+    zb: bool,
+    cipher: &FixedKeyAes,
+    gid: usize,
+) -> (Block, bool) {
+    let g_0 = encrypted_gate.gates[0] ^ sy.mac.as_block();
+    let g_1 = encrypted_gate.gates[1] ^ sx.mac.as_block();
+
+    let j = Block::new((gid as u128).to_be_bytes());
+    let k = Block::new(((gid + 1) as u128).to_be_bytes());
+
+    let mut h = [lx, ly];
+    cipher.tccr_many(&[j, k], &mut h);
+    let [hx, hy] = h;
+
+    let sz_mac = sz.mac.as_block();
+    let ss_mac = ss.mac.as_block();
+
+    let lz = hx ^ hy ^ sz_mac ^ ss_mac ^ (g_0.mul_bool(za)) ^ ((g_1^lx).mul_bool(zb));
+    let zc = lz.lsb() ^ encrypted_gate.mask;
+    
+    (lz, zc)
+}
+
+
+#[inline]
+pub(crate) fn sigma_share(triple: &mut AuthTripleShare, px: bool, py: bool) -> AuthBitShare {
+    let mut sigma_share = triple.z.clone();
+
+    if px {
+        sigma_share = sigma_share + triple.y;
+    }
+    if py {
+        sigma_share = sigma_share + triple.x;
+    }
+    if px && py {
+        sigma_share.value = !sigma_share.value;
+    }
+    sigma_share
+}
+
+#[inline]
+pub(crate) fn check_and(
+    ss: &AuthBitShare,
+    sz: &AuthBitShare,
+    sx: &AuthBitShare,
+    sy: &AuthBitShare,
+    za: bool,
+    zb: bool,
+    zc: bool,
+    delta: Block,
+) -> Block {
+    // Start with combined share of sigma and z
+    let mut share = (ss.mac.as_block() ^ ss.key.as_block() ^ delta.mul_bool(ss.bit())) ^
+                   (sz.mac.as_block() ^ sz.key.as_block() ^ delta.mul_bool(sz.bit()));
+
+    // Apply adjustments based on masked values
+    if za {
+        share = share ^ sy.mac.as_block() ^ sy.key.as_block() ^ 
+        delta.mul_bool(sy.bit());
+    }
+
+    if zb {
+        share = share ^ sx.mac.as_block() ^ sx.key.as_block() ^ 
+        delta.mul_bool(sx.bit());
+    }
+
+    if (za && zb) != zc {
+        share = share ^ delta;
+    }
+
+    share
+}
+
+/// Output of the authenticated evaluator.
+#[derive(Debug)]
+pub struct AuthEvalOutput {
+    /// Output labels of the circuit.
+    pub output_labels: Vec<Mac>,
+    /// Output auth bits of the circuit.
+    pub output_auth_bits: Vec<AuthBitShare>,
+    /// Authentication hash of the circuit.
+    pub auth_hash: Block,
+    /// Output values of the circuit.
+    pub masked_output_values: Vec<bool>,
+    /// All masked values of the circuit.
+    pub masked_values: Vec<bool>,
+}
+
+/// Authenticated garbled circuit evaluator.
+pub struct AuthEval {
+    cipher: &'static FixedKeyAes,
+    labels: Vec<Block>, 
+    auth_bits: Vec<AuthBitShare>,
+    sigma_bits: Vec<AuthBitShare>,
+    masked_values: Vec<bool>,
+    triples: Vec<AuthTripleShare>,
+    leaky_triples: Vec<AuthTripleShare>,
+    permutation: Vec<usize>,
+    seed: u64, // via secure coin toss
+    bucket_size: usize,
+}
+
+impl AuthEval {
+
+    /// Create a new AuthEval with seed from coin-tossing
+    pub fn new(seed: u64, bucket_size: usize) -> Self {
+        Self {
+            cipher: &(*FIXED_KEY_AES),
+            labels: Vec::new(),
+            auth_bits: Vec::new(),
+            sigma_bits: Vec::new(),
+            masked_values: Vec::new(),
+            triples: Vec::new(),
+            leaky_triples: Vec::new(),
+            permutation: Vec::new(),
+            seed,
+            bucket_size,
+        }
+    }
+
+    /// Set input auth bits, begin generation of triples
+    pub fn evaluate_pre_1<'a>(
+        &'a mut self, 
+        circ: &'a Circuit,
+        delta: Delta,
+        input_auth_bits: &[AuthBitShare],
+        shares: &[AuthBitShare],
+    ) -> Result<(Vec<Block>, Vec<Block>), AuthEvaluatorError> {
+
+        if input_auth_bits.len() != circ.inputs().len() {
+            return Err(AuthEvaluatorError::InvalidAuthBitCount {
+                expected: circ.inputs().len(),
+                actual: input_auth_bits.len(),
+            });
+        }
+
+        if circ.feed_count() > self.auth_bits.len() {
+            self.auth_bits.resize(circ.feed_count(), Default::default());
+        }
+
+        self.auth_bits[..input_auth_bits.len()].copy_from_slice(input_auth_bits);
+
+        let mut count = 0;
+        for gate in circ.gates() {
+            if let Gate::And { x: _, y: _, z } = gate {
+                self.auth_bits[z.id()] = shares[count];
+                count += 1;
+            }
+        }
+
+        let remaining_shares = shares.len() - count;
+        let length = remaining_shares / 3;
+        for i in 0..length {
+            let base_idx = count + (3 * i);
+            self.leaky_triples.push(AuthTripleShare {
+                x: shares[base_idx],
+                y: shares[base_idx + 1],
+                z: shares[base_idx + 2]
+            });
+        }
+
+        let length = self.leaky_triples.len();
+        let mut c = vec![Block::ZERO; length];
+        let mut g = vec![Block::ZERO; length];
+
+        for i in 0..length {
+            c[i] = self.leaky_triples[i].y.mac.as_block().clone()
+                ^ self.leaky_triples[i].y.key.as_block().clone()
+                ^ (delta.mul_bool(self.leaky_triples[i].y.bit()));
+
+            g[i] = c[i] ^ h2d(self.leaky_triples[i].x.key.into(), delta.into_inner(), self.cipher);
+        }
+        Ok((c, g))
+    }
+
+    /// Triple generation, Round 2
+    pub fn evaluate_pre_2<'a>(
+        &'a mut self, 
+        delta: Delta,
+        c: Vec<Block>, 
+        g: &mut Vec<Block>, 
+        gr: Vec<Block> // received
+    ) -> Result<Vec<bool>, AuthEvaluatorError> {
+        let length = self.leaky_triples.len();
+        let mut d = vec![false; length];
+
+        for i in 0..length {
+            let mut s = h2(self.leaky_triples[i].x.mac.as_block().clone(), self.leaky_triples[i].x.key.as_block().clone(), self.cipher);
+            s = s ^ self.leaky_triples[i].z.mac.as_block().clone() ^ self.leaky_triples[i].z.key.as_block().clone();
+            s = s ^ (gr[i] ^ c[i]).mul_bool(self.leaky_triples[i].x.bit());
+            g[i] = s ^ delta.mul_bool(self.leaky_triples[i].z.bit());
+            d[i] = g[i].lsb();
+        }
+
+        Ok(d)
+    }
+
+    /// Triple generation, Round 3
+    pub fn evaluate_pre_3<'a>(
+        &'a mut self, 
+        delta: Delta,
+        g: &mut Vec<Block>, 
+        mut d: Vec<bool>, 
+        dr: Vec<bool> // received
+    ) -> Result<Vec<bool>, AuthEvaluatorError> {
+        let length = self.leaky_triples.len();
+        for i in 0..length {
+            d[i] = d[i] ^ dr[i];
+            if d[i] {
+                self.leaky_triples[i].z.key = self.leaky_triples[i].z.key + Key::from(delta.into_inner());
+                g[i] = g[i] ^ delta.as_block();
+            }
+        }
+
+        let total = self.leaky_triples.len();
+        let bucket_size = self.bucket_size;
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+    
+        // Fisher–Yates shuffle in place
+        let mut rng = ChaCha12Rng::seed_from_u64(self.seed);
+        let mut location: Vec<usize> = (0..total).collect();
+        for i in (0..total).rev() {
+            let idx = rng.random_range(0..=i);
+            location.swap(i, idx);
+        }
+
+        self.permutation = location;
+        let mut data = vec![false; total];
+    
+        for i in 0..n {
+            let base_idx = self.permutation[i*bucket_size + 0];    
+            let y_base = self.leaky_triples[base_idx].y.bit();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.permutation[i*bucket_size + j];
+                let y_j = self.leaky_triples[idx_j].y.bit();
+                data[i*bucket_size + j] = y_base ^ y_j;
+            }
+        }
+        Ok(data)
+    }
+
+    /// Generates digest for equality check
+    pub fn check_equality<'a>(
+        &'a mut self, 
+        g: Vec<Block>, 
+    ) -> Result<Block, AuthEvaluatorError> {
+        let mut digest = self.cipher.ccr(g[0]);
+        for i in 1..g.len() {
+            digest = self.cipher.ccr(g[i]);
+        }
+        Ok(digest)
+    }
+
+    /// Uses received salt to generate expected hash for equality check
+    pub fn check_salt<'a>(
+        &'a mut self, 
+        salt: Block, 
+        digest: Block,
+    ) -> Result<Block, AuthEvaluatorError> {
+        let hash = self.cipher.tccr(salt, digest);
+        Ok(hash)
+    }
+        
+    /// Triple generation, Round 4
+    pub fn evaluate_pre_4<'a>(
+        &'a mut self,
+        data: Vec<bool>,
+        data_recv: Vec<bool>, // received
+    ) -> Result<(), AuthEvaluatorError> {
+
+        let total = self.leaky_triples.len();
+        let bucket_size = self.bucket_size;
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+
+        let mut final_data = vec![false; total];
+        for i in 0..total {
+            final_data[i] = data[i] ^ data_recv[i];
+        }
+
+        for i in 0..n {
+            let base_idx = self.permutation[i*bucket_size + 0];
+    
+            let mut combined_share = self.leaky_triples[base_idx].clone();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.permutation[i*bucket_size + j];
+    
+                combined_share.x = combined_share.x + self.leaky_triples[idx_j].x;
+                combined_share.z = combined_share.z + self.leaky_triples[idx_j].z;
+    
+                if final_data[i*bucket_size + j] {
+                    combined_share.z = combined_share.z + self.leaky_triples[idx_j].x;
+                }
+            }
+            self.triples.push(combined_share);
+        }
+        Ok(())
+    }
+
+    /// Circuit dependent local preprocessing.
+    pub fn evaluate_free<'a>(
+        &'a mut self, 
+        circ: &'a Circuit,
+    ) -> Result<(), AuthEvaluatorError> {
+        for gate in circ.gates() {
+            match gate {
+                Gate::Xor { x, y, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()] + self.auth_bits[y.id()];
+                }
+                Gate::Inv { x, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()];
+                }
+                Gate::Id { x, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()];
+                }
+                Gate::And { .. } => {
+                    // AND gates are handled separately
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Generates the derandomized bits for circuit-dependent AND gate preprocessing.
+    pub fn evaluate_de<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+    ) -> Result<(Vec<bool>, Vec<bool>), AuthEvaluatorError> {
+        let mut px = Vec::new();
+        let mut py = Vec::new();
+        let mut and_count = 0;
+
+        for gate in circ.gates() {
+            if let Gate::And { x, y, .. } = gate {
+                let sx = &self.auth_bits[x.id()];
+                let sy = &self.auth_bits[y.id()];
+                let triple = &self.triples[and_count];
+                
+                px.push(sx.bit() ^ triple.x.bit());
+                py.push(sy.bit() ^ triple.y.bit());
+                and_count += 1;
+            }
+        }
+        
+        Ok((px, py))
+    }
+
+    /// Generates a consumer over the encrypted gates of a circuit, finish circuit dependent preprocessing
+    pub fn evaluate<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+        delta: Delta,
+        input_labels: &[Mac],
+        masked_inputs: Vec<bool>,
+        px: Vec<bool>, // received
+        py: Vec<bool>, // received
+    ) -> Result<AuthEncryptedGateConsumer<'a, std::slice::Iter<'a, Gate>>, AuthEvaluatorError> {
+
+        if input_labels.len() != circ.inputs().len() {
+            return Err(AuthEvaluatorError::InvalidInputMacCount {
+                expected: circ.inputs().len(),
+                actual: input_labels.len(),
+            });
+        }
+
+        if masked_inputs.len() != circ.inputs().len() {
+            return Err(AuthEvaluatorError::InvalidMaskedInputCount {
+                expected: circ.inputs().len(),
+                actual: masked_inputs.len(),
+            });
+        }
+
+        if circ.feed_count() > self.labels.len() || circ.feed_count() > self.masked_values.len() {
+            self.labels.resize(circ.feed_count(), Default::default());
+            self.masked_values.resize(circ.feed_count(), false);
+        }
+        
+        self.labels[..input_labels.len()].copy_from_slice(Mac::as_blocks(input_labels));
+        self.masked_values[..masked_inputs.len()].copy_from_slice(&masked_inputs);
+
+        if px.len().min(py.len()) < circ.and_count() {
+            return Err(AuthEvaluatorError::InvalidDerandCount {
+                expected: circ.and_count(),
+                actual: px.len().min(py.len()),
+            });
+        }
+
+        let mut and_count = 0;
+        
+        self.sigma_bits.reserve(circ.and_count());
+
+        for gate in circ.gates() {
+            if let Gate::And { x, y, z: _ } = gate {
+                let sx = self.auth_bits[x.id()];
+                let sy = self.auth_bits[y.id()];
+                let triple = &mut self.triples[and_count];
+
+                let px = sx.bit() ^ triple.x.bit() ^ px[and_count];
+                let py = sy.bit() ^ triple.y.bit() ^ py[and_count];
+
+                // Compute auth_bit for output wire of this AND gate
+                let ss = sigma_share(triple, px, py);
+                
+                self.sigma_bits.push(ss);
+                and_count += 1;
+            }
+        }
+
+        Ok(AuthEncryptedGateConsumer::new(
+            delta,
+            circ.gates().iter(),
+            circ.gates().iter(),
+            circ.outputs(),
+            &mut self.labels,
+            &mut self.auth_bits,
+            &mut self.sigma_bits,
+            &mut self.masked_values,
+            circ.and_count(),
+        ))
+    }
+
+    /// Generates a consumer over the batched encrypted gates of a circuit, finish circuit dependent preprocessing
+    pub fn evaluate_batched<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+        delta: Delta,
+        input_labels: &[Mac], 
+        masked_inputs: Vec<bool>,
+        px: Vec<bool>,
+        py: Vec<bool>,
+    ) -> Result<AuthEncryptedGateBatchConsumer<'a, std::slice::Iter<'a, Gate>>, AuthEvaluatorError> {
+        self.evaluate(circ, delta, input_labels, masked_inputs, px, py).map(AuthEncryptedGateBatchConsumer)
+    }
+    
+}
+
+/// Consumer over the encrypted gates of a circuit.
+pub struct AuthEncryptedGateConsumer<'a, I: Iterator> {
+   /// Cipher to use to encrypt the gates.
+   cipher: &'static FixedKeyAes,
+   /// Global offset.
+   delta: Delta,
+   /// Buffer for the 0-bit labels.
+   labels: &'a mut [Block],
+   /// Buffer for the auth bits.
+   auth_bits: &'a mut [AuthBitShare],
+   /// Buffer for the sigma bits.
+   sigma_bits: &'a mut [AuthBitShare],
+   /// Buffer for the masked values.
+   masked_values: &'a mut [bool],
+   /// Iterator over the gates.
+   gates: I,
+   /// Iterator over the gates to check authenticity.
+   gates_check: I,
+   /// Circuit outputs.
+   outputs: Range<usize>,
+   /// Current gate id.
+   gid: usize,
+   /// Number of AND gates generated.
+   counter: usize,
+   /// Number of AND gates in the circuit.
+   and_count: usize,
+   /// Whether the entire circuit has been garbled.
+   complete: bool,
+}
+
+impl<'a, I: Iterator> fmt::Debug for AuthEncryptedGateConsumer<'a, I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AuthEncryptedGateConsumer {{ .. }}")
+    }
+}
+
+impl<'a, I> AuthEncryptedGateConsumer<'a, I>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    fn new(
+        delta: Delta,
+        gates: I,
+        gates_check: I,
+        outputs: Range<usize>,
+        labels: &'a mut [Block],
+        auth_bits: &'a mut [AuthBitShare],
+        sigma_bits: &'a mut [AuthBitShare],
+        masked_values: &'a mut [bool],
+        and_count: usize,
+    ) -> Self {
+        Self {
+            cipher: &(*FIXED_KEY_AES),
+            delta,
+            gates,
+            gates_check,
+            outputs,
+            labels,
+            auth_bits,
+            sigma_bits,
+            masked_values,
+            gid: 1,
+            counter: 0,
+            and_count,
+            complete: false,
+        }
+    }
+
+    /// Returns `true` if the evaluator wants more encrypted gates.
+    #[inline]
+    pub fn wants_gates(&self) -> bool {
+        self.counter != self.and_count
+    }
+
+    /// Evaluates the next encrypted gate in the circuit.
+    #[inline]
+    pub fn next(&mut self, encrypted_gate: AuthHalfGate) {
+        while let Some(gate) = self.gates.next() {
+            match gate {
+                Gate::Xor { x, y, z } => {
+                    self.labels[z.id()] = self.labels[x.id()] ^ self.labels[y.id()];
+                    self.masked_values[z.id()] = self.masked_values[x.id()] ^ self.masked_values[y.id()];
+                }
+                Gate::Inv { x, z } => {
+                    self.labels[z.id()] = self.labels[x.id()];
+                    self.masked_values[z.id()] = !self.masked_values[x.id()];
+                }
+                Gate::Id { x, z } => {
+                    self.labels[z.id()] = self.labels[x.id()];
+                    self.masked_values[z.id()] = self.masked_values[x.id()];
+                }
+                Gate::And { x, y, z } => {
+                    // Get labels for input wires
+                    let lx = self.labels[x.id()];
+                    let ly = self.labels[y.id()];
+                    
+                    // Get input auth_bits
+                    let sx = self.auth_bits[x.id()];
+                    let sy = self.auth_bits[y.id()];
+
+                    // Get AND of input auth_bits
+                    let ss = self.sigma_bits[self.counter];
+
+                    // Get output auth_bit for wire
+                    let sz = self.auth_bits[z.id()];
+
+                    // Get masked input bits
+                    let za = self.masked_values[x.id()];
+                    let zb = self.masked_values[y.id()];
+
+                    // Evaluate the AND gate
+                    let (lz, zc) = and_gate(
+                        lx, 
+                        ly, 
+                        sx, 
+                        sy, 
+                        sz, 
+                        ss, 
+                        encrypted_gate, 
+                        za, 
+                        zb, 
+                        self.cipher, 
+                        self.gid
+                    );
+
+                    // Set output masked value and label
+                    self.masked_values[z.id()] = zc;
+                    self.labels[z.id()] = lz;
+
+                    self.counter += 1;
+                    self.gid += 2;
+
+                    // If we have more AND gates to evaluate, return.
+                    if self.wants_gates() {
+                        return;
+                    }
+                }
+            }
+        }
+
+        self.complete = true;
+    }
+
+    /// Returns the encoded outputs of the circuit.
+    pub fn finish(mut self) -> Result<AuthEvalOutput, AuthEvaluatorError> {
+        if self.wants_gates() {
+            return Err(AuthEvaluatorError::NotFinished);
+        }
+
+        // If there were 0 AND gates in the circuit, we need to evaluate the "free"
+        // gates now.
+        if !self.complete {
+            self.next(Default::default());
+        }
+
+        let output_labels = Mac::from_blocks(self.labels[self.outputs.clone()].to_vec());
+        let output_auth_bits = self.auth_bits[self.outputs.clone()].to_vec();
+        let masked_output_values = self.masked_values[self.outputs.clone()].to_vec();
+
+        let mut auth_hash = Block::ZERO;
+        let mut and_count = 0;
+        let delta = self.delta.as_block();
+        
+        for gate in self.gates_check {
+            if let Gate::And { x, y, z } = gate {
+                let ss = &self.sigma_bits[and_count];
+                let sz = &self.auth_bits[z.id()];
+                let sx = &self.auth_bits[x.id()];
+                let sy = &self.auth_bits[y.id()];
+
+                // Get masked values
+                let za = self.masked_values[x.id()];
+                let zb = self.masked_values[y.id()];
+                let zc = self.masked_values[z.id()];
+
+                let share = check_and(ss, sz, sx, sy, za, zb, zc, *delta);
+                
+                // Update hash                            
+                auth_hash ^= self.cipher.tccr(Block::new((and_count as u128).to_be_bytes()), share);
+                and_count += 1;
+            }
+        }
+
+        let masked_values = self.masked_values.to_vec();
+
+        Ok(AuthEvalOutput { output_labels, output_auth_bits, masked_output_values, masked_values, auth_hash })
+    }
+}
+
+/// Consumer returned by [`Evaluator::evaluate_batched`].
+#[derive(Debug)]
+pub struct AuthEncryptedGateBatchConsumer<'a, I: Iterator, const N: usize = DEFAULT_BATCH_SIZE>(
+    AuthEncryptedGateConsumer<'a, I>,
+);
+
+impl<'a, I, const N: usize> AuthEncryptedGateBatchConsumer<'a, I, N>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    /// Returns `true` if the evaluator wants more encrypted gates.
+    pub fn wants_gates(&self) -> bool {
+        self.0.wants_gates()
+    }
+
+    /// Evaluates the next batch of gates in the circuit.
+    #[inline]
+    pub fn next(&mut self, batch: AuthHalfGateBatch<N>) {
+        for encrypted_gate in batch.into_array() {
+            self.0.next(encrypted_gate);
+            if !self.0.wants_gates() {
+                // Skipping any remaining gates which may have been used to pad the last batch.
+                return;
+            }
+        }
+    }
+
+    /// Returns the encoded outputs of the circuit, and the hash of the
+    /// encrypted gates if present.
+    pub fn finish(self) -> Result<AuthEvalOutput, AuthEvaluatorError> {
+        self.0.finish()
+    }
+}

--- a/crates/garble-core/src/auth_gen.rs
+++ b/crates/garble-core/src/auth_gen.rs
@@ -1,0 +1,716 @@
+use core::fmt;
+use std::ops::Range;
+
+use crate::{
+    circuit::{AuthHalfGate, AuthHalfGateBatch}, 
+    fpre::{AuthBitShare, AuthTripleShare}, 
+    DEFAULT_BATCH_SIZE,
+};
+use mpz_circuits::{
+    Circuit, Gate, CircuitError
+};
+use mpz_core::{
+    aes::{FixedKeyAes, FIXED_KEY_AES},
+    Block,
+};
+use mpz_memory_core::correlated::{Key, Delta};
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+
+/// Errors that can occur during authenticated garbled circuit generation.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum AuthGeneratorError {
+    #[error(transparent)]
+    CircuitError(#[from] CircuitError),
+    #[error("generator not finished")]
+    NotFinished,
+    #[error("MAC verification failed at gate {0}")]
+    MacCheckFailed(usize), 
+    #[error("expected {expected} auth bits, got {actual}")]
+    InvalidAuthBitCount { expected: usize, actual: usize },
+    #[error("expected {expected} derandomization bits, got {actual}")]
+    InvalidDerandCount { expected: usize, actual: usize },
+    #[error("expected {expected} input keys, got {actual}")]
+    InvalidInputKeyCount { expected: usize, actual: usize },
+}
+
+// hash helper
+fn h2d(a: Block, b: Block, cipher: &FixedKeyAes) -> Block {
+    let mut d = [a, a ^ b];
+    cipher.cr_many( &mut d);
+    d[0] = d[0] ^ d[1]; 
+    return d[0] ^ b;
+}
+
+// hash helper
+fn h2(a: Block, b: Block, cipher: &FixedKeyAes) -> Block {
+    let mut d = [a, b];
+    cipher.cr_many(&mut d);
+    d[0] = d[0] ^ d[1];
+    d[0] = d[0] ^ a;
+    return d[0] ^ b;
+}
+
+#[inline]
+pub(crate) fn sigma_share(
+    triple: &mut AuthTripleShare, 
+    px: bool, 
+    py: bool, 
+    delta: &Block
+) -> AuthBitShare {
+    let mut sigma_share = triple.z.clone();
+    if px {
+        sigma_share = sigma_share + triple.y;
+    }
+    if py {
+        sigma_share = sigma_share + triple.x;
+    }
+    if px && py {
+        sigma_share.key = sigma_share.key + Key::from(*delta); 
+    }
+    sigma_share
+}
+
+#[inline]
+pub(crate) fn and_gate(
+    lx: &Block,
+    ly: &Block,
+    sx: &AuthBitShare,
+    sy: &AuthBitShare,
+    sz: &AuthBitShare,
+    ss: &AuthBitShare,
+    delta: &Block,
+    cipher: &FixedKeyAes,  
+    gid: usize,
+) -> (AuthHalfGate, Block) {
+
+    let lx1 = lx ^ delta;
+    let ly1 = ly ^ delta;
+    
+    let j = Block::new((gid as u128).to_be_bytes());
+    let k = Block::new(((gid + 1) as u128).to_be_bytes());
+    
+    let mut h = [*lx, *ly, lx1, ly1];
+    cipher.tccr_many(&[j, k, j, k], &mut h);
+    let [hx, hy, hx1, hy1] = h;
+    
+    let g_0 = hx ^ hx1 ^ sy.key.as_block() ^ delta.mul_bool(sy.bit());
+              
+    let g_1 = hy ^ hy1 ^ sx.key.as_block() ^ delta.mul_bool(sx.bit()) ^ lx;
+    
+    let lz = hx ^ hy ^ sz.key.as_block() ^ delta.mul_bool(sz.bit()) ^ 
+            ss.key.as_block() ^ delta.mul_bool(ss.bit());
+    
+    let gates = [g_0, g_1];
+    let mask = lz.lsb();
+    
+    (AuthHalfGate::new(gates, mask), lz)
+}
+
+#[inline]
+pub(crate) fn check_and(
+    ss: &AuthBitShare,
+    sz: &AuthBitShare,
+    sx: &AuthBitShare,
+    sy: &AuthBitShare,
+    za: bool,
+    zb: bool,
+    zc: bool,
+    delta: Block,
+) -> Block {
+
+    let mut share = (ss.mac.as_block() ^ ss.key.as_block() ^ delta.mul_bool(ss.bit())) ^
+                   (sz.mac.as_block() ^ sz.key.as_block() ^ delta.mul_bool(sz.bit()));
+
+    if za {
+        share = share ^ sy.mac.as_block() ^ sy.key.as_block() ^ 
+        delta.mul_bool(sy.bit());
+    }
+    if zb {
+        share = share ^ sx.mac.as_block() ^ sx.key.as_block() ^ 
+        delta.mul_bool(sx.bit());
+    }
+    if (za && zb) != zc {
+        share = share ^ delta;
+    }
+    share
+}
+
+/// Output of the authenticated generator.
+#[derive(Debug)]
+pub struct AuthGenOutput {
+    /// Output labels of the circuit.
+    pub output_labels: Vec<Key>,
+    /// Output auth bits of the circuit.
+    pub output_auth_bits: Vec<AuthBitShare>,
+    /// Authentication hash of the circuit.
+    pub auth_hash: Block,
+}
+
+/// Authenticated garbled circuit generator.
+pub struct AuthGen {
+    cipher: &'static FixedKeyAes,
+    labels: Vec<Block>, 
+    auth_bits: Vec<AuthBitShare>,
+    sigma_bits: Vec<AuthBitShare>,
+    masked_values: Vec<bool>,
+    triples: Vec<AuthTripleShare>,
+    leaky_triples: Vec<AuthTripleShare>,
+    permutation: Vec<usize>,
+    seed: u64, // via secure coin toss
+    bucket_size: usize,
+}
+
+// TODO: Allow separating pre-processing from generation
+
+impl AuthGen {
+
+    /// Create a new AuthGen with seed from coin-tossing
+    pub fn new(seed: u64, bucket_size: usize) -> Self {
+        Self {
+            cipher: &(*FIXED_KEY_AES),
+            labels: Vec::new(),
+            auth_bits: Vec::new(),
+            sigma_bits: Vec::new(),
+            masked_values: Vec::new(),
+            triples: Vec::new(),
+            leaky_triples: Vec::new(),
+            permutation: Vec::new(),
+            seed,
+            bucket_size,
+        }
+    }
+    
+    /// Set input auth bits, begin generation of triples
+    pub fn generate_pre_1<'a>(
+        &'a mut self, 
+        circ: &'a Circuit,
+        delta: Delta,
+        input_auth_bits: &[AuthBitShare],
+        shares: &[AuthBitShare],
+    ) -> Result<(Vec<Block>, Vec<Block>), AuthGeneratorError> {
+
+        if input_auth_bits.len() != circ.inputs().len() {
+            return Err(AuthGeneratorError::InvalidAuthBitCount {
+                expected: circ.inputs().len(),
+                actual: input_auth_bits.len(),
+            });
+        }
+
+        if circ.feed_count() > self.auth_bits.len() {
+            self.auth_bits.resize(circ.feed_count(), Default::default());
+        }
+        self.auth_bits[..input_auth_bits.len()].copy_from_slice(input_auth_bits);
+
+        let mut count = 0;
+        for gate in circ.gates() {
+            if let Gate::And { x: _, y: _, z } = gate {
+                self.auth_bits[z.id()] = shares[count];
+                count += 1;
+            }
+        }
+
+        let remaining_shares = shares.len() - count;
+        let length = remaining_shares / 3;
+        for i in 0..length {
+            let base_idx = count + (3 * i);
+            self.leaky_triples.push(AuthTripleShare {
+                x: shares[base_idx],
+                y: shares[base_idx + 1],
+                z: shares[base_idx + 2]
+            });
+        }
+
+        let length = self.leaky_triples.len();
+        let mut c = vec![Block::ZERO; length];
+        let mut g = vec![Block::ZERO; length];
+
+        for i in 0..length {
+            c[i] = self.leaky_triples[i].y.mac.as_block().clone()
+                ^ self.leaky_triples[i].y.key.as_block().clone()
+                ^ delta.mul_bool(self.leaky_triples[i].y.bit());
+
+            g[i] = c[i] ^ h2d(self.leaky_triples[i].x.key.into(), delta.into_inner(), self.cipher);
+        }
+        Ok((c, g))
+    }
+
+    /// Triple generation, Round 2
+    pub fn generate_pre_2<'a>(
+        &'a mut self, 
+        delta: Delta,
+        c: Vec<Block>, 
+        g: &mut Vec<Block>, 
+        gr: Vec<Block> // received
+    ) -> Result<Vec<bool>, AuthGeneratorError> {
+        let length = self.leaky_triples.len();
+        let mut d = vec![false; length];
+
+        for i in 0..length {
+            let mut s = h2(self.leaky_triples[i].x.mac.as_block().clone(), self.leaky_triples[i].x.key.as_block().clone(), self.cipher);
+            s = s ^ self.leaky_triples[i].z.mac.as_block().clone() ^ self.leaky_triples[i].z.key.as_block().clone();
+            s = s ^ (gr[i] ^ c[i]).mul_bool(self.leaky_triples[i].x.bit());
+            g[i] = s ^ delta.mul_bool(self.leaky_triples[i].z.bit());
+            d[i] = g[i].lsb();
+        }
+
+        Ok(d)
+    }
+
+    /// Triple generation, Round 3
+    pub fn generate_pre_3<'a>(
+        &'a mut self, 
+        delta: Delta,
+        g: &mut Vec<Block>, 
+        mut d: Vec<bool>, 
+        dr: Vec<bool> // received
+    ) -> Result<Vec<bool>, AuthGeneratorError> {
+        let length = self.leaky_triples.len();
+        for i in 0..length {
+            d[i] = d[i] ^ dr[i];
+            if d[i] {
+                self.leaky_triples[i].z.value = !self.leaky_triples[i].z.value;
+                g[i] = g[i] ^ delta.as_block();
+            }
+        }
+
+        let total = self.leaky_triples.len();
+        let bucket_size = self.bucket_size;
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+    
+        // Fisher–Yates shuffle in place
+        let mut rng = ChaCha12Rng::seed_from_u64(self.seed);
+        let mut location: Vec<usize> = (0..total).collect();
+        for i in (0..total).rev() {
+            let idx = rng.random_range(0..=i);
+            location.swap(i, idx);
+        }
+
+        self.permutation = location;
+        let mut data = vec![false; total];
+    
+        for i in 0..n {
+            let base_idx = self.permutation[i*bucket_size + 0];    
+            let y_base = self.leaky_triples[base_idx].y.bit();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.permutation[i*bucket_size + j];
+                let y_j = self.leaky_triples[idx_j].y.bit();
+                data[i*bucket_size + j] = y_base ^ y_j;
+            }
+        }
+        Ok(data)
+    }
+
+    /// Generates digest, hash for equality check
+    pub fn check_equality<'a>(
+        &'a mut self, 
+        g: Vec<Block>, 
+    ) -> Result<(Block, Block, Block), AuthGeneratorError> {
+        let mut digest = self.cipher.ccr(g[0]);
+        for i in 1..g.len() {
+            digest = self.cipher.ccr(g[i]);
+        }
+
+        let salt = Block::new((rand::random::<u128>()).to_be_bytes());
+        let hash = self.cipher.tccr(salt, digest);
+
+        Ok((digest, salt, hash))
+    }
+
+    /// Triple generation, Round 4
+    pub fn generate_pre_4<'a>(
+        &'a mut self,
+        data: Vec<bool>,
+        data_recv: Vec<bool>, // received
+    ) -> Result<(), AuthGeneratorError> {
+
+        let total = self.leaky_triples.len();
+        let bucket_size = self.bucket_size;
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+
+        let mut final_data = vec![false; total];
+        for i in 0..total {
+            final_data[i] = data[i] ^ data_recv[i];
+        }
+
+        for i in 0..n {
+            let base_idx = self.permutation[i*bucket_size + 0];
+            let mut combined_share = self.leaky_triples[base_idx].clone();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.permutation[i*bucket_size + j];
+    
+                combined_share.x = combined_share.x + self.leaky_triples[idx_j].x;
+                combined_share.z = combined_share.z + self.leaky_triples[idx_j].z;
+    
+                if final_data[i*bucket_size + j] {
+                    combined_share.z = combined_share.z + self.leaky_triples[idx_j].x;
+                }
+            }
+            self.triples.push(combined_share);
+        }
+        Ok(())
+    }
+
+    /// Circuit dependent local preprocessing.
+    pub fn generate_free<'a>(
+        &'a mut self, 
+        circ: &'a Circuit,
+    ) -> Result<(), AuthGeneratorError> {
+        for gate in circ.gates() {
+            match gate {
+                Gate::Xor { x, y, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()] + self.auth_bits[y.id()];
+                }
+                Gate::Inv { x, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()];
+                }
+                Gate::Id { x, z } => {
+                    self.auth_bits[z.id()] = self.auth_bits[x.id()];
+                }
+                Gate::And { .. } => {
+                    // AND gates are handled separately
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Generates the derandomized bits for circuit-dependent AND gate preprocessing.
+    pub fn generate_de<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+    ) -> Result<(Vec<bool>, Vec<bool>), AuthGeneratorError> {
+        let mut px = Vec::new();
+        let mut py = Vec::new();
+        let mut and_count = 0;
+
+        for gate in circ.gates() {
+            if let Gate::And { x, y, .. } = gate {
+                let sx = &self.auth_bits[x.id()];
+                let sy = &self.auth_bits[y.id()];
+                let triple = &self.triples[and_count];
+                
+                px.push(sx.bit() ^ triple.x.bit());
+                py.push(sy.bit() ^ triple.y.bit());
+                and_count += 1;
+            }
+        }
+        
+        Ok((px, py))
+    }
+
+    /// Generates an iterator over the encrypted gates of a circuit, finish circuit dependent preprocessing
+    pub fn generate<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+        delta: Delta,
+        input_labels: &[Key],
+        px: Vec<bool>, // received
+        py: Vec<bool>, // received
+    ) -> Result<AuthEncryptedGateIter<'a, std::slice::Iter<'a, Gate>>, AuthGeneratorError> {
+        
+        if input_labels.len() != circ.inputs().len() {
+            return Err(AuthGeneratorError::InvalidInputKeyCount {
+                expected: circ.inputs().len(),
+                actual: input_labels.len(),
+            });
+        }
+
+        if circ.feed_count() > self.labels.len() {
+            self.labels.resize(circ.feed_count(), Default::default());
+        }
+
+        self.labels[..input_labels.len()].copy_from_slice(Key::as_blocks(input_labels));
+        
+        if px.len().min(py.len()) < circ.and_count() {
+            return Err(AuthGeneratorError::InvalidDerandCount {
+                expected: circ.and_count(),
+                actual: px.len().min(py.len()),
+            });
+        }
+
+        let mut and_count = 0;
+        
+        self.sigma_bits.reserve(circ.and_count());
+
+        for gate in circ.gates() {
+            if let Gate::And { x, y, z: _ } = gate {
+                let sx = self.auth_bits[x.id()];
+                let sy = self.auth_bits[y.id()];
+                let triple = &mut self.triples[and_count];
+
+                let px = sx.bit() ^ triple.x.bit() ^ px[and_count];
+                let py = sy.bit() ^ triple.y.bit() ^ py[and_count];
+
+                // Compute auth_bit for output wire of this AND gate
+                let ss = sigma_share(triple, px, py, delta.as_block());
+                
+                self.sigma_bits.push(ss);
+                and_count += 1;
+            }
+        }
+
+        self.masked_values.resize(circ.feed_count(), false);
+        Ok(AuthEncryptedGateIter::new(
+            delta,
+            circ.gates().iter(),
+            circ.gates().iter(),
+            circ.outputs(),
+            &mut self.labels,
+            &mut self.auth_bits,
+            &mut self.sigma_bits,
+            &mut self.masked_values,
+            circ.and_count(),
+        ))
+    }
+
+    /// Generates an iterator over the batched encrypted gates of a circuit, finish circuit dependent preprocessing
+    pub fn generate_batched<'a>(
+        &'a mut self,
+        circ: &'a Circuit,
+        delta: Delta,
+        input_labels: &[Key],
+        px: Vec<bool>,
+        py: Vec<bool>,
+    ) -> Result<AuthEncryptedGateBatchIter<'a, std::slice::Iter<'a, Gate>>, AuthGeneratorError> {
+        self.generate(circ, delta, input_labels, px, py)
+            .map(AuthEncryptedGateBatchIter)
+    }
+    
+}
+
+/// Iterator over the encrypted gates of a circuit.
+pub struct AuthEncryptedGateIter<'a, I> {
+    /// Cipher to use to encrypt the gates.
+    cipher: &'static FixedKeyAes,
+    /// Global offset.
+    delta: Delta,
+    /// Buffer for the 0-bit labels.
+    labels: &'a mut [Block],
+    /// Buffer for the auth bits.
+    auth_bits: &'a mut [AuthBitShare],
+    /// Buffer for the sigma bits.
+    sigma_bits: &'a mut [AuthBitShare],
+    /// Buffer for the masked values.
+    masked_values: &'a mut [bool],
+    /// Iterator over the gates.
+    gates: I,
+    /// Iterator over the gates to check authenticity.
+    gates_check: I,
+    /// Circuit outputs.
+    outputs: Range<usize>,
+    /// Current gate id.
+    gid: usize,
+    /// Number of AND gates generated.
+    counter: usize,
+    /// Number of AND gates in the circuit.
+    and_count: usize,
+    /// Whether the entire circuit has been garbled.
+    complete: bool,
+}
+
+impl<'a, I> fmt::Debug for AuthEncryptedGateIter<'a, I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AuthEncryptedGateIter {{ .. }}")
+    }
+}
+
+impl<'a, I> AuthEncryptedGateIter<'a, I>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    fn new(
+        delta: Delta,
+        gates: I,
+        gates_check: I,
+        outputs: Range<usize>,
+        labels: &'a mut [Block],
+        auth_bits: &'a mut [AuthBitShare],
+        sigma_bits: &'a mut [AuthBitShare],
+        masked_values: &'a mut [bool],
+        and_count: usize,
+    ) -> Self {
+        Self {
+            cipher: &(*FIXED_KEY_AES),
+            delta,
+            gates,
+            gates_check,
+            outputs,
+            labels,
+            auth_bits,
+            sigma_bits,
+            masked_values,
+            gid: 1,
+            counter: 0,
+            and_count,
+            complete: false,
+        }
+    }
+
+    /// Returns `true` if the generator has more encrypted gates to generate.
+    #[inline]
+    pub fn has_gates(&self) -> bool {
+        self.counter != self.and_count
+    }
+
+    /// Returns the encoded outputs of the circuit
+    pub fn finish(
+        mut self,
+        masked_values: Vec<bool>
+    ) -> Result<AuthGenOutput, AuthGeneratorError> {
+        if self.has_gates() {
+            return Err(AuthGeneratorError::NotFinished);
+        }
+
+        // Finish computing any "free" gates.
+        if !self.complete {
+            assert_eq!(self.next(), None);
+        }
+
+        let output_labels = Key::from_blocks(self.labels[self.outputs.clone()].to_vec());
+        let output_auth_bits = self.auth_bits[self.outputs.clone()].to_vec();
+
+        self.masked_values.copy_from_slice(&masked_values);
+
+        let mut auth_hash = Block::ZERO;
+        let mut and_count = 0;
+        let delta = self.delta.as_block();
+        
+        for gate in self.gates_check {
+            if let Gate::And { x, y, z } = gate {
+                let ss = &self.sigma_bits[and_count];
+                let sz = &self.auth_bits[z.id()];
+                let sx = &self.auth_bits[x.id()];
+                let sy = &self.auth_bits[y.id()];
+
+                // Get masked values
+                let za = self.masked_values[x.id()];
+                let zb = self.masked_values[y.id()];
+                let zc = self.masked_values[z.id()];
+
+                let share = check_and(ss, sz, sx, sy, za, zb, zc, *delta);
+                
+                // Update hash                            
+                auth_hash ^= self.cipher.tccr(Block::new((and_count as u128).to_be_bytes()), share);
+                and_count += 1;
+            }
+        }
+        
+        Ok(AuthGenOutput { output_labels, output_auth_bits, auth_hash })
+    }
+}
+
+impl<'a, I> Iterator for AuthEncryptedGateIter<'a, I>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    type Item = AuthHalfGate;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(gate) = self.gates.next() {
+            match gate {
+                Gate::Xor { x, y, z } => {
+                    self.labels[z.id()] = self.labels[x.id()] ^ self.labels[y.id()];
+                }
+                Gate::Inv { x, z } => {
+                    self.labels[z.id()] = self.labels[x.id()] ^ self.delta.as_block();
+                }
+                Gate::Id { x, z } => {
+                    self.labels[z.id()] = self.labels[x.id()].clone();
+                }
+                Gate::And { x, y, z } => {
+                    // Get labels for input wires
+                    let lx = self.labels[x.id()];
+                    let ly = self.labels[y.id()];
+
+                    // Get input auth_bits
+                    let sx = self.auth_bits[x.id()];
+                    let sy = self.auth_bits[y.id()];
+
+                    // Get AND of input auth_bits
+                    let ss = self.sigma_bits[self.counter];
+
+                    // Get output auth_bit for wire
+                    let sz = self.auth_bits[z.id()];
+
+                    // Garble the gate and compute output label
+                    let (half_gate, lz) = and_gate(&lx, &ly, &sx, &sy, &sz, &ss, self.delta.as_block(), self.cipher, self.gid);
+                    self.labels[z.id()] = lz;
+                    
+                    self.gid += 2;
+                    self.counter += 1;
+
+                    // If we have generated all AND gates, we can compute
+                    // the rest of the "free" gates.
+                    if !self.has_gates() {
+                        assert!(self.next().is_none());
+
+                        self.complete = true;
+                    }
+
+                    return Some(half_gate);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// Iterator returned by [`Generator::generate_batched`].
+#[derive(Debug)]
+pub struct AuthEncryptedGateBatchIter<'a, I: Iterator, const N: usize = DEFAULT_BATCH_SIZE>(
+    AuthEncryptedGateIter<'a, I>,
+);
+
+impl<'a, I, const N: usize> AuthEncryptedGateBatchIter<'a, I, N>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    /// Returns `true` if the generator has more encrypted gates to generate.
+    pub fn has_gates(&self) -> bool {
+        self.0.has_gates()
+    }
+
+    /// Returns the encoded outputs of the circuit, and the hash of the
+    /// encrypted gates if present.
+    pub fn finish(self, masked_values: Vec<bool>) -> Result<AuthGenOutput, AuthGeneratorError> {
+        self.0.finish(masked_values)
+    }
+}
+
+impl<'a, I, const N: usize> Iterator for AuthEncryptedGateBatchIter<'a, I, N>
+where
+    I: Iterator<Item = &'a Gate>,
+{
+    type Item = AuthHalfGateBatch<N>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.has_gates() {
+            return None;
+        }
+
+        let mut batch = [AuthHalfGate::default(); N];
+        let mut i = 0;
+        for gate in self.0.by_ref() {
+            batch[i] = gate;
+            i += 1;
+
+            if i == N {
+                break;
+            }
+        }
+
+        Some(AuthHalfGateBatch::new(batch))
+    }
+}

--- a/crates/garble-core/src/circuit.rs
+++ b/crates/garble-core/src/circuit.rs
@@ -12,6 +12,13 @@ pub struct GarbledCircuit {
     pub gates: Vec<EncryptedGate>,
 }
 
+/// A garbled circuit.
+#[derive(Debug, Clone)]
+pub struct AuthGarbledCircuit {
+    /// Encrypted gates.
+    pub gates: Vec<AuthHalfGate>,
+}
+
 /// Encrypted gate truth table
 ///
 /// For the half-gate garbling scheme a truth table will typically have 2 rows,
@@ -53,6 +60,43 @@ impl<const N: usize> EncryptedGateBatch<N> {
 
     /// Returns the inner array.
     pub fn into_array(self) -> [EncryptedGate; N] {
+        self.0
+    }
+}
+
+/// An authenticated half gate
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct AuthHalfGate {
+    #[serde(with = "serde_arrays")]
+    pub(crate) gates: [Block; 2],
+    pub(crate) mask: bool,
+}
+
+impl AuthHalfGate {
+    /// Creates a new authenticated half gate
+    pub fn new(gates: [Block; 2], mask: bool) -> Self {
+        Self { gates, mask }
+    }
+}
+
+/// A batch of authenticated half gates.
+///
+/// # Parameters
+///
+/// - `N`: The size of a batch.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthHalfGateBatch<const N: usize = DEFAULT_BATCH_SIZE>(
+    #[serde(with = "serde_arrays")] [AuthHalfGate; N],
+);
+
+impl<const N: usize> AuthHalfGateBatch<N> {
+    /// Creates a new batch of authenticated half gates.
+    pub fn new(batch: [AuthHalfGate; N]) -> Self {
+        Self(batch)
+    }
+
+    /// Returns the inner array.
+    pub fn into_array(self) -> [AuthHalfGate; N] {
         self.0
     }
 }

--- a/crates/garble-core/src/fpre.rs
+++ b/crates/garble-core/src/fpre.rs
@@ -1,0 +1,949 @@
+// TODO: Move all of this code elsewhere, maybe into correlated.rs. This code is not used in the auth garbling implementation right now.
+// Mostly helpful as a reference for understanding the function independent preprocessing of auth garbling.
+
+use std::ops::Add;
+use std::iter::zip;
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+use rand::rngs::StdRng;
+
+use mpz_memory_core::correlated::{Delta, Key, Mac};
+
+use mpz_ot_core::ideal::cot::IdealCOT;
+use mpz_ot_core::cot::{COTSenderOutput, COTReceiverOutput};
+use mpz_core::Block;
+
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum FpreError {
+    #[error("fpre not yet generated")]
+    NotGenerated,
+    #[error("invalid wire shares: have {0}, expected {1}")]
+    InvalidWireCount(usize, usize),
+    #[error("invalid triple shares: have {0}, expected {1}")]
+    InvalidTripleCount(usize, usize),
+}
+
+static SELECT_MASK: [Block; 2] = [Block::ZERO, Block::ONES];
+
+// insecure hash function
+fn h2d(a: Block, b: Block) -> Block {
+    let mut d = [a, a ^ b];
+    d[0] = d[0] ^ d[1]; 
+    return d[0] ^ b;
+}
+
+// insecure hash function
+fn h2(a: Block, b: Block) -> Block {
+    let mut d = [a, b];
+    d[0] = d[0] ^ d[1];
+    d[0] = d[0] ^ a;
+    return d[0] ^ b;
+}
+
+/// AuthBitShare consisting of a bool and a (key, mac) pair
+#[derive(Debug, Clone, Default, Copy)]
+pub struct AuthBitShare {
+    /// Key
+    pub key: Key,
+    /// MAC
+    pub mac: Mac,
+    /// Value
+    pub value: bool,
+}
+
+impl AuthBitShare {
+    /// Retrieves the embedded bit from the LSB of `mac`.
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.value
+    }
+
+    /// Checks that `share.mac == share.key.auth(share.bit, delta)`.
+    pub fn verify(&self, delta: &Delta) {
+        let want = self.key.auth(self.bit(), delta);
+        assert_eq!(self.mac, want, "MAC mismatch in share");
+    }
+}
+
+impl Add<AuthBitShare> for AuthBitShare {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: AuthBitShare) -> Self {
+        Self {
+            key: self.key + rhs.key,
+            mac: self.mac + rhs.mac,
+            value: self.value ^ rhs.value,
+        }
+    }
+}
+
+impl Add<&AuthBitShare> for AuthBitShare {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: &AuthBitShare) -> Self {
+        Self {
+            key: self.key + rhs.key,
+            mac: self.mac + rhs.mac,
+            value: self.value ^ rhs.value,
+        }
+    }
+}
+
+impl Add<AuthBitShare> for &AuthBitShare {
+    type Output = AuthBitShare;
+
+    #[inline]
+    fn add(self, rhs: AuthBitShare) -> AuthBitShare {
+        AuthBitShare {
+            key: self.key + rhs.key,
+            mac: self.mac + rhs.mac,
+            value: self.value ^ rhs.value,
+        }
+    }
+}
+
+impl Add<&AuthBitShare> for &AuthBitShare {
+    type Output = AuthBitShare;
+
+    #[inline]
+    fn add(self, rhs: &AuthBitShare) -> AuthBitShare {
+        AuthBitShare {
+            key: self.key + rhs.key,
+            mac: self.mac + rhs.mac,
+            value: self.value ^ rhs.value,
+        }
+    }
+}
+
+/// Builds one `AuthBitShare` from a bit and delta, ensuring `key.lsb()==false`.
+fn build_share(rng: &mut ChaCha12Rng, bit: bool, delta: &Delta) -> AuthBitShare {
+    let key: Key = rng.random();
+    let mac = key.auth(bit, delta);
+    AuthBitShare { key, mac, value: bit }
+}
+
+/// Represents an auth bit [x] = [r]+[s] where [r] is known to gen, auth by eval and [s] is known to eval, auth by gen.
+#[derive(Debug, Clone)]
+pub struct AuthBit {
+    /// Generator's share of the auth bit
+    pub gen_share: AuthBitShare,  
+    /// Evaluator's share of the auth bit
+    pub eval_share: AuthBitShare,
+}
+
+impl AuthBit {
+    /// Recover the full bit x = r ^ s
+    pub fn full_bit(&self) -> bool {
+        self.gen_share.bit() ^ self.eval_share.bit()
+    }
+
+    /// verify auth bits
+    pub fn verify(&self, delta_a: &Delta, delta_b: &Delta) {
+        // Reconstruct shares for testing
+        let r = AuthBitShare {
+            key: self.eval_share.key,
+            mac: self.gen_share.mac,
+            value: self.gen_share.bit(),
+        };
+        let s = AuthBitShare {
+            key: self.gen_share.key,
+            mac: self.eval_share.mac,
+            value: self.eval_share.bit(),
+        };
+        r.verify(delta_b);
+        s.verify(delta_a);
+    }
+}
+
+/// A triple ([x], [y], [z]) of auth bits such that z = x & y.
+#[derive(Debug, Clone)]
+pub struct AuthTriple {
+    /// x component of the triple
+    pub x: AuthBit,
+    /// y component of the triple
+    pub y: AuthBit,
+    /// z component of the triple
+    pub z: AuthBit,
+}
+
+impl AuthTriple {
+    /// verify auth triples
+    pub fn verify(&self, delta_a: &Delta, delta_b: &Delta) {
+        let x = self.x.full_bit();
+        let y = self.y.full_bit();
+        let z = self.z.full_bit();
+        assert_eq!(z, x && y, "z must equal x & y");
+        self.x.verify(delta_a, delta_b);
+        self.y.verify(delta_a, delta_b);
+        self.z.verify(delta_a, delta_b);
+    }
+}
+
+/// Per-party triple share: x,y,z each an `AuthBitShare`.
+#[derive(Debug, Clone)]
+pub struct AuthTripleShare {
+    /// x component of the triple
+    pub x: AuthBitShare,
+    /// y component of the triple
+    pub y: AuthBitShare,
+    /// z component of the triple
+    pub z: AuthBitShare,
+}
+
+/// Insecure ideal Fpre that pre-generates auth bits for wires and auth triples for AND gates.
+#[derive(Debug)]
+pub struct Fpre {
+    rng: ChaCha12Rng,
+    num_input: usize,
+    num_and: usize,
+
+    /// Evaluator's global correlation
+    delta_a: Delta,
+    /// Generator's global correlation
+    delta_b: Delta,
+
+    /// Bits for wires (input + AND-output)
+    pub auth_bits: Vec<AuthBit>,
+    /// Triples for AND gates
+    pub auth_triples: Vec<AuthTriple>,
+}
+
+impl Fpre {
+    /// Creates a new Fpre with random `delta_a`, `delta_b`.
+    pub fn new(seed: u64, num_input: usize, num_and: usize) -> Self {
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
+
+        let delta_a = Delta::random(&mut rng);
+        let delta_b = Delta::random(&mut rng);
+
+        Self {
+            rng,
+            num_input,
+            num_and,
+            delta_a,
+            delta_b,
+            auth_bits: Vec::new(),
+            auth_triples: Vec::new(),
+        }
+    }
+
+    /// Builds an AuthBit [x] from a bit b such that x=b 
+    pub fn gen_auth_bit(&mut self, x: bool) -> AuthBit {
+        
+        let r = self.rng.random_bool(0.5);
+        let s = x ^ r;
+
+        let r_share = build_share(&mut self.rng, r, &self.delta_b);
+        let s_share = build_share(&mut self.rng, s, &self.delta_a);
+
+        AuthBit {
+            // Swapped key/mac for each share so that
+            // gen knows mac from delta_b and key from delta_a, etc.
+            gen_share: AuthBitShare{ mac: r_share.mac, key: s_share.key, value: r},
+            eval_share: AuthBitShare{mac: s_share.mac, key: r_share.key, value: s},
+        }
+    }
+
+    /// Builds a random triple
+    pub fn gen_auth_triple(&mut self) -> AuthTriple {
+        let x = self.rng.random_bool(0.5);
+        let y = self.rng.random_bool(0.5);
+        let z = x && y;
+
+        AuthTriple {
+            x: self.gen_auth_bit(x),
+            y: self.gen_auth_bit(y),
+            z: self.gen_auth_bit(z),
+        }
+    }
+
+    /// Main Fpre generation: auth bits for wires (input + AND) and triples for AND gates
+    pub fn generate(&mut self) {
+        
+        let total_wire_bits = self.num_input + self.num_and;
+        self.auth_bits.reserve(total_wire_bits);
+        for _ in 0..total_wire_bits {
+            let x = self.rng.random_bool(0.5);
+            let auth_bit = self.gen_auth_bit(x);
+            self.auth_bits.push(auth_bit);
+        }
+
+        self.auth_triples.reserve(self.num_and);
+        for _ in 0..self.num_and {
+            let triple = self.gen_auth_triple();
+            self.auth_triples.push(triple);
+        }
+    }
+    
+    /// Returns a reference to the generator's global correlation.
+    pub fn delta_a(&self) -> &Delta {
+        &self.delta_a
+    }
+
+    /// Returns a reference to the evaluator's global correlation.
+    pub fn delta_b(&self) -> &Delta {
+        &self.delta_b
+    }
+
+    /// Consumes `self` to produce `(FpreGen, FpreEval)` ownership in one go.
+    pub fn into_gen_eval(mut self) -> (FpreGen, FpreEval) {
+
+        // Generator wire shares
+        let gen_wire_shares = self.auth_bits
+            .iter()
+            .map(|bit| bit.gen_share.clone())
+            .collect();
+
+        // Evaluator wire shares
+        let eval_wire_shares = self.auth_bits
+            .drain(..) // consume them
+            .map(|bit| bit.eval_share)
+            .collect::<Vec<_>>();
+
+        // Generator triple shares
+        let gen_triple_shares = self.auth_triples
+            .iter()
+            .map(|t| AuthTripleShare {
+                x: t.x.gen_share.clone(),
+                y: t.y.gen_share.clone(),
+                z: t.z.gen_share.clone(),
+            })
+            .collect();
+
+        // Evaluator triple shares
+        let eval_triple_shares = self.auth_triples
+            .drain(..) // consume
+            .map(|t| AuthTripleShare {
+                x: t.x.eval_share,
+                y: t.y.eval_share,
+                z: t.z.eval_share,
+            })
+            .collect();
+
+        let gb = FpreGen {
+            num_input: self.num_input,
+            num_and: self.num_and,
+            delta_a: self.delta_a,
+            wire_shares: gen_wire_shares,
+            triple_shares: gen_triple_shares,
+            leaky_shares: Vec::new(),
+            location: Vec::new(),
+        };
+
+        let eval = FpreEval {
+            num_input: self.num_input,
+            num_and: self.num_and,
+            delta_b: self.delta_b,
+            wire_shares: eval_wire_shares,
+            triple_shares: eval_triple_shares,
+            leaky_shares: Vec::new(),
+            location: Vec::new(),
+        };
+
+        (gb, eval)
+    }
+}
+
+
+
+/// Fpre data from the generator's perspective.
+#[derive(Debug)]
+pub struct FpreGen {
+    /// number of input wires
+    pub num_input: usize,
+    /// number of AND gates
+    pub num_and: usize,
+    /// generator's global correlation
+    pub delta_a: Delta,
+    /// wire shares
+    pub wire_shares: Vec<AuthBitShare>,
+    /// triple shares
+    pub triple_shares: Vec<AuthTripleShare>,
+    /// leaky shares
+    pub leaky_shares: Vec<AuthTripleShare>,
+    /// location
+    pub location: Vec<usize>,
+}
+
+impl FpreGen {
+    /// Creates a new FpreGen with given `num_input`, `num_and`, and `delta_a`.
+    pub fn new(num_input: usize, num_and: usize, delta_a: Delta) -> Self {
+        Self {
+            num_input,
+            num_and,
+            delta_a,
+            wire_shares: Vec::new(),
+            triple_shares: Vec::new(),
+            leaky_shares: Vec::new(),
+            location: Vec::new(),
+        }
+    }
+
+    /// Sets the wire shares for the FpreGen.
+    pub fn set_bits(&mut self, auth_bits: Vec<AuthBitShare>) {
+        self.wire_shares = auth_bits;
+    }
+
+    /// Sets the faulty triples for the FpreGen.
+    pub fn set_faulty_triples(&mut self, auth_bits: Vec<AuthBitShare>) {
+        let length = auth_bits.len() / 3;
+        for i in 0..length {
+            self.leaky_shares.push(AuthTripleShare {
+                x: auth_bits[3 * i].clone(),
+                y: auth_bits[3 * i + 1].clone(),
+                z: auth_bits[3 * i + 2].clone(),
+            });
+        }
+        println!("leaky triples: {:?}", self.leaky_shares[42]);
+    }
+
+    fn triple_check_1(&mut self) -> (Vec<Block>, Vec<Block>) {
+        let length = self.leaky_shares.len();
+        let mut c = vec![Block::ZERO; length];
+        let mut g = vec![Block::ZERO; length];
+
+        for i in 0..length {
+            c[i] = self.leaky_shares[i].y.mac.as_block().clone()
+                ^ self.leaky_shares[i].y.key.as_block().clone()
+                ^ (SELECT_MASK[self.leaky_shares[i].y.bit() as usize] & self.delta_a.as_block());
+
+            g[i] = c[i] ^ h2d(self.leaky_shares[i].x.key.into(), self.delta_a.into_inner());
+        }
+        (c, g)
+    }
+
+    fn triple_check_2(&mut self, c: Vec<Block>, g: &mut Vec<Block>, gr: Vec<Block>) -> Vec<bool> {
+        let length = self.leaky_shares.len();
+        let mut d = vec![false; length];
+
+        for i in 0..length {
+            let mut s = h2(self.leaky_shares[i].x.mac.as_block().clone(), self.leaky_shares[i].x.key.as_block().clone());
+            s = s ^ self.leaky_shares[i].z.mac.as_block().clone() ^ self.leaky_shares[i].z.key.as_block().clone();
+            s = s ^ SELECT_MASK[self.leaky_shares[i].x.bit() as usize] & (gr[i] ^ c[i]);
+            g[i] = s ^ SELECT_MASK[self.leaky_shares[i].z.bit() as usize] & self.delta_a.as_block();
+            d[i] = g[i].lsb();
+        }
+
+        return d;
+    }
+
+    fn triple_check_3(&mut self, g: &mut Vec<Block>, mut d: Vec<bool>, dr: Vec<bool>) {
+        let length = self.leaky_shares.len();
+        for i in 0..length {
+            d[i] = d[i] ^ dr[i];
+            if d[i] {
+                self.leaky_shares[i].z.value = !self.leaky_shares[i].z.value;
+                g[i] = g[i] ^ self.delta_a.as_block();
+            }
+        }
+    }
+
+    fn triple_combine_1(
+        self: &mut Self,
+        seed: u64,
+        bucket_size: usize,
+    ) -> Vec<bool> {
+        let total = self.leaky_shares.len();
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+    
+        // Fisher–Yates shuffle in place
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
+        let mut location: Vec<usize> = (0..total).collect();
+        for i in (0..total).rev() {
+            let idx = rng.random_range(0..=i);
+            location.swap(i, idx);
+        }
+
+        self.location = location;
+        println!("gen location: {:?}", self.location[42]);
+    
+        let mut data = vec![false; total];
+    
+        for i in 0..n {
+            let base_idx = self.location[i*bucket_size + 0];    
+            let y_base = self.leaky_shares[base_idx].y.bit();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.location[i*bucket_size + j];
+                let y_j = self.leaky_shares[idx_j].y.bit();
+                data[i*bucket_size + j] = y_base ^ y_j;
+            }
+        }
+        data
+    }
+
+    fn triple_combine_2(
+        self: &mut Self,
+        _seed: u64,
+        bucket_size: usize,
+        data: Vec<bool>,
+        data_recv: Vec<bool>,
+    ) {
+        let total = self.leaky_shares.len();
+        let n = total / bucket_size;
+
+        let mut final_data = vec![false; total];
+        for i in 0..total {
+            final_data[i] = data[i] ^ data_recv[i];
+        }
+    
+        for i in 0..n {
+            let base_idx = self.location[i*bucket_size + 0];
+    
+            // Start with a "copy" of the first triple in the bucket
+            let mut combined_share = self.leaky_shares[base_idx].clone();
+    
+            // For j in [1..bucket_size], merge x and z wires, keep y same as base
+            for j in 1..bucket_size {
+                let idx_j = self.location[i*bucket_size + j];
+    
+                combined_share.x = combined_share.x + self.leaky_shares[idx_j].x;
+    
+                combined_share.z = combined_share.z + self.leaky_shares[idx_j].z;
+    
+                // If d == 1, correct z-wire by xoring with x-wire
+                if final_data[i*bucket_size + j] {
+                    combined_share.z = combined_share.z + self.leaky_shares[idx_j].x;
+                }
+            }
+            self.triple_shares.push(combined_share);
+        }
+    }
+}
+
+/// Fpre data from the evaluator's perspective.
+#[derive(Debug)]
+pub struct FpreEval {
+    /// number of input wires
+    pub num_input: usize,
+    /// number of AND gates
+    pub num_and: usize,
+    /// evaluator's global correlation
+    pub delta_b: Delta,
+    /// wire shares
+    pub wire_shares: Vec<AuthBitShare>,
+    /// triple shares
+    pub triple_shares: Vec<AuthTripleShare>,
+    /// leaky shares
+    pub leaky_shares: Vec<AuthTripleShare>,
+    /// location
+    pub location: Vec<usize>,
+}
+
+impl FpreEval {
+    /// Creates a new FpreEval with given `num_input`, `num_and`, and `delta_b`.
+    pub fn new(num_input: usize, num_and: usize, delta_b: Delta) -> Self {
+        Self {
+            num_input,
+            num_and,
+            delta_b,
+            wire_shares: Vec::new(),
+            triple_shares: Vec::new(),
+            leaky_shares: Vec::new(),
+            location: Vec::new(),
+        }   
+    }
+
+    /// Sets the wire shares for the FpreEval.
+    pub fn set_bits(&mut self, auth_bits: Vec<AuthBitShare>) {
+        self.wire_shares = auth_bits;
+    }
+
+    /// Sets the faulty triples for the FpreEval.
+    pub fn set_faulty_triples(&mut self, auth_bits: Vec<AuthBitShare>) {
+        let length = auth_bits.len() / 3;
+        for i in 0..length {
+            self.leaky_shares.push(AuthTripleShare {
+                x: auth_bits[3 * i].clone(),
+                y: auth_bits[3 * i + 1].clone(),
+                z: auth_bits[3 * i + 2].clone(),
+            });
+        }
+        println!("leaky triples: {:?}", self.leaky_shares[0]);
+    }
+
+    fn triple_check_1(&mut self) -> (Vec<Block>, Vec<Block>) {
+        let length = self.leaky_shares.len();
+        let mut c = vec![Block::ZERO; length];
+        let mut g = vec![Block::ZERO; length];
+
+        for i in 0..length {
+            c[i] = self.leaky_shares[i].y.mac.as_block().clone()
+                ^ self.leaky_shares[i].y.key.as_block().clone()
+                ^ (SELECT_MASK[self.leaky_shares[i].y.bit() as usize] & self.delta_b.as_block());
+
+            g[i] = c[i] ^ h2d(self.leaky_shares[i].x.key.into(), self.delta_b.into_inner());
+        }
+        (c, g)
+    }
+
+    fn triple_check_2(&mut self, c: Vec<Block>, g: &mut Vec<Block>, gr: Vec<Block>) -> Vec<bool> {
+        let length = self.leaky_shares.len();
+        let mut d = vec![false; length];
+
+        for i in 0..length {
+            let mut s = h2(self.leaky_shares[i].x.mac.as_block().clone(), self.leaky_shares[i].x.key.as_block().clone());
+            s = s ^ self.leaky_shares[i].z.mac.as_block().clone() ^ self.leaky_shares[i].z.key.as_block().clone();
+            s = s ^ SELECT_MASK[self.leaky_shares[i].x.bit() as usize] & (gr[i] ^ c[i]);
+            g[i] = s ^ SELECT_MASK[self.leaky_shares[i].z.bit() as usize] & self.delta_b.as_block();
+            d[i] = g[i].lsb();
+        }
+
+        return d;
+
+    }
+
+    fn triple_check_3(&mut self, g: &mut Vec<Block>, mut d: Vec<bool>, dr: Vec<bool>) {
+        let length = self.leaky_shares.len();
+        for i in 0..length {
+            d[i] = d[i] ^ dr[i];
+            if d[i] {
+                self.leaky_shares[i].z.key = self.leaky_shares[i].z.key + Key::from(self.delta_b.into_inner());
+                g[i] = g[i] ^ self.delta_b.as_block();
+            }
+        }
+    }
+
+    fn triple_combine_1(
+        self: &mut Self,
+        seed: u64,
+        bucket_size: usize,
+    ) -> Vec<bool> {
+        let total = self.leaky_shares.len();
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+    
+        // Fisher–Yates shuffle in place
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
+        let mut location: Vec<usize> = (0..total).collect();
+        for i in (0..total).rev() {
+            let idx = rng.random_range(0..=i);
+            location.swap(i, idx);
+        }
+
+        self.location = location;
+        println!("eval location: {:?}", self.location[42]);
+
+        let mut data = vec![false; total];
+    
+        for i in 0..n {
+            let base_idx = self.location[i*bucket_size + 0];    
+            let y_base = self.leaky_shares[base_idx].y.bit();
+    
+            for j in 1..bucket_size {
+                let idx_j = self.location[i*bucket_size + j];
+                let y_j = self.leaky_shares[idx_j].y.bit();
+                data[i*bucket_size + j] = y_base ^ y_j;
+            }
+        }
+        data
+    }
+
+    fn triple_combine_2(
+        self: &mut Self,
+        _seed: u64,
+        bucket_size: usize,
+        data: Vec<bool>,
+        data_recv: Vec<bool>,
+    ) {
+
+        let total = self.leaky_shares.len();
+        assert_eq!(total % bucket_size, 0,
+            "total length must be multiple of bucket_size");
+        let n = total / bucket_size;
+
+        let mut final_data = vec![false; total];
+        for i in 0..total {
+            final_data[i] = data[i] ^ data_recv[i];
+        }
+
+        for i in 0..n {
+            let base_idx = self.location[i*bucket_size + 0];
+    
+            // Start with a "copy" of the first triple in the bucket
+            let mut combined_share = self.leaky_shares[base_idx].clone();
+    
+            // For j in [1..bucket_size], merge x and z wires, keep y same as base
+            for j in 1..bucket_size {
+                let idx_j = self.location[i*bucket_size + j];
+    
+                combined_share.x = combined_share.x + self.leaky_shares[idx_j].x;
+    
+                combined_share.z = combined_share.z + self.leaky_shares[idx_j].z;
+    
+                // If d == 1, correct z-wire by xoring with x-wire
+                if final_data[i*bucket_size + j] {
+                    combined_share.z = combined_share.z + self.leaky_shares[idx_j].x;
+                }
+            }
+            self.triple_shares.push(combined_share);
+        }
+    }
+}
+
+/// Generate auth bit shares using ideal COT
+pub fn bit_shares_from_cot(
+    length: usize,
+    delta_a: Delta,
+    delta_b: Delta,
+) -> Result<(Vec<AuthBitShare>, Vec<AuthBitShare>), FpreError> {
+
+    let mut rng = ChaCha12Rng::seed_from_u64(0);
+
+    // Perform COT with delta_b and eval keys so that received messages are macs on bits known to eval
+    let mut cot_eval = IdealCOT::new(delta_b.into_inner());
+    let gen_bits: Vec<bool> = (0..length).map(|_| rng.random()).collect::<Vec<_>>();
+    let eval_keys: Vec<Block> = (0..length).map(|_| rng.random()).collect::<Vec<_>>();
+
+    let (
+        COTSenderOutput { id: _sender_id },
+        COTReceiverOutput {
+            id: _receiver_id,
+            msgs: received,
+        },
+    ) = cot_eval.transfer(&gen_bits, &eval_keys).unwrap();
+
+    let gen_macs = received;
+
+    // Perform COT with delta_a and gen keys so that received messages are macs on bits known to gen
+    let mut cot_gen = IdealCOT::new(delta_a.into_inner());
+    let eval_bits: Vec<bool> = (0..length).map(|_| rng.random()).collect::<Vec<_>>();
+    let gen_keys: Vec<Block> = (0..length).map(|_| rng.random()).collect::<Vec<_>>();
+
+    let (
+        COTSenderOutput { id: _sender_id },
+        COTReceiverOutput {
+            id: _receiver_id,
+            msgs: received,
+        },
+    ) = cot_gen.transfer(&eval_bits, &gen_keys).unwrap();
+
+    let eval_macs = received;
+
+    // Construct auth bit shares from COT outputs
+    let mut gen_shares: Vec<AuthBitShare> = Vec::with_capacity(length);
+    let mut eval_shares: Vec<AuthBitShare> = Vec::with_capacity(length);
+
+    for i in 0..length {
+        let r = gen_bits[i];
+        let m_r = gen_macs[i];
+
+        let k_r = gen_keys[i];
+
+        gen_shares.push(AuthBitShare {
+            key: k_r.into(),
+            mac: m_r.into(),
+            value: r,
+        });
+
+        let s = eval_bits[i];
+        let m_s = eval_macs[i];
+
+        let k_s = eval_keys[i];
+
+        eval_shares.push(AuthBitShare {
+            key: k_s.into(),
+            mac: m_s.into(),
+            value: s,
+        });
+    }
+
+    Ok((gen_shares, eval_shares))
+    
+}
+
+/// Generate Fpre data
+pub fn fpre(
+    num_wires: usize,
+    num_and: usize,
+    bucket_size: usize,
+    _seed: u64,
+    rng: &mut StdRng,
+) -> (FpreGen, FpreEval) {
+
+    // need to set LSB of deltas to XOR to 1 for an optimization
+    let delta_a = Delta::random(rng).set_lsb(true);
+    let delta_b = Delta::random(rng).set_lsb(false);
+
+    println!("delta_a: {:?}", delta_a);
+    println!("delta_b: {:?}", delta_b);
+
+    let mut fpre_gen = FpreGen::new(num_wires, num_and, delta_a);
+    let mut fpre_eval = FpreEval::new(num_wires, num_and, delta_b);
+
+    // Calculate total number of shares needed
+    let num_wires_shares = num_wires + num_and;
+    let num_and_shares = num_and*(3*bucket_size);
+    let total_shares = num_wires_shares + num_and_shares;
+
+    // Get all shares in one call
+    let (gen_all_shares, eval_all_shares) = 
+        bit_shares_from_cot(total_shares, delta_a, delta_b)
+        .unwrap();
+
+    // Split into input and AND shares
+    let (gen_wire_shares, gen_and_shares) = {
+        let (wire, and) = gen_all_shares.split_at(num_wires_shares);
+        (wire.to_vec(), and.to_vec())
+    };
+    let (eval_wire_shares, eval_and_shares) = {
+        let (wire, and) = eval_all_shares.split_at(num_wires_shares);
+        (wire.to_vec(), and.to_vec())
+    };
+
+    println!("gen wire shares: {:?}", gen_wire_shares[42]);
+
+    fpre_gen.set_bits(gen_wire_shares);
+    fpre_eval.set_bits(eval_wire_shares);
+
+    fpre_gen.set_faulty_triples(gen_and_shares);
+    fpre_eval.set_faulty_triples(eval_and_shares);
+
+    let (c_gen, mut g_gen) = fpre_gen.triple_check_1();
+    let (c_eval, mut g_eval) = fpre_eval.triple_check_1();
+
+    // Comm 1
+    let gr_gen = g_eval.clone();
+    let gr_eval = g_gen.clone();
+
+    let d_gen = fpre_gen.triple_check_2(c_gen, &mut g_gen, gr_gen);
+    let d_eval = fpre_eval.triple_check_2(c_eval, &mut g_eval, gr_eval);
+
+    // Comm 2
+    let dr_gen = d_eval.clone();    
+    let dr_eval = d_gen.clone();
+
+    fpre_gen.triple_check_3(&mut g_gen, d_gen, dr_gen);
+    fpre_eval.triple_check_3(&mut g_eval, d_eval, dr_eval);
+
+    // Comm 3
+    for (g_gen, g_eval) in zip(g_gen, g_eval) {
+        assert_eq!(g_gen, g_eval);
+    }
+
+    // Comm 4: coin-tossing to agree on a seed
+    let seed = 0;
+
+    let data_gen = fpre_gen.triple_combine_1(seed, bucket_size);
+    let data_eval = fpre_eval.triple_combine_1(seed, bucket_size);
+
+    // Comm 5
+    let data_recv_gen = data_eval.clone();
+    let data_recv_eval = data_gen.clone();
+
+    fpre_gen.triple_combine_2(seed, bucket_size, data_gen, data_recv_gen);
+    fpre_eval.triple_combine_2(seed, bucket_size, data_eval, data_recv_eval);
+
+    (fpre_gen, fpre_eval)
+}
+
+fn _verify_fpre(fpre_gen: FpreGen, fpre_eval: FpreEval){
+    for (gen_share, eval_share) in zip(fpre_gen.wire_shares, fpre_eval.wire_shares) {
+        AuthBit {
+            gen_share,
+            eval_share,
+        }.verify(&fpre_gen.delta_a, &fpre_eval.delta_b);
+    }
+
+    for (gen_triple, eval_triple) in zip(fpre_gen.triple_shares, fpre_eval.triple_shares) {
+        AuthTriple {
+            x: AuthBit {
+                gen_share: gen_triple.x,
+                eval_share: eval_triple.x,
+            },
+            y: AuthBit {
+                gen_share: gen_triple.y,
+                eval_share: eval_triple.y,
+            },
+            z: AuthBit {
+                gen_share: gen_triple.z,
+                eval_share: eval_triple.z,
+            },
+        }.verify(&fpre_gen.delta_a, &fpre_eval.delta_b);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fpre(){
+        let num_wires = 10000;
+        let num_and = 6000;
+        let bucket_size = 5;
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let (fpre_gen, fpre_eval) = fpre(num_wires, num_and, bucket_size, 0, &mut rng);
+
+        _verify_fpre(fpre_gen, fpre_eval);
+    }
+
+    #[test]
+    fn test_fpre_insecure() {
+        let num_input = 100;
+        let num_and = 50;
+        let mut fpre = Fpre::new(5, num_input, num_and);
+        fpre.generate();
+
+        assert_eq!(fpre.auth_bits.len(), num_input + num_and);
+        assert_eq!(fpre.auth_triples.len(), num_and);
+
+        for bit in &fpre.auth_bits {
+            bit.verify(fpre.delta_a(), fpre.delta_b());
+        }
+        for triple in &fpre.auth_triples {
+            triple.verify(fpre.delta_a(), fpre.delta_b());
+        }
+
+        let (fpre_gen, fpre_eval) = fpre.into_gen_eval();
+
+        // wire shares length
+        assert_eq!(
+            fpre_gen.wire_shares.len(),
+            num_input + num_and
+        );
+        assert_eq!(
+            fpre_eval.wire_shares.len(),
+            num_input + num_and
+        );
+
+        // triple shares length
+        assert_eq!(fpre_gen.triple_shares.len(), num_and);
+        assert_eq!(fpre_eval.triple_shares.len(), num_and);
+
+        // Check generator/evaluator shares align
+        for (gen_share, eval_share) in zip(fpre_gen.wire_shares, fpre_eval.wire_shares) {
+            let bit = AuthBit {
+                gen_share,
+                eval_share,
+            };
+            bit.verify(&fpre_gen.delta_a, &fpre_eval.delta_b);
+        }
+
+        for (gen_triple, eval_triple) in zip(fpre_gen.triple_shares, fpre_eval.triple_shares) {
+            let triple = AuthTriple {
+                x: AuthBit {
+                    gen_share: gen_triple.x,
+                    eval_share: eval_triple.x,
+                },
+                y: AuthBit {
+                    gen_share: gen_triple.y,
+                    eval_share: eval_triple.y,
+                },
+                z: AuthBit {
+                    gen_share: gen_triple.z,
+                    eval_share: eval_triple.z,
+                },
+            };
+            triple.verify(&fpre_gen.delta_a, &fpre_eval.delta_b);
+        }
+    }
+}

--- a/crates/garble-core/src/lib.rs
+++ b/crates/garble-core/src/lib.rs
@@ -7,19 +7,34 @@
 
 pub(crate) mod circuit;
 mod evaluator;
+mod auth_eval;
 mod garbler;
+mod auth_gen;
+/// Module for free pre-processing functionality in garbled circuits
+pub mod fpre;
 pub mod store;
 pub(crate) mod view;
 
-pub use circuit::{EncryptedGate, EncryptedGateBatch, GarbledCircuit};
-pub use evaluator::{
-    EncryptedGateBatchConsumer, EncryptedGateConsumer, Evaluator, EvaluatorError, EvaluatorOutput,
-    evaluate_garbled_circuits,
+pub use circuit::{AuthHalfGate, AuthHalfGateBatch, EncryptedGate, EncryptedGateBatch, GarbledCircuit, AuthGarbledCircuit};
+
+pub use evaluator::{evaluate_garbled_circuits, EncryptedGateBatchConsumer, EncryptedGateConsumer, Evaluator,
+    EvaluatorError, EvaluatorOutput,};
+pub use auth_eval::{
+     AuthEvaluatorError, AuthEvalOutput, AuthEval, AuthEncryptedGateBatchConsumer, AuthEncryptedGateConsumer
 };
+
 pub use garbler::{
     EncryptedGateBatchIter, EncryptedGateIter, Garbler, GarblerError, GarblerOutput,
 };
+pub use auth_gen::{AuthGen, AuthGeneratorError, AuthEncryptedGateBatchIter, AuthGenOutput};
+
+pub use fpre::{Fpre, FpreError, fpre, bit_shares_from_cot, AuthBit, AuthTriple};
 pub use mpz_memory_core::correlated::{Delta, Key, Mac};
+
+pub use mpz_circuits::Circuit;
+
+/// Statistical security parameter for authenticated garbling
+pub const SSP: usize = 40;
 
 const KB: usize = 1024;
 const BYTES_PER_GATE: usize = 32;
@@ -51,6 +66,8 @@ mod tests {
     use crate::evaluator::evaluate_garbled_circuits;
 
     use super::*;
+
+    const SSP: usize = 40;
 
     #[test]
     fn test_and_gate() {
@@ -134,6 +151,7 @@ mod tests {
 
         assert_eq!(output, expected);
     }
+
 
     #[test]
     fn test_garble_preprocessed() {
@@ -260,5 +278,152 @@ mod tests {
         );
 
         assert_eq!(output, expected);
+    }
+    
+    #[test]
+    fn test_auth_garble() {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let key = [69u8; 16];
+        let msg = [42u8; 16];
+
+        let circuit = &AES128;
+
+        let expected: [u8; 16] = {
+            let cipher = Aes128::new_from_slice(&key).unwrap();
+            let mut out = msg.into();
+            cipher.encrypt_block(&mut out);
+            out.into()
+        };
+
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+
+        // Calculate total number of shares needed
+        let bucket_size = (SSP as f64 / (circuit.and_count() as f64).log2()).ceil() as usize;
+        let num_input_shares = circuit.inputs().len();
+        let num_and_shares = circuit.and_count()*(3*bucket_size+1);
+        let total_shares = num_input_shares + num_and_shares;
+
+        // Get all shares in one call
+        let (gen_all_shares, eval_all_shares) = 
+            bit_shares_from_cot(total_shares, delta_a, delta_b)
+            .unwrap();
+
+        // Split into input and AND shares
+        let (gen_input_shares, gen_and_shares) = {
+            let (input, and) = gen_all_shares.split_at(num_input_shares);
+            (input.to_vec(), and.to_vec())
+        };
+        let (eval_input_shares, eval_and_shares) = {
+            let (input, and) = eval_all_shares.split_at(num_input_shares);
+            (input.to_vec(), and.to_vec())
+        };
+
+        // Coin-tossing to agree on a seed
+        let seed = 0;
+
+        let mut gb = AuthGen::new(seed, bucket_size);
+        let mut ev = AuthEval::new(seed, bucket_size);
+
+        let input_keys = (0..circuit.inputs().len())
+            .map(|_| rng.random())
+            .collect::<Vec<Key>>();
+
+        let masked_inputs = key.iter().copied().chain(msg).into_iter_lsb0()
+            .enumerate()
+            .map(|(i, b)| b ^ gen_input_shares[i].bit() ^ eval_input_shares[i].bit())
+            .collect::<Vec<bool>>();
+
+        // Calculate MACs for authenticated garbling
+        let input_macs = masked_inputs.iter()
+            .enumerate()
+            .map(|(i, b)| {
+                if *b {
+                    Mac::from(input_keys[i].as_block().clone()) + Mac::from(delta_a.as_block().clone())
+                } else {
+                    Mac::from(input_keys[i].as_block().clone())
+                }
+            })
+            .collect::<Vec<Mac>>();    
+
+        let (c_gen, mut g_gen) = gb.generate_pre_1(circuit, delta_a, &gen_input_shares, &gen_and_shares).unwrap();
+        let (c_eval, mut g_eval) = ev.evaluate_pre_1(circuit, delta_b, &eval_input_shares, &eval_and_shares).unwrap();
+
+        let gr_gen = g_eval.clone();
+        let gr_eval = g_gen.clone();
+
+        let d_gen = gb.generate_pre_2(delta_a, c_gen, &mut g_gen, gr_gen).unwrap();
+        let d_eval = ev.evaluate_pre_2(delta_b, c_eval, &mut g_eval, gr_eval).unwrap();
+
+        let dr_gen = d_eval.clone();    
+        let dr_eval = d_gen.clone();
+
+        let data_gen = gb.generate_pre_3(delta_a, &mut g_gen, d_gen, dr_gen).unwrap();
+        let data_eval = ev.evaluate_pre_3(delta_b, &mut g_eval, d_eval, dr_eval).unwrap();
+
+        for (g_gen, g_eval) in g_gen.iter().zip(g_eval.iter()) {
+            assert_eq!(g_gen, g_eval, "fpre triple check failed");
+        }
+
+        let data_recv_gen = data_eval.clone();
+        let data_recv_eval = data_gen.clone();
+
+        gb.generate_pre_4(data_gen, data_recv_gen).unwrap();
+        ev.evaluate_pre_4(data_eval, data_recv_eval).unwrap();
+
+        gb.generate_free(circuit).unwrap();
+        ev.evaluate_free(circuit).unwrap();
+
+        let (px_gen, py_gen) = gb.generate_de(circuit).unwrap();
+        let (px_eval, py_eval) = ev.evaluate_de(circuit).unwrap();
+
+        let mut gen_iter: AuthEncryptedGateBatchIter<'_, std::slice::Iter<'_, mpz_circuits::Gate>> = gb.generate_batched(&AES128, delta_a, &input_keys, px_eval, py_eval).unwrap();
+        let mut ev_consumer: AuthEncryptedGateBatchConsumer<'_, std::slice::Iter<'_, mpz_circuits::Gate>> = ev.evaluate_batched(&AES128, delta_b, &input_macs, masked_inputs, px_gen, py_gen).unwrap();
+
+        for gate in gen_iter.by_ref() {
+            ev_consumer.next(gate);
+        }
+
+        let AuthEvalOutput {
+            output_labels: eval_output_labels,
+            output_auth_bits: eval_output_auth_bits,
+            auth_hash: eval_auth_hash,
+            masked_output_values,
+            masked_values,
+        } = ev_consumer.finish().unwrap();
+
+        let AuthGenOutput {
+            output_labels: gen_output_labels,
+            output_auth_bits: gen_output_auth_bits,
+            auth_hash: gen_auth_hash,
+        } = gen_iter.finish(masked_values).unwrap();
+
+        // authentication check
+        assert_eq!(gen_auth_hash, eval_auth_hash, "auth hash mismatch");
+
+        let masks = gen_output_auth_bits.iter()
+            .zip(eval_output_auth_bits.iter())
+            .map(|(gen_auth_bit, eval_auth_bit)| gen_auth_bit.bit() ^ eval_auth_bit.bit())
+            .collect::<Vec<bool>>();
+        
+        // Unmask the output
+        let output: Vec<u8> = Vec::from_lsb0_iter(
+            masked_output_values
+                .clone()
+                .into_iter()
+                .enumerate()
+                .map(|(i, masked_value)| masked_value ^ masks[i]),
+        );
+
+        assert_eq!(output, expected, "output mismatch");
+
+        // Check output labels
+        for (i, (gen_label, eval_label)) in gen_output_labels.iter().zip(eval_output_labels.iter()).enumerate() {
+            let xor = gen_label.as_block() ^ eval_label.as_block();
+            let masked_value = masked_output_values[i];
+            let expected = delta_a.mul_bool(masked_value);
+            assert_eq!(xor, expected, "output label mismatch");
+        }
     }
 }

--- a/crates/garble-core/src/store.rs
+++ b/crates/garble-core/src/store.rs
@@ -1,17 +1,21 @@
 //! Memory stores.
 
 mod evaluator;
+mod auth_eval;
 mod garbler;
+mod auth_gen;
 
 pub use evaluator::{EvaluatorStore, EvaluatorStoreError};
+pub use auth_eval::{AuthEvalStore, AuthEvalStoreError};
 pub use garbler::{GarblerStore, GarblerStoreError};
+pub use auth_gen::{AuthGenStore, AuthGenStoreError};
 
 use blake3::Hash;
 use mpz_core::bitvec::BitVec;
 use mpz_memory_core::correlated::{Mac, MacCommitment};
 use serde::{Deserialize, Serialize};
 
-use crate::view::FlushView;
+use crate::view::{AuthFlushView, FlushView};
 
 /// Flush message sent by the garbler.
 #[derive(Debug, Serialize, Deserialize)]
@@ -27,6 +31,21 @@ pub struct GarblerFlush {
     mac_commitments: Vec<MacCommitment>,
 }
 
+/// Flush message sent by auth generator.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthGenFlush {
+    /// Flush view.
+    view: AuthFlushView,
+    /// Share proof.
+    share_proof: Option<ShareProof>,
+    /// Half masked inputs.
+    half_masked_inputs: BitVec,
+    /// Input labels.
+    labels: Vec<Mac>,
+    /// Decode share proof.
+    decode_share_proof: Option<ShareProof>,
+}
+
 /// Flush message sent by the evaluator.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(try_from = "validation::EvaluatorFlushUnchecked")]
@@ -37,6 +56,21 @@ pub struct EvaluatorFlush {
     mac_proof: Option<MacProof>,
 }
 
+/// Flush message sent by auth evaluator.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthEvalFlush {
+    /// Flush view.
+    view: AuthFlushView,
+    /// Share proof.
+    share_proof: Option<ShareProof>,
+    /// Half masked inputs.
+    half_masked_inputs: BitVec,
+    /// Output labels.
+    labels: Vec<Mac>,
+    /// Decode share proof.
+    decode_share_proof: Option<ShareProof>,
+}
+
 /// MAC proof sent from the evaluator to the garbler to prove
 /// the output of a circuit.
 #[derive(Debug, Serialize, Deserialize)]
@@ -45,6 +79,14 @@ pub struct MacProof {
     proof: Hash,
 }
 
+/// Share proof sent from the generator to the evaluator to prove inputs shares
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ShareProof {
+    bits: BitVec,
+    macs: Vec<Mac>,
+}
+
+// TODO: Add validation for auth flush messages
 mod validation {
     use super::*;
 
@@ -207,5 +249,103 @@ mod tests {
         assert_eq!(val_a_gb, val_a);
         assert_eq!(val_b_gb, val_b);
         assert_eq!(val_c_gb, val_c);
+    }
+
+    #[test]
+    fn test_auth_store_decode() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+        let cot_gen = IdealCOT::new(delta_a.into_inner());
+        let cot_eval = IdealCOT::new(delta_b.into_inner());
+        let mut gb = AuthGenStore::new(rng.random(), delta_a, cot_gen.clone(), cot_eval.clone());
+        let mut ev = AuthEvalStore::new(rng.random(), delta_b, cot_eval.clone(), cot_gen.clone());
+
+        let val_a = [0u8; 16];
+        let val_b = [42u8; 16];
+        let val_c = [69u8; 16];
+
+        let ref_a_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_public(ref_a_gen).unwrap();
+        let ref_b_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_private(ref_b_gen).unwrap();
+        let ref_c_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_blind(ref_c_gen).unwrap();
+
+        let ref_a_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_public(ref_a_ev).unwrap();
+        let ref_b_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_blind(ref_b_ev).unwrap();
+        let ref_c_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_private(ref_c_ev).unwrap();
+
+        gb.assign(ref_a_gen, val_a).unwrap();
+        gb.assign(ref_b_gen, val_b).unwrap();
+
+        ev.assign(ref_a_ev, val_a).unwrap();
+        ev.assign(ref_c_ev, val_c).unwrap();
+
+        gb.commit(ref_a_gen).unwrap();
+        gb.commit(ref_b_gen).unwrap();
+        gb.commit(ref_c_gen).unwrap();
+
+        ev.commit(ref_a_ev).unwrap();
+        ev.commit(ref_b_ev).unwrap();
+        ev.commit(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.acquire_cot_sender().flush().unwrap();
+        ev.acquire_cot_sender().flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        let mut fut_a_gen = gb.decode(ref_a_gen).unwrap();
+        let mut fut_b_gen = gb.decode(ref_b_gen).unwrap();
+        let mut fut_c_gen = gb.decode(ref_c_gen).unwrap();
+
+        let mut fut_a_ev = ev.decode(ref_a_ev).unwrap();
+        let mut fut_b_ev = ev.decode(ref_b_ev).unwrap();
+        let mut fut_c_ev = ev.decode(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        assert!(!gb.wants_flush());
+        assert!(!ev.wants_flush());
+
+        let val_a_gen = fut_a_gen.try_recv().unwrap().unwrap();
+        let val_a_ev = fut_a_ev.try_recv().unwrap().unwrap();
+        let val_b_gen = fut_b_gen.try_recv().unwrap().unwrap();
+        let val_b_ev = fut_b_ev.try_recv().unwrap().unwrap();
+        let val_c_gen = fut_c_gen.try_recv().unwrap().unwrap();
+        let val_c_ev = fut_c_ev.try_recv().unwrap().unwrap();
+
+        assert_eq!(val_a_gen, val_a_ev);
+        assert_eq!(val_b_gen, val_b_ev);
+        assert_eq!(val_c_gen, val_c_ev);
+        assert_eq!(val_a_gen, val_a);
+        assert_eq!(val_b_gen, val_b);
+        assert_eq!(val_c_gen, val_c);
     }
 }

--- a/crates/garble-core/src/store/auth_eval.rs
+++ b/crates/garble-core/src/store/auth_eval.rs
@@ -1,0 +1,628 @@
+use rand::Rng;
+
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use mpz_common::future::Output;
+use mpz_core::{bitvec::{BitVec, BitSlice}, Block, prg::Prg};
+use mpz_memory_core::{
+    binary::Binary,
+    correlated::{Key, Delta, Mac, MacCommitmentError, MacStore, MacStoreError, AuthBitStore, AuthBitStoreError},
+    store::{BitStore, StoreError},
+    DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
+};
+use mpz_ot_core::cot::{COTReceiver, COTReceiverOutput, COTSender};
+use utils::filter_drain::FilterDrain;
+
+use crate::{
+    store::{ShareProof, AuthEvalFlush, AuthGenFlush},
+    view::{AuthFlushView, AuthView, ViewError},
+};
+
+type Error = AuthEvalStoreError;
+type Result<T> = core::result::Result<T, Error>;
+
+struct PendingFlush {
+    cot: Option<Box<dyn Output<COTReceiverOutput<Block>> + Send>>,
+}
+
+impl std::fmt::Debug for PendingFlush {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingFlush").finish_non_exhaustive()
+    }
+}
+
+/// Authenticated evaluator memory store.
+#[derive(Debug)]
+pub struct AuthEvalStore<S, R> {
+    cot_sender: Arc<Mutex<S>>,
+    cot_receiver: Arc<Mutex<R>>,
+    prg: Prg,
+    mac_store: MacStore,
+    mask_store: AuthBitStore,
+    masked_value_store: BitStore,
+    data_store: BitStore,
+    view: AuthView,
+    buffer_decode: Vec<DecodeOp<BitVec>>,
+    auth_hash: Block,
+    // Whether the store is waiting for a flush.
+    pending: bool,
+    // Pending COT flush
+    pending_flush: Option<PendingFlush>,
+}
+
+impl<S, R> AuthEvalStore<S, R> {
+    /// Creates a new evaluator store.
+    pub fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+        Self {
+            cot_sender: Arc::new(Mutex::new(cot_sender)),
+            cot_receiver: Arc::new(Mutex::new(cot_receiver)),
+            prg: Prg::new_with_seed(seed),
+            mac_store: MacStore::default(),
+            mask_store: AuthBitStore::new(delta),
+            masked_value_store: BitStore::default(),
+            data_store: BitStore::default(),
+            view: AuthView::new_evaluator(),
+            buffer_decode: Vec::default(),
+            auth_hash: Block::default(),
+            pending: false,
+            pending_flush: None,
+        }
+    }
+
+    /// Returns the delta of the eval store.
+    pub fn delta(&self) -> &Delta {
+        self.mask_store.delta()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub fn acquire_cot_sender(&self) -> OwnedMutexGuard<S> {
+        Mutex::try_lock_owned(self.cot_sender.clone()).unwrap()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub fn acquire_cot_receiver(&self) -> OwnedMutexGuard<R> {
+        Mutex::try_lock_owned(self.cot_receiver.clone()).unwrap()
+    }
+
+    /// Returns the COT sender.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the sender is still held.
+    pub fn into_inner_sender(self) -> S {
+        Arc::try_unwrap(self.cot_sender)
+            .map_err(|_| ())
+            .expect("sender lock should be dropped")
+            .into_inner()
+    }
+
+    /// Returns the COT receiver.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the receiver is still held.
+    pub fn into_inner_receiver(self) -> R {
+        Arc::try_unwrap(self.cot_receiver)
+            .map_err(|_| ())
+            .expect("receiver lock should be dropped")
+            .into_inner()
+    }
+
+    /// Allocates an output slice.
+    pub fn alloc_output(&mut self, size: usize) -> Slice {
+        self.view.alloc_output(size);
+        self.mac_store.alloc(size);
+        self.data_store.alloc(size);
+        self.masked_value_store.alloc(size);
+        self.mask_store.alloc(size)
+    }
+
+    /// Returns whether the MACs are set for a slice.
+    pub fn is_set_macs(&self, slice: Slice) -> bool {
+        self.mac_store.is_set(slice)
+    }
+
+    /// Returns whether the masks are set for a slice.
+    pub fn is_set_masks(&self, slice: Slice) -> bool {
+        self.mask_store.is_set(slice)
+    }
+
+    /// Returns whether the slice is committed.
+    pub fn is_committed(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    /// Returns the MACs for a slice.
+    pub fn try_get_macs(&self, slice: Slice) -> Result<&[Mac]> {
+        self.mac_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Returns the masked values for a slice.
+    pub fn try_get_masked_values(&self, slice: Slice) -> Result<&BitSlice> {
+        self.masked_value_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Returns the masks for a slice.
+    pub fn try_get_mask_bits(&self, slice: Slice) -> Result<&BitSlice> {
+        self.mask_store.try_get_bits(slice).map_err(Error::from)
+    }
+
+    /// Returns the masks for a slice.
+    pub fn try_get_mask_macs(&self, slice: Slice) -> Result<&[Mac]> {
+        self.mask_store.try_get_macs(slice).map_err(Error::from)
+    }
+
+    /// Returns the masks for a slice.
+    pub fn try_get_mask_keys(&self, slice: Slice) -> Result<&[Key]> {
+        self.mask_store.try_get_keys(slice).map_err(Error::from)
+    }
+
+    /// Updates the auth hash.
+    pub fn update_hash(&mut self, hash: Block) {
+        self.auth_hash ^= hash;
+    }
+
+    /// Returns the auth hash.
+    pub fn get_hash(&self) -> Block {
+        self.auth_hash
+    }
+
+    /// Sets the MACs for a slice corresponding to output.
+    pub fn set_output(&mut self, slice: Slice, macs: &[Mac], mask_bits: &BitSlice, mask_macs: &[Mac], mask_keys: &[Key], masked_values: &BitSlice) -> Result<()> {
+        self.view.set_output(slice.to_range())?;
+        self.mac_store.try_set(slice, macs)?;
+        self.mask_store.try_set_bits(slice, mask_bits)?;
+        self.mask_store.try_set_macs(slice, mask_macs)?;
+        self.mask_store.try_set_keys(slice, mask_keys)?;
+        self.masked_value_store.try_set(slice, masked_values)?;
+        Ok(())
+    }
+
+    /// Marks an output as preprocessed.
+    pub fn mark_output_preprocessed(&mut self, slice: Slice) -> Result<()> {
+        self.view
+            .set_preprocessed(slice.to_range())
+            .map_err(Error::from)
+    }
+
+    /// Returns `true` if the store wants to flush.
+    pub fn wants_flush(&self) -> bool {
+        self.view.wants_flush()
+    }
+
+    /// Flushes decode operations.
+    pub fn flush_decode(&mut self) -> Result<()> {
+        for mut op in self
+            .buffer_decode
+            .filter_drain(|op| self.data_store.is_set(op.slice))
+        {
+            let data = self.data_store.try_get(op.slice)?;
+            op.send(data.to_bitvec())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<S, R> AuthEvalStore<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+    R::Future: Send + 'static,
+{
+    /// Sends a flush to the generator.
+    ///
+    /// This queues any necessary COTs.
+    pub fn send_flush(&mut self) -> Result<AuthEvalFlush> {
+        if self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let view = self.view.flush().clone();
+
+        // Send OT keys for masks.
+        let masks = view.gen_masks.clone() | view.eval_masks.clone() | view.public.clone();
+        if !masks.is_empty() {
+            let keys = (0..masks.len()).map(|_| self.prg.random()).collect::<Vec<_>>();
+            // Store keys in mask store.
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_keys(slice, &keys)?;
+            }
+            // Queue COT, we don't need the output here.
+            _ = self
+                .cot_sender
+                .try_lock()
+                .unwrap()
+                .queue_send_cot(Key::as_blocks(&keys))
+                .map_err(Error::cot)?;
+        }
+
+        // Send OT choices for masks, receive MACs as a future.
+        let cot = if !masks.is_empty() {
+            // Collect the choices for oblivious transfer.
+            let choices: Vec<bool> = (0..masks.len()).map(|_| self.prg.random()).collect::<Vec<_>>();
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_bits(slice, &BitVec::from_iter(choices.iter()))?;
+            }
+            let output = self
+                .cot_receiver
+                .try_lock()
+                .unwrap()
+                .queue_recv_cot(&choices)
+                .map_err(Error::cot)?;
+            Some(Box::new(output) as Box<dyn Output<COTReceiverOutput<Block>> + Send>)
+        } else {
+            None
+        };
+
+        // Prove Eval's share of Gen input wires
+        let share_proof = if !view.gen_reveal.is_empty() || !view.public_decode.is_empty() {
+            let (bits1, macs1) = self.mask_store.prove_share(&view.gen_reveal)?;
+            // Set masked_value_store using sent bits
+            let mut i = 0;
+            for range in view.gen_reveal.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store
+                    .try_set(slice, &bits1[i..i + slice.len()])?;
+                i += slice.len();
+            }
+
+            i = 0;
+            let (bits2, macs2) = self.mask_store.prove_share(&view.public_decode)?;
+            for range in view.public_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store.try_set(slice, &bits2[i..i + slice.len()])?;
+                let data = self.data_store.try_get(slice)?;
+                self.masked_value_store.update_xor(slice, &data)?;
+                i += slice.len();
+            }
+
+            let bits = BitVec::from_iter(bits1.iter().chain(bits2.iter()));
+            Some(ShareProof { bits, macs: [macs1, macs2].concat() })
+        } else {
+            None
+        };
+
+        // Send half masked inputs corresponding to Eval's input wires. 
+        let mut half_masked_inputs = BitVec::with_capacity(view.eval_reveal.len());
+        for range in view.eval_reveal.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let mask_bits = self.mask_store.try_get_bits(slice)?;
+            let data_bits = self.data_store.try_get(slice)?;
+            
+            // might be a cleaner way to do this
+            let mut half_masked = mask_bits.to_bitvec();
+            for (mut half_masked_bit, data_bit) in half_masked.iter_mut().zip(data_bits) {
+                *half_masked_bit ^= *data_bit;
+            }
+            
+            self.masked_value_store.try_set(slice, &half_masked)?;
+            half_masked_inputs.extend_from_bitslice(&half_masked);
+        }
+
+        // output labels
+        let mut labels = Vec::with_capacity(view.decode_info.len());
+        for range in view.decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            labels.extend(self.mac_store.try_get(slice)?);
+        }
+
+        // Prove Eval's share of Eval's input wires for decoding.
+        let decode_share_proof = if !view.eval_decode.is_empty() {
+            let (bits, macs) = self.mask_store.prove_share(&view.eval_decode)?;
+
+            Some(ShareProof { bits, macs })
+        } else {
+            None
+        };
+
+        let flush = AuthEvalFlush {
+            view,
+            share_proof,
+            half_masked_inputs,
+            labels,
+            decode_share_proof,
+        };
+
+        self.pending = true;
+        self.pending_flush = Some(PendingFlush { cot });
+
+        Ok(flush)
+    }
+
+    /// Receives flush from the generator.
+    ///
+    /// This expects that the COT receiver has been flushed.
+    pub fn receive_flush(&mut self, flush: AuthGenFlush) -> Result<()> {
+        if !self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let Some(PendingFlush { cot }) = self.pending_flush.take() else {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        };
+
+        let AuthGenFlush { 
+            view, 
+            share_proof, 
+            half_masked_inputs, 
+            labels,
+            decode_share_proof,
+        } = flush;
+
+        if &view != self.view.flush() {
+            return Err(ErrorRepr::InconsistentFlush {
+                expected: self.view.flush().clone(),
+                actual: view,
+            }.into());
+        }
+
+        // Receive OT macs for masks, expects COT to be flushed.
+        let masks = view.gen_masks.clone() | view.eval_masks.clone() | view.public.clone();
+        let mut i = 0;
+        if let Some(mut cot) = cot {
+            let COTReceiverOutput { msgs: macs, .. } = cot
+                .try_recv()
+                .map_err(Error::cot)?
+                .ok_or_else(|| Error::cot("COT output is not ready"))?;
+            let macs = Mac::from_blocks(macs);
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_macs(slice, &macs[i..i + slice.len()])?;
+                i += slice.len();
+            }
+        }
+
+        // Check Gen's share of Eval input wires
+        if let Some(ShareProof { bits, macs }) = share_proof {
+            let bits1 = bits[0..view.eval_reveal.len()].to_bitvec();
+            let bits2 = bits[view.eval_reveal.len()..].to_bitvec();
+            self.mask_store.check_share(&view.eval_reveal, &bits1, &macs[0..view.eval_reveal.len()])?;
+            self.mask_store.check_share(&view.public_decode, &bits2, &macs[view.eval_reveal.len()..])?;
+            // Update masked values of eval's input wires with share proof bits
+            let mut i = 0;
+            for range in view.eval_reveal.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store.update_xor(slice, &bits1[i..i + slice.len()])?;
+                i += slice.len();
+            }
+
+            i = 0;
+            for range in view.public_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store.update_xor(slice, &bits2[i..i + slice.len()])?;
+                i += slice.len();
+            }
+        }
+
+        // Update masked values with gen's half masked inputs
+        i = 0;
+        for range in view.gen_reveal.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.masked_value_store.update_xor(slice, &half_masked_inputs[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        // Store MAC labels
+        let mut i = 0;
+        for range in view.labels.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.mac_store.try_set(slice, &labels[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        if let Some(ShareProof { bits, macs }) = decode_share_proof {
+            self.mask_store.check_share(&view.gen_decode, &bits, &macs)?;
+
+            // Decode gen's input wires.
+            let mut i = 0;
+            for range in view.gen_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.data_store.try_set(slice, &bits[i..i + slice.len()])?;
+                self.data_store.update_xor(slice, self.masked_value_store.try_get(slice)?)?;
+                self.data_store.update_xor(slice, self.mask_store.try_get_bits(slice)?)?;
+                i += slice.len();
+            }
+        }
+        self.view.complete_flush(view);
+        self.flush_decode()?;
+        self.pending = false;
+        Ok(())
+    }
+}
+
+impl<S, R> Memory<Binary> for AuthEvalStore<S, R>
+{
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.view.is_alloc(slice.to_range())
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.view.alloc_input(size);
+        self.mac_store.alloc(size);
+        self.mask_store.alloc(size);
+        self.masked_value_store.alloc(size);
+        let slice = self.data_store.alloc(size);
+        Ok(slice)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.data_store.is_set(slice)
+    }
+    
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        Ok(())
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.data_store
+            .try_get(slice)
+            .map(|data| Some(data.to_bitvec()))
+            .map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.view.decode(slice.to_range())?;
+
+        let (fut, mut op) = DecodeFuture::new(slice);
+        // If data is already decoded, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        Ok(fut)
+    }
+}
+
+impl<S, R> ViewTrait<Binary> for AuthEvalStore<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for public data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for private data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for blind data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+/// Error for [`EvaluatorStore`].
+#[derive(Debug, thiserror::Error)]
+#[error("evaluator store error: {}", .0)]
+pub struct AuthEvalStoreError(#[from] ErrorRepr);
+
+impl AuthEvalStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("cot error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    MacStore(MacStoreError),
+    #[error(transparent)]
+    AuthBitStore(#[from] AuthBitStoreError),
+    #[error(transparent)]
+    Store(StoreError),
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    #[error(transparent)]
+    View(#[from] ViewError),
+    #[error("store was not expecting a flush")]
+    UnexpectedFlush,
+    #[error("inconsistent flush: expected={expected:?}, actual={actual:?}")]
+    InconsistentFlush {
+        expected: AuthFlushView,
+        actual: AuthFlushView,
+    },
+    #[error("invalid MAC commitment: {0}")]
+    MacCommitment(#[from] MacCommitmentError),
+}
+
+impl From<MacStoreError> for AuthEvalStoreError {
+    fn from(err: MacStoreError) -> Self {
+        Self(ErrorRepr::MacStore(err))
+    }
+}
+
+impl From<AuthBitStoreError> for AuthEvalStoreError {
+    fn from(err: AuthBitStoreError) -> Self {
+        Self(ErrorRepr::AuthBitStore(err))
+    }
+}
+
+impl From<StoreError> for AuthEvalStoreError {
+    fn from(err: StoreError) -> Self {
+        Self(ErrorRepr::Store(err))
+    }
+}
+
+impl From<DecodeError> for AuthEvalStoreError {
+    fn from(err: DecodeError) -> Self {
+        Self(ErrorRepr::Decode(err))
+    }
+}
+
+impl From<ViewError> for AuthEvalStoreError {
+    fn from(err: ViewError) -> Self {
+        Self(ErrorRepr::View(err))
+    }
+}
+
+impl From<MacCommitmentError> for AuthEvalStoreError {
+    fn from(err: MacCommitmentError) -> Self {
+        Self(ErrorRepr::MacCommitment(err))
+    }
+}

--- a/crates/garble-core/src/store/auth_gen.rs
+++ b/crates/garble-core/src/store/auth_gen.rs
@@ -1,0 +1,660 @@
+use std::sync::Arc;
+
+use rand::Rng;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use mpz_common::future::Output;
+use mpz_core::{bitvec::{BitVec, BitSlice}, prg::Prg, Block};
+use mpz_memory_core::{
+    binary::Binary,
+    correlated::{Delta, Mac, Key, KeyStore, KeyStoreError, AuthBitStore, AuthBitStoreError},
+    store::{BitStore, StoreError},
+    DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
+};
+use mpz_ot_core::cot::{COTSender, COTReceiver, COTReceiverOutput};
+use utils::filter_drain::FilterDrain;
+
+use crate::{
+    store::{AuthGenFlush, ShareProof, AuthEvalFlush},
+    view::{AuthFlushView, AuthView, ViewError},
+};
+
+type Error = AuthGenStoreError;
+type Result<T> = core::result::Result<T, Error>;
+
+struct PendingFlush {
+    cot: Option<Box<dyn Output<COTReceiverOutput<Block>> + Send>>,
+}
+
+impl std::fmt::Debug for PendingFlush {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingFlush").finish_non_exhaustive()
+    }
+}
+
+/// Authenticated generator memory store.
+#[derive(Debug)]
+pub struct AuthGenStore<S, R> {
+    cot_sender: Arc<Mutex<S>>,
+    cot_receiver: Arc<Mutex<R>>,
+    prg: Prg,
+    key_store: KeyStore,
+    mask_store: AuthBitStore,
+    masked_value_store: BitStore,
+    data_store: BitStore,
+    view: AuthView,
+    buffer_decode: Vec<DecodeOp<BitVec>>,
+    auth_hash: Block,
+    // Whether the store is waiting for a flush.
+    pending: bool,
+    // Pending COT flush
+    pending_flush: Option<PendingFlush>,
+}
+
+
+impl<S, R> AuthGenStore<S, R> {
+    /// Creates a new generator store.
+    pub fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+        Self {
+            cot_sender: Arc::new(Mutex::new(cot_sender)),
+            cot_receiver: Arc::new(Mutex::new(cot_receiver)),
+            prg: Prg::new_with_seed(seed),
+            key_store: KeyStore::new(delta),
+            mask_store: AuthBitStore::new(delta),
+            masked_value_store: BitStore::new(),
+            data_store: BitStore::new(),
+            view: AuthView::new_generator(),
+            buffer_decode: Vec::new(),
+            auth_hash: Block::default(),
+            pending: false,
+            pending_flush: None,
+        }
+    }
+
+    /// Returns delta.
+    pub fn delta(&self) -> &Delta {
+        self.key_store.delta()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub fn acquire_cot_sender(&self) -> OwnedMutexGuard<S> {
+        Mutex::try_lock_owned(self.cot_sender.clone()).unwrap()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub fn acquire_cot_receiver(&self) -> OwnedMutexGuard<R> {
+        Mutex::try_lock_owned(self.cot_receiver.clone()).unwrap()
+    }
+
+    /// Returns the COT sender.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the sender is still held.
+    pub fn into_inner_sender(self) -> S {
+        Arc::try_unwrap(self.cot_sender)
+            .map_err(|_| ())
+            .expect("sender lock should be dropped")
+            .into_inner()
+    }
+
+    /// Returns the COT receiver.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the receiver is still held.
+    pub fn into_inner_receiver(self) -> R {
+        Arc::try_unwrap(self.cot_receiver)
+            .map_err(|_| ())
+            .expect("receiver lock should be dropped")
+            .into_inner()
+    }
+
+    /// Returns whether all the keys are set.
+    pub fn is_set_keys(&self, slice: Slice) -> bool {
+        self.key_store.is_set(slice)
+    }
+
+    /// Returns whether the input masks are set.
+    pub fn is_set_masks(&self, slice: Slice) -> bool {
+        self.mask_store.is_set(slice)
+    }
+
+    /// Returns whether the slice is committed.
+    pub fn is_committed(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    /// Returns keys if they are set.
+    ///
+    /// # Security
+    ///
+    /// **Never** use this method to transfer MACs to the evaluator.
+    pub fn try_get_keys(&self, slice: Slice) -> Result<&[Key]> {
+        self.key_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Returns masked values if they are set.
+    pub fn try_get_masked_values(&self, slice: Slice) -> Result<&BitSlice> {
+        self.masked_value_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Returns masks if they are set.
+    pub fn try_get_mask_bits(&self, slice: Slice) -> Result<&BitSlice> {
+        self.mask_store.try_get_bits(slice).map_err(Error::from)
+    }
+
+    /// Returns masks if they are set.
+    pub fn try_get_mask_macs(&self, slice: Slice) -> Result<&[Mac]> {
+        self.mask_store.try_get_macs(slice).map_err(Error::from)
+    }
+
+    /// Returns masks if they are set.
+    pub fn try_get_mask_keys(&self, slice: Slice) -> Result<&[Key]> {
+        self.mask_store.try_get_keys(slice).map_err(Error::from)
+    }
+
+    /// Updates the auth hash.
+    pub fn update_hash(&mut self, hash: Block) {
+        self.auth_hash ^= hash;
+    }
+
+    /// Returns the auth hash.
+    pub fn get_hash(&self) -> Block {
+        self.auth_hash
+    }
+
+    /// Allocates uninitialized memory for output values.
+    pub fn alloc_output(&mut self, len: usize) -> Slice {
+        self.view.alloc_output(len);
+        self.key_store.alloc(len);
+        self.data_store.alloc(len);
+        self.masked_value_store.alloc(len);
+        self.mask_store.alloc(len)
+    }
+
+    /// Sets the keys and masks for output data.
+    pub fn set_output(&mut self, slice: Slice, keys: &[Key], mask_bits: &BitSlice, mask_macs: &[Mac], mask_keys: &[Key]) -> Result<()> {
+        self.key_store.try_set(slice, keys)?;
+        self.mask_store.try_set_bits(slice, mask_bits)?;
+        self.mask_store.try_set_macs(slice, mask_macs)?;
+        self.mask_store.try_set_keys(slice, mask_keys)?;
+        // self.masked_value_store.try_set(slice, masked_values)?;
+        self.view.set_output(slice.to_range())?;
+
+        Ok(())
+    }
+
+    /// Marks an output as executed.
+    ///
+    /// This indicates that both parties have *executed* the call which produces
+    /// this output.
+    pub fn mark_output_complete(&mut self, slice: Slice) -> Result<()> {
+        self.view.set_output(slice.to_range()).map_err(Error::from)
+    }
+
+    /// Returns `true` if the store wants to flush.
+    pub fn wants_flush(&self) -> bool {
+        self.view.wants_flush()
+    }
+
+    /// Flushes decode operations.
+    fn flush_decode(&mut self) -> Result<()> {
+        for mut op in self
+            .buffer_decode
+            .filter_drain(|op| self.data_store.is_set(op.slice))
+        {
+            let data = self.data_store.try_get(op.slice)?;
+            op.send(data.to_bitvec())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<S, R> AuthGenStore<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+    R::Future: Send + 'static,
+{
+    /// Sends a flush to the evaluator.
+    ///
+    /// This queues any necessary COTs.
+    pub fn send_flush(&mut self) -> Result<AuthGenFlush> {
+        if self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let view = self.view.flush().clone();
+
+        // Send OT keys for masks.
+        let masks = view.gen_masks.clone() | view.eval_masks.clone() | view.public.clone();
+        if !masks.is_empty() {
+            let keys = (0..masks.len()).map(|_| self.prg.random()).collect::<Vec<_>>();
+            // Store keys in mask store.
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_keys(slice, &keys)?;
+            }
+
+            // Queue COT, we don't need the output here.
+            _ = self
+                .cot_sender
+                .try_lock()
+                .unwrap()
+                .queue_send_cot(Key::as_blocks(&keys))
+                .map_err(Error::cot)?;
+        }
+
+        // Send OT choices for masks, receive MACs as a future.
+        let cot = if !masks.is_empty() {
+            let choices = (0..masks.len()).map(|_| self.prg.random::<bool>()).collect::<Vec<bool>>();
+            // Store choices in mask store.
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_bits(slice, &BitVec::from_iter(choices.iter()))?;
+            }
+
+            let output = self
+                .cot_receiver
+                .try_lock()
+                .unwrap()
+                .queue_recv_cot(&choices)
+                .map_err(Error::cot)?;
+            Some(Box::new(output) as Box<dyn Output<COTReceiverOutput<Block>> + Send>)
+        } else {
+            None
+        };
+
+        // Prove Gen's share of Eval input wires and public wires.
+        let share_proof = if !view.eval_reveal.is_empty() || !view.public_decode.is_empty() {
+            let (bits1, macs1) = self.mask_store.prove_share(&view.eval_reveal)?;
+            // Set masked_value_store using sent bits
+            let mut i = 0;
+            for range in view.eval_reveal.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store
+                    .try_set(slice, &bits1[i..i + slice.len()])?;
+                i += slice.len();
+            }
+
+            let (bits2, macs2) = self.mask_store.prove_share(&view.public_decode)?;
+            
+            i = 0;
+            for range in view.public_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store
+                    .try_set(slice, &bits2[i..i + slice.len()])?;
+                let data = self.data_store.try_get(slice)?;
+                self.masked_value_store.update_xor(slice, &data)?;
+                i += slice.len();
+            }
+            
+            let bits = BitVec::from_iter(bits1.iter().chain(bits2.iter()));
+            Some(ShareProof { bits, macs: [macs1, macs2].concat() })
+        } else {
+            None
+        };
+
+        // Send half masked inputs corresponding to Gen's input wires. 
+        let mut half_masked_inputs = BitVec::with_capacity(view.gen_reveal.len());
+        for range in view.gen_reveal.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let mask_bits = self.mask_store.try_get_bits(slice)?;
+            let data_bits = self.data_store.try_get(slice)?;
+            
+            // might be a cleaner way to do this
+            let mut half_masked = mask_bits.to_bitvec();
+            for (mut half_masked_bit, data_bit) in half_masked.iter_mut().zip(data_bits) {
+                *half_masked_bit ^= *data_bit;
+            }
+            
+            self.masked_value_store.try_set(slice, &half_masked)?;
+            half_masked_inputs.extend_from_bitslice(&half_masked);
+        }
+
+        // for both gen and eval's input wires here
+        let mut labels = Vec::with_capacity(view.labels.len());
+        for range in view.labels.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let data = self.masked_value_store.try_get(slice)?;
+            labels.extend(self.key_store.authenticate(slice, data)?);
+        }
+
+        // Prove Gen's share of Gen's input wires for decoding.
+        let decode_share_proof = if !view.gen_decode.is_empty() {
+            let (bits, macs) = self.mask_store.prove_share(&view.gen_decode)?;
+
+            Some(ShareProof { bits, macs })
+        } else {
+            None
+        };
+
+        let flush = AuthGenFlush {
+            view,
+            share_proof,
+            half_masked_inputs,
+            labels,
+            decode_share_proof,
+        };
+
+        self.pending = true;
+        self.pending_flush = Some(PendingFlush { cot });
+
+        Ok(flush)
+    }
+
+    /// Receives a flush from the evaluator.
+    ///
+    /// This expects that the COT receiver has been flushed.
+    pub fn receive_flush(&mut self, flush: AuthEvalFlush) -> Result<()> {
+        if !self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let Some(PendingFlush { cot }) = self.pending_flush.take() else {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        };
+
+        let AuthEvalFlush {
+            view,
+            share_proof,
+            half_masked_inputs,
+            labels,
+            decode_share_proof,
+        } = flush;
+
+        if &view != self.view.flush() {
+            return Err(ErrorRepr::InconsistentFlush {
+                expected: self.view.flush().clone(),
+                actual: view,
+            }.into());
+        }
+
+        // Receive OT macs for masks, expects COT to be flushed.
+        let masks = view.gen_masks.clone() | view.eval_masks.clone() | view.public.clone();
+        let mut i = 0;
+        if let Some(mut cot) = cot {
+            let COTReceiverOutput { msgs: macs, .. } = cot
+                .try_recv()
+                .map_err(Error::cot)?
+                .ok_or_else(|| Error::cot("COT output is not ready"))?;
+            let macs = Mac::from_blocks(macs);
+            for range in masks.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.mask_store.try_set_macs(slice, &macs[i..i + slice.len()])?;
+                i += slice.len();
+            }
+        }
+
+        if let Some(ShareProof { bits, macs }) = share_proof {
+            let bits1 = bits[0..view.gen_reveal.len()].to_bitvec();
+            let bits2 = bits[view.gen_reveal.len()..].to_bitvec();
+            self.mask_store.check_share(&view.gen_reveal, &bits1, &macs[0..view.gen_reveal.len()])?;
+            self.mask_store.check_share(&view.public_decode, &bits2, &macs[view.gen_reveal.len()..])?;
+
+            // Update masked values of gen's input wires and public wires with share proof bits
+            let mut i = 0;
+            for range in view.gen_reveal.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store.update_xor(slice, &bits1[i..i + slice.len()])?;
+                i += slice.len();
+            }
+
+            i = 0;
+            for range in view.public_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.masked_value_store.update_xor(slice, &bits2[i..i + slice.len()])?;
+                i += slice.len();
+            }
+        }
+
+        // Update masked values with eval's half masked inputs
+        i = 0;
+        for range in view.eval_reveal.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.masked_value_store.update_xor(slice, &half_masked_inputs[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        // Expected output labels
+        let mut output_keys: Vec<Key> = Vec::with_capacity(view.decode_info.len());
+        for range in view.decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let keys = self.key_store.try_get(slice)?;
+            output_keys.extend(keys);
+        }
+
+        let mut masked_outputs = Vec::new();
+        for (index, (key, mac)) in output_keys.iter().zip(labels.iter()).enumerate() {
+            let bit = if *mac == key.auth(false, self.delta()) {
+                false
+            } else if *mac == key.auth(true, self.delta()) {
+                true
+            } else {
+                return Err(ErrorRepr::OutputLabelMismatch {
+                    index,
+                }.into());
+            };
+            masked_outputs.push(bit);
+        }
+        
+        let masked_outputs = BitVec::from_iter(masked_outputs.iter());
+
+        i = 0;
+        for range in view.decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.masked_value_store.try_set(slice, &masked_outputs[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        if let Some(ShareProof { bits, macs }) = decode_share_proof {
+            self.mask_store.check_share(&view.eval_decode, &bits, &macs)?;
+
+            // Decode eval's input wires.
+            let mut i = 0;
+            for range in view.eval_decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.data_store.try_set(slice, &bits[i..i + slice.len()])?;
+                self.data_store.update_xor(slice, self.masked_value_store.try_get(slice)?)?;
+                self.data_store.update_xor(slice, self.mask_store.try_get_bits(slice)?)?;
+                i += slice.len();
+            }
+        }
+
+        self.view.complete_flush(view);
+        self.flush_decode()?;
+        self.pending = false;
+        Ok(())
+    }
+}
+
+impl<S, R> Memory<Binary> for AuthGenStore<S, R>
+{
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.view.is_alloc(slice.to_range())
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        let keys = (0..size).map(|_| self.prg.random()).collect::<Vec<_>>();
+        self.mask_store.alloc(size);
+        self.masked_value_store.alloc(size);
+        self.view.alloc_input(size);
+        self.key_store.alloc_with(&keys);
+        let slice = self.data_store.alloc(size);
+
+        Ok(slice)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.data_store.is_set(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        Ok(())
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+    
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.data_store
+            .try_get(slice)
+            .map(|data| Some(data.to_bitvec()))
+            .map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.view.decode(slice.to_range())?;
+
+        let (fut, mut op) = DecodeFuture::new(slice);
+        // If data is already available, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        Ok(fut)
+    }
+}
+
+impl<S, R> ViewTrait<Binary> for AuthGenStore<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for public data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for private data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate both sender and receiver COTs for blind data.
+        self.cot_sender
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.cot_receiver
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+/// Error for [`GeneratorStore`].
+#[derive(Debug, thiserror::Error)]
+#[error("generator store error: {}", .0)]
+pub struct AuthGenStoreError(#[from] ErrorRepr);
+
+impl AuthGenStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("cot error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    KeyStore(KeyStoreError),
+    #[error(transparent)]
+    Store(StoreError),
+    #[error(transparent)]
+    AuthBitStore(#[from] AuthBitStoreError),
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    #[error(transparent)]
+    View(#[from] ViewError),
+    #[error("store was not expecting a flush")]
+    UnexpectedFlush,
+    #[error("inconsistent flush: expected={expected:?}, actual={actual:?}")]
+    InconsistentFlush {
+        expected: AuthFlushView,
+        actual: AuthFlushView,
+    },
+    #[error("output label mismatch: index={index:?}")]
+    OutputLabelMismatch {
+        index: usize
+    },
+}
+
+impl From<KeyStoreError> for AuthGenStoreError {
+    fn from(err: KeyStoreError) -> Self {
+        Self(ErrorRepr::KeyStore(err))
+    }
+}
+
+impl From<StoreError> for AuthGenStoreError {
+    fn from(err: StoreError) -> Self {
+        Self(ErrorRepr::Store(err))
+    }
+}
+
+impl From<AuthBitStoreError> for AuthGenStoreError {
+    fn from(err: AuthBitStoreError) -> Self {
+        Self(ErrorRepr::AuthBitStore(err))
+    }
+}
+
+impl From<DecodeError> for AuthGenStoreError {
+    fn from(err: DecodeError) -> Self {
+        Self(ErrorRepr::Decode(err))
+    }
+}
+
+impl From<ViewError> for AuthGenStoreError {
+    fn from(err: ViewError) -> Self {
+        Self(ErrorRepr::View(err))
+    }
+}

--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -17,6 +17,16 @@ struct InputView {
 }
 
 #[derive(Debug, Default)]
+struct AuthInputView {
+    /// Ranges which have been assigned.
+    assigned: RangeSet,
+    /// Ranges which are fully committed in both parties views.
+    complete: RangeSet,
+    /// All input ranges.
+    all: RangeSet,
+}
+
+#[derive(Debug, Default)]
 struct OutputView {
     /// Output ranges which are preprocessed but not executed.
     preprocessed: RangeSet,
@@ -64,6 +74,61 @@ impl FlushView {
         self.ot.clear();
         self.decode_info.clear();
         self.decode.clear();
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct AuthFlushView {
+
+    /// Both send public input masks via COTs. 
+    pub(crate) public: RangeSet,
+    /// Both send Gen input masks via COTs. 
+    pub(crate) gen_masks: RangeSet,
+    /// Both send Eval input masks via COTs. 
+    pub(crate) eval_masks: RangeSet,
+    /// Eval sends share and MACs for gen's inputs.
+    pub(crate) gen_reveal: RangeSet,
+    /// Gen sends share and MACs for eval's inputs.
+    pub(crate) eval_reveal: RangeSet,
+    /// Both reveal shares of public inputs, which is then verified by the other party. 
+    pub(crate) public_decode: RangeSet,
+    /// Gen sends masked input labels to Eval.
+    pub(crate) labels: RangeSet,
+    /// Eval sends output labels to Gen to authenticate masked output
+    pub(crate) decode_info: RangeSet,
+    /// Both send MACs for decoding gen input/output
+    pub(crate) gen_decode: RangeSet,
+    /// Both send MACs for decoding eval input/output
+    pub(crate) eval_decode: RangeSet,
+}
+
+impl AuthFlushView {
+    /// Returns `true` if the flush state is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.public.is_empty()
+            && self.gen_masks.is_empty()
+            && self.eval_masks.is_empty()
+            && self.gen_reveal.is_empty()
+            && self.eval_reveal.is_empty()
+            && self.public_decode.is_empty()
+            && self.labels.is_empty()
+            && self.decode_info.is_empty()
+            && self.gen_decode.is_empty()
+            && self.eval_decode.is_empty()
+    }
+
+    /// Clears the flush state.
+    fn clear(&mut self) {
+        self.public.clear();
+        self.gen_masks.clear();
+        self.eval_masks.clear();
+        self.gen_reveal.clear();
+        self.eval_reveal.clear();
+        self.public_decode.clear();
+        self.labels.clear();
+        self.decode_info.clear();
+        self.gen_decode.clear();
+        self.eval_decode.clear();
     }
 }
 
@@ -321,6 +386,268 @@ impl View {
 }
 
 impl ViewTrait<Binary> for View {
+    type Error = ViewError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.mark_public(slice.to_range())
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.mark_private(slice.to_range())
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.mark_blind(slice.to_range())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AuthView {
+    role: Role,
+    len: usize,
+    input: AuthInputView,
+    output: OutputView,
+    vis: VisibilityView,
+    decode: DecodeView,
+    flush: AuthFlushView,
+}
+
+impl AuthView {
+    pub(crate) fn new_generator() -> Self {
+        Self {
+            role: Role::Garbler,
+            len: 0,
+            input: AuthInputView::default(),
+            output: OutputView::default(),
+            vis: VisibilityView::new(),
+            decode: DecodeView::default(),
+            flush: AuthFlushView::default(),
+        }
+    }
+
+    pub(crate) fn new_evaluator() -> Self {
+        Self {
+            role: Role::Evaluator,
+            len: 0,
+            input: AuthInputView::default(),
+            output: OutputView::default(),
+            vis: VisibilityView::new(),
+            decode: DecodeView::default(),
+            flush: AuthFlushView::default(),
+        }
+    }
+
+    pub(crate) fn is_alloc(&self, range: Range) -> bool {
+        range.end <= self.len
+    }
+    
+    fn alloc(&mut self, size: usize) -> Range {
+        let range = self.len..self.len + size;
+        self.len += size;
+        self.vis.alloc(size);
+        range
+    }
+
+    pub(crate) fn wants_flush(&self) -> bool {
+        !self.flush.is_empty()
+    }
+
+    pub(crate) fn flush(&self) -> &AuthFlushView {
+        &self.flush
+    }
+
+    pub(crate) fn alloc_input(&mut self, size: usize) {
+        let range = self.alloc(size);
+
+        self.input.all |= &range;
+    }
+
+    pub(crate) fn alloc_output(&mut self, size: usize) {
+        let range = self.alloc(size);
+
+        self.output.all |= &range;
+    }
+
+    fn mark_public(&mut self, range: Range) -> Result<()> {
+        if self.vis.is_set_any(range.clone()) {
+            return Err(ErrorRepr::VisibilityAlreadySet { range }.into());
+        } else if !range.is_disjoint(&self.output.all) {
+            return Err(ErrorRepr::VisibilityOutput { range }.into());
+        }
+
+        self.vis.set_public(range);
+
+        Ok(())
+    }
+
+    fn mark_private(&mut self, range: Range) -> Result<()> {
+        if self.vis.is_set_any(range.clone()) {
+            return Err(ErrorRepr::VisibilityAlreadySet { range }.into());
+        } else if !range.is_disjoint(&self.output.all) {
+            return Err(ErrorRepr::VisibilityOutput { range }.into());
+        }
+
+        self.vis.set_private(range);
+
+        Ok(())
+    }
+
+    fn mark_blind(&mut self, range: Range) -> Result<()> {
+        if self.vis.is_set_any(range.clone()) {
+            return Err(ErrorRepr::VisibilityAlreadySet { range }.into());
+        } else if !range.is_disjoint(&self.output.all) {
+            return Err(ErrorRepr::VisibilityOutput { range }.into());
+        }
+
+        self.vis.set_blind(range);
+
+        Ok(())
+    }
+
+    pub(crate) fn assign(&mut self, range: Range) -> Result<()> {
+        if !self.vis.is_visible(range.clone()) {
+            return Err(ErrorRepr::VisibilityAssign { range }.into());
+        } else if !range.is_disjoint(&self.output.all) {
+            return Err(ErrorRepr::OutputAssign { range }.into());
+        }
+
+        self.input.assigned |= range;
+
+        Ok(())
+    }
+
+    /// Marks an output range as preprocessed.
+    pub(crate) fn set_preprocessed(&mut self, range: Range) -> Result<()> {
+        // Assert is output.
+        if !range.is_subset(&self.output.all) {
+            return Err(ErrorRepr::NotOutput { range }.into());
+        }
+
+        self.output.preprocessed |= &range;
+
+        Ok(())
+    }
+
+    /// Marks an output range as complete.
+    pub(crate) fn set_output(&mut self, range: Range) -> Result<()> {
+        // Assert is output.
+        if !range.is_subset(&self.output.all) {
+            return Err(ErrorRepr::NotOutput { range }.into());
+        }
+
+        self.output.preprocessed |= &range;
+        self.output.complete |= &range;
+        
+        // Eval sends labels to gen to authenticate masked outputs, flush handles sending decode (bit,mac) afterwards 
+        self.flush.decode_info |= range.intersection(&self.decode.all) - &self.decode.decode_info;
+
+        Ok(())
+    }
+
+    pub(crate) fn is_committed(&self, range: Range) -> bool {
+        range.is_subset(&self.input.complete) || range.is_subset(&self.output.complete)
+    }
+
+    pub(crate) fn commit(&mut self, range: Range) -> Result<()> {
+        // Assert visibility is set.
+        if !self.vis.is_set(range.clone()) {
+            return Err(ErrorRepr::VisibilityNotSet { range }.into());
+        }
+
+        // Assert not output data.
+        if !range.is_disjoint(&self.output.all) {
+            return Err(ErrorRepr::OutputCommit { range }.into());
+        }
+
+        // Assert not committed.
+        if !range.is_disjoint(&self.input.complete) {
+            return Err(ErrorRepr::AlreadyCommitted { range }.into());
+        }
+
+        let blind = range.intersection(self.vis.blind());
+        let private = range.intersection(self.vis.private());
+        let public = range.intersection(self.vis.public());
+
+        // Assert visible data is assigned.
+        if !public.is_subset(&self.input.assigned) {
+            return Err(ErrorRepr::NotAssigned { range }.into());
+        } else if !private.is_subset(&self.input.assigned) {
+            return Err(ErrorRepr::NotAssigned { range }.into());
+        }
+
+        match self.role {
+            Role::Garbler => {
+                self.flush.public |= public;
+                self.flush.gen_masks |= private;
+                self.flush.eval_masks |= blind;
+            }
+            Role::Evaluator => {
+                self.flush.public |= public;
+                self.flush.gen_masks |= blind;
+                self.flush.eval_masks |= private;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn decode(&mut self, range: Range) -> Result<()> {
+        // Ignore already decoded data.
+        let undecoded = range.difference(&self.decode.complete);
+        if undecoded.is_empty() {
+            return Ok(());
+        }
+
+        self.decode.all |= &undecoded;
+
+
+        // CHECK: This seems redundant.
+        // Just adding everything to undecoded works fine.
+        // All other ranges are set in complete_flush as and when they are ready, and you would never call decode after flushing.
+
+        let input = range.intersection(&self.input.complete);
+        let gen_decode_input = match self.role {
+            Role::Garbler => input.intersection(self.vis.private()),
+            Role::Evaluator => input.intersection(self.vis.blind()),
+        };
+        let eval_decode_input = match self.role {
+            Role::Garbler => input.intersection(self.vis.blind()),
+            Role::Evaluator => input.intersection(self.vis.private()),
+        };
+
+        let output = range.intersection(&self.output.complete);
+        self.flush.decode_info |= &output;
+        self.flush.gen_decode |= gen_decode_input;
+        self.flush.eval_decode |= eval_decode_input;
+
+        Ok(())
+    }
+
+    pub(crate) fn complete_flush(&mut self, view: AuthFlushView) {
+        self.input.complete |= &view.gen_reveal;
+        self.input.complete |= &view.eval_reveal;
+        self.input.complete |= &view.public_decode;
+
+        self.decode.decode_info |= view.decode_info.clone();
+        self.decode.complete |= view.gen_decode.clone() | view.eval_decode.clone();
+
+        self.flush.clear();
+
+        // Reveal opposite shares for inputs whose auth bits have been set, send own half masked inputs, check opposite shares.
+        self.flush.gen_reveal |= view.gen_masks;
+        self.flush.eval_reveal |= view.eval_masks;
+        self.flush.public_decode |= view.public;
+
+        // send masked labels, can be done in parallel with decode info
+        self.flush.labels |= view.gen_reveal.clone() | view.eval_reveal.clone() | view.public_decode.clone();
+
+        // Send decode info for inputs / outputs
+        self.flush.gen_decode |= (view.gen_reveal | view.decode_info.clone()).intersection(&self.decode.all) - &self.decode.complete;
+        self.flush.eval_decode |= (view.eval_reveal | view.decode_info.clone()).intersection(&self.decode.all) - &self.decode.complete;
+    }
+}
+
+impl ViewTrait<Binary> for AuthView {
     type Error = ViewError;
 
     fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {

--- a/crates/garble/Cargo.toml
+++ b/crates/garble/Cargo.toml
@@ -15,6 +15,7 @@ rayon = ["mpz-common/rayon", "mpz-garble-core/rayon"]
 mock = ["mpz-ot/ideal"]
 
 [dependencies]
+mpz-cointoss = { workspace = true }
 mpz-circuits.workspace = true
 mpz-common = { workspace = true, features = ["test-utils", "executor"] }
 mpz-memory-core = { workspace = true }
@@ -25,6 +26,8 @@ mpz-vm-core = { workspace = true }
 tlsn-utils.workspace = true
 serio.workspace = true
 
+aes = { workspace = true, features = [] }
+cipher.workspace = true
 async-trait.workspace = true
 rand.workspace = true
 thiserror.workspace = true
@@ -40,6 +43,7 @@ tokio = { workspace = true, features = ["sync"] }
 [dev-dependencies]
 mpz-common = { workspace = true, features = ["test-utils", "ideal"] }
 mpz-ot = { workspace = true, features = ["ideal"] }
+mpz-ot-core = { workspace = true, features = ["test-utils"] }
 rstest = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 tokio = { workspace = true, features = [
@@ -52,4 +56,8 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [[bench]]
 name = "semihonest"
+harness = false
+
+[[bench]]
+name = "authenticated"
 harness = false

--- a/crates/garble/benches/authenticated.rs
+++ b/crates/garble/benches/authenticated.rs
@@ -1,0 +1,92 @@
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+use mpz_circuits::circuits::AES128;
+use mpz_common::context::{test_mt_context, test_st_context};
+use mpz_garble::protocol::authenticated::{AuthEval, AuthGen};
+use mpz_memory_core::{Array, binary::*, correlated::Delta};
+use mpz_ot::ideal::cot::ideal_cot;
+use mpz_vm_core::{Call, prelude::*};
+use rand::{SeedableRng, rngs::StdRng};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("authenticated");
+    group.sample_size(10);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    group.throughput(Throughput::Bytes(16));
+    group.bench_function("aes", |b| {
+        b.to_async(&rt).iter(|| async {
+            let mut rng = StdRng::seed_from_u64(0);
+        
+            let delta_a = Delta::random(&mut rng).set_lsb(true);
+            let delta_b = Delta::random(&mut rng).set_lsb(false);
+    
+            let (mut ctx_a, mut ctx_b) = test_st_context(8);
+            let (cot_gen_send, cot_eval_recv) = ideal_cot(delta_a.into_inner());
+            let (cot_eval_send, cot_gen_recv) = ideal_cot(delta_b.into_inner());
+    
+            let mut gb = AuthGen::new([0u8; 16], delta_a, cot_gen_send, cot_gen_recv);
+            let mut ev = AuthEval::new([0u8; 16], delta_b, cot_eval_send, cot_eval_recv);
+    
+            let (gen_out, ev_out) = futures::join!(
+                async {
+                    let key: Array<U8, 16> = gb.alloc().unwrap();
+                    let msg: Array<U8, 16> = gb.alloc().unwrap();
+    
+                    gb.mark_private(key).unwrap();
+                    gb.mark_blind(msg).unwrap();
+    
+                    let ciphertext: Array<U8, 16> = gb
+                        .call(
+                            Call::builder(AES128.clone())
+                                .arg(key)
+                                .arg(msg)
+                                .build()
+                                .unwrap(),
+                        )
+                        .unwrap();
+    
+                    let mut ciphertext = gb.decode(ciphertext).unwrap();
+    
+                    gb.assign(key, [0u8; 16]).unwrap();
+                    gb.commit(key).unwrap();
+                    gb.commit(msg).unwrap();
+    
+                    gb.execute_all(&mut ctx_a).await.unwrap();
+                    ciphertext.try_recv().unwrap().unwrap()
+                },
+                async {
+                    let key: Array<U8, 16> = ev.alloc().unwrap();
+                    let msg: Array<U8, 16> = ev.alloc().unwrap();
+    
+                    ev.mark_blind(key).unwrap();
+                    ev.mark_private(msg).unwrap();
+    
+                    let ciphertext: Array<U8, 16> = ev
+                        .call(
+                            Call::builder(AES128.clone())
+                                .arg(key)
+                                .arg(msg)
+                                .build()
+                                .unwrap(),
+                        )
+                        .unwrap();
+    
+                    let mut ciphertext = ev.decode(ciphertext).unwrap();
+    
+                    ev.assign(msg, [42u8; 16]).unwrap();
+                    ev.commit(key).unwrap();
+                    ev.commit(msg).unwrap();
+    
+                    ev.execute_all(&mut ctx_b).await.unwrap();
+                    ciphertext.try_recv().unwrap().unwrap()
+                }
+            );
+    
+            black_box((gen_out, ev_out));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/garble/src/auth_eval.rs
+++ b/crates/garble/src/auth_eval.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use mpz_circuits::Circuit;
+use mpz_common::Context;
+use mpz_garble_core::{
+    AuthHalfGateBatch, AuthEval as AuthEvalCore, AuthEvalOutput, AuthGarbledCircuit, SSP
+};
+use mpz_garble_core::fpre::AuthBitShare;
+
+use mpz_memory_core::correlated::{Delta, Mac};
+use serio::{SinkExt, stream::IoStreamExt};
+
+use mpz_core::Block;
+use mpz_cointoss::{cointoss_receiver, CointossError};
+
+#[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+pub async fn receive_garbled_circuit(
+    ctx: &mut Context,
+    circ: &Circuit,
+) -> Result<AuthGarbledCircuit, AuthEvaluatorError> {
+    let gate_count = circ.and_count();
+    let mut gates = Vec::with_capacity(gate_count);
+
+    while gates.len() < gate_count {
+        let batch: AuthHalfGateBatch = ctx.io_mut().expect_next().await?;
+        gates.extend_from_slice(&batch.into_array());
+    }
+
+    // Trim off any batch padding.
+    gates.truncate(gate_count);
+
+    Ok(AuthGarbledCircuit { gates })
+}
+
+/// Evaluate an authenticated garbled circuit, streaming the encrypted gates from the evaluator
+/// in batches.
+///
+/// # Blocking
+///
+/// This function performs blocking computation, so be careful when calling it
+/// from an async context.
+#[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+pub async fn evaluate(
+    ctx: &mut Context,
+    circ: Arc<Circuit>,
+    delta: Delta,
+    input_labels: &[Mac],
+    masked_inputs: Vec<bool>,
+    input_auth_bits: &[AuthBitShare],
+    shares: &[AuthBitShare],
+) -> Result<AuthEvalOutput, AuthEvaluatorError> {
+    // Use cointoss to agree on a random seed
+    let receiver_seed = vec![Block::random(&mut rand::rng())];
+    let receiver_output = cointoss_receiver(ctx, receiver_seed).await?;
+    let seed = u64::from_le_bytes(receiver_output[0].as_bytes()[..8].try_into().unwrap());
+    
+    let bucket_size = (SSP as f64 / (circ.and_count() as f64).log2()).ceil() as usize;
+    let mut ev = AuthEvalCore::new(seed, bucket_size);
+    let io = ctx.io_mut();  
+
+    // Function independent pre-processing: using auth bits to generate auth triples
+    let (c, mut g) = ev.evaluate_pre_1(&circ, delta, input_auth_bits, shares).unwrap();
+    io.feed(g.clone()).await?;
+    io.flush().await?;
+    let gr: Vec<Block>  = io.expect_next().await?;
+
+    let d = ev.evaluate_pre_2(delta, c, &mut g, gr).unwrap();
+    io.feed(d.clone()).await?;
+    io.flush().await?;
+    let dr: Vec<bool> = io.expect_next().await?;
+
+    let data = ev.evaluate_pre_3(delta, &mut g, d, dr).unwrap();
+    
+
+    // Secure equality check for authenticity of triples
+    let digest = ev.check_equality(g).unwrap();
+    let hash_recv: Block = io.expect_next().await?;
+    io.feed(digest).await?;
+    io.flush().await?;
+    
+    let salt_recv: Block = io.expect_next().await?;
+
+    let expected_hash = ev.check_salt(salt_recv, digest).unwrap();
+    if expected_hash != hash_recv {
+        return Err(AuthEvaluatorError(ErrorRepr::EqualityCheckFailed));
+    }
+
+    io.feed(data.clone()).await?;
+    io.flush().await?;
+    let data_recv: Vec<bool> = io.expect_next().await?;
+
+    ev.evaluate_pre_4(data, data_recv).unwrap();
+    
+    
+    // Function dependent pre-processing: generate auth bits for all wires in the circuit
+    ev.evaluate_free(&circ).unwrap();
+    let (px, py) = ev.evaluate_de(&circ).unwrap();
+    io.feed((px,py)).await?;
+    io.flush().await?;
+    let (px_recv, py_recv): (Vec<bool>, Vec<bool>) = io.expect_next().await?;
+
+    let mut ev_consumer = ev.evaluate_batched(&circ, delta, &input_labels, masked_inputs, px_recv, py_recv).unwrap();
+
+    while ev_consumer.wants_gates() {
+        let batch: AuthHalfGateBatch = io.expect_next().await?;
+        ev_consumer.next(batch);
+    }
+
+    let output = ev_consumer.finish()?;
+    let masked_values = output.masked_values.clone();
+
+    // TODO: For preprocessing, send all the masked values at the end
+    io.feed(masked_values).await?;
+    io.flush().await?;
+
+    Ok(output)
+}
+
+/// Authenticated evaluator error.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct AuthEvaluatorError(#[from] ErrorRepr);
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] mpz_garble_core::AuthEvaluatorError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("equality check failed")]
+    EqualityCheckFailed,
+    #[error("cointoss error: {0}")]
+    Cointoss(#[from] CointossError),
+}
+
+impl From<std::io::Error> for AuthEvaluatorError {
+    fn from(err: std::io::Error) -> Self {
+        AuthEvaluatorError(ErrorRepr::Io(err))
+    }
+}
+
+impl From<mpz_garble_core::AuthEvaluatorError> for AuthEvaluatorError {
+    fn from(err: mpz_garble_core::AuthEvaluatorError) -> Self {
+        AuthEvaluatorError(ErrorRepr::Core(err))
+    }
+}
+
+impl From<CointossError> for AuthEvaluatorError {
+    fn from(err: CointossError) -> Self {
+        AuthEvaluatorError(ErrorRepr::Cointoss(err))
+    }
+}

--- a/crates/garble/src/auth_gen.rs
+++ b/crates/garble/src/auth_gen.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use mpz_circuits::Circuit;
+use mpz_common::Context;
+use mpz_core::Block;
+use mpz_garble_core::{AuthGen as AuthGenCore, AuthGenOutput, SSP};
+use mpz_memory_core::correlated::{Delta, Key};
+use mpz_garble_core::fpre::AuthBitShare;
+use serio::{SinkExt, stream::IoStreamExt};
+use mpz_cointoss::{cointoss_sender, CointossError};
+
+/// Generate an authenticated garbled circuit, streaming the encrypted gates to the evaluator
+///
+/// # Blocking
+///
+/// This function performs blocking computation, so be careful when calling it
+/// from an async context.
+#[tracing::instrument(fields(thread = %ctx.id()), skip_all)]
+pub async fn generate(
+    ctx: &mut Context,
+    circ: Arc<Circuit>,
+    delta: Delta,
+    input_labels: &[Key],
+    input_auth_bits: &[AuthBitShare],
+    shares: &[AuthBitShare],
+) -> Result<AuthGenOutput, AuthGeneratorError> {
+    // Use cointoss to agree on a random seed
+    let sender_seed = vec![Block::random(&mut rand::rng())];
+    let sender_output = cointoss_sender(ctx, sender_seed).await?;
+    let seed = u64::from_le_bytes(sender_output[0].as_bytes()[..8].try_into().unwrap());
+    
+    let bucket_size = (SSP as f64 / (circ.and_count() as f64).log2()).ceil() as usize;
+    let mut gb = AuthGenCore::new(seed, bucket_size);
+    let io = ctx.io_mut();
+
+    // Function independent pre-processing: using auth bits to generate auth triples
+    let (c, mut g) = gb.generate_pre_1(&circ, delta, input_auth_bits, shares).unwrap();
+    io.feed(g.clone()).await?;
+    io.flush().await?;
+    let gr: Vec<Block>  = io.expect_next().await?;
+
+    let d = gb.generate_pre_2(delta, c, &mut g, gr).unwrap();
+    io.feed(d.clone()).await?;
+    io.flush().await?;
+    let dr: Vec<bool> = io.expect_next().await?;
+
+    let data = gb.generate_pre_3(delta, &mut g, d, dr).unwrap();
+    
+    
+    // Secure equality check for authenticity of triples
+    let (digest, salt, hash) = gb.check_equality(g).unwrap();
+    io.feed(hash).await?;
+    io.flush().await?;
+    
+    let digest_recv: Block = io.expect_next().await?;
+    if digest != digest_recv {
+        return Err(AuthGeneratorError(ErrorRepr::EqualityCheckFailed));
+    }
+
+    io.feed(salt).await?;
+    io.flush().await?;
+
+    
+    io.feed(data.clone()).await?;
+    io.flush().await?;
+    let data_recv: Vec<bool> = io.expect_next().await?;
+
+    gb.generate_pre_4(data, data_recv).unwrap();
+    
+    // Function dependent pre-processing: generate auth bits for all wires in the circuit
+    gb.generate_free(&circ).unwrap();
+    let (px, py) = gb.generate_de(&circ).unwrap();
+    io.feed((px,py)).await?;
+    io.flush().await?;
+    let (px_recv, py_recv): (Vec<bool>, Vec<bool>) = io.expect_next().await?;
+
+    let mut gb_iter= gb.generate_batched(&circ, delta, &input_labels, px_recv, py_recv).unwrap();
+    while let Some(batch) = gb_iter.by_ref().next() {
+        io.feed(batch).await?;
+    }
+    io.flush().await?;
+
+    // TODO: For preprocessing, receive all the masked values at the end
+    let masked_values: Vec<bool> = io.expect_next().await?;
+    Ok(gb_iter.finish(masked_values)?)
+}
+
+/// Authenticated generator error.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct AuthGeneratorError(#[from] ErrorRepr);
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] mpz_garble_core::AuthGeneratorError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("equality check failed")]
+    EqualityCheckFailed,
+    #[error("cointoss error: {0}")]
+    Cointoss(#[from] CointossError),
+}
+
+impl From<std::io::Error> for AuthGeneratorError {
+    fn from(err: std::io::Error) -> Self {
+        AuthGeneratorError(ErrorRepr::Io(err))
+    }
+}
+
+impl From<mpz_garble_core::AuthGeneratorError> for AuthGeneratorError {
+    fn from(err: mpz_garble_core::AuthGeneratorError) -> Self {
+        AuthGeneratorError(ErrorRepr::Core(err))
+    }
+}
+
+impl From<CointossError> for AuthGeneratorError {
+    fn from(err: CointossError) -> Self {
+        AuthGeneratorError(ErrorRepr::Cointoss(err))
+    }
+}

--- a/crates/garble/src/lib.rs
+++ b/crates/garble/src/lib.rs
@@ -6,5 +6,200 @@
 
 pub(crate) mod evaluator;
 pub(crate) mod garbler;
+pub(crate) mod auth_gen;
+pub(crate) mod auth_eval;
 pub mod protocol;
 pub(crate) mod store;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use mpz_circuits::circuits::AES128;
+    use itybity::{FromBitIterator, IntoBitIterator, ToBits};
+    use mpz_common::context::test_st_context;
+    use mpz_memory_core::correlated::{Delta, Key, Mac};
+    use mpz_garble_core::{AuthGenOutput, AuthEvalOutput};
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+    use aes::{
+        Aes128,
+        cipher::{BlockCipherEncrypt, KeyInit},
+    };
+    use mpz_garble_core::{fpre::bit_shares_from_cot, SSP};
+    use super::*;
+
+    #[tokio::test]
+    async fn test_semihonest_core() {
+
+        let (mut ctx_0, mut ctx_1) = test_st_context(8);
+
+        let circ = &**AES128;
+        
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let key = [69u8; 16];
+        let msg = [42u8; 16];
+
+        let expected: [u8; 16] = {
+            let cipher = Aes128::new_from_slice(&key).unwrap();
+            let mut out = msg.into();
+            cipher.encrypt_block(&mut out);
+            out.into()
+        };
+
+        let delta = Delta::random(&mut rng);
+        let input_keys = (0..AES128.inputs().len())
+            .map(|_| rng.random())
+            .collect::<Vec<Key>>();
+
+        let input_macs = input_keys
+            .iter()
+            .zip(key.iter().copied().chain(msg).into_iter_lsb0())
+            .map(|(key, bit)| key.auth(bit, &delta))
+            .collect::<Vec<_>>();
+
+        // Run garbler and evaluator concurrently
+        let (garbler_output, evaluator_output) = tokio::join!(
+            async {
+                garbler::generate(&mut ctx_0, Arc::new(circ.clone()), delta, &input_keys).await
+            },
+            async {
+                evaluator::evaluate(&mut ctx_1, Arc::new(circ.clone()), &input_macs).await
+            }
+        );
+
+        let output_keys = garbler_output.unwrap().outputs;
+        let output_macs = evaluator_output.unwrap().outputs;
+
+        assert!(
+            output_keys
+                .iter()
+                .zip(&output_macs)
+                .zip(expected.iter_lsb0())
+                .all(|((key, mac), bit)| &key.auth(bit, &delta) == mac)
+        );
+
+        let output: Vec<u8> = Vec::from_lsb0_iter(
+            output_macs
+                .into_iter()
+                .zip(output_keys)
+                .map(|(mac, key)| mac.pointer() ^ key.pointer()),
+        );
+
+        assert_eq!(output, expected);
+    }
+
+    #[tokio::test]
+    async fn test_auth_core() {
+        let (mut ctx_0, mut ctx_1) = test_st_context(8);
+
+        let circ = &**AES128;
+        
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let key = [69u8; 16];
+        let msg = [42u8; 16];
+
+        let expected: [u8; 16] = {
+            let cipher = Aes128::new_from_slice(&key).unwrap();
+            let mut out = msg.into();
+            cipher.encrypt_block(&mut out);
+            out.into()
+        };
+
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+
+        // Calculate total number of shares needed
+        let bucket_size = (SSP as f64 / (circ.and_count() as f64).log2()).ceil() as usize;
+        let num_input_shares = circ.inputs().len();
+        let num_and_shares = circ.and_count()*(3*bucket_size+1);
+        let total_shares = num_input_shares + num_and_shares;
+
+        // Get all shares in one call
+        let (gen_all_shares, eval_all_shares) = 
+            bit_shares_from_cot(total_shares, delta_a, delta_b)
+            .unwrap();
+
+        // Split into input and AND shares
+        let (gen_input_shares, gen_and_shares) = {
+            let (input, and) = gen_all_shares.split_at(num_input_shares);
+            (input.to_vec(), and.to_vec())
+        };
+        let (eval_input_shares, eval_and_shares) = {
+            let (input, and) = eval_all_shares.split_at(num_input_shares);
+            (input.to_vec(), and.to_vec())
+        };
+
+        let input_keys = (0..circ.inputs().len())
+            .map(|_| rng.random())
+            .collect::<Vec<Key>>();
+
+        let masked_inputs = key.iter().copied().chain(msg).into_iter_lsb0()
+            .enumerate()
+            .map(|(i, b)| b ^ gen_input_shares[i].bit() ^ eval_input_shares[i].bit())
+            .collect::<Vec<bool>>();
+
+        // Calculate MACs for authenticated garbling
+        let input_macs = masked_inputs.iter()
+            .enumerate()
+            .map(|(i, b)| {
+                if *b {
+                    Mac::from(input_keys[i].as_block().clone()) + Mac::from(delta_a.as_block().clone())
+                } else {
+                    Mac::from(input_keys[i].as_block().clone())
+                }
+            })
+            .collect::<Vec<Mac>>();   
+
+        // Run garbler and evaluator concurrently
+        let (garbler_output, evaluator_output) = tokio::join!(
+            async {
+                auth_gen::generate(&mut ctx_0, Arc::new(circ.clone()), delta_a, &input_keys, &gen_input_shares, &gen_and_shares).await
+            },
+            async {
+                auth_eval::evaluate(&mut ctx_1, Arc::new(circ.clone()), delta_b, &input_macs, masked_inputs, &eval_input_shares, &eval_and_shares).await
+            }
+        );
+
+        let AuthEvalOutput {
+            output_labels: eval_output_labels,
+            output_auth_bits: eval_output_auth_bits,
+            auth_hash: eval_auth_hash,
+            masked_output_values,
+            masked_values: _masked_values,
+        } = evaluator_output.unwrap();
+
+        let AuthGenOutput {
+            output_labels: gen_output_labels,
+            output_auth_bits: gen_output_auth_bits,
+            auth_hash: gen_auth_hash,
+        } = garbler_output.unwrap();
+
+        // authentication check
+        assert_eq!(gen_auth_hash, eval_auth_hash);
+
+        let masks = gen_output_auth_bits.iter()
+            .zip(eval_output_auth_bits.iter())
+            .map(|(gen_auth_bit, eval_auth_bit)| gen_auth_bit.bit() ^ eval_auth_bit.bit())
+            .collect::<Vec<bool>>();
+        
+        // Unmask the output
+        let output: Vec<u8> = Vec::from_lsb0_iter(
+            masked_output_values
+                .clone()
+                .into_iter()
+                .enumerate()
+                .map(|(i, masked_value)| masked_value ^ masks[i]),
+        );
+
+        assert_eq!(output, expected);   
+
+        // Check output labels
+        for (i, (gen_label, eval_label)) in gen_output_labels.iter().zip(eval_output_labels.iter()).enumerate() {
+            let xor = gen_label.as_block() ^ eval_label.as_block();
+            let masked_value = masked_output_values[i];
+            let expected = delta_a.mul_bool(masked_value);
+            assert_eq!(xor, expected);
+        }
+    }
+}

--- a/crates/garble/src/protocol.rs
+++ b/crates/garble/src/protocol.rs
@@ -1,3 +1,4 @@
 //! Protocol implementations.
 
 pub mod semihonest;
+pub mod authenticated;

--- a/crates/garble/src/protocol/authenticated.rs
+++ b/crates/garble/src/protocol/authenticated.rs
@@ -1,0 +1,264 @@
+//! Authenticated garbling protocol.
+
+mod auth_eval;
+mod auth_gen;
+
+pub use auth_eval::AuthEval;
+pub use auth_gen::AuthGen;
+
+
+#[cfg(test)]
+mod tests {
+    use mpz_circuits::circuits::AES128;
+    use mpz_common::context::test_st_context;
+    use mpz_memory_core::{
+        Array, MemoryExt, ViewExt,
+        binary::{Binary, U8},
+        correlated::Delta,
+    };
+    use mpz_ot::ideal::cot::{IdealCOTReceiver, IdealCOTSender, ideal_cot};
+    use mpz_vm_core::{Call, CallableExt, Execute, Vm};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
+
+    #[test]
+    fn test_semihonest_is_vm() {
+        fn is_vm<T: Vm<Binary>>() {}
+        is_vm::<AuthGen<IdealCOTSender, IdealCOTReceiver>>();
+        is_vm::<AuthEval<IdealCOTSender, IdealCOTReceiver>>();
+    }
+
+    #[tokio::test]
+    async fn test_authenticated() {
+        let mut rng = StdRng::seed_from_u64(0);
+        
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_gen_send, cot_eval_recv) = ideal_cot(delta_a.into_inner());
+        let (cot_eval_send, cot_gen_recv) = ideal_cot(delta_b.into_inner());
+
+        let mut gb = AuthGen::new([0u8; 16], delta_a, cot_gen_send, cot_gen_recv);
+        let mut ev = AuthEval::new([0u8; 16], delta_b, cot_eval_send, cot_eval_recv);
+
+        let ((gen_key, gen_msg, gen_ciphertext), (ev_key, ev_msg, ev_ciphertext)) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_blind(msg).unwrap();
+
+                let mut decoded_key = gb.decode(key).unwrap();
+                let mut decoded_msg = gb.decode(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(msg).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                (decoded_key.try_recv().unwrap().unwrap(), decoded_msg.try_recv().unwrap().unwrap(), ciphertext.try_recv().unwrap().unwrap())
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_private(msg).unwrap();
+
+                let mut decoded_key = ev.decode(key).unwrap();
+                let mut decoded_msg = ev.decode(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(msg).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                (decoded_key.try_recv().unwrap().unwrap(), decoded_msg.try_recv().unwrap().unwrap(), ciphertext.try_recv().unwrap().unwrap())
+            }
+        );
+
+        assert_eq!(gen_key, ev_key);
+        assert_eq!(gen_msg, ev_msg);
+        assert_eq!(gen_ciphertext, ev_ciphertext);
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_nothing_to_do() {
+        let mut rng = StdRng::seed_from_u64(0);
+        
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_gen_send, cot_eval_recv) = ideal_cot(delta_a.into_inner());
+        let (cot_eval_send, cot_gen_recv) = ideal_cot(delta_b.into_inner());
+
+        let mut gb = AuthGen::new([0u8; 16], delta_a, cot_gen_send, cot_gen_recv);
+        let mut ev = AuthEval::new([0u8; 16], delta_b, cot_eval_send, cot_eval_recv);
+
+        gb.flush(&mut ctx_a).await.unwrap();
+        ev.flush(&mut ctx_b).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_chain() {
+        let mut rng = StdRng::seed_from_u64(0);
+        
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_gen_send, cot_eval_recv) = ideal_cot(delta_a.into_inner());
+        let (cot_eval_send, cot_gen_recv) = ideal_cot(delta_b.into_inner());
+
+        let mut gb = AuthGen::new([0u8; 16], delta_a, cot_gen_send, cot_gen_recv);
+        let mut ev = AuthEval::new([0u8; 16], delta_b, cot_eval_send, cot_eval_recv);
+
+        let (gen_out, ev_out) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let key_2: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+                let msg_2: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_public(key_2).unwrap();
+                gb.mark_blind(msg).unwrap();
+                gb.mark_blind(msg_2).unwrap();
+
+                let output: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Parallel AES calls.
+                let ciphertext_2: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key_2)
+                            .arg(msg_2)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+                let mut ciphertext_2 = gb.decode(ciphertext_2).unwrap();
+
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.assign(key_2, [69u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(key_2).unwrap();
+                gb.commit(msg).unwrap();
+                gb.commit(msg_2).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap();
+                ciphertext_2.try_recv().unwrap().unwrap()
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let key_2: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+                let msg_2: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_public(key_2).unwrap();
+                ev.mark_private(msg).unwrap();
+                ev.mark_private(msg_2).unwrap();    
+
+                let output: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Parallel AES calls.
+                let ciphertext_2: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key_2)
+                            .arg(msg_2)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+                let mut ciphertext_2 = ev.decode(ciphertext_2).unwrap();
+
+                ev.assign(key_2, [69u8; 16]).unwrap();
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.assign(msg_2, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(key_2).unwrap();
+                ev.commit(msg).unwrap();
+                ev.commit(msg_2).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap();
+                ciphertext_2.try_recv().unwrap().unwrap()
+            }
+        );
+
+        assert_eq!(gen_out, ev_out);
+    }
+}

--- a/crates/garble/src/protocol/authenticated/auth_eval.rs
+++ b/crates/garble/src/protocol/authenticated/auth_eval.rs
@@ -1,0 +1,481 @@
+use rand::Rng;
+use core::num;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hashbrown::HashMap;
+use tokio::sync::Mutex;
+use utils::{
+    filter_drain::FilterDrain,
+    range::{Disjoint, RangeSet},
+};
+use mpz_common::future::Output;
+
+use mpz_common::{Context, Flush};
+use mpz_core::{Block, bitvec::BitVec, prg::Prg};
+use mpz_garble_core::{AuthEvalOutput, AuthGarbledCircuit, evaluate_garbled_circuits, fpre::AuthBitShare, SSP};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary, correlated::{Delta, Key, Mac}};
+use mpz_ot::cot::{COTReceiver, COTSender};
+use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
+use mpz_ot::cot::COTReceiverOutput;
+
+use serio::{SinkExt, stream::IoStreamExt};
+
+use crate::{auth_eval::receive_garbled_circuit, store::AuthEvalStore};
+
+struct PendingFlush {
+    cot: Option<Box<dyn Output<COTReceiverOutput<Block>> + Send>>,
+}
+
+/// Preprocessed auth bits for each call.
+#[derive(Default)]
+struct Prep {
+    cot: Option<PendingFlush>,
+    choices: Vec<bool>,
+    keys: Vec<Key>,
+}
+/// Authenticated evaluator.
+pub struct AuthEval<S, R> {
+    store: Arc<Mutex<AuthEvalStore<S, R>>>,
+    call_stack: Vec<(Call, Slice, Prep)>,
+    // preprocessed: HashMap<Slice, (Call, AuthGarbledCircuit)>,
+    prg: Prg,
+}
+
+impl<S, R> AuthEval<S, R> 
+    {
+        /// Creates a new evaluator.
+        pub fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+            Self {
+            store: Arc::new(Mutex::new(AuthEvalStore::new(seed, delta, cot_sender, cot_receiver))),
+            call_stack: Vec::new(),
+            prg: Prg::new_with_seed(seed),
+            // preprocessed: HashMap::new(),
+        }
+    }
+
+    // Should I move COT generation to a new function here? And then store the COTs in the call_stack...
+
+    // fn take_preprocess_calls(&mut self) -> Vec<(Call, Slice)> {
+    //     let mut idx_outputs = RangeSet::default();
+    //     self.call_stack
+    //         // Extract calls which have no dependencies on other prior calls.
+    //         .filter_drain(|(call, output)| {
+    //             if call
+    //                 .inputs()
+    //                 .iter()
+    //                 .all(|input| input.to_range().is_disjoint(&idx_outputs))
+    //             {
+    //                 idx_outputs |= output.to_range();
+    //                 true
+    //             } else {
+    //                 idx_outputs |= output.to_range();
+    //                 false
+    //             }
+    //         })
+    //         .collect()
+    // }
+
+    fn take_execute_calls(&mut self) -> Vec<(Call, Slice, Prep)> {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            // Extract calls which have no dependencies on other prior calls.
+            .filter_drain(|(call, _, _)| call.inputs().iter().all(|input| store.is_committed(*input)))
+            .collect()
+    }
+
+    // fn execute_preprocessed(&mut self) -> Result<()> {
+    //     let mut store = self.store.try_lock().unwrap();
+    //     loop {
+    //         let (calls, outputs): (Vec<_>, Vec<_>) = self
+    //             .preprocessed
+    //             .extract_if(|_, (call, _)| {
+    //                 call.inputs().iter().all(|input| store.is_committed(*input))
+    //             })
+    //             .map(|(output, (call, garbled_circuit))| {
+    //                 let (circ, inputs) = call.into_parts();
+    //                 let mut input_macs = Vec::with_capacity(circ.inputs().len());
+    //                 for input in inputs {
+    //                     input_macs.extend_from_slice(
+    //                         store
+    //                             .try_get_macs(input)
+    //                             .expect("committed MACs should be set"),
+    //                     );
+    //                 }
+
+    //                 ((circ, input_macs, garbled_circuit), output)
+    //             })
+    //             .unzip();
+
+    //         if calls.is_empty() {
+    //             break;
+    //         }
+
+    //         for (
+    //             EvaluatorOutput {
+    //                 outputs: output_macs,
+    //             },
+    //             output,
+    //         ) in evaluate_garbled_circuits(calls)
+    //             .map_err(VmError::execute)?
+    //             .into_iter()
+    //             .zip(outputs)
+    //         {
+    //             store
+    //                 .set_output(output, &output_macs)
+    //                 .map_err(VmError::memory)?;
+    //         }
+
+    //         store.flush_decode().map_err(VmError::memory)?;
+    //     }
+
+    //     Ok(())
+    // }
+}
+
+impl<S, R> Memory<Binary> for AuthEval<S, R>
+where
+{
+    type Error = VmError;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .alloc_raw(size)
+            .map_err(VmError::memory)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, value: BitVec) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .assign_raw(slice, value)
+            .map_err(VmError::memory)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .commit_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .get_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .decode_raw(slice)
+            .map_err(VmError::memory)
+    }
+}
+
+impl<S, R> View<Binary> for AuthEval<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_public_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_private_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_blind_raw(slice)
+            .map_err(VmError::view)
+    }
+}
+
+impl<S, R> Callable<Binary> for AuthEval<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+        let mut store = self.store.try_lock().unwrap();
+        let output = store.alloc_output(call.circ().outputs().len());
+        let mut cot_sender = store.acquire_cot_sender();
+        let mut cot_receiver = store.acquire_cot_receiver();
+
+        let bucket_size = (SSP as f64 / (call.circ().and_count() as f64).log2()).ceil() as usize;
+        let num_and_shares = call.circ().and_count()*(3*bucket_size+1);
+
+        cot_sender.alloc(num_and_shares).map_err(VmError::call)?;
+        cot_receiver.alloc(num_and_shares).map_err(VmError::call)?;
+
+        let keys: Vec<Key> = (0..num_and_shares).map(|_| self.prg.random()).collect::<Vec<_>>();
+        // Queue COT, we don't need the output here.
+        _ = cot_sender
+            .queue_send_cot(Key::as_blocks(&keys))
+            .map_err(VmError::call)?;
+
+        let choices: Vec<bool> = (0..num_and_shares).map(|_| self.prg.random()).collect::<Vec<_>>();
+        let cot = if num_and_shares > 0 {
+            let output = cot_receiver
+                .queue_recv_cot(&choices)
+                .map_err(VmError::call)?;
+            Some(Box::new(output) as Box<dyn Output<COTReceiverOutput<Block>> + Send>)
+        } else {
+            None
+        };
+
+        self.call_stack.push((call, output, Prep { cot: Some(PendingFlush { cot }), choices, keys }));
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl<S, R> Execute for AuthEval<S, R>
+where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    fn wants_flush(&self) -> bool {
+        self.store.try_lock().unwrap().wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+        let mut store = self.store.try_lock().unwrap();
+        if store.wants_flush() {
+            store.flush(ctx).await.map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    fn wants_preprocess(&self) -> bool {
+        // let mut idx_outputs = RangeSet::default();
+        // self.call_stack.iter().any(|(call, output)| {
+        //     let ready = call
+        //         .inputs()
+        //         .iter()
+        //         .all(|input| input.to_range().is_disjoint(&idx_outputs));
+        //     idx_outputs |= output.to_range();
+        //     ready
+        // })
+        unimplemented!()
+    }
+
+    async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
+        // while !self.call_stack.is_empty() {
+        //     let calls = self.take_preprocess_calls();
+
+        //     if calls.is_empty() {
+        //         break;
+        //     }
+
+        //     let outputs = ctx
+        //         .map(
+        //             calls,
+        //             async move |ctx, (call, output): (Call, Slice)| {
+        //                 let garbled_circuit = receive_garbled_circuit(ctx, call.circ())
+        //                     .await
+        //                     .map_err(VmError::execute)?;
+        //                 Ok::<_, VmError>((call, output, garbled_circuit))
+        //             },
+        //             |(call, _)| call.circ().and_count(),
+        //         )
+        //         .await
+        //         .map_err(VmError::execute)?;
+
+        //     let mut store = self.store.try_lock().unwrap();
+        //     for output in outputs {
+        //         let (call, output, garbled_circuit) = output?;
+
+        //         self.preprocessed.insert(output, (call, garbled_circuit));
+        //         store
+        //             .mark_output_preprocessed(output)
+        //             .map_err(VmError::memory)?;
+        //     }
+        // }
+
+        // Ok(())
+        unimplemented!()
+    }
+
+    fn wants_execute(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        // self.preprocessed
+        //     .iter()
+        //     .any(|(_, (call, _))| call.inputs().iter().all(|input| store.is_committed(*input)))
+        //     || 
+                self.call_stack
+                .iter()
+                .any(|(call, _, _)| call.inputs().iter().all(|input| store.is_committed(*input)))
+    }
+
+    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+        // if !self.preprocessed.is_empty() {
+        //     self.execute_preprocessed()?;
+        // }
+
+        let delta = *self.store.try_lock().unwrap().delta();
+
+        while !self.call_stack.is_empty() {
+            let calls = self.take_execute_calls();
+
+            if calls.is_empty() {
+                break;
+            }
+
+            // For calls that aren't dependent on each other
+            let mut call_data = Vec::new();
+            for (call, slice, prep) in calls {
+                let and_shares = if let Prep { cot: Some(PendingFlush { cot }), choices, keys } = prep {
+                    if let Some(mut cot_box) = cot {
+                        let cot_output = cot_box
+                            .try_recv()
+                            .map_err(VmError::execute)?
+                            .ok_or_else(|| VmError::execute("COT output is not ready"))?;
+                        
+                        let COTReceiverOutput { msgs: macs, .. } = cot_output;
+                        let macs = Mac::from_blocks(macs);
+                        
+                        // Create auth bit shares for this call
+                        let mut and_shares = Vec::new();
+                        for ((value, mac), key) in choices.iter().zip(macs).zip(keys) {
+                            and_shares.push(AuthBitShare {
+                                value: *value,
+                                mac,
+                                key,
+                            });
+                        }
+                        Some(and_shares)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                
+                if let Some(shares) = and_shares {
+                    call_data.push((call, slice, shares));
+                }
+            }
+
+            let store = self.store.clone();
+
+            let outputs = ctx
+                .map(
+                    call_data.into_iter().collect::<Vec<_>>(),
+                    async move |ctx, (call, output, and_shares)| {
+                        evaluate(ctx, store.clone(), delta, call, output, and_shares).await
+                    },
+                    |(call, _, _)| call.circ().and_count(),
+                )
+                .await
+                .map_err(VmError::execute)?;
+
+            outputs.into_iter().collect::<Result<()>>()?;
+        }
+
+        // Should I move this somewhere else? Maybe flush it whenever a decode operation is called?
+        let io = ctx.io_mut();
+        let hash = self.store.try_lock().unwrap().get_hash();
+        let recv_hash: Block = io.expect_next().await?;
+        if recv_hash != hash {
+            Err(VmError::execute("Auth hash mismatch"))?;
+        }
+
+        Ok(())
+    }
+}
+
+async fn evaluate<S,R>(
+    ctx: &mut Context,
+    store: Arc<Mutex<AuthEvalStore<S, R>>>,
+    delta: Delta,
+    call: Call,
+    output: Slice,
+    and_shares: Vec<AuthBitShare>,
+) -> Result<()> 
+where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+{
+    let (circ, inputs) = call.into_parts();
+
+    let mut input_macs = Vec::with_capacity(circ.inputs().len());
+    let mut input_masked_values = Vec::with_capacity(circ.inputs().len());
+    let mut input_auth_bits = Vec::with_capacity(circ.inputs().len());
+    {
+        let lock = store.lock().await;
+        for input in inputs {
+            input_macs.extend_from_slice(lock.try_get_macs(input).map_err(VmError::memory)?);
+            let masked_values = lock.try_get_masked_values(input).map_err(VmError::memory)?.to_bitvec();
+            input_masked_values.extend(masked_values);
+            let mask_bits = lock.try_get_mask_bits(input).map_err(VmError::memory)?;
+            let mask_macs = lock.try_get_mask_macs(input).map_err(VmError::memory)?;
+            let mask_keys = lock.try_get_mask_keys(input).map_err(VmError::memory)?;
+            
+            for ((value, mac), key) in mask_bits.iter().zip(mask_macs).zip(mask_keys) {
+                input_auth_bits.push(AuthBitShare {
+                    value: *value,
+                    mac: *mac,
+                    key: *key,
+                });
+            }
+        }
+    }
+
+    let AuthEvalOutput {
+        output_labels,
+        output_auth_bits,
+        auth_hash,
+        masked_output_values,
+        masked_values: _masked_values,
+    } = crate::auth_eval::evaluate(ctx, circ, delta,  &input_macs, input_masked_values, &input_auth_bits, &and_shares)
+        .await
+        .map_err(VmError::execute)?;
+
+    let output_bits: Vec<_> = output_auth_bits.iter().map(|share| share.value).collect();
+    let output_macs: Vec<_> = output_auth_bits.iter().map(|share| share.mac).collect();
+    let output_keys: Vec<_> = output_auth_bits.iter().map(|share| share.key).collect();
+
+    let output_bits = BitVec::from_iter(output_bits);
+    let masked_output_values = BitVec::from_iter(masked_output_values);
+    let mut lock = store.lock().await;
+    lock.set_output(output, &output_labels, &output_bits, &output_macs, &output_keys, &masked_output_values)
+        .map_err(VmError::memory)?;
+    lock.update_hash(auth_hash);
+    Ok(())
+}

--- a/crates/garble/src/protocol/authenticated/auth_gen.rs
+++ b/crates/garble/src/protocol/authenticated/auth_gen.rs
@@ -1,0 +1,432 @@
+use rand::Rng;
+use core::num;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hashbrown::HashMap;
+use tokio::sync::Mutex;
+use utils::{
+    filter_drain::FilterDrain,
+    range::{Disjoint, RangeSet},
+};
+use mpz_common::future::Output;
+
+use mpz_common::{Context, Flush};
+use mpz_core::{Block, bitvec::BitVec, prg::Prg};
+use mpz_garble_core::{AuthGenOutput, AuthGarbledCircuit, evaluate_garbled_circuits, fpre::AuthBitShare, SSP};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary, correlated::{Delta, Key, Mac}};
+use mpz_ot::cot::{COTReceiver, COTSender};
+use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
+use mpz_ot::cot::COTReceiverOutput;
+
+use serio::{SinkExt, stream::IoStreamExt};
+
+use crate::store::AuthGenStore;
+
+struct PendingFlush {
+    cot: Option<Box<dyn Output<COTReceiverOutput<Block>> + Send>>,
+}
+
+/// Preprocessed auth bits for each call.
+#[derive(Default)]
+struct Prep {
+    cot: Option<PendingFlush>,
+    choices: Vec<bool>,
+    keys: Vec<Key>,
+}
+
+/// Authenticated garbler.
+pub struct AuthGen<S,R> {
+    store: Arc<Mutex<AuthGenStore<S,R>>>,
+    call_stack: Vec<(Call, Slice, Prep)>,
+    // preprocessed: Vec<(Vec<Slice>, Slice)>,
+    prg: Prg,
+}
+
+impl<S,R> AuthGen<S,R> 
+    {
+    /// Creates a new garbler.
+    pub fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(AuthGenStore::new(seed, delta, cot_sender, cot_receiver))),
+            call_stack: Vec::new(),
+            prg: Prg::new_with_seed(seed),
+            // preprocessed: Vec::new(),
+        }
+    }
+
+    // fn take_preprocess_calls(&mut self) -> Vec<(Call, Slice)> {
+    //     let store = self.store.try_lock().unwrap();
+    //     self.call_stack
+    //         .filter_drain(|(call, _)| call.inputs().iter().all(|slice| store.is_set_keys(*slice)))
+    //         .collect()
+    // }
+
+    fn take_execute_calls(&mut self) -> Vec<(Call, Slice, Prep)> {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            .filter_drain(|(call, _, _)| call.inputs().iter().all(|slice| store.is_committed(*slice)))
+            .collect()
+    }
+
+    // Marks the outputs of preprocessed calls as executed.
+    // fn mark_executed(&mut self) -> Result<()> {
+    //     let mut store = self.store.try_lock().unwrap();
+    //     loop {
+    //         let outputs = self
+    //             .preprocessed
+    //             .filter_drain(|(inputs, _)| inputs.iter().all(|input| store.is_committed(*input)))
+    //             .map(|(_, output)| output)
+    //             .collect::<Vec<_>>();
+
+    //         if outputs.is_empty() {
+    //             break;
+    //         }
+
+    //         for output in outputs {
+    //             store
+    //                 .mark_output_complete(output)
+    //                 .map_err(VmError::memory)?;
+    //         }
+    //     }
+
+    //     Ok(())
+    // }
+}
+
+impl<S,R> Memory<Binary> for AuthGen<S,R> 
+    {
+    type Error = VmError;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .alloc_raw(size)
+            .map_err(VmError::memory)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, value: BitVec) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .assign_raw(slice, value)
+            .map_err(VmError::memory)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .commit_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .get_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .decode_raw(slice)
+            .map_err(VmError::memory)
+    }
+}
+
+impl<S,R> View<Binary> for AuthGen<S,R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_public_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_private_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_blind_raw(slice)
+            .map_err(VmError::view)
+    }
+}
+
+impl<S,R> Callable<Binary> for AuthGen<S,R> 
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+        let mut store = self.store.try_lock().unwrap();
+        let output = store.alloc_output(call.circ().outputs().len());
+        let mut cot_sender = store.acquire_cot_sender();
+        let mut cot_receiver = store.acquire_cot_receiver();
+
+        let bucket_size = (SSP as f64 / (call.circ().and_count() as f64).log2()).ceil() as usize;
+        let num_and_shares = call.circ().and_count()*(3*bucket_size+1);
+
+        cot_sender.alloc(num_and_shares).map_err(VmError::call)?;
+        cot_receiver.alloc(num_and_shares).map_err(VmError::call)?;
+
+        let keys: Vec<Key> = (0..num_and_shares).map(|_| self.prg.random()).collect::<Vec<_>>();
+        // Queue COT, we don't need the output here.
+        _ = cot_sender
+            .queue_send_cot(Key::as_blocks(&keys))
+            .map_err(VmError::call)?;
+
+        let choices: Vec<bool> = (0..num_and_shares).map(|_| self.prg.random()).collect::<Vec<_>>();
+        let cot = if num_and_shares > 0 {
+            let output = cot_receiver
+                .queue_recv_cot(&choices)
+                .map_err(VmError::call)?;
+            Some(Box::new(output) as Box<dyn Output<COTReceiverOutput<Block>> + Send>)
+        } else {
+            None
+        };
+
+        self.call_stack.push((call, output, Prep { cot: Some(PendingFlush { cot }), choices, keys }));
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl<S,R> Execute for AuthGen<S,R>
+where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    fn wants_flush(&self) -> bool {
+        self.store.try_lock().unwrap().wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+        let mut store = self.store.try_lock().unwrap();
+        if store.wants_flush() {
+            store.flush(ctx).await.map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    fn wants_preprocess(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            .iter()
+            .any(|(call, _, _)| call.inputs().iter().all(|slice| store.is_set_keys(*slice)))
+    }
+
+    async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
+        // let delta = *self.store.try_lock().unwrap().delta();
+
+        // while !self.call_stack.is_empty() {
+        //     let calls = self.take_preprocess_calls();
+
+        //     if calls.is_empty() {
+        //         break;
+        //     } else {
+        //         for (call, output) in &calls {
+        //             let inputs = call.inputs().to_vec();
+        //             self.preprocessed.push((inputs, *output));
+        //         }
+        //     }
+
+        //     let store = self.store.clone();
+        //     let outputs = ctx
+        //         .map(
+        //             calls,
+        //             async move |ctx: &mut Context, (call, output): (Call, Slice)| {
+        //                 generate(ctx, store.clone(), delta, call, output, Mode::Preprocess).await
+        //             },
+        //             |(call, _)| call.circ().and_count(),
+        //         )
+        //         .await
+        //         .map_err(VmError::execute)?;
+
+        //     outputs.into_iter().collect::<Result<()>>()?;
+        // }
+
+        // Ok(())
+        unimplemented!()
+    }
+
+    fn wants_execute(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        // self.preprocessed
+        //     .iter()
+        //     .any(|(inputs, _)| inputs.iter().all(|input| store.is_committed(*input)))
+        //     || 
+            self
+                .call_stack
+                .iter()
+                .any(|(call, _, _)| call.inputs().iter().all(|slice| store.is_committed(*slice)))
+    }
+
+    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+        // if !self.preprocessed.is_empty() {
+        //     self.execute_preprocessed()?;
+        // }
+
+        let delta = *self.store.try_lock().unwrap().delta();
+        while !self.call_stack.is_empty() {
+            let calls = self.take_execute_calls();
+
+            if calls.is_empty() {
+                break;
+            }
+
+            // For calls that aren't dependent on each other
+            let mut call_data = Vec::new();
+            for (call, slice, prep) in calls {
+                let and_shares = if let Prep { cot: Some(PendingFlush{cot}), choices, keys } = prep {
+                    if let Some(mut cot_box) = cot {
+                        let cot_output = cot_box
+                            .try_recv()
+                            .map_err(VmError::execute)?
+                            .ok_or_else(|| VmError::execute("COT output is not ready"))?;
+                        
+                        let COTReceiverOutput { msgs: macs, .. } = cot_output;
+                        let macs = Mac::from_blocks(macs);
+                        
+                        // Create auth bit shares for this call
+                        let mut and_shares = Vec::new();
+                        for ((value, mac), key) in choices.iter().zip(macs).zip(keys) {
+                            and_shares.push(AuthBitShare {
+                                value: *value,
+                                mac,
+                                key,
+                            });
+                        }
+                        Some(and_shares)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                
+                if let Some(shares) = and_shares {
+                    call_data.push((call, slice, shares));
+                }
+            }
+
+            let store = self.store.clone();
+
+            let outputs = ctx
+                .map(
+                    call_data.into_iter().collect::<Vec<_>>(),
+                    async move |ctx, (call, output, and_shares)| {
+                        generate(ctx, store.clone(), delta, call, output, and_shares).await
+                    },
+                    |(call, _, _)| call.circ().and_count(),
+                )
+                .await
+                .map_err(VmError::execute)?;
+
+            outputs.into_iter().collect::<Result<()>>()?;
+        }
+
+        // Should I move this somewhere else? Maybe flush it whenever a decode operation is called?
+        let io = ctx.io_mut();
+        let hash = self.store.try_lock().unwrap().get_hash();
+        io.feed(hash).await?;
+        io.flush().await?;
+        Ok(())
+        // self.mark_executed()?;
+    }
+}
+
+// enum Mode {
+//     Preprocess,
+//     Execute,
+// }
+
+async fn generate<S,R>(
+    ctx: &mut Context,
+    store: Arc<Mutex<AuthGenStore<S,R>>>,
+    delta: Delta,
+    call: Call,
+    output: Slice,
+    and_shares: Vec<AuthBitShare>,
+) -> Result<()> 
+    where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+{
+    let (circ, inputs) = call.into_parts();
+
+    let mut input_keys = Vec::with_capacity(circ.inputs().len());
+    let mut input_auth_bits = Vec::with_capacity(circ.inputs().len());
+    {
+        let lock = store.lock().await;
+        for input in inputs {
+            input_keys.extend_from_slice(lock.try_get_keys(input).map_err(VmError::memory)?);
+            let mask_bits = lock.try_get_mask_bits(input).map_err(VmError::memory)?;
+            let mask_macs = lock.try_get_mask_macs(input).map_err(VmError::memory)?;
+            let mask_keys = lock.try_get_mask_keys(input).map_err(VmError::memory)?;
+            for ((value, mac), key) in mask_bits.iter().zip(mask_macs).zip(mask_keys) {
+                input_auth_bits.push(AuthBitShare {
+                    value: *value,
+                    mac: *mac,
+                    key: *key,
+                });
+            }
+        }
+    }
+
+    let AuthGenOutput {
+        output_labels,
+        output_auth_bits,
+        auth_hash,
+    } = crate::auth_gen::generate(ctx, circ, delta, &input_keys, &input_auth_bits, &and_shares)
+        .await
+        .map_err(VmError::execute)?;
+
+    let output_bits: Vec<_> = output_auth_bits.iter().map(|share| share.value).collect();
+    let output_macs: Vec<_> = output_auth_bits.iter().map(|share| share.mac).collect();
+    let output_keys: Vec<_> = output_auth_bits.iter().map(|share| share.key).collect();
+
+    let output_bits = BitVec::from_iter(output_bits);
+    let mut lock = store.lock().await;
+    lock.set_output(output, &output_labels, &output_bits, &output_macs, &output_keys)
+        .map_err(VmError::memory)?;
+    lock.update_hash(auth_hash);
+    // if let Mode::Execute = mode {
+        lock.mark_output_complete(output).map_err(VmError::memory)?;
+    // }
+
+    Ok(())
+}

--- a/crates/garble/src/store.rs
+++ b/crates/garble/src/store.rs
@@ -1,5 +1,178 @@
 mod evaluator;
 mod garbler;
+mod auth_gen;
+mod auth_eval;
 
 pub(crate) use evaluator::EvaluatorStore;
 pub(crate) use garbler::GarblerStore;
+pub(crate) use auth_gen::AuthGenStore;
+pub(crate) use auth_eval::AuthEvalStore;
+
+#[cfg(test)]
+mod tests {
+    use mpz_memory_core::{binary::U8, correlated::Delta, Array, MemoryExt, ViewExt};
+    use mpz_ot::ideal::cot::ideal_cot;
+    // use mpz_ot_core::ideal::cot::IdealCOT;
+    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use mpz_common::context::test_st_context;
+    use mpz_common::Flush;
+
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_store_decode() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+
+        let delta = Delta::random(&mut rng);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = GarblerStore::new(rng.random(), delta, cot_send);
+        let mut ev = EvaluatorStore::new(cot_recv);
+
+        let val_a = [0u8; 16];
+        let val_b = [42u8; 16];
+        let val_c = [69u8; 16];
+
+        let ref_a_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_public(ref_a_gb).unwrap();
+        let ref_b_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_private(ref_b_gb).unwrap();
+        let ref_c_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_blind(ref_c_gb).unwrap();
+
+        let ref_a_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_public(ref_a_ev).unwrap();
+        let ref_b_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_blind(ref_b_ev).unwrap();
+        let ref_c_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_private(ref_c_ev).unwrap();
+
+        gb.assign(ref_a_gb, val_a).unwrap();
+        gb.assign(ref_b_gb, val_b).unwrap();
+
+        ev.assign(ref_a_ev, val_a).unwrap();
+        ev.assign(ref_c_ev, val_c).unwrap();
+
+        gb.commit(ref_a_gb).unwrap();
+        gb.commit(ref_b_gb).unwrap();
+        gb.commit(ref_c_gb).unwrap();
+
+        ev.commit(ref_a_ev).unwrap();
+        ev.commit(ref_b_ev).unwrap();
+        ev.commit(ref_c_ev).unwrap();
+
+        let mut fut_a_gb = gb.decode(ref_a_gb).unwrap();
+        let mut fut_b_gb = gb.decode(ref_b_gb).unwrap();
+        let mut fut_c_gb = gb.decode(ref_c_gb).unwrap();
+
+        let mut fut_a_ev = ev.decode(ref_a_ev).unwrap();
+        let mut fut_b_ev = ev.decode(ref_b_ev).unwrap();
+        let mut fut_c_ev = ev.decode(ref_c_ev).unwrap();
+
+        tokio::join!(
+            async {
+                gb.flush(&mut ctx_a).await.unwrap();
+            },
+            async {
+                ev.flush(&mut ctx_b).await.unwrap();
+            }
+        );
+
+        let (val_a_gb, val_b_gb, val_c_gb) = (
+            fut_a_gb.try_recv().unwrap().unwrap(),
+            fut_b_gb.try_recv().unwrap().unwrap(),
+            fut_c_gb.try_recv().unwrap().unwrap(),
+        );
+
+        let (val_a_ev, val_b_ev, val_c_ev) = (
+            fut_a_ev.try_recv().unwrap().unwrap(),
+            fut_b_ev.try_recv().unwrap().unwrap(),
+            fut_c_ev.try_recv().unwrap().unwrap(),
+        );
+
+        assert_eq!(val_a_gb, val_a_ev);
+        assert_eq!(val_b_gb, val_b_ev);
+        assert_eq!(val_c_gb, val_c_ev);
+        assert_eq!(val_a_gb, val_a);
+        assert_eq!(val_b_gb, val_b);
+        assert_eq!(val_c_gb, val_c);
+    }
+
+    #[tokio::test]
+    async fn test_auth_store_decode() {
+        println!("test_auth_store_decode");
+        let mut rng = StdRng::seed_from_u64(0);
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let delta_a = Delta::random(&mut rng).set_lsb(true);
+        let delta_b = Delta::random(&mut rng).set_lsb(false);
+        let (cot_gen_send, cot_eval_recv) = ideal_cot(delta_a.into_inner());
+        let (cot_eval_send, cot_gen_recv) = ideal_cot(delta_b.into_inner());
+        let mut gb = AuthGenStore::new(rng.random(), delta_a, cot_gen_send, cot_gen_recv);
+        let mut ev = AuthEvalStore::new(rng.random(), delta_b, cot_eval_send, cot_eval_recv);
+
+        let val_a = [0u8; 16];
+        let val_b = [42u8; 16];
+        let val_c = [69u8; 16];
+
+        let ref_a_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_public(ref_a_gen).unwrap();
+        let ref_b_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_private(ref_b_gen).unwrap();
+        let ref_c_gen: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_blind(ref_c_gen).unwrap();
+
+        let ref_a_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_public(ref_a_ev).unwrap();
+        let ref_b_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_blind(ref_b_ev).unwrap();
+        let ref_c_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_private(ref_c_ev).unwrap();
+
+        gb.assign(ref_a_gen, val_a).unwrap();
+        gb.assign(ref_b_gen, val_b).unwrap();
+
+        ev.assign(ref_a_ev, val_a).unwrap();
+        ev.assign(ref_c_ev, val_c).unwrap();
+
+        gb.commit(ref_a_gen).unwrap();
+        gb.commit(ref_b_gen).unwrap();
+        gb.commit(ref_c_gen).unwrap();
+
+        ev.commit(ref_a_ev).unwrap();
+        ev.commit(ref_b_ev).unwrap();
+        ev.commit(ref_c_ev).unwrap();
+
+        let mut fut_a_gen = gb.decode(ref_a_gen).unwrap();
+        let mut fut_b_gen = gb.decode(ref_b_gen).unwrap();
+        let mut fut_c_gen = gb.decode(ref_c_gen).unwrap();
+
+        let mut fut_a_ev = ev.decode(ref_a_ev).unwrap();
+        let mut fut_b_ev = ev.decode(ref_b_ev).unwrap();
+        let mut fut_c_ev = ev.decode(ref_c_ev).unwrap();
+
+        tokio::join!(
+            async {
+                gb.flush(&mut ctx_a).await.unwrap();
+            },
+            async {
+                ev.flush(&mut ctx_b).await.unwrap();
+            }
+        );
+
+        let val_a_gen = fut_a_gen.try_recv().unwrap().unwrap();
+        let val_a_ev = fut_a_ev.try_recv().unwrap().unwrap();
+        let val_b_gen = fut_b_gen.try_recv().unwrap().unwrap();
+        let val_b_ev = fut_b_ev.try_recv().unwrap().unwrap();
+        let val_c_gen = fut_c_gen.try_recv().unwrap().unwrap();
+        let val_c_ev = fut_c_ev.try_recv().unwrap().unwrap();
+
+        assert_eq!(val_a_gen, val_a_ev);
+        assert_eq!(val_b_gen, val_b_ev);
+        assert_eq!(val_c_gen, val_c_ev);
+        assert_eq!(val_a_gen, val_a);
+        assert_eq!(val_b_gen, val_b);
+        assert_eq!(val_c_gen, val_c);
+    }
+}

--- a/crates/garble/src/store/auth_eval.rs
+++ b/crates/garble/src/store/auth_eval.rs
@@ -1,0 +1,236 @@
+use async_trait::async_trait;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use mpz_common::{Context, ContextError, Flush};
+use mpz_core::{Block, bitvec::{BitVec, BitSlice}};
+use mpz_garble_core::{
+    Delta, Mac, Key,
+    store::{AuthEvalStore as Core, AuthEvalStoreError as CoreError},
+};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
+use mpz_ot::cot::{COTReceiver, COTSender};
+use serio::{SinkExt, stream::IoStreamExt};
+
+type Error = AuthEvalStoreError;
+type Result<T, E = Error> = core::result::Result<T, E>;
+
+#[derive(Debug)]
+pub(crate) struct AuthEvalStore<S, R> {
+    core: Core<S, R>,
+}
+
+impl<S, R> AuthEvalStore<S, R>
+{
+    pub(crate) fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+        Self { core: Core::new(seed, delta, cot_sender, cot_receiver) }
+    }
+
+    pub(crate) fn delta(&self) -> &Delta {
+        self.core.delta()
+    }
+    
+    pub(crate) fn acquire_cot_sender(&self) -> OwnedMutexGuard<S> {
+        self.core.acquire_cot_sender()
+    }
+
+    pub(crate) fn acquire_cot_receiver(&self) -> OwnedMutexGuard<R> {
+        self.core.acquire_cot_receiver()
+    }
+    
+    pub(crate) fn is_set_macs(&self, slice: Slice) -> bool {
+        self.core.is_set_macs(slice)
+    }
+
+    pub(crate) fn is_set_masks(&self, slice: Slice) -> bool {
+        self.core.is_set_masks(slice)
+    }
+
+    pub(crate) fn is_committed(&self, slice: Slice) -> bool {
+        self.core.is_committed(slice)
+    }
+
+    pub(crate) fn try_get_macs(&self, slice: Slice) -> Result<&[Mac], Error> {
+        self.core.try_get_macs(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_masked_values(&self, slice: Slice) -> Result<&BitSlice, Error> {
+        self.core.try_get_masked_values(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_bits(&self, slice: Slice) -> Result<&BitSlice, Error> {
+        self.core.try_get_mask_bits(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_macs(&self, slice: Slice) -> Result<&[Mac], Error> {
+        self.core.try_get_mask_macs(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_keys(&self, slice: Slice) -> Result<&[Key], Error> {
+        self.core.try_get_mask_keys(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn update_hash(&mut self, hash: Block) {
+        self.core.update_hash(hash);
+    }
+
+    pub(crate) fn get_hash(&self) -> Block {
+        self.core.get_hash()
+    }
+
+    pub(crate) fn alloc_output(&mut self, len: usize) -> Slice {
+        self.core.alloc_output(len)
+    }
+
+    pub(crate) fn set_output(&mut self, slice: Slice, macs: &[Mac], mask_bits: &BitSlice, mask_macs: &[Mac], mask_keys: &[Key], masked_values: &BitSlice) -> Result<(), Error> {
+        self.core.set_output(slice, macs, mask_bits, mask_macs, mask_keys, masked_values).map_err(Error::from)
+    }
+
+    pub(crate) fn mark_output_preprocessed(&mut self, slice: Slice) -> Result<(), Error> {
+        self.core.mark_output_preprocessed(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn flush_decode(&mut self) -> Result<(), Error> {
+        self.core.flush_decode().map_err(Error::from)
+    }
+}
+
+impl<S, R> Memory<Binary> for AuthEvalStore<S, R>
+{
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.core.is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice, Self::Error> {
+        self.core.alloc_raw(size).map_err(Error::from)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.core.is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<(), Self::Error> {
+        self.core.assign_raw(slice, data).map_err(Error::from)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.core.is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.commit_raw(slice).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>, Self::Error> {
+        self.core.get_raw(slice).map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>, Self::Error> {
+        self.core.decode_raw(slice).map_err(Error::from)
+    }
+}
+
+impl<S, R> View<Binary> for AuthEvalStore<S, R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+#[async_trait]
+impl<S, R> Flush for AuthEvalStore<S, R>
+where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    type Error = Error;
+
+    fn wants_flush(&self) -> bool {
+        self.core.wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        while self.core.wants_flush() {
+            let flush = self.core.send_flush()?;
+            let mut cot_sender = self.core.acquire_cot_sender();
+            let mut cot_receiver = self.core.acquire_cot_receiver();
+            let (flush, (), ()) = ctx
+            .try_join3(
+                async |ctx| {
+                    ctx.io_mut().send(flush).await?;
+                    ctx.io_mut().expect_next().await.map_err(Error::from)
+                },
+                async move |ctx| {
+                    let ret = cot_receiver.flush(ctx).await.map_err(Error::cot);
+                    ret
+                },
+                async move |ctx| {
+                    let ret = cot_sender.flush(ctx).await.map_err(Error::cot);
+                    ret
+                },
+            )
+            .await??;
+
+            self.core.receive_flush(flush)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct AuthEvalStoreError(#[from] ErrorRepr);
+
+impl AuthEvalStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] CoreError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("COT error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("context error: {0}")]
+    Context(#[from] ContextError),
+}
+
+impl From<CoreError> for AuthEvalStoreError {
+    fn from(value: CoreError) -> Self {
+        AuthEvalStoreError(ErrorRepr::Core(value))
+    }
+}
+
+impl From<std::io::Error> for AuthEvalStoreError {
+    fn from(value: std::io::Error) -> Self {
+        AuthEvalStoreError(ErrorRepr::Io(value))
+    }
+}
+
+impl From<ContextError> for AuthEvalStoreError {
+    fn from(value: ContextError) -> Self {
+        AuthEvalStoreError(ErrorRepr::Context(value))
+    }
+}

--- a/crates/garble/src/store/auth_gen.rs
+++ b/crates/garble/src/store/auth_gen.rs
@@ -1,0 +1,233 @@
+use async_trait::async_trait;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use mpz_common::{Context, ContextError, Flush};
+use mpz_core::{Block, bitvec::{BitVec, BitSlice}};
+use mpz_garble_core::{
+    Delta, Key, Mac,
+    store::{AuthGenStore as Core, AuthGenStoreError as CoreError},
+};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
+use mpz_ot::cot::{COTReceiver, COTSender};
+use serio::{SinkExt, stream::IoStreamExt};
+
+type Error = AuthGenStoreError;
+
+#[derive(Debug)]
+pub(crate) struct AuthGenStore<S, R> {
+    core: Core<S, R>,
+}
+
+impl<S,R> AuthGenStore<S,R>
+{
+    pub(crate) fn new(seed: [u8; 16], delta: Delta, cot_sender: S, cot_receiver: R) -> Self {
+        Self { core: Core::new(seed, delta, cot_sender, cot_receiver) }
+    }
+
+    pub(crate) fn delta(&self) -> &Delta {
+        self.core.delta()
+    }
+
+    pub(crate) fn acquire_cot_sender(&self) -> OwnedMutexGuard<S> {
+        self.core.acquire_cot_sender()
+    }
+
+    pub(crate) fn acquire_cot_receiver(&self) -> OwnedMutexGuard<R> {
+        self.core.acquire_cot_receiver()
+    }
+    
+    pub(crate) fn is_set_keys(&self, slice: Slice) -> bool {
+        self.core.is_set_keys(slice)
+    }
+
+    pub(crate) fn is_set_masks(&self, slice: Slice) -> bool {
+        self.core.is_set_masks(slice)
+    }
+
+    pub(crate) fn is_committed(&self, slice: Slice) -> bool {
+        self.core.is_committed(slice)
+    }
+
+    pub(crate) fn try_get_keys(&self, slice: Slice) -> Result<&[Key], Error> {
+        self.core.try_get_keys(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_masked_values(&self, slice: Slice) -> Result<&BitSlice, Error> {
+        self.core.try_get_masked_values(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_bits(&self, slice: Slice) -> Result<&BitSlice, Error> {
+        self.core.try_get_mask_bits(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_macs(&self, slice: Slice) -> Result<&[Mac], Error> {
+        self.core.try_get_mask_macs(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn try_get_mask_keys(&self, slice: Slice) -> Result<&[Key], Error> {
+        self.core.try_get_mask_keys(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn update_hash(&mut self, hash: Block) {
+        self.core.update_hash(hash);
+    }
+
+    pub(crate) fn get_hash(&self) -> Block {
+        self.core.get_hash()
+    }
+
+    pub(crate) fn alloc_output(&mut self, len: usize) -> Slice {
+        self.core.alloc_output(len)
+    }
+
+    pub(crate) fn set_output(&mut self, slice: Slice, keys: &[Key], mask_bits: &BitSlice, mask_macs: &[Mac], mask_keys: &[Key]) -> Result<(), Error> {
+        self.core.set_output(slice, keys, mask_bits, mask_macs, mask_keys).map_err(Error::from)
+    }
+
+    pub(crate) fn mark_output_complete(&mut self, slice: Slice) -> Result<(), Error> {
+        self.core.mark_output_complete(slice).map_err(Error::from)
+    }
+    
+}
+
+impl<S,R> Memory<Binary> for AuthGenStore<S,R>
+{
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.core.is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice, Self::Error> {
+        self.core.alloc_raw(size).map_err(Error::from)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.core.is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<(), Self::Error> {
+        self.core.assign_raw(slice, data).map_err(Error::from)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.core.is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.commit_raw(slice).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>, Self::Error> {
+        self.core.get_raw(slice).map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>, Self::Error> {
+        self.core.decode_raw(slice).map_err(Error::from)
+    }
+}
+
+impl<S,R> View<Binary> for AuthGenStore<S,R>
+where
+    S: COTSender<Block>,
+    R: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+#[async_trait]
+impl<S,R> Flush for AuthGenStore<S,R>
+where
+    S: COTSender<Block> + Flush + Send + 'static,
+    R: COTReceiver<bool, Block> + Flush + Send + 'static,
+    R::Future: Send + 'static,
+{
+    type Error = Error;
+
+    fn wants_flush(&self) -> bool {
+        self.core.wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        while self.core.wants_flush() {
+            let flush = self.core.send_flush()?;
+            let mut cot_sender = self.core.acquire_cot_sender();
+            let mut cot_receiver = self.core.acquire_cot_receiver();
+
+            let (flush, (), ()) = ctx
+            .try_join3(
+                async |ctx| {
+                    ctx.io_mut().send(flush).await?;
+                    ctx.io_mut().expect_next().await.map_err(Error::from)
+                },
+                async move |ctx| {
+                    let ret = cot_sender.flush(ctx).await.map_err(Error::cot);
+                    ret
+                },
+                async move |ctx| {
+                    let ret = cot_receiver.flush(ctx).await.map_err(Error::cot);
+                    ret
+                },
+            )
+            .await??;
+
+            self.core.receive_flush(flush)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct AuthGenStoreError(#[from] ErrorRepr);
+
+impl AuthGenStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] CoreError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("COT error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("context error: {0}")]
+    Context(#[from] ContextError),
+}
+
+impl From<CoreError> for AuthGenStoreError {
+    fn from(value: CoreError) -> Self {
+        AuthGenStoreError(ErrorRepr::Core(value))
+    }
+}
+
+impl From<std::io::Error> for AuthGenStoreError {
+    fn from(value: std::io::Error) -> Self {
+        AuthGenStoreError(ErrorRepr::Io(value))
+    }
+}
+
+impl From<ContextError> for AuthGenStoreError {
+    fn from(value: ContextError) -> Self {
+        AuthGenStoreError(ErrorRepr::Context(value))
+    }
+}

--- a/crates/memory-core/src/correlated.rs
+++ b/crates/memory-core/src/correlated.rs
@@ -55,11 +55,13 @@
 
 mod keys;
 mod macs;
+mod auth;
 
 use std::{ops::BitXor, sync::LazyLock};
 
 pub use keys::{Key, KeyStore, KeyStoreError};
 pub use macs::{Mac, MacStore, MacStoreError};
+pub use auth::{AuthBit, AuthBitStore, AuthBitStoreError};
 
 use mpz_core::{
     Block,
@@ -103,10 +105,26 @@ impl Delta {
         Self(value)
     }
 
+    /// Set the pointer bit of the Delta
+    #[inline]
+    pub fn set_lsb(mut self, value: bool) -> Self {
+        self.0.set_lsb(value);
+        self
+    }
+
     /// Generate a random block using the provided RNG
     #[inline]
     pub fn random<R: Rng + CryptoRng + ?Sized>(rng: &mut R) -> Self {
         Self::new(rng.random())
+    }
+
+    #[inline]
+    pub fn mul_bool(self, value: bool) -> Block {
+        if value {
+            self.0
+        } else {
+            Block::ZERO
+        }
     }
 
     /// Returns the inner block

--- a/crates/memory-core/src/correlated/auth.rs
+++ b/crates/memory-core/src/correlated/auth.rs
@@ -1,0 +1,235 @@
+use mpz_core::bitvec::{BitSlice, BitVec};
+
+use crate::{
+    correlated::{Delta, Key, Mac, MacStore, KeyStore, MacStoreError, KeyStoreError},
+    store::{BitStore, StoreError},
+    RangeSet, Slice,
+};
+
+type Result<T> = core::result::Result<T, AuthBitStoreError>;
+
+/// A store for authenticated bits, consisting of a bool value, a MAC, and a Key.
+#[derive(Debug, Clone, Copy)]
+pub struct AuthBit {
+    value: bool,
+    mac: Mac,
+    key: Key,
+}
+
+impl AuthBit {
+    /// Creates a new authenticated bit.
+    #[inline]
+    pub fn new(value: bool, mac: Mac, key: Key) -> Self {
+        Self { value, mac, key }
+    }
+
+    /// Returns the value of the authenticated bit.
+    #[inline]
+    pub fn value(&self) -> bool {
+        self.value
+    }
+
+    /// Returns the MAC of the authenticated bit.
+    #[inline]
+    pub fn mac(&self) -> &Mac {
+        &self.mac
+    }
+
+    /// Returns the key of the authenticated bit.
+    #[inline]
+    pub fn key(&self) -> &Key {
+        &self.key
+    }
+
+    /// Sets the value of the authenticated bit.
+    #[inline]
+    pub fn set_value(&mut self, value: bool) {
+        self.value = value;
+    }
+}
+
+/// A linear store which manages authenticated bits.
+#[derive(Debug, Clone)]
+pub struct AuthBitStore {
+    bits: BitStore,
+    macs: MacStore,
+    keys: KeyStore,
+}
+
+impl AuthBitStore {
+    /// Creates a new authenticated bit store.
+    #[inline]
+    pub fn new(delta: Delta) -> Self {
+        Self {
+            bits: BitStore::new(),
+            macs: MacStore::new(),
+            keys: KeyStore::new(delta),
+        }
+    }
+
+    /// Returns the delta of the authenticated bit store.
+    #[inline]
+    pub fn delta(&self) -> &Delta {
+        self.keys.delta()
+    }
+
+    /// Returns whether all the authenticated bits are set.
+    #[inline]
+    pub fn is_set(&self, slice: Slice) -> bool {
+        self.bits.is_set(slice)
+    }
+
+    /// Returns the ranges which have authenticated bits set.
+    #[inline]
+    pub fn set_ranges(&self) -> &RangeSet {
+        self.bits.set_ranges()
+    }
+
+    /// Allocates uninitialized memory.
+    #[inline]
+    pub fn alloc(&mut self, len: usize) -> Slice {
+        self.bits.alloc(len);
+        self.macs.alloc(len);
+        self.keys.alloc(len)
+    }
+
+    /// Allocates bits.
+    #[inline]
+    pub fn alloc_bits(&mut self, bits: &BitSlice) -> Slice {
+        self.bits.alloc_with(bits)
+    }
+
+    /// Allocates bits.
+    #[inline]
+    pub fn alloc_macs(&mut self, macs: &[Mac]) -> Slice {
+        self.macs.alloc_with(macs)
+    }
+
+    /// Allocates keys.
+    #[inline]
+    pub fn alloc_keys(&mut self, keys: &[Key]) -> Slice {
+        self.keys.alloc_with(keys)
+    }
+
+    /// Returns bits if they are set.
+    #[inline]
+    pub fn try_get_bits(&self, slice: Slice) -> Result<&BitSlice> {
+        self.bits.try_get(slice).map_err(From::from)
+    }
+
+    /// Returns bits if they are set.
+    #[inline]
+    pub fn try_get_macs(&self, slice: Slice) -> Result<&[Mac]> {
+        self.macs.try_get(slice).map_err(From::from)
+    }
+
+    /// Returns keys if they are set.
+    #[inline]
+    pub fn try_get_keys(&self, slice: Slice) -> Result<&[Key]> {
+        self.keys.try_get(slice).map_err(From::from)
+    }
+
+    /// Sets authenticated bits, returning an error if they are already set.
+    #[inline]
+    pub fn try_set_bits(&mut self, slice: Slice, bits: &BitSlice) -> Result<()> {
+        self.bits.try_set(slice, bits).map_err(From::from)
+    }
+
+    /// Sets authenticated bits, returning an error if they are already set.
+    #[inline]
+    pub fn try_set_macs(&mut self, slice: Slice, macs: &[Mac]) -> Result<()> {
+        self.macs.try_set(slice, macs).map_err(From::from)
+    }
+
+    /// Sets authenticated bits, returning an error if they are already set.
+    #[inline]
+    pub fn try_set_keys(&mut self, slice: Slice, keys: &[Key]) -> Result<()> {
+        self.keys.try_set(slice, keys).map_err(From::from)
+    }
+
+    /// Proves MACs.
+    ///
+    /// # Arguments
+    ///
+    /// * `ranges` - Ranges to prove.
+    pub fn prove_share(&self, ranges: &RangeSet) -> Result<(BitVec, Vec<Mac>)> {
+        let mut bits = BitVec::with_capacity(ranges.len());
+        let mut macs = Vec::with_capacity(ranges.len());
+        for range in ranges.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let slice_bits = self.bits.try_get(slice)?;
+            let slice_macs = self.macs.try_get(slice)?;    
+            for (bit, mac) in slice_bits.iter().zip(slice_macs) {
+                bits.push(*bit);
+                macs.push(*mac);
+            }
+        }
+
+        Ok((bits, macs))
+    }
+
+    pub fn check_share(&mut self, ranges: &RangeSet, bits: &BitVec, macs: &[Mac]) -> Result<()> {
+        let mut expected_macs = Vec::with_capacity(ranges.len());
+        for range in ranges.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            expected_macs.extend(self.keys.authenticate(slice, bits)?);
+        }
+
+        if expected_macs != macs {
+            return Err(AuthBitStoreError::Verify);
+        }
+        
+        Ok(())
+    }
+
+}
+
+/// Error for [`AuthBitStore`].
+#[derive(Debug, thiserror::Error)]
+pub enum AuthBitStoreError {
+    #[error("invalid slice: {}", .0)]
+    InvalidSlice(Slice),
+    #[error("authenticated bits are not initialized: {}", .0)]
+    Uninit(Slice),
+    #[error("authenticated bits are already set: {}", .0)]
+    AlreadySet(Slice),
+    #[error("authenticated bits are already assigned: {}", .0)]
+    AlreadyAssigned(Slice),
+    #[error("authenticated bits verification failed")]
+    Verify,
+}
+
+impl From<StoreError> for AuthBitStoreError {
+    fn from(err: StoreError) -> Self {
+        match err {
+            StoreError::InvalidSlice(slice) => Self::InvalidSlice(slice),
+            StoreError::Uninit(slice) => Self::Uninit(slice),
+            StoreError::AlreadySet(slice) => Self::AlreadySet(slice),
+        }
+    }
+}
+
+impl From<MacStoreError> for AuthBitStoreError {
+    fn from(err: MacStoreError) -> Self {
+        match err {
+            MacStoreError::InvalidSlice(slice) => Self::InvalidSlice(slice),
+            MacStoreError::Uninit(slice) => Self::Uninit(slice),
+            MacStoreError::AlreadySet(slice) => Self::AlreadySet(slice),
+            MacStoreError::AlreadyAssigned(slice) => Self::AlreadyAssigned(slice),
+            MacStoreError::Verify => Self::Verify,
+        }
+    }
+}
+
+impl From<KeyStoreError> for AuthBitStoreError {
+    fn from(err: KeyStoreError) -> Self {
+        match err {
+            KeyStoreError::InvalidSlice(slice) => Self::InvalidSlice(slice),
+            KeyStoreError::Uninit(slice) => Self::Uninit(slice),
+            KeyStoreError::AlreadySet(slice) => Self::AlreadySet(slice),
+            KeyStoreError::AlreadyAssigned(slice) => Self::AlreadyAssigned(slice),
+            KeyStoreError::Verify => Self::Verify,
+        }
+    }
+}
+

--- a/crates/memory-core/src/correlated/keys.rs
+++ b/crates/memory-core/src/correlated/keys.rs
@@ -28,6 +28,12 @@ impl Key {
         self.0.lsb()
     }
 
+    /// Sets the pointer bit.
+    #[inline]
+    pub fn set_pointer(&mut self, bit: bool) {
+        self.0.set_lsb(bit);
+    }
+
     /// Adjusts the truth value of the corresponding MAC.
     #[inline]
     pub fn adjust(&mut self, adjust: bool, delta: &Delta) {

--- a/crates/memory-core/src/lib.rs
+++ b/crates/memory-core/src/lib.rs
@@ -126,6 +126,7 @@ pub trait MemoryExt<T: MemoryType>: Memory<T> {
     /// Decodes the value.
     ///
     /// Returns a future which will resolve to the value when it is ready.
+    /// Also decodes the evaluator's inputs if included in the decode range.
     fn decode<R>(&mut self, value: R) -> Result<DecodeFutureTyped<T::Raw, R::Clear>, Self::Error>
     where
         R: Repr<T>,

--- a/crates/memory-core/src/store.rs
+++ b/crates/memory-core/src/store.rs
@@ -227,6 +227,24 @@ impl BitStore {
 
         Ok(())
     }
+
+    /// Updates the bits at the given slice by XORing with the provided bits
+    pub fn update_xor(&mut self, slice: Slice, bits: &BitSlice) -> Result<()> {
+        assert_eq!(
+            slice.size,
+            bits.len(),
+            "bits are not the same length as the slice"
+        );
+
+        self.try_get_mut(slice)?
+            .iter_mut()
+            .zip(bits)
+            .for_each(|(mut bit, update)| {
+                *bit ^= *update;
+            });
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
This PR adds optimized authenticated garbling (distributed half-gates from https://eprint.iacr.org/2018/578) to garble/ and garble-core/. The commits have been squashed and rebased onto dev as requested in #217. 