### PR TITLE
fix(garble): use strong hash for mac commitments

### DIFF
--- a/crates/garble-core/src/store/evaluator.rs
+++ b/crates/garble-core/src/store/evaluator.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use blake3::Hasher;
 use rangeset::{Difference, Intersection};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
@@ -8,7 +9,7 @@ use mpz_core::{Block, bitvec::BitVec};
 use mpz_memory_core::{
     DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
     binary::Binary,
-    correlated::{COMMIT_CIPHER, Mac, MacCommitment, MacCommitmentError, MacStore, MacStoreError},
+    correlated::{Mac, MacCommitment, MacCommitmentError, MacStore, MacStoreError},
     store::{BitStore, Store, StoreError},
 };
 use mpz_ot_core::cot::{COTReceiver, COTReceiverOutput};
@@ -156,7 +157,7 @@ impl<COT> EvaluatorStore<COT> {
                     *bit ^= mac_bit;
                 });
 
-            let hasher = &(*COMMIT_CIPHER);
+            let mut hasher = Hasher::new();
             let start_id = slice.ptr().as_usize();
             for (i, ((mac, bit), commitment)) in self
                 .mac_store
@@ -166,7 +167,8 @@ impl<COT> EvaluatorStore<COT> {
                 .zip(self.commit_store.try_get(slice)?)
                 .enumerate()
             {
-                commitment.check((start_id + i) as u64, *bit, mac, hasher)?;
+                hasher.reset();
+                commitment.check((start_id + i) as u64, *bit, mac, &mut hasher)?;
             }
 
             self.data_store.try_set(slice, &data)?;

--- a/crates/memory-core/src/correlated.rs
+++ b/crates/memory-core/src/correlated.rs
@@ -56,32 +56,16 @@
 mod keys;
 mod macs;
 
-use std::{ops::BitXor, sync::LazyLock};
+use std::ops::BitXor;
 
 pub use keys::{Key, KeyStore, KeyStoreError};
 pub use macs::{Mac, MacStore, MacStoreError};
 
-use mpz_core::{
-    Block,
-    aes::{FIXED_KEY, FixedKeyAes},
-};
+use mpz_core::Block;
+
+use blake3::Hasher;
 use rand::{CryptoRng, Rng, distr::StandardUniform, prelude::Distribution};
 use serde::{Deserialize, Serialize};
-
-/// AES cipher used for MAC commitments.
-///
-/// It uses a different key than in garbling to ensure domain separation.
-pub static COMMIT_CIPHER: LazyLock<FixedKeyAes> = LazyLock::new(|| {
-    // Arbitrary key.
-    const KEY: [u8; 16] = [
-        42, 13, 37, 99, 1, 55, 89, 144, 233, 11, 251, 8, 21, 177, 66, 3,
-    ];
-    assert_ne!(
-        FIXED_KEY, KEY,
-        "commit key must be different from garbling key"
-    );
-    FixedKeyAes::new(KEY)
-});
 
 /// Block for public 0 MAC.
 pub(crate) const MAC_ZERO: Block = Block::new([
@@ -216,7 +200,7 @@ impl MacCommitment {
         id: u64,
         value: bool,
         mac: &Mac,
-        hasher: &FixedKeyAes,
+        hasher: &mut Hasher,
     ) -> Result<(), MacCommitmentError> {
         let [low, high] = &self.0;
         let select = &self.0[value as usize];
@@ -229,7 +213,12 @@ impl MacCommitment {
             });
         }
 
-        let expected = hasher.tccr(Block::from((id as u128).to_be_bytes()), *mac.as_block());
+        hasher.update(&id.to_be_bytes());
+        hasher.update(mac.as_bytes());
+        let out: [u8; 16] = hasher.finalize().as_bytes()[0..16]
+            .try_into()
+            .expect("16 bytes");
+        let expected = Block::from(out);
         if &expected != select {
             return Err(MacCommitmentError {
                 id,

--- a/crates/memory-core/src/correlated/keys.rs
+++ b/crates/memory-core/src/correlated/keys.rs
@@ -3,7 +3,6 @@ use std::ops::Add;
 use blake3::{Hash, Hasher};
 use mpz_core::{
     Block,
-    aes::FixedKeyAes,
     bitvec::{BitSlice, BitVec},
 };
 use rand::{distr::StandardUniform, prelude::Distribution};
@@ -11,7 +10,7 @@ use rangeset::Disjoint;
 
 use crate::{
     RangeSet, Slice,
-    correlated::{COMMIT_CIPHER, Delta, MAC_ONE, MAC_ZERO, MacCommitment, macs::Mac},
+    correlated::{Delta, MAC_ONE, MAC_ZERO, MacCommitment, macs::Mac},
     store::{Store, StoreError},
 };
 
@@ -44,11 +43,23 @@ impl Key {
 
     /// Commits to the MACs of a value.
     #[inline]
-    pub fn commit(&self, id: u64, delta: &Delta, hasher: &FixedKeyAes) -> MacCommitment {
-        let mut macs = [self.0, self.0 ^ delta.as_block()];
-        let tweak = Block::from((id as u128).to_be_bytes());
-        hasher.tccr_many(&[tweak, tweak], &mut macs);
-        MacCommitment(macs)
+    pub fn commit(&self, id: u64, delta: &Delta, hasher: &mut Hasher) -> MacCommitment {
+        let macs = [self.0, self.0 ^ delta.as_block()];
+
+        let commitments = macs
+            .into_iter()
+            .map(|mac| {
+                hasher.reset();
+                hasher.update(&id.to_be_bytes());
+                hasher.update(mac.as_bytes());
+                let out: [u8; 16] = hasher.finalize().as_bytes()[0..16]
+                    .try_into()
+                    .expect("16 bytes");
+                Block::from(out)
+            })
+            .collect::<Vec<_>>();
+
+        MacCommitment(commitments.try_into().expect("only 2 MACs"))
     }
 
     /// Returns a MAC for the given bit.
@@ -249,12 +260,15 @@ impl KeyStore {
     pub fn commit(&self, slice: Slice) -> Result<Vec<MacCommitment>> {
         let start_id = slice.ptr.0;
         let keys = self.keys.try_get(slice)?;
-        let hasher = &(*COMMIT_CIPHER);
+        let mut hasher = Hasher::new();
 
         let commitments = keys
             .iter()
             .enumerate()
-            .map(|(i, key)| key.commit((start_id + i) as u64, &self.delta, hasher))
+            .map(|(i, key)| {
+                hasher.reset();
+                key.commit((start_id + i) as u64, &self.delta, &mut hasher)
+            })
             .collect();
 
         Ok(commitments)


### PR DESCRIPTION
This PR fixes MAC commitments to use a strong hash as discussed in https://github.com/privacy-scaling-explorations/mpz/issues/260