### PR TITLE
chore: enforce lints during pre-commit check

### DIFF
--- a/crates/circuits/src/circuits/blake3.rs
+++ b/crates/circuits/src/circuits/blake3.rs
@@ -139,6 +139,9 @@ mod tests {
     use crate::evaluate;
 
     #[test]
+    #[allow(clippy::same_item_push)]
+    #[allow(clippy::needless_range_loop)]
+    #[allow(clippy::vec_init_then_push)]
     fn test_blake3_mix() {
         let mut builder = CircuitBuilder::new();
 
@@ -178,7 +181,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 1: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 1: State[{i}] mismatch");
             }
         }
 
@@ -200,7 +203,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 2: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 2: State[{i}] mismatch");
             }
         }
 
@@ -222,7 +225,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 3: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 3: State[{i}] mismatch");
             }
         }
 
@@ -247,7 +250,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 4: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 4: State[{i}] mismatch");
             }
         }
 
@@ -275,7 +278,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 5: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 5: State[{i}] mismatch");
             }
         }
 
@@ -307,7 +310,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 6: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 6: State[{i}] mismatch");
             }
         }
 
@@ -339,7 +342,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 7: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 7: State[{i}] mismatch");
             }
         }
 
@@ -371,7 +374,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 8: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 8: State[{i}] mismatch");
             }
         }
 
@@ -403,12 +406,15 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..4 {
-                assert_eq!(output[i], state[i], "Test 9: State[{}] mismatch", i);
+                assert_eq!(output[i], state[i], "Test 9: State[{i}] mismatch");
             }
         }
     }
 
     #[test]
+    #[allow(clippy::same_item_push)]
+    #[allow(clippy::needless_range_loop)]
+    #[allow(clippy::vec_init_then_push)]
     fn test_blake3_round() {
         use std::array::from_fn;
 
@@ -456,11 +462,14 @@ mod tests {
 
         // Check results
         for i in 0..16 {
-            assert_eq!(output[i], expected_state[i], "State[{}] mismatch", i);
+            assert_eq!(output[i], expected_state[i], "State[{i}] mismatch");
         }
     }
 
     #[test]
+    #[allow(clippy::same_item_push)]
+    #[allow(clippy::needless_range_loop)]
+    #[allow(clippy::vec_init_then_push)]
     fn test_blake3_compress() {
         use crate::circuits::blake3::compress;
 
@@ -485,7 +494,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 1: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 1: State[{i}] mismatch");
             }
         }
 
@@ -511,7 +520,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 2: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 2: State[{i}] mismatch");
             }
         }
 
@@ -534,7 +543,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 3: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 3: State[{i}] mismatch");
             }
         }
 
@@ -561,7 +570,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 4: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 4: State[{i}] mismatch");
             }
         }
 
@@ -596,7 +605,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 5: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 5: State[{i}] mismatch");
             }
         }
 
@@ -619,7 +628,7 @@ mod tests {
             let output: Vec<u32> = evaluate!(&circ, input_values).unwrap();
 
             for i in 0..16 {
-                assert_eq!(output[i], test_state[i], "Test 6: State[{}] mismatch", i);
+                assert_eq!(output[i], test_state[i], "Test 6: State[{i}] mismatch");
             }
         }
     }
@@ -672,7 +681,7 @@ mod tests {
 
         // Ref: https://github.com/BLAKE3-team/BLAKE3/blob/3a90f0f06a429e6ce1d337b28156a75d2a372d7b/reference_impl/reference_impl.rs#L74-L111.
         pub(crate) fn compress(block: &mut [u32; 16], state: &mut [u32; 16]) {
-            let initial_state = state.clone();
+            let initial_state = *state;
 
             round(state, block); // round 1
             permute(block);

--- a/crates/hash/src/sha256.rs
+++ b/crates/hash/src/sha256.rs
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn test_sha256_serialize_state() {
         let output: [u8; 32] = evaluate!(SERIALIZE_STATE, IV).unwrap();
-        let expected: Vec<_> = IV.iter().map(|word| word.to_be_bytes()).flatten().collect();
+        let expected: Vec<_> = IV.iter().flat_map(|word| word.to_be_bytes()).collect();
         assert_eq!(&output, expected.as_slice());
     }
 

--- a/crates/matrix-transpose/src/lib.rs
+++ b/crates/matrix-transpose/src/lib.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(
     feature = "simd-transpose",
     feature(portable_simd),
-    feature(stmt_expr_attributes),
-    feature(slice_as_chunks)
+    feature(stmt_expr_attributes)
 )]
 
 #[cfg(feature = "simd-transpose")]

--- a/crates/matrix-transpose/src/simd.rs
+++ b/crates/matrix-transpose/src/simd.rs
@@ -61,12 +61,13 @@ where
         std::mem::swap(&mut write_reference, &mut read_reference);
     }
     for _ in 0..rounds {
-        for (k, (v1, v2)) in read_reference
-            .as_chunks_unchecked::<N>()
-            .iter()
-            .zip(read_reference[half..].as_chunks_unchecked())
-            .enumerate()
-        {
+        for (k, (v1, v2)) in unsafe {
+            read_reference
+                .as_chunks_unchecked::<N>()
+                .iter()
+                .zip(read_reference[half..].as_chunks_unchecked())
+                .enumerate()
+        } {
             (s1, s2) = Simd::from_array(*v1).interleave(Simd::from_array(*v2));
             write_reference[N * 2 * k..N * (2 * k + 1)].copy_from_slice(&s1.to_array());
             write_reference[N * (2 * k + 1)..N * (2 * k + 2)].copy_from_slice(&s2.to_array());
@@ -95,10 +96,10 @@ pub unsafe fn bitmask_shift_unchecked(matrix: &mut [u8], columns: usize) {
     for row in matrix.chunks_mut(columns) {
         let mut shifted_row = Vec::with_capacity(columns);
         for _ in 0..8 {
-            for chunk in row.as_chunks_unchecked_mut::<LANE_COUNT>() {
+            for chunk in unsafe { row.as_chunks_unchecked_mut::<LANE_COUNT>() } {
                 s = Simd::from_array(*chunk);
                 #[cfg(target_arch = "x86_64")]
-                let high_bits = _mm256_movemask_epi8(s.reverse().into());
+                let high_bits = unsafe { _mm256_movemask_epi8(s.reverse().into()) };
                 #[cfg(target_arch = "wasm32")]
                 let high_bits = u8x16_bitmask(s.reverse().into());
                 let high_bits: Vec<u8> = high_bits

--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -10,4 +10,4 @@ set -e
 cargo +nightly fmt --check --all
 
 # Check clippy
-cargo +nightly clippy --all-targets --all-features
+cargo +nightly clippy --all-targets --all-features --locked -- -D warnings


### PR DESCRIPTION
This PR fixes clippy lints and modifies the script to treat warnings as errors.