### PR TITLE
perf(zk): improve quicksilver performance

### DIFF
--- a/crates/zk-core/benches/zk.rs
+++ b/crates/zk-core/benches/zk.rs
@@ -64,15 +64,26 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let mut prover = Prover::default();
         let mut verifier = Verifier::new(delta);
-        let mut prover_transcript = Hasher::default();
-        let mut verifier_transcript = Hasher::default();
+        let prover_transcript = Hasher::default();
+        let verifier_transcript = Hasher::default();
 
         b.iter(|| {
             let mut prover_execute = prover
-                .execute(AES128.clone(), &input_macs, &gate_masks, &gate_macs)
+                .execute(
+                    AES128.clone(),
+                    input_macs.clone(),
+                    gate_masks.clone(),
+                    gate_macs.clone(),
+                    prover_transcript.clone(),
+                )
                 .unwrap();
             let mut verifier_execute = verifier
-                .execute(AES128.clone(), &input_keys, &gate_keys)
+                .execute(
+                    AES128.clone(),
+                    input_keys.clone(),
+                    gate_keys.clone(),
+                    verifier_transcript.clone(),
+                )
                 .unwrap();
 
             let mut verifier_consumer = verifier_execute.consumer();
@@ -83,12 +94,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             let output_macs = prover_execute.finish().unwrap();
             let output_keys = verifier_execute.finish().unwrap();
 
-            let uv = prover
-                .check(&mut prover_transcript, &svole_choices, &svole_ev)
-                .unwrap();
-            verifier
-                .check(&mut verifier_transcript, &svole_keys, uv)
-                .unwrap();
+            let uv = prover.check(&svole_choices, &svole_ev).unwrap();
+            verifier.check(&svole_keys, uv).unwrap();
 
             black_box((output_macs, output_keys))
         })

--- a/crates/zk-core/src/check.rs
+++ b/crates/zk-core/src/check.rs
@@ -1,5 +1,7 @@
 //! QuickSilver consistency check.
 
+use std::{collections::HashMap, mem};
+
 use blake3::Hasher;
 use mpz_core::Block;
 use serde::{Deserialize, Serialize};
@@ -24,98 +26,131 @@ pub(crate) struct Triple {
 
 /// Prover’s unblinded preprocessed values for the consistency check.
 ///
-/// These are random linear combinations aggregated over one or more
-/// circuit executions. The values `u` and `v` are kept private and will later
-/// be masked (blinded) with random elements to derive the public values
-/// `U = u + u*` and `V = v + v*` sent to the verifier.
+/// These are random linear combinations for each circuit execution. The
+/// values `u` and `v` are kept private and will later be masked (blinded)
+/// with random elements to derive the public values `U = u + u*` and
+/// `V = v + v*` sent to the verifier.
 #[derive(Debug, Default)]
 pub(crate) struct ProverCheck {
-    u: Option<Block>,
-    v: Option<Block>,
+    /// Maps an id to the preprocessed values `u` and `v` from a single
+    /// circuit execution.
+    uv: HashMap<usize, (Block, Block)>,
+    /// Next id to assign to the preprocessed values.
+    next_id: usize,
 }
 
 impl ProverCheck {
-    /// Aggregates the values for the consistency check.
-    pub fn update(&mut self, u: Block, v: Block) {
-        match &mut self.u {
-            Some(prev_u) => *prev_u ^= u,
-            None => self.u = Some(u),
-        }
-
-        match &mut self.v {
-            Some(prev_v) => *prev_v ^= v,
-            None => self.v = Some(v),
-        }
+    pub fn next_id(&mut self) -> usize {
+        let next_id = self.next_id;
+        self.next_id += 1;
+        next_id
     }
 
-    /// Executes the prover check, returning `U` and `V` defined in Figure 5,
-    /// Step 7.b.
-    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<UV> {
-        let (a_0, a_1) = vole_receiver(
-            svole_choices.try_into().map_err(|_| CheckError::SVole)?,
-            svole_ev.try_into().map_err(|_| CheckError::SVole)?,
-        );
+    /// Inserts preprocessed values for the consistency check.
+    pub fn insert(&mut self, u: Block, v: Block, id: usize) {
+        self.uv.insert(id, (u, v));
+    }
 
-        let u = self.u.ok_or(CheckError::NoExecutions)?;
-        let v = self.v.ok_or(CheckError::NoExecutions)?;
+    /// Executes the prover check, returning `U` and `V` (for each circuit)
+    /// defined in Figure 5, Step 7.b.
+    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<Vec<UV>> {
+        if self.total_circuits() * 128 != svole_choices.len() {
+            return Err(CheckError::SVole);
+        }
+        if svole_ev.len() != svole_choices.len() {
+            return Err(CheckError::SVole);
+        }
 
-        // Reset the values.
-        self.u = None;
-        self.v = None;
+        let uv = mem::take(&mut self.uv);
+        let mut uv: Vec<(usize, (Block, Block))> = uv.into_iter().collect();
+        uv.sort_by_key(|&(k, _)| k);
 
-        Ok(UV {
-            u: u ^ a_0,
-            v: v ^ a_1,
-        })
+        let uvs = uv
+            .iter()
+            .zip(svole_choices.chunks(128))
+            .zip(svole_ev.chunks(128))
+            .map(|(((_, (u, v)), svole_choices), svole_ev)| {
+                let (a_0, a_1) = vole_receiver(
+                    svole_choices.try_into().map_err(|_| CheckError::SVole)?,
+                    svole_ev.try_into().map_err(|_| CheckError::SVole)?,
+                );
+
+                Ok(UV {
+                    u: u ^ a_0,
+                    v: v ^ a_1,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(uvs)
     }
 
     /// Returns `true` if there are gates to check.
     #[inline]
     pub(crate) fn wants_check(&self) -> bool {
-        // `true` if at least one AND gate was executed.
-        self.u.is_some()
+        !self.uv.is_empty()
+    }
+
+    /// Returns the number of circuits that need to be checked.
+    pub fn total_circuits(&self) -> usize {
+        self.uv.len()
     }
 }
 
 /// Verifier’s unmasked preprocessed values for the consistency check.
 ///
-/// This is a random linear combination aggregated over one or more
-/// circuit executions. The value will later be masked with a random
-/// element to derive `W`.
+/// This is a random linear combination for each circuit execution. The value
+/// will later be masked with a random element to derive `W`.
 #[derive(Debug, Default)]
 pub(crate) struct VerifierCheck {
-    w: Option<Block>,
+    /// Maps an id to the preprocessed values `w` from a single
+    /// circuit execution.
+    w: HashMap<usize, Block>,
+    /// Next id to assign to the preprocessed values.
+    next_id: usize,
 }
 
 impl VerifierCheck {
-    /// Aggregates the values for the consistency check.
-    pub fn update(&mut self, w: Block) {
-        match &mut self.w {
-            Some(prev_w) => *prev_w ^= w,
-            None => self.w = Some(w),
-        }
+    pub fn next_id(&mut self) -> usize {
+        let next_id = self.next_id;
+        self.next_id += 1;
+        next_id
+    }
+
+    /// Inserts a preprocessed value for the consistency check.
+    pub fn insert(&mut self, w: Block, id: usize) {
+        self.w.insert(id, w);
     }
 
     /// Executes the verifier check, returning `W` defined in Figure 5, Step
     /// 7.c.
-    pub fn check(&mut self, delta: &Block, svole_keys: &[Block], uv: UV) -> Result<()> {
-        let w = self.w.ok_or(CheckError::NoExecutions)?;
-
-        let b = vole_sender(
-            &svole_keys
-                .try_into()
-                .map_err(|_| CheckError::SVole)
-                .unwrap(),
-        );
-
-        let UV { u, v } = uv;
-
-        if w ^ b != u ^ delta.gfmul(v) {
-            return Err(CheckError::Invalid);
+    pub fn check(&mut self, delta: &Block, svole_keys: &[Block], uvs: Vec<UV>) -> Result<()> {
+        if self.total_circuits() * 128 != svole_keys.len() {
+            return Err(CheckError::SVole);
+        }
+        if self.total_circuits() != uvs.len() {
+            return Err(CheckError::SVole);
         }
 
-        // Reset the value.
-        self.w = None;
+        let w = mem::take(&mut self.w);
+        let mut w: Vec<(usize, Block)> = w.into_iter().collect();
+        w.sort_by_key(|&(k, _)| k);
+
+        w.iter()
+            .zip(uvs)
+            .zip(svole_keys.chunks(128))
+            .map(|(((_, w), uv), svole_keys)| {
+                let b = vole_sender(&svole_keys.try_into().map_err(|_| CheckError::SVole)?);
+
+                let UV { u, v } = uv;
+
+                if w ^ b != u ^ delta.gfmul(v) {
+                    return Err(CheckError::Invalid);
+                }
+
+                Ok(())
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(())
     }
@@ -123,8 +158,13 @@ impl VerifierCheck {
     /// Returns `true` if there are gates to check.
     #[inline]
     pub(crate) fn wants_check(&self) -> bool {
-        // `true` if at least one AND gate was executed.
-        self.w.is_some()
+        !self.w.is_empty()
+    }
+
+    /// Returns the number of circuits that need to be checked.
+    #[inline]
+    pub fn total_circuits(&self) -> usize {
+        self.w.len()
     }
 }
 

--- a/crates/zk-core/src/check.rs
+++ b/crates/zk-core/src/check.rs
@@ -1,15 +1,8 @@
 //! QuickSilver consistency check.
 
-use std::mem;
-
 use blake3::Hasher;
-use cfg_if::cfg_if;
-use mpz_core::{
-    Block,
-    bitvec::{BitSlice, BitVec},
-};
+use mpz_core::Block;
 use serde::{Deserialize, Serialize};
-use zerocopy::IntoBytes;
 
 use crate::vole::{vole_receiver, vole_sender};
 
@@ -29,185 +22,180 @@ pub(crate) struct Triple {
     pub(crate) z: Block,
 }
 
+/// Prover’s unblinded preprocessed values for the consistency check.
+///
+/// These are random linear combinations aggregated over one or more
+/// circuit executions. The values `u` and `v` are kept private and will later
+/// be masked (blinded) with random elements to derive the public values
+/// `U = u + u*` and `V = v + v*` sent to the verifier.
 #[derive(Debug, Default)]
-pub(crate) struct Check {
-    triples: Vec<Triple>,
-    adjust: BitVec,
+pub(crate) struct ProverCheck {
+    u: Option<Block>,
+    v: Option<Block>,
 }
 
-impl Check {
-    /// Reserves capacity for at least `n` AND gates, returns the starting
-    /// index.
-    pub(crate) fn reserve(&mut self, n: usize) -> usize {
-        let idx = self.triples.len();
-        self.triples.resize_with(idx + n, Default::default);
-        self.adjust.resize_with(idx + n, |_| Default::default());
-        idx
-    }
-
-    pub(crate) fn write(&mut self, idx: usize, triples: &[Triple], adjust: &BitSlice) {
-        self.triples[idx..idx + triples.len()].copy_from_slice(triples);
-        self.adjust[idx..idx + triples.len()].copy_from_bitslice(adjust);
-    }
-
-    /// Returns `true` if there are gates to check.
-    #[inline]
-    pub(crate) fn wants_check(&self) -> bool {
-        !self.triples.is_empty()
-    }
-
-    fn compute_chis(&self, mut chi: Block) -> Vec<Block> {
-        // TODO: Consider using a PRG instead so computing the coefficients
-        // can be done in parallel.
-        let mut chis = Vec::with_capacity(self.triples.len());
-        chis.push(chi);
-        for _ in 1..self.triples.len() {
-            chi = chi.gfmul(chi);
-            chis.push(chi);
+impl ProverCheck {
+    /// Aggregates the values for the consistency check.
+    pub fn update(&mut self, u: Block, v: Block) {
+        match &mut self.u {
+            Some(prev_u) => *prev_u ^= u,
+            None => self.u = Some(u),
         }
 
-        chis
+        match &mut self.v {
+            Some(prev_v) => *prev_v ^= v,
+            None => self.v = Some(v),
+        }
     }
 
     /// Executes the prover check, returning `U` and `V` defined in Figure 5,
     /// Step 7.b.
-    pub(crate) fn check_prover(
-        &mut self,
-        transcript: &mut Hasher,
-        svole_choices: &[bool],
-        svole_ev: &[Block],
-    ) -> Result<UV> {
-        #[inline]
-        fn compute_terms(triple: Triple, chi: Block) -> (Block, Block) {
-            let Triple { x, y, z } = triple;
-
-            let u = x.gfmul(y).gfmul(chi);
-
-            // (Note that the LSB of a MAC contains the authenticated bit).
-            let a_10 = if x.lsb() { y } else { Block::ZERO };
-            let a_11 = if y.lsb() { x } else { Block::ZERO };
-            let v = (a_10 ^ a_11 ^ z).gfmul(chi);
-
-            (u, v)
-        }
-
-        let adjust_len = self.adjust.len();
-        transcript.update(&self.adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
-
-        let chi = Block::try_from(&transcript.finalize().as_bytes()[..16])
-            .expect("block should be 16 bytes");
-        let chis = self.compute_chis(chi);
-        let macs = mem::take(&mut self.triples);
-        cfg_if! {
-            if #[cfg(all(feature = "rayon", not(feature = "force-st")))] {
-                use rayon::prelude::*;
-
-                let (mut u, mut v) = macs
-                    .into_par_iter()
-                    .zip(chis)
-                    .map(|(macs, chi)| compute_terms(macs, chi))
-                    .reduce(
-                        || (Block::ZERO, Block::ZERO),
-                        |(u_acc, v_acc), (u, v)| (u_acc ^ u, v_acc ^ v),
-                    );
-            } else {
-                let (mut u, mut v) = macs
-                    .into_iter()
-                    .zip(chis)
-                    .map(|(macs, chi)| compute_terms(macs, chi))
-                    .fold(
-                        (Block::ZERO, Block::ZERO),
-                        |(u_acc, v_acc), (u, v)| (u_acc ^ u, v_acc ^ v),
-                    );
-            }
-        }
-
+    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<UV> {
         let (a_0, a_1) = vole_receiver(
             svole_choices.try_into().map_err(|_| CheckError::SVole)?,
             svole_ev.try_into().map_err(|_| CheckError::SVole)?,
         );
 
-        u ^= a_0;
-        v ^= a_1;
+        let u = self.u.ok_or(CheckError::NoExecutions)?;
+        let v = self.v.ok_or(CheckError::NoExecutions)?;
 
-        transcript.update(&u.to_bytes());
-        transcript.update(&v.to_bytes());
+        // Reset the values.
+        self.u = None;
+        self.v = None;
 
-        self.adjust.clear();
+        Ok(UV {
+            u: u ^ a_0,
+            v: v ^ a_1,
+        })
+    }
 
-        Ok(UV { u, v })
+    /// Returns `true` if there are gates to check.
+    #[inline]
+    pub(crate) fn wants_check(&self) -> bool {
+        // `true` if at least one AND gate was executed.
+        self.u.is_some()
+    }
+}
+
+/// Verifier’s unmasked preprocessed values for the consistency check.
+///
+/// This is a random linear combination aggregated over one or more
+/// circuit executions. The value will later be masked with a random
+/// element to derive `W`.
+#[derive(Debug, Default)]
+pub(crate) struct VerifierCheck {
+    w: Option<Block>,
+}
+
+impl VerifierCheck {
+    /// Aggregates the values for the consistency check.
+    pub fn update(&mut self, w: Block) {
+        match &mut self.w {
+            Some(prev_w) => *prev_w ^= w,
+            None => self.w = Some(w),
+        }
     }
 
     /// Executes the verifier check, returning `W` defined in Figure 5, Step
     /// 7.c.
-    pub(crate) fn check_verifier(
-        &mut self,
-        transcript: &mut Hasher,
-        delta: &Block,
-        svole_keys: &[Block],
-        uv: UV,
-    ) -> Result<()> {
-        #[inline]
-        fn compute_term(triple: Triple, chi: Block, delta: &Block) -> Block {
-            let Triple { x, y, z } = triple;
-            let b = x.gfmul(y) ^ delta.gfmul(z);
-            b.gfmul(chi)
-        }
+    pub fn check(&mut self, delta: &Block, svole_keys: &[Block], uv: UV) -> Result<()> {
+        let w = self.w.ok_or(CheckError::NoExecutions)?;
 
-        let adjust_len = self.adjust.len();
-        transcript.update(&self.adjust.as_raw_slice().as_bytes()[..adjust_len.div_ceil(8)]);
-
-        let chi = Block::try_from(&transcript.finalize().as_bytes()[..16])
-            .expect("block should be 16 bytes");
-        let chis = self.compute_chis(chi);
-        let keys = mem::take(&mut self.triples);
-        cfg_if! {
-            if #[cfg(all(feature = "rayon", not(feature = "force-st")))] {
-                use rayon::prelude::*;
-
-                let mut w = keys
-                    .into_par_iter()
-                    .zip(chis)
-                    .map(|(keys, chi)| compute_term(keys, chi, delta))
-                    .reduce(
-                        || Block::ZERO,
-                        |w_acc, w| w_acc ^ w,
-                    );
-            } else {
-                let mut w = keys
-                    .into_iter()
-                    .zip(chis)
-                    .map(|(keys, chi)| compute_term(keys, chi, delta))
-                    .fold(
-                        Block::ZERO,
-                        |w_acc, w| w_acc ^ w,
-                    );
-            }
-        }
-
-        let b = vole_sender(svole_keys.try_into().map_err(|_| CheckError::SVole)?);
-
-        w ^= b;
+        let b = vole_sender(
+            &svole_keys
+                .try_into()
+                .map_err(|_| CheckError::SVole)
+                .unwrap(),
+        );
 
         let UV { u, v } = uv;
-        transcript.update(&u.to_bytes());
-        transcript.update(&v.to_bytes());
 
-        self.adjust.clear();
-
-        if w != u ^ delta.gfmul(v) {
-            // Invalid! Call the police.
+        if w ^ b != u ^ delta.gfmul(v) {
             return Err(CheckError::Invalid);
         }
 
+        // Reset the value.
+        self.w = None;
+
         Ok(())
+    }
+
+    /// Returns `true` if there are gates to check.
+    #[inline]
+    pub(crate) fn wants_check(&self) -> bool {
+        // `true` if at least one AND gate was executed.
+        self.w.is_some()
     }
 }
 
+/// Computes the values `u` and `v` as defined in [ProverCheck].
+pub(crate) fn compute_uv(transcript: &mut Hasher, triples: &[Triple]) -> (Block, Block) {
+    #[inline]
+    fn compute_terms(triple: Triple, chi: Block) -> (Block, Block) {
+        let Triple { x, y, z } = triple;
+
+        let u = x.gfmul(y).gfmul(chi);
+
+        // (Note that the LSB of a MAC contains the authenticated bit).
+        let a_10 = if x.lsb() { y } else { Block::ZERO };
+        let a_11 = if y.lsb() { x } else { Block::ZERO };
+        let v = (a_10 ^ a_11 ^ z).gfmul(chi);
+
+        (u, v)
+    }
+
+    let chi =
+        Block::try_from(&transcript.finalize().as_bytes()[..16]).expect("block should be 16 bytes");
+    let chis = compute_chis(chi, triples.len());
+
+    triples
+        .iter()
+        .zip(chis)
+        .map(|(mac, chi)| compute_terms(*mac, chi))
+        .fold((Block::ZERO, Block::ZERO), |(u_acc, v_acc), (u, v)| {
+            (u_acc ^ u, v_acc ^ v)
+        })
+}
+
+/// Computes the value `w` as defined in [VerifierCheck].
+pub(crate) fn compute_w(transcript: &mut Hasher, triples: &[Triple], delta: &Block) -> Block {
+    #[inline]
+    fn compute_term(triple: Triple, chi: Block, delta: &Block) -> Block {
+        let Triple { x, y, z } = triple;
+        let b = x.gfmul(y) ^ delta.gfmul(z);
+        b.gfmul(chi)
+    }
+
+    let chi =
+        Block::try_from(&transcript.finalize().as_bytes()[..16]).expect("block should be 16 bytes");
+    let chis = compute_chis(chi, triples.len());
+
+    triples
+        .iter()
+        .zip(chis)
+        .map(|(key, chi)| compute_term(*key, chi, delta))
+        .fold(Block::ZERO, |w_acc, w| w_acc ^ w)
+}
+
+fn compute_chis(mut chi: Block, count: usize) -> Vec<Block> {
+    debug_assert!(count > 0);
+
+    let mut chis = Vec::with_capacity(count);
+    chis.push(chi);
+    for _ in 1..count {
+        chi = chi.gfmul(chi);
+        chis.push(chi);
+    }
+
+    chis
+}
+
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum CheckError {
+pub enum CheckError {
     #[error("incorrect number of sVOLE instances provided")]
     SVole,
     #[error("invalid consistency check")]
     Invalid,
+    #[error("check was called when no AND gates were executed")]
+    NoExecutions,
 }

--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -144,10 +144,21 @@ mod tests {
         let gate_macs = Mac::from_blocks(gate_macs);
 
         let mut prover_exec = prover
-            .execute(AES128.clone(), &input_macs, &gate_masks, &gate_macs)
+            .execute(
+                AES128.clone(),
+                input_macs,
+                gate_masks,
+                gate_macs,
+                prover_transcript.clone(),
+            )
             .unwrap();
         let mut verifier_exec = verifier
-            .execute(AES128.clone(), &input_keys, &gate_keys)
+            .execute(
+                AES128.clone(),
+                input_keys,
+                gate_keys,
+                verifier_transcript.clone(),
+            )
             .unwrap();
         let mut verifier_consumer = verifier_exec.consumer();
 
@@ -174,12 +185,8 @@ mod tests {
             },
         ) = rcot.transfer(128).unwrap();
 
-        let uv = prover
-            .check(&mut prover_transcript, &svole_choices, &svole_ev)
-            .unwrap();
-        verifier
-            .check(&mut verifier_transcript, &svole_keys, uv)
-            .unwrap();
+        let uv = prover.check(&svole_choices, &svole_ev).unwrap();
+        verifier.check(&svole_keys, uv).unwrap();
 
         prover_store
             .set_output_macs(ct_p.to_raw(), &output_macs)

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -47,7 +47,10 @@ impl Prover {
             .into());
         }
 
+        let id = self.check.lock().unwrap().next_id();
+
         Ok(ProverExecute::new(
+            id,
             circ,
             input_macs,
             gate_masks,
@@ -63,7 +66,7 @@ impl Prover {
     }
 
     /// Executes the consistency check.
-    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<UV> {
+    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<Vec<UV>> {
         if Arc::strong_count(&self.check) > 1 {
             return Err(ErrorRepr::Inprogress.into());
         }
@@ -74,11 +77,16 @@ impl Prover {
             .check(svole_choices, svole_ev)
             .map_err(From::from)
     }
+
+    pub fn total_circuits(&self) -> usize {
+        self.check.lock().unwrap().total_circuits()
+    }
 }
 
 /// Prover circuit execution.
 #[derive(Debug)]
 pub struct ProverExecute {
+    id: usize,
     circ: Arc<Circuit>,
     macs: Vec<Mac>,
     triples: Vec<Triple>,
@@ -96,6 +104,7 @@ pub struct ProverExecute {
 
 impl ProverExecute {
     fn new(
+        id: usize,
         circ: Arc<Circuit>,
         macs: Vec<Mac>,
         gate_masks: Vec<bool>,
@@ -105,6 +114,7 @@ impl ProverExecute {
     ) -> Self {
         let and_count = circ.and_count();
         Self {
+            id,
             circ,
             macs,
             triples: Vec::default(),
@@ -158,10 +168,10 @@ impl ProverExecute {
             return Err(ErrorRepr::Incomplete.into());
         }
 
-        // Only update the consistency check value if there were actual AND
-        // gates in the execution.
+        // The consistency check will only be performed if there actually were
+        // AND gates in the execution.
         if self.counter > 0 {
-            // For 40-bit statistical security against the adverary guessing
+            // For 40-bit statistical security against the adversary guessing
             // the transcript, we require the circuit to consist of at least
             // 40 AND gates.
             if self.counter < 40 {
@@ -172,8 +182,9 @@ impl ProverExecute {
                 .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
 
             let (u, v) = compute_uv(&mut self.transcript, &self.triples);
-            self.check.lock().unwrap().update(u, v);
-        }
+
+            self.check.lock().unwrap().insert(u, v, self.id);
+        };
 
         Ok(self.macs[self.circ.outputs()].to_vec())
     }

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -161,6 +161,13 @@ impl ProverExecute {
         // Only update the consistency check value if there were actual AND
         // gates in the execution.
         if self.counter > 0 {
+            // For 40-bit statistical security against the adverary guessing
+            // the transcript, we require the circuit to consist of at least
+            // 40 AND gates.
+            if self.counter < 40 {
+                return Err(ErrorRepr::InsufficientEntropy.into());
+            }
+
             self.transcript
                 .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
 
@@ -262,6 +269,8 @@ enum ErrorRepr {
     Incomplete,
     #[error("cannot run consistency check while execution is in progress")]
     Inprogress,
+    #[error("cannot run consistency check with insufficient transcript entropy")]
+    InsufficientEntropy,
     #[error(transparent)]
     Check(CheckError),
     #[error("cannot return Macs: {0}")]

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -4,9 +4,10 @@ use blake3::Hasher;
 use mpz_circuits::{Circuit, Gate};
 use mpz_core::{Block, bitvec::BitVec};
 use mpz_memory_core::correlated::Mac;
+use zerocopy::IntoBytes;
 
 use crate::{
-    check::{Check, CheckError, Triple, UV},
+    check::{CheckError, ProverCheck, Triple, UV, compute_uv},
     store::ProverStoreError,
 };
 
@@ -14,16 +15,17 @@ type Result<T> = core::result::Result<T, ProverError>;
 
 #[derive(Debug, Default)]
 pub struct Prover {
-    check: Arc<Mutex<Check>>,
+    check: Arc<Mutex<ProverCheck>>,
 }
 
 impl Prover {
-    pub fn execute<'a>(
+    pub fn execute(
         &mut self,
         circ: Arc<Circuit>,
-        input_macs: &'a [Mac],
-        gate_masks: &'a [bool],
-        gate_macs: &'a [Mac],
+        input_macs: Vec<Mac>,
+        gate_masks: Vec<bool>,
+        gate_macs: Vec<Mac>,
+        transcript: Hasher,
     ) -> Result<ProverExecute> {
         if input_macs.len() != circ.inputs().len() {
             return Err(ErrorRepr::InputMacCount {
@@ -45,15 +47,13 @@ impl Prover {
             .into());
         }
 
-        let check_idx = self.check.lock().unwrap().reserve(circ.and_count());
-
         Ok(ProverExecute::new(
             circ,
-            input_macs.to_vec(),
-            gate_masks.to_vec(),
-            gate_macs.to_vec(),
+            input_macs,
+            gate_masks,
+            gate_macs,
+            transcript,
             self.check.clone(),
-            check_idx,
         ))
     }
 
@@ -63,12 +63,7 @@ impl Prover {
     }
 
     /// Executes the consistency check.
-    pub fn check(
-        &mut self,
-        transcript: &mut Hasher,
-        svole_choices: &[bool],
-        svole_ev: &[Block],
-    ) -> Result<UV> {
+    pub fn check(&mut self, svole_choices: &[bool], svole_ev: &[Block]) -> Result<UV> {
         if Arc::strong_count(&self.check) > 1 {
             return Err(ErrorRepr::Inprogress.into());
         }
@@ -76,7 +71,7 @@ impl Prover {
         self.check
             .lock()
             .unwrap()
-            .check_prover(transcript, svole_choices, svole_ev)
+            .check(svole_choices, svole_ev)
             .map_err(From::from)
     }
 }
@@ -90,11 +85,13 @@ pub struct ProverExecute {
     adjust: BitVec,
     gate_masks: Vec<bool>,
     gate_macs: Vec<Mac>,
-    check: Arc<Mutex<Check>>,
-    check_idx: usize,
-
+    /// The number of AND gates executed so far.
     counter: usize,
     and_count: usize,
+    /// The transcript to be used for the consistency check of this execution.
+    transcript: Hasher,
+    /// The consistency check value to be updated after this execution.
+    check: Arc<Mutex<ProverCheck>>,
 }
 
 impl ProverExecute {
@@ -103,8 +100,8 @@ impl ProverExecute {
         macs: Vec<Mac>,
         gate_masks: Vec<bool>,
         gate_macs: Vec<Mac>,
-        check: Arc<Mutex<Check>>,
-        check_idx: usize,
+        transcript: Hasher,
+        check: Arc<Mutex<ProverCheck>>,
     ) -> Self {
         let and_count = circ.and_count();
         Self {
@@ -114,10 +111,10 @@ impl ProverExecute {
             adjust: BitVec::default(),
             gate_masks,
             gate_macs,
-            check,
-            check_idx,
             counter: 0,
             and_count,
+            transcript,
+            check,
         }
     }
 
@@ -155,16 +152,21 @@ impl ProverExecute {
         }
     }
 
-    pub fn finish(self) -> Result<Vec<Mac>> {
+    /// Finishes the execution and preprocesses the consistency check values.
+    pub fn finish(mut self) -> Result<Vec<Mac>> {
         if self.counter != self.and_count {
             return Err(ErrorRepr::Incomplete.into());
         }
 
-        // Flush check state.
-        self.check
-            .lock()
-            .unwrap()
-            .write(self.check_idx, &self.triples, &self.adjust);
+        // Only update the consistency check value if there were actual AND
+        // gates in the execution.
+        if self.counter > 0 {
+            self.transcript
+                .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
+
+            let (u, v) = compute_uv(&mut self.transcript, &self.triples);
+            self.check.lock().unwrap().update(u, v);
+        }
 
         Ok(self.macs[self.circ.outputs()].to_vec())
     }

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -166,6 +166,13 @@ impl VerifierExecute {
         // Only update the consistency check value if there were actual AND
         // gates in the execution.
         if self.counter > 0 {
+            // For 40-bit statistical security against the adverary guessing
+            // the transcript, we require the circuit to consist of at least
+            // 40 AND gates.
+            if self.counter < 40 {
+                return Err(ErrorRepr::InsufficientEntropy.into());
+            }
+
             self.transcript
                 .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
 
@@ -273,6 +280,8 @@ enum ErrorRepr {
     Incomplete,
     #[error("cannot run consistency check while execution is in progress")]
     Inprogress,
+    #[error("cannot run consistency check with insufficient transcript entropy")]
+    InsufficientEntropy,
     #[error(transparent)]
     Check(CheckError),
     #[error("cannot return keys: {0}")]

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -52,7 +52,10 @@ impl Verifier {
             .into());
         }
 
+        let id = self.check.lock().unwrap().next_id();
+
         Ok(VerifierExecute::new(
+            id,
             circ,
             self.delta,
             input_keys,
@@ -63,7 +66,7 @@ impl Verifier {
     }
 
     /// Executes the consistency check.
-    pub fn check(&mut self, svole_keys: &[Block], uv: UV) -> Result<()> {
+    pub fn check(&mut self, svole_keys: &[Block], uv: Vec<UV>) -> Result<()> {
         if Arc::strong_count(&self.check) > 1 {
             return Err(ErrorRepr::Inprogress.into());
         }
@@ -74,11 +77,16 @@ impl Verifier {
             .check(self.delta.as_block(), svole_keys, uv)
             .map_err(From::from)
     }
+
+    pub fn total_circuits(&self) -> usize {
+        self.check.lock().unwrap().total_circuits()
+    }
 }
 
 /// Verifier circuit execution.
 #[derive(Debug)]
 pub struct VerifierExecute {
+    id: usize,
     circ: Arc<Circuit>,
     delta: Delta,
     keys: Vec<Key>,
@@ -96,6 +104,7 @@ pub struct VerifierExecute {
 
 impl VerifierExecute {
     fn new(
+        id: usize,
         circ: Arc<Circuit>,
         delta: Delta,
         keys: Vec<Key>,
@@ -105,6 +114,7 @@ impl VerifierExecute {
     ) -> Self {
         let and_count = circ.and_count();
         Self {
+            id,
             circ,
             delta,
             keys,
@@ -163,10 +173,10 @@ impl VerifierExecute {
             return Err(ErrorRepr::Incomplete.into());
         }
 
-        // Only update the consistency check value if there were actual AND
-        // gates in the execution.
+        // The consistency check will only be performed if there actually were
+        // AND gates in the execution.
         if self.counter > 0 {
-            // For 40-bit statistical security against the adverary guessing
+            // For 40-bit statistical security against the adversary guessing
             // the transcript, we require the circuit to consist of at least
             // 40 AND gates.
             if self.counter < 40 {
@@ -177,7 +187,7 @@ impl VerifierExecute {
                 .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
 
             let w = compute_w(&mut self.transcript, &self.triples, self.delta.as_block());
-            self.check.lock().unwrap().update(w);
+            self.check.lock().unwrap().insert(w, self.id);
         }
 
         Ok(self.keys[self.circ.outputs()].to_vec())

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -4,9 +4,10 @@ use blake3::Hasher;
 use mpz_circuits::{Circuit, Gate};
 use mpz_core::{Block, bitvec::BitVec};
 use mpz_memory_core::correlated::{Delta, Key};
+use zerocopy::IntoBytes;
 
 use crate::{
-    check::{Check, CheckError, Triple, UV},
+    check::{CheckError, Triple, UV, VerifierCheck, compute_w},
     store::VerifierStoreError,
 };
 
@@ -14,7 +15,7 @@ type Result<T> = core::result::Result<T, VerifierError>;
 
 pub struct Verifier {
     delta: Delta,
-    check: Arc<Mutex<Check>>,
+    check: Arc<Mutex<VerifierCheck>>,
 }
 
 impl Verifier {
@@ -22,7 +23,7 @@ impl Verifier {
     pub fn new(delta: Delta) -> Self {
         Self {
             delta,
-            check: Arc::new(Mutex::new(Check::default())),
+            check: Arc::new(Mutex::new(VerifierCheck::default())),
         }
     }
 
@@ -30,12 +31,12 @@ impl Verifier {
     pub fn wants_check(&self) -> bool {
         self.check.lock().unwrap().wants_check()
     }
-
     pub fn execute(
         &mut self,
         circ: Arc<Circuit>,
-        input_keys: &[Key],
-        gate_keys: &[Key],
+        input_keys: Vec<Key>,
+        gate_keys: Vec<Key>,
+        transcript: Hasher,
     ) -> Result<VerifierExecute> {
         if input_keys.len() != circ.inputs().len() {
             return Err(ErrorRepr::InputKeyCount {
@@ -51,20 +52,18 @@ impl Verifier {
             .into());
         }
 
-        let check_idx = self.check.lock().unwrap().reserve(circ.and_count());
-
         Ok(VerifierExecute::new(
             circ,
             self.delta,
-            input_keys.to_vec(),
-            gate_keys.to_vec(),
+            input_keys,
+            gate_keys,
+            transcript,
             self.check.clone(),
-            check_idx,
         ))
     }
 
     /// Executes the consistency check.
-    pub fn check(&mut self, transcript: &mut Hasher, svole_keys: &[Block], uv: UV) -> Result<()> {
+    pub fn check(&mut self, svole_keys: &[Block], uv: UV) -> Result<()> {
         if Arc::strong_count(&self.check) > 1 {
             return Err(ErrorRepr::Inprogress.into());
         }
@@ -72,7 +71,7 @@ impl Verifier {
         self.check
             .lock()
             .unwrap()
-            .check_verifier(transcript, self.delta.as_block(), svole_keys, uv)
+            .check(self.delta.as_block(), svole_keys, uv)
             .map_err(From::from)
     }
 }
@@ -86,11 +85,13 @@ pub struct VerifierExecute {
     gate_keys: Vec<Key>,
     triples: Vec<Triple>,
     adjust: BitVec,
-    check: Arc<Mutex<Check>>,
-    check_idx: usize,
-
+    /// The number of AND gates executed so far.
     counter: usize,
     and_count: usize,
+    /// The transcript to be used for the consistency check of this execution.
+    transcript: Hasher,
+    /// The consistency check value to be updated after this execution.
+    check: Arc<Mutex<VerifierCheck>>,
 }
 
 impl VerifierExecute {
@@ -99,8 +100,8 @@ impl VerifierExecute {
         delta: Delta,
         keys: Vec<Key>,
         gate_keys: Vec<Key>,
-        check: Arc<Mutex<Check>>,
-        check_idx: usize,
+        hasher: Hasher,
+        check: Arc<Mutex<VerifierCheck>>,
     ) -> Self {
         let and_count = circ.and_count();
         Self {
@@ -110,10 +111,10 @@ impl VerifierExecute {
             gate_keys,
             triples: Vec::default(),
             adjust: BitVec::default(),
-            check,
-            check_idx,
             counter: 0,
             and_count,
+            transcript: hasher,
+            check,
         }
     }
 
@@ -156,16 +157,21 @@ impl VerifierExecute {
         consumer
     }
 
-    pub fn finish(self) -> Result<Vec<Key>> {
+    /// Finishes the execution and preprocesses the consistency check values.
+    pub fn finish(mut self) -> Result<Vec<Key>> {
         if self.counter < self.and_count {
             return Err(ErrorRepr::Incomplete.into());
         }
 
-        // Flush check state.
-        self.check
-            .lock()
-            .unwrap()
-            .write(self.check_idx, &self.triples, &self.adjust);
+        // Only update the consistency check value if there were actual AND
+        // gates in the execution.
+        if self.counter > 0 {
+            self.transcript
+                .update(&(self.adjust.as_raw_slice().as_bytes()[..self.adjust.len().div_ceil(8)]));
+
+            let w = compute_w(&mut self.transcript, &self.triples, self.delta.as_block());
+            self.check.lock().unwrap().update(w);
+        }
 
         Ok(self.keys[self.circ.outputs()].to_vec())
     }

--- a/crates/zk/Cargo.toml
+++ b/crates/zk/Cargo.toml
@@ -11,25 +11,19 @@ default = ["rayon"]
 rayon = ["mpz-zk-core/rayon", "mpz-common/rayon"]
 
 [dependencies]
+async-trait = { workspace = true }
+blake3 = { workspace = true, features = ["serde"] }
+futures = { workspace = true }
+serio = { workspace = true }
+thiserror = { workspace = true }
+mpz-common = { workspace = true }
+mpz-core = { workspace = true }
+mpz-ot = { workspace = true }
 mpz-vm-core = { workspace = true }
 mpz-zk-core = { workspace = true }
-mpz-ot = { workspace = true }
-mpz-core = { workspace = true }
-mpz-common = { workspace = true }
-futures = { workspace = true }
-thiserror = { workspace = true }
-async-trait = { workspace = true }
-serio = { workspace = true }
-blake3 = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = [
-    "net",
-    "macros",
-    "rt",
-    "rt-multi-thread",
-] }
-rand = { workspace = true }
+criterion = { workspace = true }
 mpz-circuits = { workspace = true }
 mpz-common = { workspace = true, features = [
     "test-utils",
@@ -37,7 +31,13 @@ mpz-common = { workspace = true, features = [
     "executor",
 ] }
 mpz-ot = { workspace = true, features = ["ideal"] }
-criterion = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true, features = [
+    "net",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+] }
 
 [[bench]]
 name = "zk"

--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -197,12 +197,14 @@ where
                 choices: svole_choices,
                 msgs: svole_ev,
                 ..
-            } = self.ot.try_recv_rcot(128).map_err(VmError::execute)?;
+            } = self
+                .ot
+                .try_recv_rcot(prover.total_circuits() * 128)
+                .map_err(VmError::execute)?;
 
             let uv = prover
                 .check(&svole_choices, &svole_ev)
                 .map_err(VmError::execute)?;
-
             ctx.io_mut().send(uv).await?;
         }
 
@@ -219,10 +221,8 @@ where
 
         let mut count = call.circ().and_count();
         if count > 0 {
-            // If the callstack is empty, we allocate more for the consistency check.
-            if self.callstack.is_empty() {
-                count += 128
-            }
+            // Allocate for the consistency check of this circuit.
+            count += 128;
 
             self.ot.alloc(count).map_err(VmError::execute)?;
         }

--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -106,6 +106,7 @@ where
 
     async fn execute(&mut self, ctx: &mut Context) -> VmResult<()> {
         let mut prover = Core::default();
+
         while !self.callstack.is_empty() {
             let ready_calls: Vec<_> = self
                 .callstack
@@ -145,7 +146,13 @@ where
                 let gate_macs = Mac::from_blocks(gate_macs);
 
                 let execute = prover
-                    .execute(circ, &input_macs, &gate_masks, &gate_macs)
+                    .execute(
+                        circ,
+                        input_macs,
+                        gate_masks,
+                        gate_macs,
+                        self.transcript.clone(),
+                    )
                     .map_err(VmError::execute)?;
                 tasks.push((execute, output));
             }
@@ -156,7 +163,8 @@ where
                     async move |ctx, (mut execute, output)| {
                         let mut iter = execute.iter();
                         loop {
-                            // Stream the `adjust` bits to avoid buffering them in memory.
+                            // Stream the `adjust` bits to avoid buffering them in
+                            // memory.
                             let adjust: BitVec = BitVec::from_iter(iter.by_ref().take(8000));
 
                             if !adjust.is_empty() {
@@ -192,8 +200,9 @@ where
             } = self.ot.try_recv_rcot(128).map_err(VmError::execute)?;
 
             let uv = prover
-                .check(&mut self.transcript, &svole_choices, &svole_ev)
+                .check(&svole_choices, &svole_ev)
                 .map_err(VmError::execute)?;
+
             ctx.io_mut().send(uv).await?;
         }
 

--- a/crates/zk/src/verifier.rs
+++ b/crates/zk/src/verifier.rs
@@ -102,6 +102,7 @@ where
 
     async fn execute(&mut self, ctx: &mut Context) -> VmResult<()> {
         let mut verifier = Core::new(*self.store.delta());
+
         while !self.callstack.is_empty() {
             let ready_calls: Vec<_> = self
                 .callstack
@@ -139,7 +140,7 @@ where
                 let gate_keys = Key::from_blocks(gate_keys);
 
                 let execute = verifier
-                    .execute(circ, &input_keys, &gate_keys)
+                    .execute(circ, input_keys, gate_keys, self.transcript.clone())
                     .map_err(VmError::execute)?;
                 tasks.push((execute, output));
             }
@@ -149,6 +150,7 @@ where
                     tasks,
                     async move |ctx, (mut execute, output)| {
                         let mut consumer = execute.consumer();
+
                         while consumer.wants_adjust() {
                             let adjust: BitVec = ctx.io_mut().expect_next().await?;
                             for bit in adjust {
@@ -180,9 +182,7 @@ where
             } = self.ot.try_send_rcot(128).map_err(VmError::execute)?;
 
             let uv = ctx.io_mut().expect_next().await?;
-            verifier
-                .check(&mut self.transcript, &svole_keys, uv)
-                .map_err(VmError::execute)?;
+            verifier.check(&svole_keys, uv).map_err(VmError::execute)?;
         }
 
         Ok(())

--- a/crates/zk/src/verifier.rs
+++ b/crates/zk/src/verifier.rs
@@ -179,7 +179,10 @@ where
         if verifier.wants_check() {
             let RCOTSenderOutput {
                 keys: svole_keys, ..
-            } = self.ot.try_send_rcot(128).map_err(VmError::execute)?;
+            } = self
+                .ot
+                .try_send_rcot(verifier.total_circuits() * 128)
+                .map_err(VmError::execute)?;
 
             let uv = ctx.io_mut().expect_next().await?;
             verifier.check(&svole_keys, uv).map_err(VmError::execute)?;
@@ -198,10 +201,8 @@ where
 
         let mut count = call.circ().and_count();
         if count > 0 {
-            // If the callstack is empty, we allocate more for the consistency check.
-            if self.callstack.is_empty() {
-                count += 128
-            }
+            // Allocate for the consistency check for each circuit.
+            count += 128;
 
             self.ot.alloc(count).map_err(VmError::execute)?;
         }


### PR DESCRIPTION
This PR improves QuickSilver performance by ~ 50%. Notable changes:
- preprocesses the consistency check values immediately after a circuit execution, eliminating the need to store triples in memory (and later copying them)

- stops using rayon for preprocessing the consistency check values, to avoid starving the threads executing the circuits

- performs a separate consistency check for each circuit


### Benchmarks
running `cargo bench` in mpz/crates/zk/benches 

before this PR
`zk/aes128               time:   [178.00 ms 187.11 ms 198.20 ms]`

after this PR
`zk/aes128               time:   [100.36 ms 103.20 ms 106.35 ms]`

