### PR TITLE
fix: adjust frame limit for garbler and evaluator dependent on message size

### DIFF
--- a/crates/garble-core/src/lib.rs
+++ b/crates/garble-core/src/lib.rs
@@ -20,6 +20,7 @@ pub use garbler::{
     EncryptedGateBatchIter, EncryptedGateIter, Garbler, GarblerError, GarblerOutput,
 };
 pub use mpz_memory_core::correlated::{Delta, Key, Mac};
+pub use view::FlushView;
 
 const KB: usize = 1024;
 const BYTES_PER_GATE: usize = 32;

--- a/crates/garble-core/src/store.rs
+++ b/crates/garble-core/src/store.rs
@@ -27,6 +27,13 @@ pub struct GarblerFlush {
     mac_commitments: Vec<MacCommitment>,
 }
 
+impl GarblerFlush {
+    /// Returns the inner [`FlushView`].
+    pub fn view(&self) -> &FlushView {
+        &self.view
+    }
+}
+
 /// Flush message sent by the evaluator.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(try_from = "validation::EvaluatorFlushUnchecked")]
@@ -35,6 +42,13 @@ pub struct EvaluatorFlush {
     view: FlushView,
     /// Proof of MACs for decoding.
     mac_proof: Option<MacProof>,
+}
+
+impl EvaluatorFlush {
+    /// Returns the inner [`FlushView`].
+    pub fn view(&self) -> &FlushView {
+        &self.view
+    }
 }
 
 /// MAC proof sent from the evaluator to the garbler to prove

--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -1,8 +1,8 @@
 use mpz_memory_core::{
     Slice, View as ViewTrait, binary::Binary, correlated::Mac, view::VisibilityView,
 };
+use rangeset::{Difference, Disjoint, Intersection, Subset};
 use serde::{Deserialize, Serialize};
-use utils::range::{Difference, Disjoint, Intersection, Subset};
 
 type Range = std::ops::Range<usize>;
 type RangeSet = rangeset::RangeSet<usize>;

--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -1,6 +1,8 @@
-use mpz_memory_core::{Slice, View as ViewTrait, binary::Binary, view::VisibilityView};
-use rangeset::{Difference, Disjoint, Intersection, Subset};
+use mpz_memory_core::{
+    Slice, View as ViewTrait, binary::Binary, correlated::Mac, view::VisibilityView,
+};
 use serde::{Deserialize, Serialize};
+use utils::range::{Difference, Disjoint, Intersection, Subset};
 
 type Range = std::ops::Range<usize>;
 type RangeSet = rangeset::RangeSet<usize>;
@@ -36,8 +38,9 @@ struct DecodeView {
     all: RangeSet,
 }
 
+/// Information on the content of the expected flushes.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct FlushView {
+pub struct FlushView {
     /// Ranges for which the garbler is to send MACs.
     pub(crate) macs: RangeSet,
     /// Ranges for which the garbler is to send MACs using oblivious
@@ -50,6 +53,29 @@ pub(crate) struct FlushView {
 }
 
 impl FlushView {
+    /// Returns the expected garbler flush size in bytes.
+    pub fn garbler_flush_size(&self) -> usize {
+        let macs = self.macs.len() * Mac::BIT_SIZE;
+        let decode_info = self.decode_info.len();
+        let mac_commitments = self.decode_info.len() * Mac::BIT_SIZE * 2;
+
+        // Add 128 bytes of cushion room.
+        (macs + decode_info + mac_commitments) / 8 + self.size() + 128
+    }
+
+    /// Returns the expected evaluator flush size in bytes.
+    /// [`blake3`]
+    pub fn evaluator_flush_size(&self) -> usize {
+        let proof_size = if self.decode.is_empty() {
+            0
+        } else {
+            blake3::OUT_LEN
+        };
+
+        // Add 128 bytes of cushion room.
+        self.decode.len() / 8 + proof_size + self.size() + 128
+    }
+
     /// Returns `true` if the flush state is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.macs.is_empty()
@@ -64,6 +90,16 @@ impl FlushView {
         self.ot.clear();
         self.decode_info.clear();
         self.decode.clear();
+    }
+
+    /// Returns the size in bytes for [`FlushView`].
+    fn size(&self) -> usize {
+        let range_count = self.macs.len_ranges()
+            + self.ot.len_ranges()
+            + self.decode_info.len_ranges()
+            + self.decode.len_ranges();
+
+        range_count * 2 * usize::BITS as usize / 8
     }
 }
 

--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -64,7 +64,6 @@ impl FlushView {
     }
 
     /// Returns the expected evaluator flush size in bytes.
-    /// [`blake3`]
     pub fn evaluator_flush_size(&self) -> usize {
         let proof_size = if self.decode.is_empty() {
             0

--- a/crates/garble/Cargo.toml
+++ b/crates/garble/Cargo.toml
@@ -36,6 +36,7 @@ serde = { workspace = true, features = ["derive"] }
 hashbrown = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+bincode = { workspace = true }
 
 [dev-dependencies]
 mpz-common = { workspace = true, features = ["test-utils", "ideal"] }

--- a/crates/garble/Cargo.toml
+++ b/crates/garble/Cargo.toml
@@ -36,7 +36,6 @@ serde = { workspace = true, features = ["derive"] }
 hashbrown = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
-bincode = { workspace = true }
 
 [dev-dependencies]
 mpz-common = { workspace = true, features = ["test-utils", "ideal"] }

--- a/crates/garble/src/store/evaluator.rs
+++ b/crates/garble/src/store/evaluator.rs
@@ -120,17 +120,18 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
-            //------------------------------------------
-            let flush_size = bincode::serialized_size(&flush).unwrap();
-            println!("evaluator flush size: {}", &flush_size);
-            //------------------------------------------
+            let garbler_flush_size = flush.view().garbler_flush_size();
+            let evaluator_flush_size = flush.view().evaluator_flush_size();
 
             let (flush, ()) = ctx
                 .try_join(
-                    async |ctx| {
-                        ctx.io_mut().send(flush).await?;
+                    async move |ctx| {
                         ctx.io_mut()
-                            .with_limit(1024 * 1024 * 1024)
+                            .with_limit(evaluator_flush_size)
+                            .send(flush)
+                            .await?;
+                        ctx.io_mut()
+                            .with_limit(garbler_flush_size)
                             .expect_next()
                             .await
                             .map_err(Error::from)

--- a/crates/garble/src/store/evaluator.rs
+++ b/crates/garble/src/store/evaluator.rs
@@ -123,8 +123,15 @@ where
             let (flush, ()) = ctx
                 .try_join(
                     async |ctx| {
-                        ctx.io_mut().send(flush).await?;
-                        ctx.io_mut().expect_next().await.map_err(Error::from)
+                        ctx.io_mut()
+                            .with_limit(1024 * 1024 * 1024)
+                            .send(flush)
+                            .await?;
+                        ctx.io_mut()
+                            .with_limit(1024 * 1024 * 1024)
+                            .expect_next()
+                            .await
+                            .map_err(Error::from)
                     },
                     async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
                 )

--- a/crates/garble/src/store/evaluator.rs
+++ b/crates/garble/src/store/evaluator.rs
@@ -120,13 +120,15 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
+            //------------------------------------------
+            let flush_size = bincode::serialized_size(&flush).unwrap();
+            println!("evaluator flush size: {}", &flush_size);
+            //------------------------------------------
+
             let (flush, ()) = ctx
                 .try_join(
                     async |ctx| {
-                        ctx.io_mut()
-                            .with_limit(1024 * 1024 * 1024)
-                            .send(flush)
-                            .await?;
+                        ctx.io_mut().send(flush).await?;
                         ctx.io_mut()
                             .with_limit(1024 * 1024 * 1024)
                             .expect_next()

--- a/crates/garble/src/store/garbler.rs
+++ b/crates/garble/src/store/garbler.rs
@@ -120,19 +120,21 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
-            //------------------------------------------
-            let flush_size = bincode::serialized_size(&flush).unwrap();
-            println!("garbler flush size: {}", &flush_size);
-            //------------------------------------------
+            let garbler_flush_size = flush.view().garbler_flush_size();
+            let evaluator_flush_size = flush.view().evaluator_flush_size();
 
             let (flush, ()) = ctx
                 .try_join(
-                    async |ctx| {
+                    async move |ctx| {
                         ctx.io_mut()
-                            .with_limit(1024 * 1024 * 1024)
+                            .with_limit(garbler_flush_size)
                             .send(flush)
                             .await?;
-                        ctx.io_mut().expect_next().await.map_err(Error::from)
+                        ctx.io_mut()
+                            .with_limit(evaluator_flush_size)
+                            .expect_next()
+                            .await
+                            .map_err(Error::from)
                     },
                     async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
                 )

--- a/crates/garble/src/store/garbler.rs
+++ b/crates/garble/src/store/garbler.rs
@@ -123,8 +123,15 @@ where
             let (flush, ()) = ctx
                 .try_join(
                     async |ctx| {
-                        ctx.io_mut().send(flush).await?;
-                        ctx.io_mut().expect_next().await.map_err(Error::from)
+                        ctx.io_mut()
+                            .with_limit(1024 * 1024 * 1024)
+                            .send(flush)
+                            .await?;
+                        ctx.io_mut()
+                            .with_limit(1024 * 1024 * 1024)
+                            .expect_next()
+                            .await
+                            .map_err(Error::from)
                     },
                     async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
                 )

--- a/crates/garble/src/store/garbler.rs
+++ b/crates/garble/src/store/garbler.rs
@@ -120,6 +120,11 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
+            //------------------------------------------
+            let flush_size = bincode::serialized_size(&flush).unwrap();
+            println!("garbler flush size: {}", &flush_size);
+            //------------------------------------------
+
             let (flush, ()) = ctx
                 .try_join(
                     async |ctx| {
@@ -127,11 +132,7 @@ where
                             .with_limit(1024 * 1024 * 1024)
                             .send(flush)
                             .await?;
-                        ctx.io_mut()
-                            .with_limit(1024 * 1024 * 1024)
-                            .expect_next()
-                            .await
-                            .map_err(Error::from)
+                        ctx.io_mut().expect_next().await.map_err(Error::from)
                     },
                     async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
                 )

--- a/crates/memory-core/src/correlated/macs.rs
+++ b/crates/memory-core/src/correlated/macs.rs
@@ -22,6 +22,7 @@ pub struct Mac(Block);
 impl Mac {
     /// Public MACs.
     pub const PUBLIC: [Mac; 2] = [Mac(MAC_ZERO), Mac(MAC_ONE)];
+    pub const BIT_SIZE: usize = 128;
 
     /// Creates a new MAC.
     #[inline]


### PR DESCRIPTION
This PR sets the frame size for `GarblerFlush` and `EvaluatorFlush` depending on information from the synchronized `FlushView`.

Closes #284.