### PR TITLE
Ferret: correctly estimate params when not sufficient OTs available

### DIFF
--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -107,14 +107,14 @@ fn default_parameter_selector(ty: LpnType, available: usize, additional: usize) 
         let cost = iteration_cost(ty, *param);
         let net = param.n - cost;
 
-        // Only select params for which we have enough OTs available
+        // Only selects params for which we have enough OTs available.
         if available < cost {
             return last_valid_param;
         } else {
             last_valid_param = *param;
         }
 
-        // Return smallest params that satisfy the additionaly requested amount
+        // Returns the smallest params that satisfy the additionaly requested amount.
         if net >= additional {
             return *param;
         }

--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -114,7 +114,7 @@ fn default_parameter_selector(ty: LpnType, available: usize, additional: usize) 
             last_valid_param = *param;
         }
 
-        // Returns the smallest params that satisfy the additionaly requested amount.
+        // Returns the smallest params that satisfy the additionally requested amount.
         if net >= additional {
             return *param;
         }

--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -102,12 +102,20 @@ fn default_parameter_selector(ty: LpnType, available: usize, additional: usize) 
     };
 
     // *Assumes the parameters are in ascending order.*
+    let mut last_valid_param = params[0];
     for param in params {
         let cost = iteration_cost(ty, *param);
         let net = param.n - cost;
-        // If we don't have enough available we select the smallest parameters
-        // immediately.
-        if available <= cost || net >= additional {
+
+        // Only select params for which we have enough OTs available
+        if available < cost {
+            return last_valid_param;
+        } else {
+            last_valid_param = *param;
+        }
+
+        // Return smallest params that satisfy the additionaly requested amount
+        if net >= additional {
             return *param;
         }
     }


### PR DESCRIPTION
This PR fixes that the current `default_param_selector` does not correctly return valid parameters when the amount of available OTs is too small. The `if available <= cost` branch returns the `params` of the current iteration, but it should return those of the iteration before.