### PR TITLE
refactor(garble): remove view from flush message

### DIFF
--- a/crates/common/src/context.rs
+++ b/crates/common/src/context.rs
@@ -81,6 +81,11 @@ impl Context {
         &self.id
     }
 
+    /// Returns a reference to the thread's I/O channel.
+    pub fn io(&self) -> &Io {
+        &self.io
+    }
+
     /// Returns a mutable reference to the thread's I/O channel.
     pub fn io_mut(&mut self) -> &mut Io {
         &mut self.io

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -122,6 +122,14 @@ impl Io {
         }
     }
 
+    /// Returns the maximum message size that can be received.
+    pub fn limit(&self) -> usize {
+        match &self.inner {
+            Inner::Transport { framed } => framed.inner().frame_limit(),
+            Inner::Memory { channel: _ } => usize::MAX,
+        }
+    }
+
     /// Adjusts the frame limit temporarily and returns a [`WithLimit`].
     ///
     /// # Arguments

--- a/crates/garble-core/src/store.rs
+++ b/crates/garble-core/src/store.rs
@@ -11,14 +11,10 @@ use mpz_core::bitvec::BitVec;
 use mpz_memory_core::correlated::{Mac, MacCommitment};
 use serde::{Deserialize, Serialize};
 
-use crate::view::FlushView;
-
 /// Flush message sent by the garbler.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(try_from = "validation::GarblerFlushUnchecked")]
 pub struct GarblerFlush {
-    /// Flush view.
-    view: FlushView,
     /// MACs sent directly to the evaluator.
     macs: Vec<Mac>,
     /// Key bits for decoding.
@@ -27,28 +23,11 @@ pub struct GarblerFlush {
     mac_commitments: Vec<MacCommitment>,
 }
 
-impl GarblerFlush {
-    /// Returns the inner [`FlushView`].
-    pub fn view(&self) -> &FlushView {
-        &self.view
-    }
-}
-
 /// Flush message sent by the evaluator.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(try_from = "validation::EvaluatorFlushUnchecked")]
 pub struct EvaluatorFlush {
-    /// Flush view.
-    view: FlushView,
     /// Proof of MACs for decoding.
     mac_proof: Option<MacProof>,
-}
-
-impl EvaluatorFlush {
-    /// Returns the inner [`FlushView`].
-    pub fn view(&self) -> &FlushView {
-        &self.view
-    }
 }
 
 /// MAC proof sent from the evaluator to the garbler to prove
@@ -64,7 +43,6 @@ mod validation {
 
     #[derive(Debug, Deserialize)]
     pub(super) struct GarblerFlushUnchecked {
-        pub view: FlushView,
         pub macs: Vec<Mac>,
         pub key_bits: BitVec,
         pub mac_commitments: Vec<MacCommitment>,
@@ -75,52 +53,19 @@ mod validation {
 
         fn try_from(value: GarblerFlushUnchecked) -> Result<Self, Self::Error> {
             let GarblerFlushUnchecked {
-                view: idx,
                 macs,
                 key_bits,
                 mac_commitments,
             } = value;
-
-            if idx.macs.len() != macs.len() {
-                return Err("garbler sent flush with invalid number of MACs".to_string());
-            }
-
-            if idx.decode_info.len() != key_bits.len() {
-                return Err("garbler sent flush with invalid number of key bits".to_string());
-            }
 
             if mac_commitments.len() != key_bits.len() {
                 return Err("garbler sent flush with invalid number of MAC commitments".to_string());
             }
 
             Ok(GarblerFlush {
-                view: idx,
                 macs,
                 key_bits,
                 mac_commitments,
-            })
-        }
-    }
-
-    #[derive(Debug, Deserialize)]
-    pub(super) struct EvaluatorFlushUnchecked {
-        pub view: FlushView,
-        pub macs: Option<MacProof>,
-    }
-
-    impl TryFrom<EvaluatorFlushUnchecked> for EvaluatorFlush {
-        type Error = String;
-
-        fn try_from(value: EvaluatorFlushUnchecked) -> Result<Self, Self::Error> {
-            let EvaluatorFlushUnchecked { view: idx, macs } = value;
-
-            if idx.decode.len() != macs.as_ref().map_or(0, |m| m.bits.len()) {
-                return Err("evaluator sent flush with invalid number of MACs".to_string());
-            }
-
-            Ok(EvaluatorFlush {
-                view: idx,
-                mac_proof: macs,
             })
         }
     }

--- a/crates/garble-core/src/store/evaluator.rs
+++ b/crates/garble-core/src/store/evaluator.rs
@@ -183,7 +183,7 @@ where
 {
     /// Returns the flush view.
     pub fn flush_view(&self) -> &FlushView {
-        &self.view.flush()
+        self.view.flush()
     }
 
     /// Sends a flush to the garbler.

--- a/crates/garble-core/src/store/evaluator.rs
+++ b/crates/garble-core/src/store/evaluator.rs
@@ -14,8 +14,9 @@ use mpz_memory_core::{
 use mpz_ot_core::cot::{COTReceiver, COTReceiverOutput};
 
 use crate::{
+    FlushView,
     store::{EvaluatorFlush, GarblerFlush, MacProof},
-    view::{FlushView, View, ViewError},
+    view::{View, ViewError},
 };
 
 type Error = EvaluatorStoreError;
@@ -180,6 +181,11 @@ where
     COT: COTReceiver<bool, Block>,
     COT::Future: Send + 'static,
 {
+    /// Returns the flush view.
+    pub fn flush_view(&self) -> &FlushView {
+        &self.view.flush()
+    }
+
     /// Sends a flush to the garbler.
     ///
     /// This queues any necessary COTs.
@@ -219,7 +225,7 @@ where
             None
         };
 
-        let flush = EvaluatorFlush { view, mac_proof };
+        let flush = EvaluatorFlush { mac_proof };
 
         self.pending = Some(PendingFlush { cot });
 
@@ -235,24 +241,22 @@ where
         };
 
         let GarblerFlush {
-            view,
             macs,
             key_bits,
             mac_commitments,
         } = flush;
 
-        // Ensure the garblers flush is consistent.
-        if &view != self.view.flush() {
-            return Err(ErrorRepr::InconsistentFlush {
-                expected: Box::new(view),
-                actual: Box::new(self.view.flush().clone()),
+        // Receive the MACs.
+        if macs.len() != self.view.flush().macs.len() {
+            return Err(ErrorRepr::IncorrectMacCount {
+                expected: self.view.flush().macs.len(),
+                actual: macs.len(),
             }
             .into());
         }
 
-        // Receive the MACs.
         let mut i = 0;
-        for range in view.macs.iter_ranges() {
+        for range in self.view.flush().macs.iter_ranges() {
             let slice = Slice::from_range_unchecked(range);
             self.mac_store.try_set(slice, &macs[i..i + slice.len()])?;
             i += slice.len();
@@ -267,7 +271,7 @@ where
             let macs = Mac::from_blocks(macs);
 
             i = 0;
-            for range in view.ot.iter_ranges() {
+            for range in self.view.flush().ot.iter_ranges() {
                 let slice = Slice::from_range_unchecked(range);
                 self.mac_store.try_set(slice, &macs[i..i + slice.len()])?;
                 i += slice.len();
@@ -275,8 +279,22 @@ where
         }
 
         // Receive the decode info.
+        if key_bits.len() != self.view.flush().decode_info.len() {
+            return Err(ErrorRepr::IncorrectDecodeCount {
+                expected: self.view.flush().decode_info.len(),
+                actual: key_bits.len(),
+            }
+            .into());
+        } else if mac_commitments.len() != self.view.flush().decode_info.len() {
+            return Err(ErrorRepr::IncorrectMacCommitmentCount {
+                expected: self.view.flush().decode_info.len(),
+                actual: mac_commitments.len(),
+            }
+            .into());
+        }
+
         i = 0;
-        for range in view.decode_info.iter_ranges() {
+        for range in self.view.flush().decode_info.iter_ranges() {
             let slice = Slice::from_range_unchecked(range);
             self.key_bit_store
                 .try_set(slice, &key_bits[i..i + slice.len()])?;
@@ -285,7 +303,7 @@ where
             i += slice.len();
         }
 
-        self.view.complete_flush(view);
+        self.view.complete_flush();
         self.flush_decode()?;
 
         Ok(())
@@ -401,11 +419,16 @@ enum ErrorRepr {
     View(#[from] ViewError),
     #[error("store was not expecting a flush")]
     UnexpectedFlush,
-    #[error("inconsistent flush: expected={expected:?}, actual={actual:?}")]
-    InconsistentFlush {
-        expected: Box<FlushView>,
-        actual: Box<FlushView>,
-    },
+    #[error("generator sent incorrect number of MACs, expected={expected}, actual={actual}")]
+    IncorrectMacCount { expected: usize, actual: usize },
+    #[error(
+        "generator sent incorrect number of MAC commitments, expected={expected}, actual={actual}"
+    )]
+    IncorrectMacCommitmentCount { expected: usize, actual: usize },
+    #[error(
+        "generator sent incorrect number of decoding bits, expected={expected}, actual={actual}"
+    )]
+    IncorrectDecodeCount { expected: usize, actual: usize },
     #[error("invalid MAC commitment: {0}")]
     MacCommitment(#[from] MacCommitmentError),
 }

--- a/crates/garble-core/src/store/garbler.rs
+++ b/crates/garble-core/src/store/garbler.rs
@@ -13,8 +13,9 @@ use mpz_memory_core::{
 use mpz_ot_core::cot::COTSender;
 
 use crate::{
+    FlushView,
     store::{EvaluatorFlush, GarblerFlush, MacProof},
-    view::{FlushView, View, ViewError},
+    view::{View, ViewError},
 };
 
 type Error = GarblerStoreError;
@@ -134,6 +135,11 @@ impl<COT> GarblerStore<COT>
 where
     COT: COTSender<Block>,
 {
+    /// Returns the flush view.
+    pub fn flush_view(&self) -> &FlushView {
+        self.view.flush()
+    }
+
     /// Sends a flush to the evaluator.
     ///
     /// This queues any necessary COTs.
@@ -184,7 +190,6 @@ where
         }
 
         let flush = GarblerFlush {
-            view,
             macs,
             key_bits,
             mac_commitments,
@@ -201,33 +206,30 @@ where
             return Err(ErrorRepr::UnexpectedFlush.into());
         }
 
-        let EvaluatorFlush {
-            view,
-            mac_proof: macs,
-        } = flush;
-
-        // Ensure the evaluators view is consistent.
-        if &view != self.view.flush() {
-            return Err(ErrorRepr::InconsistentFlush {
-                expected: Box::new(self.view.flush().clone()),
-                actual: Box::new(view.clone()),
-            }
-            .into());
-        }
+        let EvaluatorFlush { mac_proof } = flush;
 
         // Verify MACs and store the data.
-        if let Some(MacProof { mut bits, proof }) = macs {
-            self.key_store.verify(&view.decode, &mut bits, proof)?;
+        if let Some(MacProof { mut bits, proof }) = mac_proof {
+            if bits.len() != self.view.flush().decode.len() {
+                return Err(ErrorRepr::IncorrectMacCount {
+                    expected: self.view.flush().decode.len(),
+                    actual: bits.len(),
+                }
+                .into());
+            }
+
+            self.key_store
+                .verify(&self.view.flush().decode, &mut bits, proof)?;
 
             let mut i = 0;
-            for range in view.decode.iter_ranges() {
+            for range in self.view.flush().decode.iter_ranges() {
                 let slice = Slice::from_range_unchecked(range);
                 self.data_store.try_set(slice, &bits[i..i + slice.len()])?;
                 i += slice.len();
             }
         }
 
-        self.view.complete_flush(view);
+        self.view.complete_flush();
         self.flush_decode()?;
         self.pending = false;
 
@@ -341,13 +343,10 @@ enum ErrorRepr {
     Decode(#[from] DecodeError),
     #[error(transparent)]
     View(#[from] ViewError),
+    #[error("evaluator sent incorrect number of MAC bits, expected={expected}, actual={actual}")]
+    IncorrectMacCount { expected: usize, actual: usize },
     #[error("store was not expecting a flush")]
     UnexpectedFlush,
-    #[error("inconsistent flush: expected={expected:?}, actual={actual:?}")]
-    InconsistentFlush {
-        expected: Box<FlushView>,
-        actual: Box<FlushView>,
-    },
 }
 
 impl From<KeyStoreError> for GarblerStoreError {

--- a/crates/garble-core/src/view.rs
+++ b/crates/garble-core/src/view.rs
@@ -55,16 +55,17 @@ pub struct FlushView {
 impl FlushView {
     /// Returns the expected garbler flush size in bytes.
     pub fn garbler_flush_size(&self) -> usize {
-        let macs = self.macs.len() * Mac::BIT_SIZE;
-        let decode_info = self.decode_info.len();
-        let mac_commitments = self.decode_info.len() * Mac::BIT_SIZE * 2;
+        let macs = self.macs.len() * Mac::BYTE_SIZE;
+        let decode_info = self.decode_info.len().div_ceil(8);
+        let mac_commitments = self.decode_info.len() * Mac::BYTE_SIZE * 2;
 
         // Add 1024 bytes of cushion room.
-        (macs + decode_info + mac_commitments) / 8 + self.size() + 1024
+        macs + decode_info + mac_commitments + 1024
     }
 
     /// Returns the expected evaluator flush size in bytes.
     pub fn evaluator_flush_size(&self) -> usize {
+        let decode_info = self.decode_info.len().div_ceil(8);
         let proof_size = if self.decode.is_empty() {
             0
         } else {
@@ -72,7 +73,7 @@ impl FlushView {
         };
 
         // Add 1024 bytes of cushion room.
-        self.decode.len() / 8 + proof_size + self.size() + 1024
+        decode_info + proof_size + 1024
     }
 
     /// Returns `true` if the flush state is empty.
@@ -89,16 +90,6 @@ impl FlushView {
         self.ot.clear();
         self.decode_info.clear();
         self.decode.clear();
-    }
-
-    /// Returns the size in bytes for [`FlushView`].
-    fn size(&self) -> usize {
-        let range_count = self.macs.len_ranges()
-            + self.ot.len_ranges()
-            + self.decode_info.len_ranges()
-            + self.decode.len_ranges();
-
-        range_count * 2 * usize::BITS as usize / 8
     }
 }
 
@@ -337,21 +328,25 @@ impl View {
         Ok(())
     }
 
-    pub(crate) fn complete_flush(&mut self, view: FlushView) {
-        self.input.complete |= view.macs;
-        self.input.complete |= &view.ot;
-        self.decode.decode_info |= &view.decode_info;
-        self.decode.complete |= view.decode;
+    pub(crate) fn complete_flush(&mut self) {
+        self.input.complete |= &self.flush.macs;
+        self.input.complete |= &self.flush.ot;
+        self.decode.decode_info |= &self.flush.decode_info;
+        self.decode.complete |= &self.flush.decode;
+
+        let ready_inputs = self.flush.ot.intersection(&self.decode.all);
+        let ready_outputs = self
+            .flush
+            .decode_info
+            .intersection(&self.output.complete)
+            .difference(&self.decode.complete);
 
         self.flush.clear();
 
         // Decode evaluator inputs if they are ready.
-        self.flush.decode |= view.ot.intersection(&self.decode.all);
+        self.flush.decode |= ready_inputs;
         // Decode outputs if they are ready.
-        self.flush.decode |= view
-            .decode_info
-            .intersection(&self.output.complete)
-            .difference(&self.decode.complete);
+        self.flush.decode |= ready_outputs;
     }
 }
 

--- a/crates/garble/src/store/evaluator.rs
+++ b/crates/garble/src/store/evaluator.rs
@@ -126,18 +126,16 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
-            let garbler_flush_size = flush.view().garbler_flush_size();
-            let evaluator_flush_size = flush.view().evaluator_flush_size();
-
+            let expected_size = self.core.flush_view().garbler_flush_size();
             let (flush, ()) = ctx
                 .try_join(
                     async move |ctx| {
+                        ctx.io_mut().send(flush).await?;
+
+                        // Adjust the limit to expected size.
+                        let limit = ctx.io().limit().max(expected_size);
                         ctx.io_mut()
-                            .with_limit(evaluator_flush_size)
-                            .send(flush)
-                            .await?;
-                        ctx.io_mut()
-                            .with_limit(garbler_flush_size)
+                            .with_limit(limit)
                             .expect_next()
                             .await
                             .map_err(Error::from)

--- a/crates/garble/src/store/garbler.rs
+++ b/crates/garble/src/store/garbler.rs
@@ -126,18 +126,16 @@ where
             let flush = self.core.send_flush()?;
             let mut cot = self.core.acquire_cot();
 
-            let garbler_flush_size = flush.view().garbler_flush_size();
-            let evaluator_flush_size = flush.view().evaluator_flush_size();
-
+            let expected_size = self.core.flush_view().evaluator_flush_size();
             let (flush, ()) = ctx
                 .try_join(
                     async move |ctx| {
+                        ctx.io_mut().send(flush).await?;
+
+                        // Adjust the limit to expected size.
+                        let limit = ctx.io().limit().max(expected_size);
                         ctx.io_mut()
-                            .with_limit(garbler_flush_size)
-                            .send(flush)
-                            .await?;
-                        ctx.io_mut()
-                            .with_limit(evaluator_flush_size)
+                            .with_limit(limit)
                             .expect_next()
                             .await
                             .map_err(Error::from)

--- a/crates/memory-core/src/correlated/macs.rs
+++ b/crates/memory-core/src/correlated/macs.rs
@@ -22,7 +22,7 @@ pub struct Mac(Block);
 impl Mac {
     /// Public MACs.
     pub const PUBLIC: [Mac; 2] = [Mac(MAC_ZERO), Mac(MAC_ONE)];
-    pub const BIT_SIZE: usize = 128;
+    pub const BYTE_SIZE: usize = 16;
 
     /// Creates a new MAC.
     #[inline]


### PR DESCRIPTION
This PR removes the view from the flush messages in the garble vm, as it is unnecessary. I've also adjusted the message limit logic to account for this.