### PR TITLE
Ferret: consider available OTs when allocating more than once

### DIFF
--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -35,6 +35,7 @@ struct Queued {
 pub struct Receiver<COT> {
     cot: Arc<Mutex<COT>>,
     alloc: usize,
+    missing: usize,
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     prg: Prg,
@@ -54,6 +55,7 @@ where
         Self {
             cot: Arc::new(Mutex::new(cot)),
             alloc: 0,
+            missing: 0,
             queue: VecDeque::new(),
             transfer_id: TransferId::default(),
             prg: Prg::from_seed(seed),
@@ -77,12 +79,12 @@ where
 
     /// Returns `true` if the receiver wants to bootstrap.
     pub fn wants_bootstrap(&self) -> bool {
-        self.macs.is_empty()
+        self.macs.len() < self.config.bootstrap_cost()
     }
 
     /// Returns `true` if the receiver wants to extend.
     pub fn wants_extend(&self) -> bool {
-        self.alloc > 0
+        self.available() < self.alloc
     }
 
     /// Initializes the receiver.
@@ -102,11 +104,11 @@ where
 
     /// Allocates COTs for bootstrapping.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let cost = self.config.bootstrap_cost();
+        let missing = self.config.bootstrap_cost() - self.macs.len();
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?
-            .alloc(cost)
+            .alloc(missing)
             .map_err(Error::bootstrap)?;
 
         Ok(())
@@ -119,7 +121,8 @@ where
         };
 
         // If COTs are empty, we haven't bootstrapped from inner COT yet.
-        if self.macs.is_empty() {
+        if self.wants_bootstrap() {
+            let missing = self.config.bootstrap_cost() - self.macs.len();
             let RCOTReceiverOutput {
                 msgs: macs,
                 choices,
@@ -128,7 +131,7 @@ where
                 .cot
                 .try_lock()
                 .map_err(|_| ErrorRepr::MutexLocked)?
-                .try_recv_rcot(self.config.bootstrap_cost())
+                .try_recv_rcot(missing)
                 .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
 
             self.macs.extend_from_slice(&macs);
@@ -136,7 +139,7 @@ where
         }
 
         let lpn_type = self.config.lpn_type();
-        let params = self.config.select_params(self.macs.len(), self.alloc);
+        let params = self.config.select_params(self.macs.len(), self.missing);
 
         let err = sample_error_indices(&mut self.prg, lpn_type, params.n, params.t);
 
@@ -265,8 +268,8 @@ where
         self.macs.extend_from_slice(&z);
         self.choices.extend_from_slice(&x);
 
-        self.alloc = self.alloc.saturating_sub(self.macs.len() - start);
-        if self.alloc == 0 {
+        self.missing = self.missing.saturating_sub(self.macs.len() - start);
+        if self.missing == 0 {
             // We've finished extending.
             self.process_queue();
         }
@@ -286,6 +289,7 @@ where
             let id = self.transfer_id.next();
             let macs = self.macs.split_off(self.macs.len() - next.count);
             let choices = self.choices.split_off(self.choices.len() - next.count);
+            self.alloc -= next.count;
 
             next.sender.send(RCOTReceiverOutput {
                 id,
@@ -305,6 +309,7 @@ where
 
     fn alloc(&mut self, count: usize) -> Result<()> {
         self.alloc += count;
+        self.missing += count;
         Ok(())
     }
 

--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -35,7 +35,6 @@ struct Queued {
 pub struct Receiver<COT> {
     cot: Arc<Mutex<COT>>,
     alloc: usize,
-    missing: usize,
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     prg: Prg,
@@ -55,7 +54,6 @@ where
         Self {
             cot: Arc::new(Mutex::new(cot)),
             alloc: 0,
-            missing: 0,
             queue: VecDeque::new(),
             transfer_id: TransferId::default(),
             prg: Prg::from_seed(seed),
@@ -138,9 +136,10 @@ where
             self.choices.extend_from_slice(&choices);
         }
 
-        let lpn_type = self.config.lpn_type();
-        let params = self.config.select_params(self.macs.len(), self.missing);
+        let missing = self.alloc.saturating_sub(self.available());
+        let params = self.config.select_params(self.macs.len(), missing);
 
+        let lpn_type = self.config.lpn_type();
         let err = sample_error_indices(&mut self.prg, lpn_type, params.n, params.t);
 
         let (mpcot, spcot_lengths, spcot_idxs) =
@@ -155,7 +154,6 @@ where
 
         self.state = State::Extending(Extending {
             public_prg,
-            start: self.macs.len(),
             params,
             err,
             mpcot,
@@ -177,7 +175,6 @@ where
 
         let State::Extending(Extending {
             public_prg,
-            start,
             params,
             err: e,
             mpcot,
@@ -209,7 +206,6 @@ where
 
         self.state = State::Finish(Finish {
             public_prg,
-            start,
             params,
             err: e,
             r,
@@ -228,7 +224,6 @@ where
 
         let State::Finish(Finish {
             mut public_prg,
-            start,
             params,
             err,
             r,
@@ -268,9 +263,10 @@ where
         self.macs.extend_from_slice(&z);
         self.choices.extend_from_slice(&x);
 
-        self.missing = self.missing.saturating_sub(self.macs.len() - start);
-        if self.missing == 0 {
+        let missing = self.alloc.saturating_sub(self.available());
+        if missing == 0 {
             // We've finished extending.
+            self.alloc = 0;
             self.process_queue();
         }
 
@@ -289,7 +285,6 @@ where
             let id = self.transfer_id.next();
             let macs = self.macs.split_off(self.macs.len() - next.count);
             let choices = self.choices.split_off(self.choices.len() - next.count);
-            self.alloc -= next.count;
 
             next.sender.send(RCOTReceiverOutput {
                 id,
@@ -309,7 +304,6 @@ where
 
     fn alloc(&mut self, count: usize) -> Result<()> {
         self.alloc += count;
-        self.missing += count;
         Ok(())
     }
 
@@ -379,7 +373,6 @@ struct Extend {
 
 struct Extending {
     public_prg: Prg,
-    start: usize,
     params: LpnParameters,
     err: Vec<usize>,
     mpcot: MPCOTReceiver<mpcot_state::Extension>,
@@ -390,7 +383,6 @@ struct Extending {
 
 struct Finish {
     public_prg: Prg,
-    start: usize,
     params: LpnParameters,
     err: Vec<usize>,
     r: Vec<Block>,

--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -118,7 +118,7 @@ where
             return Err(ErrorRepr::State("not in extend state".to_string()).into());
         };
 
-        // If COTs are empty, we haven't bootstrapped from inner COT yet.
+        // If available COTs are insufficient, we bootstrap from the inner COT instance.
         if self.wants_bootstrap() {
             let missing = self.config.bootstrap_cost() - self.macs.len();
             let RCOTReceiverOutput {

--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -102,7 +102,7 @@ where
 
     /// Allocates COTs for bootstrapping.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let missing = self.config.bootstrap_cost() - self.macs.len();
+        let missing = self.config.bootstrap_cost().saturating_sub(self.macs.len());
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -119,7 +119,7 @@ where
             return Err(ErrorRepr::State("not in extend state".to_string()).into());
         };
 
-        // If COTs are empty, we haven't bootstrapped from inner COT yet.
+        // If available COTs are insufficient, we bootstrap from the inner COT instance.
         if self.wants_bootstrap() {
             let missing = self.config.bootstrap_cost() - self.keys.len();
             let RCOTSenderOutput { keys, .. } = self

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -35,6 +35,7 @@ struct Queued {
 pub struct Sender<COT> {
     cot: Arc<Mutex<COT>>,
     alloc: usize,
+    missing: usize,
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     prg: Prg,
@@ -55,6 +56,7 @@ where
         Self {
             cot: Arc::new(Mutex::new(cot)),
             alloc: 0,
+            missing: 0,
             queue: VecDeque::new(),
             transfer_id: TransferId::default(),
             prg: Prg::from_seed(seed),
@@ -78,12 +80,12 @@ where
 
     /// Returns `true` if the sender wants to bootstrap.
     pub fn wants_bootstrap(&self) -> bool {
-        self.keys.is_empty()
+        self.keys.len() < self.config.bootstrap_cost()
     }
 
     /// Returns `true` if the sender wants to extend.
     pub fn wants_extend(&self) -> bool {
-        self.alloc > 0
+        self.available() < self.alloc
     }
 
     /// Initializes the sender, receiving message from the receiver.
@@ -103,11 +105,11 @@ where
 
     /// Allocates COTs for bootstrapping.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let cost = self.config.bootstrap_cost();
+        let missing = self.config.bootstrap_cost() - self.keys.len();
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?
-            .alloc(cost)
+            .alloc(missing)
             .map_err(Error::bootstrap)?;
 
         Ok(())
@@ -120,18 +122,19 @@ where
         };
 
         // If COTs are empty, we haven't bootstrapped from inner COT yet.
-        if self.keys.is_empty() {
+        if self.wants_bootstrap() {
+            let missing = self.config.bootstrap_cost() - self.keys.len();
             let RCOTSenderOutput { keys, .. } = self
                 .cot
                 .try_lock()
                 .map_err(|_| ErrorRepr::MutexLocked)?
-                .try_send_rcot(self.config.bootstrap_cost())
+                .try_send_rcot(missing)
                 .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
 
             self.keys.extend_from_slice(&keys);
         }
 
-        let params = self.config.select_params(self.keys.len(), self.alloc);
+        let params = self.config.select_params(self.keys.len(), self.missing);
 
         let (mpcot, spcot_lengths) = MPCOTSender::new(public_prg.random(), self.config.lpn_type())
             .start_extend(params.t, params.n)?;
@@ -245,8 +248,8 @@ where
         self.keys.truncate(self.keys.len() - params.k);
         self.keys.extend_from_slice(&y);
 
-        self.alloc = self.alloc.saturating_sub(self.keys.len() - start);
-        if self.alloc == 0 {
+        self.missing = self.missing.saturating_sub(self.keys.len() - start);
+        if self.missing == 0 {
             // We've finished extending.
             self.process_queue();
         }
@@ -265,6 +268,7 @@ where
 
             let id = self.transfer_id.next();
             let keys = self.keys.split_off(self.keys.len() - next.count);
+            self.alloc -= next.count;
 
             next.sender.send(RCOTSenderOutput { id, keys });
         }
@@ -280,6 +284,7 @@ where
 
     fn alloc(&mut self, count: usize) -> Result<()> {
         self.alloc += count;
+        self.missing += count;
         Ok(())
     }
 

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -35,7 +35,6 @@ struct Queued {
 pub struct Sender<COT> {
     cot: Arc<Mutex<COT>>,
     alloc: usize,
-    missing: usize,
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     prg: Prg,
@@ -56,7 +55,6 @@ where
         Self {
             cot: Arc::new(Mutex::new(cot)),
             alloc: 0,
-            missing: 0,
             queue: VecDeque::new(),
             transfer_id: TransferId::default(),
             prg: Prg::from_seed(seed),
@@ -133,15 +131,14 @@ where
 
             self.keys.extend_from_slice(&keys);
         }
-
-        let params = self.config.select_params(self.keys.len(), self.missing);
+        let missing = self.alloc.saturating_sub(self.available());
+        let params = self.config.select_params(self.keys.len(), missing);
 
         let (mpcot, spcot_lengths) = MPCOTSender::new(public_prg.random(), self.config.lpn_type())
             .start_extend(params.t, params.n)?;
 
         self.state = State::Extending(Extending {
             public_prg,
-            start: self.keys.len(),
             params,
             mpcot,
             spcot_lengths,
@@ -160,7 +157,6 @@ where
 
         let State::Extending(Extending {
             public_prg,
-            start,
             params,
             mpcot,
             spcot_lengths,
@@ -183,7 +179,6 @@ where
 
         self.state = State::Check(Check {
             public_prg,
-            start,
             params,
             s,
         });
@@ -201,7 +196,6 @@ where
 
         let State::Check(Check {
             public_prg,
-            start,
             params,
             s,
         }) = self.state.take()
@@ -217,7 +211,6 @@ where
 
         self.state = State::Finish(Finish {
             public_prg,
-            start,
             params,
             s,
         });
@@ -229,7 +222,6 @@ where
     pub fn finish_extend(&mut self) -> Result<()> {
         let State::Finish(Finish {
             mut public_prg,
-            start,
             params,
             s,
         }) = self.state.take()
@@ -248,9 +240,10 @@ where
         self.keys.truncate(self.keys.len() - params.k);
         self.keys.extend_from_slice(&y);
 
-        self.missing = self.missing.saturating_sub(self.keys.len() - start);
-        if self.missing == 0 {
+        let missing = self.alloc.saturating_sub(self.available());
+        if missing == 0 {
             // We've finished extending.
+            self.alloc = 0;
             self.process_queue();
         }
 
@@ -268,7 +261,6 @@ where
 
             let id = self.transfer_id.next();
             let keys = self.keys.split_off(self.keys.len() - next.count);
-            self.alloc -= next.count;
 
             next.sender.send(RCOTSenderOutput { id, keys });
         }
@@ -284,7 +276,6 @@ where
 
     fn alloc(&mut self, count: usize) -> Result<()> {
         self.alloc += count;
-        self.missing += count;
         Ok(())
     }
 
@@ -357,7 +348,6 @@ struct Extend {
 
 struct Extending {
     public_prg: Prg,
-    start: usize,
     params: LpnParameters,
     mpcot: MPCOTSender<mpcot_state::Extension>,
     spcot_lengths: Vec<usize>,
@@ -365,14 +355,12 @@ struct Extending {
 
 struct Check {
     public_prg: Prg,
-    start: usize,
     params: LpnParameters,
     s: Vec<Block>,
 }
 
 struct Finish {
     public_prg: Prg,
-    start: usize,
     params: LpnParameters,
     s: Vec<Block>,
 }

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -103,7 +103,7 @@ where
 
     /// Allocates COTs for bootstrapping.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let missing = self.config.bootstrap_cost() - self.keys.len();
+        let missing = self.config.bootstrap_cost().saturating_sub(self.keys.len());
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?


### PR DESCRIPTION
Currently Ferret [always extends](https://github.com/privacy-scaling-explorations/mpz/blob/dev/crates/ot-core/src/ferret/sender.rs#L84-L87) when new OTs are requested via `alloc`, although it could satisfy the requested amount with left-over OTs from previous extensions.

This PR changes the Ferret implementation so that available OTs are used when allocating again after an iteration. I noticed when benching TLSNotary with our harness that Ferret extended 3x although 2x is more than sufficient.

It also changes that from now on available OTs are considered for bootstrapping.


