### PR TITLE
fix(zk): remove redundant verifier flush

### DIFF
--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -110,12 +110,12 @@ mod tests {
         assert!(verifier_store.wants_flush());
 
         let flush_p = prover_store.send_flush(&mut prover_transcript).unwrap();
-        let flush_v = verifier_store.send_flush().unwrap();
+        verifier_store.mark_flush_pending().unwrap();
 
-        prover_store.receive_flush(flush_v).unwrap();
         verifier_store
             .receive_flush(flush_p, &mut verifier_transcript)
             .unwrap();
+        prover_store.complete_flush().unwrap();
 
         let mut prover = Prover::default();
         let mut verifier = Verifier::new(delta);
@@ -192,12 +192,12 @@ mod tests {
         assert!(verifier_store.wants_flush());
 
         let flush_p = prover_store.send_flush(&mut prover_transcript).unwrap();
-        let flush_v = verifier_store.send_flush().unwrap();
+        verifier_store.mark_flush_pending().unwrap();
 
-        prover_store.receive_flush(flush_v).unwrap();
         verifier_store
             .receive_flush(flush_p, &mut verifier_transcript)
             .unwrap();
+        prover_store.complete_flush().unwrap();
 
         let out_p = out_p.try_recv().unwrap().unwrap();
         let out_v = out_v.try_recv().unwrap().unwrap();

--- a/crates/zk-core/src/store.rs
+++ b/crates/zk-core/src/store.rs
@@ -18,11 +18,6 @@ pub struct ProverFlush {
     mac_proof: Option<(BitVec, Hash)>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct VerifierFlush {
-    view: FlushView,
-}
-
 mod validation {
     use super::*;
 
@@ -130,25 +125,25 @@ mod tests {
         assert!(verifier.wants_flush());
         assert!(prover.wants_flush());
 
-        let flush_v = verifier.send_flush().unwrap();
+        verifier.mark_flush_pending().unwrap();
         let flush_p = prover.send_flush(&mut prover_transcript).unwrap();
 
         verifier
             .receive_flush(flush_p, &mut verifier_transcript)
             .unwrap();
-        prover.receive_flush(flush_v).unwrap();
+        prover.complete_flush().unwrap();
 
         // Prove
         assert!(verifier.wants_flush());
         assert!(prover.wants_flush());
 
-        let flush_v = verifier.send_flush().unwrap();
+        verifier.mark_flush_pending().unwrap();
         let flush_p = prover.send_flush(&mut prover_transcript).unwrap();
 
         verifier
             .receive_flush(flush_p, &mut verifier_transcript)
             .unwrap();
-        prover.receive_flush(flush_v).unwrap();
+        prover.complete_flush().unwrap();
 
         let b_v = b_v.try_recv().unwrap().unwrap();
 

--- a/crates/zk-core/src/store/prover.rs
+++ b/crates/zk-core/src/store/prover.rs
@@ -9,8 +9,8 @@ use mpz_memory_core::{
 use zerocopy::IntoBytes;
 
 use crate::{
-    store::{ProverFlush, VerifierFlush},
-    view::{FlushView, View, ViewError},
+    store::ProverFlush,
+    view::{View, ViewError},
 };
 
 type Error = ProverStoreError;
@@ -147,20 +147,12 @@ impl ProverStore {
         Ok(flush)
     }
 
-    pub fn receive_flush(&mut self, flush: VerifierFlush) -> Result<()> {
+    pub fn complete_flush(&mut self) -> Result<()> {
         if !self.pending {
             return Err(ErrorRepr::UnexpectedFlush.into());
         }
 
-        let VerifierFlush { view } = flush;
-
-        if &view != self.view.flush() {
-            return Err(ErrorRepr::Flush {
-                expected: self.view.flush().clone(),
-                actual: view,
-            }
-            .into());
-        }
+        let view = self.view.flush().clone();
 
         self.view.complete_flush(view);
         self.flush_decode()?;
@@ -293,11 +285,6 @@ enum ErrorRepr {
     WrongMacCount { expected: usize, actual: usize },
     #[error("store was not expecting a flush")]
     UnexpectedFlush,
-    #[error("verifier flush view mismatch: expected {expected:?}, got {actual:?}")]
-    Flush {
-        expected: FlushView,
-        actual: FlushView,
-    },
 }
 
 impl From<MacStoreError> for ProverStoreError {

--- a/crates/zk-core/src/store/verifier.rs
+++ b/crates/zk-core/src/store/verifier.rs
@@ -9,7 +9,7 @@ use mpz_memory_core::{
 use zerocopy::IntoBytes;
 
 use crate::{
-    store::{ProverFlush, VerifierFlush},
+    store::ProverFlush,
     view::{FlushView, View, ViewError},
 };
 
@@ -96,18 +96,14 @@ impl VerifierStore {
         Ok(())
     }
 
-    pub fn send_flush(&mut self) -> Result<VerifierFlush> {
+    pub fn mark_flush_pending(&mut self) -> Result<()> {
         if self.pending {
             return Err(ErrorRepr::UnexpectedFlush.into());
         }
 
         self.pending = true;
 
-        let flush = VerifierFlush {
-            view: self.view.flush().clone(),
-        };
-
-        Ok(flush)
+        Ok(())
     }
 
     pub fn receive_flush(&mut self, flush: ProverFlush, transcript: &mut Hasher) -> Result<()> {

--- a/crates/zk-core/src/view.rs
+++ b/crates/zk-core/src/view.rs
@@ -268,7 +268,7 @@ impl View {
         self.input.complete |= &view.commit;
         // Since the verifier learned the plaintext of the proven ranges, those ranges
         // are now decoded.
-        self.decode.complete |= view.prove;
+        self.decode.complete |= &view.prove;
 
         self.flush.clear();
 

--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -8,7 +8,7 @@ use mpz_vm_core::{
     memory::{DecodeFuture, Memory, Repr, Slice, View, binary::Binary, correlated::Mac},
 };
 use mpz_zk_core::{Prover as Core, ProverError, store::ProverStore};
-use serio::{SinkExt, stream::IoStreamExt};
+use serio::SinkExt;
 
 #[derive(Debug)]
 pub struct Prover<OT> {
@@ -77,13 +77,12 @@ where
         }
 
         while self.store.wants_flush() {
-            let flush = self
+            let flush: mpz_zk_core::store::ProverFlush = self
                 .store
                 .send_flush(&mut self.transcript)
                 .map_err(VmError::memory)?;
             ctx.io_mut().send(flush).await?;
-            let flush = ctx.io_mut().expect_next().await?;
-            self.store.receive_flush(flush).map_err(VmError::memory)?;
+            self.store.complete_flush().map_err(VmError::memory)?;
         }
 
         Ok(())

--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -77,7 +77,7 @@ where
         }
 
         while self.store.wants_flush() {
-            let flush: mpz_zk_core::store::ProverFlush = self
+            let flush = self
                 .store
                 .send_flush(&mut self.transcript)
                 .map_err(VmError::memory)?;

--- a/crates/zk/src/verifier.rs
+++ b/crates/zk/src/verifier.rs
@@ -12,7 +12,7 @@ use mpz_vm_core::{
     },
 };
 use mpz_zk_core::{Verifier as Core, VerifierError, store::VerifierStore};
-use serio::{SinkExt, stream::IoStreamExt};
+use serio::stream::IoStreamExt;
 
 #[derive(Debug)]
 pub struct Verifier<OT> {
@@ -74,8 +74,7 @@ where
         }
 
         while self.store.wants_flush() {
-            let flush = self.store.send_flush().map_err(VmError::memory)?;
-            ctx.io_mut().send(flush).await?;
+            self.store.mark_flush_pending().map_err(VmError::memory)?;
             let flush = ctx.io_mut().expect_next().await?;
             self.store
                 .receive_flush(flush, &mut self.transcript)


### PR DESCRIPTION
This PR removes the redundant zk verifier flush message, improving prover latency.

Closes https://github.com/privacy-scaling-explorations/mpz/issues/245