### PR TITLE
fix(garble): bump estimated flush size

### DIFF
--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -59,8 +59,8 @@ impl FlushView {
         let decode_info = self.decode_info.len();
         let mac_commitments = self.decode_info.len() * Mac::BIT_SIZE * 2;
 
-        // Add 128 bytes of cushion room.
-        (macs + decode_info + mac_commitments) / 8 + self.size() + 128
+        // Add 1024 bytes of cushion room.
+        (macs + decode_info + mac_commitments) / 8 + self.size() + 1024
     }
 
     /// Returns the expected evaluator flush size in bytes.
@@ -71,8 +71,8 @@ impl FlushView {
             blake3::OUT_LEN
         };
 
-        // Add 128 bytes of cushion room.
-        self.decode.len() / 8 + proof_size + self.size() + 128
+        // Add 1024 bytes of cushion room.
+        self.decode.len() / 8 + proof_size + self.size() + 1024
     }
 
     /// Returns `true` if the flush state is empty.


### PR DESCRIPTION
This PR bumps the flush size estimation cushion to 1024 bytes.

After https://github.com/privacy-scaling-explorations/mpz/pull/299 was merged, I'm already seeing `frame size too big` errors 
coming from https://github.com/tokio-rs/tokio/blob/2440d113ff9841060b1876628c1153f0bcf2945c/tokio-util/src/codec/length_delimited.rs#L1082

The error went away when I bumped the cushion.

While we try to figure out the best estimation algorithm, let's just temporarily bump the value.