### PR TITLE
build: configure wasm target runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.wasm32-wasip1-threads]
+rustflags = [
+    "-C",
+    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
+    "-C",
+    "link-arg=--max-memory=4294967296",
+]
+runner = "wasmtime --wasi threads"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ uid-mux = { version = "0.2" }
 # testing
 rstest = "0.12"
 pretty_assertions = "1"
-criterion = "0.5"
+criterion = { version = "0.5", default-features = false }
 
 # config
 cfg-if = "1"


### PR DESCRIPTION
This PR configures cargo to use `wasmtime` as the runner for the `wasm32-wasip1-threads` target. This facilitates running tests and benchmarks in `wasmtime` using the typical cargo commands.

For example

```sh
cargo bench --target wasm32-wasip1-threads
```

Note that tests/benches which currently rely on `tokio/net` will not work.