### PR TITLE
feat(garble): flush and preprocess in parallel

### DIFF
--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -5,6 +5,30 @@ mod garbler;
 
 pub use evaluator::Evaluator;
 pub use garbler::Garbler;
+use mpz_memory_core::Slice;
+use mpz_vm_core::Call;
+use rangeset::{Disjoint, RangeSet};
+
+/// Takes those calls from the `call_stack` which are ready for preprocessing.
+fn take_preprocess_calls(call_stack: &mut Vec<(Call, Slice)>) -> Vec<(Call, Slice)> {
+    let mut idx_outputs = RangeSet::default();
+    call_stack
+        // Extract calls which have no dependencies on other prior calls.
+        .extract_if(.., |(call, output)| {
+            if call
+                .inputs()
+                .iter()
+                .all(|input| input.to_range().is_disjoint(&idx_outputs))
+            {
+                idx_outputs |= output.to_range();
+                true
+            } else {
+                idx_outputs |= output.to_range();
+                false
+            }
+        })
+        .collect()
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -223,8 +223,12 @@ mod tests {
         let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
 
         // Put the sender and the receiver in a state where they want to flush.
-        let _ = cot_send.queue_send_cot(&[Block::default()]).unwrap();
-        let _ = cot_recv.queue_recv_cot(&[true]).unwrap();
+        let _ = cot_send
+            .queue_send_cot(&[Block::default()])
+            .unwrap()
+            .await
+            .unwrap();
+        let _ = cot_recv.queue_recv_cot(&[true]).unwrap().await.unwrap();
         assert!(cot_send.wants_flush());
         assert!(cot_recv.wants_flush());
 

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -247,8 +247,8 @@ mod tests {
         let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
 
         // Put the sender and the receiver in a state where they want to flush.
-        let _ = cot_send.queue_send_cot(&[Block::default()]).unwrap();
-        let _ = cot_recv.queue_recv_cot(&[true]).unwrap();
+        drop(cot_send.queue_send_cot(&[Block::default()]).unwrap());
+        drop(cot_recv.queue_recv_cot(&[true]).unwrap());
         assert!(cot_send.wants_flush());
         assert!(cot_recv.wants_flush());
 

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -247,12 +247,8 @@ mod tests {
         let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
 
         // Put the sender and the receiver in a state where they want to flush.
-        let _ = cot_send
-            .queue_send_cot(&[Block::default()])
-            .unwrap()
-            .await
-            .unwrap();
-        let _ = cot_recv.queue_recv_cot(&[true]).unwrap().await.unwrap();
+        let _ = cot_send.queue_send_cot(&[Block::default()]).unwrap();
+        let _ = cot_recv.queue_recv_cot(&[true]).unwrap();
         assert!(cot_send.wants_flush());
         assert!(cot_recv.wants_flush());
 

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -9,13 +9,17 @@ pub use garbler::Garbler;
 #[cfg(test)]
 mod tests {
     use mpz_circuits::circuits::AES128;
-    use mpz_common::context::test_st_context;
+    use mpz_common::{Flush, context::test_st_context};
+    use mpz_core::Block;
     use mpz_memory_core::{
         Array, MemoryExt, ViewExt,
         binary::{Binary, U8},
         correlated::Delta,
     };
-    use mpz_ot::ideal::cot::{IdealCOTReceiver, IdealCOTSender, ideal_cot};
+    use mpz_ot::{
+        cot::{COTReceiver, COTSender},
+        ideal::cot::{IdealCOTReceiver, IdealCOTSender, ideal_cot},
+    };
     use mpz_vm_core::{Call, CallableExt, Execute, Vm};
     use rand::{SeedableRng, rngs::StdRng};
 
@@ -207,5 +211,38 @@ mod tests {
         );
 
         assert_eq!(gen_out, ev_out);
+    }
+
+    #[tokio::test]
+    // Tests that OT is flushed when `preprocess` is called.
+    async fn test_semihonest_concurrent_flush() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
+
+        // Put the sender and the receiver in a state where they want to flush.
+        let _ = cot_send.queue_send_cot(&[Block::default()]).unwrap();
+        let _ = cot_recv.queue_recv_cot(&[true]).unwrap();
+        assert!(cot_send.wants_flush());
+        assert!(cot_recv.wants_flush());
+
+        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = Evaluator::new(cot_recv);
+
+        let (_, _) = futures::join!(
+            async {
+                gb.preprocess(&mut ctx_a).await.unwrap();
+            },
+            async {
+                ev.preprocess(&mut ctx_b).await.unwrap();
+            }
+        );
+
+        let gb_cot = gb.store().try_lock().unwrap().acquire_cot();
+        let ev_cot = ev.store().try_lock().unwrap().acquire_cot();
+        assert!(!gb_cot.wants_flush());
+        assert!(!ev_cot.wants_flush());
     }
 }

--- a/crates/garble/src/protocol/semihonest/evaluator.rs
+++ b/crates/garble/src/protocol/semihonest/evaluator.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use hashbrown::HashMap;
-use rangeset::{Disjoint, RangeSet};
 use tokio::sync::Mutex;
 
 use mpz_common::{Context, Flush};
@@ -12,7 +11,10 @@ use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
 use mpz_ot::cot::COTReceiver;
 use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
 
-use crate::{evaluator::receive_garbled_circuit, store::EvaluatorStore};
+use crate::{
+    evaluator::receive_garbled_circuit, protocol::semihonest::take_preprocess_calls,
+    store::EvaluatorStore,
+};
 
 /// Semi-honest evaluator.
 #[derive(Debug)]
@@ -228,7 +230,7 @@ where
 
         let mut call_stack = std::mem::take(&mut self.call_stack);
 
-        let (_, (preprocessed, call_stack)) = ctx
+        let (_, preprocessed) = ctx
             .try_join(
                 async move |ctx| {
                     // This flush is primarily intended to perform OT setup
@@ -241,9 +243,9 @@ where
                     while !call_stack.is_empty() {
                         let calls = take_preprocess_calls(&mut call_stack);
 
-                        if calls.is_empty() {
-                            break;
-                        }
+                        // There must be at least one call ready for preprocessing
+                        // in a non-empty call stack.
+                        debug_assert!(!calls.is_empty());
 
                         let mut outputs = ctx
                             .map(
@@ -262,13 +264,11 @@ where
                         preprocessed.append(&mut outputs);
                     }
 
-                    Ok::<_, VmError>((preprocessed, call_stack))
+                    Ok::<_, VmError>(preprocessed)
                 },
             )
             .await
             .map_err(VmError::execute)??;
-
-        let _ = std::mem::replace(&mut self.call_stack, call_stack);
 
         let mut store = self.store.try_lock().unwrap();
         for output in preprocessed {
@@ -360,24 +360,4 @@ async fn evaluate<COT>(
         .map_err(VmError::memory)?;
 
     Ok(())
-}
-
-fn take_preprocess_calls(call_stack: &mut Vec<(Call, Slice)>) -> Vec<(Call, Slice)> {
-    let mut idx_outputs = RangeSet::default();
-    call_stack
-        // Extract calls which have no dependencies on other prior calls.
-        .extract_if(.., |(call, output)| {
-            if call
-                .inputs()
-                .iter()
-                .all(|input| input.to_range().is_disjoint(&idx_outputs))
-            {
-                idx_outputs |= output.to_range();
-                true
-            } else {
-                idx_outputs |= output.to_range();
-                false
-            }
-        })
-        .collect()
 }

--- a/crates/garble/src/protocol/semihonest/evaluator.rs
+++ b/crates/garble/src/protocol/semihonest/evaluator.rs
@@ -32,26 +32,6 @@ impl<COT> Evaluator<COT> {
         }
     }
 
-    fn take_preprocess_calls(&mut self) -> Vec<(Call, Slice)> {
-        let mut idx_outputs = RangeSet::default();
-        self.call_stack
-            // Extract calls which have no dependencies on other prior calls.
-            .extract_if(.., |(call, output)| {
-                if call
-                    .inputs()
-                    .iter()
-                    .all(|input| input.to_range().is_disjoint(&idx_outputs))
-                {
-                    idx_outputs |= output.to_range();
-                    true
-                } else {
-                    idx_outputs |= output.to_range();
-                    false
-                }
-            })
-            .collect()
-    }
-
     fn take_execute_calls(&mut self) -> Vec<(Call, Slice)> {
         let store = self.store.try_lock().unwrap();
         self.call_stack
@@ -112,6 +92,11 @@ impl<COT> Evaluator<COT> {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn store(&self) -> Arc<Mutex<EvaluatorStore<COT>>> {
+        self.store.clone()
     }
 }
 
@@ -239,36 +224,60 @@ where
     }
 
     async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
-        while !self.call_stack.is_empty() {
-            let calls = self.take_preprocess_calls();
+        let mut cot = self.store.try_lock().unwrap().acquire_cot();
 
-            if calls.is_empty() {
-                break;
-            }
+        let mut call_stack = std::mem::take(&mut self.call_stack);
 
-            let outputs = ctx
-                .map(
-                    calls,
-                    async move |ctx, (call, output): (Call, Slice)| {
-                        let garbled_circuit = receive_garbled_circuit(ctx, call.circ())
+        let (_, (preprocessed, call_stack)) = ctx
+            .try_join(
+                async move |ctx| {
+                    // This flush is primarily intended to perform OT setup
+                    // concurrently with preprocessing.
+                    cot.flush(ctx).await.map_err(VmError::execute)
+                },
+                async move |ctx| {
+                    let mut preprocessed = Vec::new();
+
+                    while !call_stack.is_empty() {
+                        let calls = take_preprocess_calls(&mut call_stack);
+
+                        if calls.is_empty() {
+                            break;
+                        }
+
+                        let mut outputs = ctx
+                            .map(
+                                calls,
+                                async move |ctx, (call, output): (Call, Slice)| {
+                                    let garbled_circuit = receive_garbled_circuit(ctx, call.circ())
+                                        .await
+                                        .map_err(VmError::execute)?;
+                                    Ok::<_, VmError>((call, output, garbled_circuit))
+                                },
+                                |(call, _)| call.circ().and_count(),
+                            )
                             .await
                             .map_err(VmError::execute)?;
-                        Ok::<_, VmError>((call, output, garbled_circuit))
-                    },
-                    |(call, _)| call.circ().and_count(),
-                )
-                .await
-                .map_err(VmError::execute)?;
 
-            let mut store = self.store.try_lock().unwrap();
-            for output in outputs {
-                let (call, output, garbled_circuit) = output?;
+                        preprocessed.append(&mut outputs);
+                    }
 
-                self.preprocessed.insert(output, (call, garbled_circuit));
-                store
-                    .mark_output_preprocessed(output)
-                    .map_err(VmError::memory)?;
-            }
+                    Ok::<_, VmError>((preprocessed, call_stack))
+                },
+            )
+            .await
+            .map_err(VmError::execute)??;
+
+        let _ = std::mem::replace(&mut self.call_stack, call_stack);
+
+        let mut store = self.store.try_lock().unwrap();
+        for output in preprocessed {
+            let (call, output, garbled_circuit) = output?;
+
+            self.preprocessed.insert(output, (call, garbled_circuit));
+            store
+                .mark_output_preprocessed(output)
+                .map_err(VmError::memory)?;
         }
 
         Ok(())
@@ -351,4 +360,24 @@ async fn evaluate<COT>(
         .map_err(VmError::memory)?;
 
     Ok(())
+}
+
+fn take_preprocess_calls(call_stack: &mut Vec<(Call, Slice)>) -> Vec<(Call, Slice)> {
+    let mut idx_outputs = RangeSet::default();
+    call_stack
+        // Extract calls which have no dependencies on other prior calls.
+        .extract_if(.., |(call, output)| {
+            if call
+                .inputs()
+                .iter()
+                .all(|input| input.to_range().is_disjoint(&idx_outputs))
+            {
+                idx_outputs |= output.to_range();
+                true
+            } else {
+                idx_outputs |= output.to_range();
+                false
+            }
+        })
+        .collect()
 }

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -346,14 +346,3 @@ async fn generate<COT>(
     Ok(())
 }
 
-// fn take_preprocess_calls<COT>(
-//     store: Arc<Mutex<GarblerStore<COT>>>,
-//     call_stack: &mut Vec<(Call, Slice)>,
-// ) -> Vec<(Call, Slice)> {
-//     let store = store.try_lock().unwrap();
-//     call_stack
-//         .extract_if(.., |(call, _)| {
-//             call.inputs().iter().all(|slice| store.is_set_keys(*slice))
-//         })
-//         .collect()
-// }

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -212,7 +212,7 @@ where
             .map(|(call, output)| (call.inputs().to_vec(), *output))
             .collect::<Vec<_>>();
 
-        let (_, _) = ctx
+        ctx
             .try_join(
                 async move |ctx| {
                     // This flush is primarily intended to perform OT setup

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -212,49 +212,41 @@ where
             .map(|(call, output)| (call.inputs().to_vec(), *output))
             .collect::<Vec<_>>();
 
-        ctx
-            .try_join(
-                async move |ctx| {
-                    // This flush is primarily intended to perform OT setup
-                    // concurrently with preprocessing.
-                    cot.flush(ctx).await.map_err(VmError::execute)
-                },
-                async move |ctx| {
-                    while !call_stack.is_empty() {
-                        let calls = take_preprocess_calls(&mut call_stack);
+        ctx.try_join(
+            async move |ctx| {
+                // This flush is primarily intended to perform OT setup
+                // concurrently with preprocessing.
+                cot.flush(ctx).await.map_err(VmError::execute)
+            },
+            async move |ctx| {
+                while !call_stack.is_empty() {
+                    let calls = take_preprocess_calls(&mut call_stack);
 
-                        // There must be at least one call ready for preprocessing
-                        // in a non-empty call stack.
-                        debug_assert!(!calls.is_empty());
+                    // There must be at least one call ready for preprocessing
+                    // in a non-empty call stack.
+                    debug_assert!(!calls.is_empty());
 
-                        let store = store.clone();
-                        let outputs = ctx
-                            .map(
-                                calls,
-                                async move |ctx: &mut Context, (call, output): (Call, Slice)| {
-                                    generate(
-                                        ctx,
-                                        store.clone(),
-                                        delta,
-                                        call,
-                                        output,
-                                        Mode::Preprocess,
-                                    )
+                    let store = store.clone();
+                    let outputs = ctx
+                        .map(
+                            calls,
+                            async move |ctx: &mut Context, (call, output): (Call, Slice)| {
+                                generate(ctx, store.clone(), delta, call, output, Mode::Preprocess)
                                     .await
-                                },
-                                |(call, _)| call.circ().and_count(),
-                            )
-                            .await
-                            .map_err(VmError::execute)?;
+                            },
+                            |(call, _)| call.circ().and_count(),
+                        )
+                        .await
+                        .map_err(VmError::execute)?;
 
-                        outputs.into_iter().collect::<Result<()>>()?;
-                    }
+                    outputs.into_iter().collect::<Result<()>>()?;
+                }
 
-                    Ok::<_, VmError>(())
-                },
-            )
-            .await
-            .map_err(VmError::execute)??;
+                Ok::<_, VmError>(())
+            },
+        )
+        .await
+        .map_err(VmError::execute)??;
 
         self.preprocessed.append(&mut preprocessed);
 
@@ -345,4 +337,3 @@ async fn generate<COT>(
 
     Ok(())
 }
-

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -209,12 +209,9 @@ where
         let (_, mut preprocessed) = ctx
             .try_join(
                 async move |ctx| {
-                    if cot.wants_flush() {
-                        // This flush is primarily intended to perform OT setup
-                        // concurrently with preprocessing.
-                        cot.flush(ctx).await.map_err(VmError::execute)?;
-                    }
-                    Ok::<_, VmError>(())
+                    // This flush is primarily intended to perform OT setup
+                    // concurrently with preprocessing.
+                    cot.flush(ctx).await.map_err(VmError::execute)
                 },
                 async move |ctx| {
                     let mut preprocessed = Vec::new();

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -30,15 +30,6 @@ impl<COT> Garbler<COT> {
         }
     }
 
-    fn take_preprocess_calls(&mut self) -> Vec<(Call, Slice)> {
-        let store = self.store.try_lock().unwrap();
-        self.call_stack
-            .extract_if(.., |(call, _)| {
-                call.inputs().iter().all(|slice| store.is_set_keys(*slice))
-            })
-            .collect()
-    }
-
     fn take_execute_calls(&mut self) -> Vec<(Call, Slice)> {
         let store = self.store.try_lock().unwrap();
         self.call_stack
@@ -74,6 +65,11 @@ impl<COT> Garbler<COT> {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn store(&self) -> Arc<Mutex<GarblerStore<COT>>> {
+        self.store.clone()
     }
 }
 
@@ -202,34 +198,71 @@ where
     }
 
     async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
-        let delta = *self.store.try_lock().unwrap().delta();
+        let (delta, mut cot) = {
+            let store = self.store.try_lock().unwrap();
+            (*store.delta(), store.acquire_cot())
+        };
 
-        while !self.call_stack.is_empty() {
-            let calls = self.take_preprocess_calls();
+        let mut call_stack = std::mem::take(&mut self.call_stack);
+        let store = self.store.clone();
 
-            if calls.is_empty() {
-                break;
-            } else {
-                for (call, output) in &calls {
-                    let inputs = call.inputs().to_vec();
-                    self.preprocessed.push((inputs, *output));
-                }
-            }
+        let (_, (mut preprocessed, call_stack)) = ctx
+            .try_join(
+                async move |ctx| {
+                    if cot.wants_flush() {
+                        // This flush is primarily intended to perform OT setup
+                        // concurrently with preprocessing.
+                        cot.flush(ctx).await.map_err(VmError::execute)?;
+                    }
+                    Ok::<_, VmError>(())
+                },
+                async move |ctx| {
+                    let mut preprocessed = Vec::new();
 
-            let store = self.store.clone();
-            let outputs = ctx
-                .map(
-                    calls,
-                    async move |ctx: &mut Context, (call, output): (Call, Slice)| {
-                        generate(ctx, store.clone(), delta, call, output, Mode::Preprocess).await
-                    },
-                    |(call, _)| call.circ().and_count(),
-                )
-                .await
-                .map_err(VmError::execute)?;
+                    while !call_stack.is_empty() {
+                        let calls = take_preprocess_calls(store.clone(), &mut call_stack);
 
-            outputs.into_iter().collect::<Result<()>>()?;
-        }
+                        if calls.is_empty() {
+                            break;
+                        } else {
+                            for (call, output) in &calls {
+                                let inputs = call.inputs().to_vec();
+                                preprocessed.push((inputs, *output));
+                            }
+                        }
+
+                        let store = store.clone();
+                        let outputs = ctx
+                            .map(
+                                calls,
+                                async move |ctx: &mut Context, (call, output): (Call, Slice)| {
+                                    generate(
+                                        ctx,
+                                        store.clone(),
+                                        delta,
+                                        call,
+                                        output,
+                                        Mode::Preprocess,
+                                    )
+                                    .await
+                                },
+                                |(call, _)| call.circ().and_count(),
+                            )
+                            .await
+                            .map_err(VmError::execute)?;
+
+                        outputs.into_iter().collect::<Result<()>>()?;
+                    }
+
+                    Ok::<_, VmError>((preprocessed, call_stack))
+                },
+            )
+            .await
+            .map_err(VmError::execute)??;
+
+        self.preprocessed.append(&mut preprocessed);
+
+        let _ = std::mem::replace(&mut self.call_stack, call_stack);
 
         Ok(())
     }
@@ -317,4 +350,16 @@ async fn generate<COT>(
     }
 
     Ok(())
+}
+
+fn take_preprocess_calls<COT>(
+    store: Arc<Mutex<GarblerStore<COT>>>,
+    call_stack: &mut Vec<(Call, Slice)>,
+) -> Vec<(Call, Slice)> {
+    let store = store.try_lock().unwrap();
+    call_stack
+        .extract_if(.., |(call, _)| {
+            call.inputs().iter().all(|slice| store.is_set_keys(*slice))
+        })
+        .collect()
 }

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -206,7 +206,13 @@ where
         let mut call_stack = std::mem::take(&mut self.call_stack);
         let store = self.store.clone();
 
-        let (_, mut preprocessed) = ctx
+        // All calls will be added to preprocessed once preprocessing completes.
+        let mut preprocessed = call_stack
+            .iter()
+            .map(|(call, output)| (call.inputs().to_vec(), *output))
+            .collect::<Vec<_>>();
+
+        let (_, _) = ctx
             .try_join(
                 async move |ctx| {
                     // This flush is primarily intended to perform OT setup
@@ -214,19 +220,12 @@ where
                     cot.flush(ctx).await.map_err(VmError::execute)
                 },
                 async move |ctx| {
-                    let mut preprocessed = Vec::new();
-
                     while !call_stack.is_empty() {
                         let calls = take_preprocess_calls(&mut call_stack);
 
                         // There must be at least one call ready for preprocessing
                         // in a non-empty call stack.
                         debug_assert!(!calls.is_empty());
-
-                        for (call, output) in &calls {
-                            let inputs = call.inputs().to_vec();
-                            preprocessed.push((inputs, *output));
-                        }
 
                         let store = store.clone();
                         let outputs = ctx
@@ -251,7 +250,7 @@ where
                         outputs.into_iter().collect::<Result<()>>()?;
                     }
 
-                    Ok::<_, VmError>(preprocessed)
+                    Ok::<_, VmError>(())
                 },
             )
             .await

--- a/crates/garble/src/protocol/semihonest/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/garbler.rs
@@ -10,7 +10,7 @@ use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary, correla
 use mpz_ot::cot::COTSender;
 use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
 
-use crate::store::GarblerStore;
+use crate::{protocol::semihonest::take_preprocess_calls, store::GarblerStore};
 
 /// Semi-honest garbler.
 #[derive(Debug)]
@@ -206,7 +206,7 @@ where
         let mut call_stack = std::mem::take(&mut self.call_stack);
         let store = self.store.clone();
 
-        let (_, (mut preprocessed, call_stack)) = ctx
+        let (_, mut preprocessed) = ctx
             .try_join(
                 async move |ctx| {
                     if cot.wants_flush() {
@@ -220,15 +220,15 @@ where
                     let mut preprocessed = Vec::new();
 
                     while !call_stack.is_empty() {
-                        let calls = take_preprocess_calls(store.clone(), &mut call_stack);
+                        let calls = take_preprocess_calls(&mut call_stack);
 
-                        if calls.is_empty() {
-                            break;
-                        } else {
-                            for (call, output) in &calls {
-                                let inputs = call.inputs().to_vec();
-                                preprocessed.push((inputs, *output));
-                            }
+                        // There must be at least one call ready for preprocessing
+                        // in a non-empty call stack.
+                        debug_assert!(!calls.is_empty());
+
+                        for (call, output) in &calls {
+                            let inputs = call.inputs().to_vec();
+                            preprocessed.push((inputs, *output));
                         }
 
                         let store = store.clone();
@@ -254,15 +254,13 @@ where
                         outputs.into_iter().collect::<Result<()>>()?;
                     }
 
-                    Ok::<_, VmError>((preprocessed, call_stack))
+                    Ok::<_, VmError>(preprocessed)
                 },
             )
             .await
             .map_err(VmError::execute)??;
 
         self.preprocessed.append(&mut preprocessed);
-
-        let _ = std::mem::replace(&mut self.call_stack, call_stack);
 
         Ok(())
     }
@@ -352,14 +350,14 @@ async fn generate<COT>(
     Ok(())
 }
 
-fn take_preprocess_calls<COT>(
-    store: Arc<Mutex<GarblerStore<COT>>>,
-    call_stack: &mut Vec<(Call, Slice)>,
-) -> Vec<(Call, Slice)> {
-    let store = store.try_lock().unwrap();
-    call_stack
-        .extract_if(.., |(call, _)| {
-            call.inputs().iter().all(|slice| store.is_set_keys(*slice))
-        })
-        .collect()
-}
+// fn take_preprocess_calls<COT>(
+//     store: Arc<Mutex<GarblerStore<COT>>>,
+//     call_stack: &mut Vec<(Call, Slice)>,
+// ) -> Vec<(Call, Slice)> {
+//     let store = store.try_lock().unwrap();
+//     call_stack
+//         .extract_if(.., |(call, _)| {
+//             call.inputs().iter().all(|slice| store.is_set_keys(*slice))
+//         })
+//         .collect()
+// }

--- a/crates/garble/src/store/evaluator.rs
+++ b/crates/garble/src/store/evaluator.rs
@@ -8,6 +8,7 @@ use mpz_garble_core::{
 use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
 use mpz_ot::cot::COTReceiver;
 use serio::{SinkExt, stream::IoStreamExt};
+use tokio::sync::OwnedMutexGuard;
 
 type Error = EvaluatorStoreError;
 type Result<T, E = Error> = core::result::Result<T, E>;
@@ -23,6 +24,11 @@ impl<COT> EvaluatorStore<COT> {
         Self {
             core: Core::new(cot),
         }
+    }
+
+    /// Returns a lock on the COT receiver.
+    pub(crate) fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        self.core.acquire_cot()
     }
 
     pub(crate) fn try_get_macs(&self, slice: Slice) -> Result<&[Mac], Error> {

--- a/crates/garble/src/store/garbler.rs
+++ b/crates/garble/src/store/garbler.rs
@@ -8,6 +8,7 @@ use mpz_garble_core::{
 use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
 use mpz_ot::cot::COTSender;
 use serio::{SinkExt, stream::IoStreamExt};
+use tokio::sync::OwnedMutexGuard;
 
 type Error = GarblerStoreError;
 
@@ -26,6 +27,11 @@ impl<COT> GarblerStore<COT> {
 
     pub(crate) fn delta(&self) -> &Delta {
         self.core.delta()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub(crate) fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        self.core.acquire_cot()
     }
 
     pub(crate) fn is_set_keys(&self, slice: Slice) -> bool {


### PR DESCRIPTION
This PR refactors the `preprocess` method to allow OT setup to be run concurrently.