### PR TITLE
add mocks for garbler/verifier

### DIFF
--- a/crates/garble-core/src/store.rs
+++ b/crates/garble-core/src/store.rs
@@ -2,6 +2,8 @@
 
 mod evaluator;
 mod garbler;
+/// Docs
+pub mod mock;
 
 pub use evaluator::{EvaluatorStore, EvaluatorStoreError};
 pub use garbler::{GarblerStore, GarblerStoreError};
@@ -76,13 +78,14 @@ mod tests {
     use mpz_core::Block;
     use mpz_memory_core::{
         Array, Memory, MemoryExt, ViewExt,
-        binary::U8,
+        binary::{Binary, U8},
         correlated::{Delta, Key},
     };
     use mpz_ot_core::ideal::cot::IdealCOT;
+    use mpz_vm_core::Vm;
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
-    use super::*;
+    use crate::store::mock::{EvaluatorStore, GarblerStore};
 
     #[test]
     fn test_store_decode() {

--- a/crates/garble-core/src/store/mock/evaluator.rs
+++ b/crates/garble-core/src/store/mock/evaluator.rs
@@ -1,0 +1,492 @@
+use std::sync::Arc;
+
+use blake3::{Hash, Hasher};
+use rangeset::{Difference, Intersection};
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use mpz_common::future::Output;
+use mpz_core::{Block, bitvec::BitVec};
+use mpz_memory_core::{
+    DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
+    binary::Binary,
+    correlated::{Mac, MacCommitment, MacCommitmentError, MacStore, MacStoreError},
+    store::{BitStore, Store, StoreError},
+};
+use mpz_ot_core::cot::{COTReceiver, COTReceiverOutput};
+
+use crate::{
+    FlushView,
+    store::{EvaluatorFlush, GarblerFlush, MacProof},
+    view::{View, ViewError},
+};
+
+type Error = EvaluatorStoreError;
+type Result<T> = core::result::Result<T, Error>;
+
+struct PendingFlush {
+    cot: Option<Box<dyn Output<COTReceiverOutput<Block>> + Send>>,
+}
+
+impl std::fmt::Debug for PendingFlush {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingFlush").finish_non_exhaustive()
+    }
+}
+
+/// Evaluator memory store.
+#[derive(Debug)]
+pub struct EvaluatorStore<COT> {
+    cot: Arc<Mutex<COT>>,
+    mac_store: MacStore,
+    key_bit_store: BitStore,
+    // TODO: We need a sparse store as this takes up a lot of space.
+    commit_store: Store<MacCommitment>,
+    data_store: BitStore,
+    view: View,
+    buffer_decode: Vec<DecodeOp<BitVec>>,
+    pending: Option<PendingFlush>,
+}
+
+impl<COT> EvaluatorStore<COT> {
+    /// Creates a new evaluator store.
+    ///
+    /// # Argument
+    ///
+    /// * `cot` - Correlated OT receiver.
+    pub fn new(cot: COT) -> Self {
+        Self {
+            cot: Arc::new(Mutex::new(cot)),
+            mac_store: MacStore::default(),
+            key_bit_store: BitStore::default(),
+            commit_store: Store::default(),
+            data_store: BitStore::default(),
+            view: View::new_evaluator(),
+            buffer_decode: Vec::default(),
+            pending: None,
+        }
+    }
+
+    /// Returns a lock on the COT receiver.
+    pub fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        Mutex::try_lock_owned(self.cot.clone()).unwrap()
+    }
+
+    /// Returns the COT receiver.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the receiver is still held.
+    pub fn into_inner(self) -> COT {
+        Arc::try_unwrap(self.cot)
+            .map_err(|_| ())
+            .expect("receiver lock should be dropped")
+            .into_inner()
+    }
+
+    /// Allocates an output slice.
+    pub fn alloc_output(&mut self, size: usize) -> Slice {
+        self.view.alloc_output(size);
+        self.mac_store.alloc(size);
+        self.key_bit_store.alloc(size);
+        self.commit_store.alloc(size);
+        self.data_store.alloc(size)
+    }
+
+    /// Returns whether the MACs are set for a slice.
+    pub fn is_set_macs(&self, slice: Slice) -> bool {
+        self.mac_store.is_set(slice)
+    }
+
+    /// Returns the MACs for a slice.
+    pub fn try_get_macs(&self, slice: Slice) -> Result<&[Mac]> {
+        self.mac_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Sets the MACs for a slice corresponding to output.
+    pub fn set_output(&mut self, slice: Slice, macs: &[Mac]) -> Result<()> {
+        self.view.set_output(slice.to_range())?;
+        self.mac_store.try_set(slice, macs)?;
+
+        Ok(())
+    }
+
+    /// Marks an output as preprocessed.
+    pub fn mark_output_preprocessed(&mut self, slice: Slice) -> Result<()> {
+        self.view
+            .set_preprocessed(slice.to_range())
+            .map_err(Error::from)
+    }
+
+    /// Returns `true` if the store wants to flush.
+    pub fn wants_flush(&self) -> bool {
+        self.view.wants_flush()
+    }
+
+    /// Flushes decode operations.
+    pub fn flush_decode(&mut self) -> Result<()> {
+        self.decode_macs()?;
+
+        for mut op in self
+            .buffer_decode
+            .extract_if(.., |op| self.data_store.is_set(op.slice))
+        {
+            let data = self.data_store.try_get(op.slice)?;
+            op.send(data.to_bitvec())?;
+        }
+
+        Ok(())
+    }
+
+    /// Decodes all data which are not set but we have the MACs and key bits.
+    fn decode_macs(&mut self) -> Result<()> {
+        let idx = self
+            .mac_store
+            .set_ranges()
+            .intersection(self.key_bit_store.set_ranges())
+            .difference(self.data_store.set_ranges());
+
+        for range in idx.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+
+            // CHANGED: don't check commitments, decode differently.
+            let data = self
+                .mac_store
+                .try_get(slice)?
+                .iter()
+                .map(|mac| {
+                    if *mac.as_block() == Block::ZERO {
+                        false
+                    } else if *mac.as_block() == Block::ONE {
+                        true
+                    } else {
+                        panic!("Macs should be either 1 or 0");
+                    }
+                })
+                .collect::<BitVec>();
+
+            self.data_store.try_set(slice, &data)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<COT> EvaluatorStore<COT>
+where
+    COT: COTReceiver<bool, Block>,
+    COT::Future: Send + 'static,
+{
+    /// Returns the flush view.
+    pub fn flush_view(&self) -> &FlushView {
+        self.view.flush()
+    }
+
+    /// Sends a flush to the garbler.
+    ///
+    /// This queues any necessary COTs.
+    pub fn send_flush(&mut self) -> Result<EvaluatorFlush> {
+        if self.pending.is_some() {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let view = self.view.flush().clone();
+
+        let cot = if !view.ot.is_empty() {
+            // Collect the choices for oblivious transfer.
+            let mut choices: Vec<_> = Vec::with_capacity(view.ot.len());
+            for range in view.ot.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                choices.extend(self.data_store.try_get(slice)?.iter().by_vals());
+            }
+
+            let output = self
+                .cot
+                .try_lock()
+                .unwrap()
+                .queue_recv_cot(&choices)
+                .map_err(Error::cot)?;
+
+            Some(Box::new(output) as Box<dyn Output<COTReceiverOutput<Block>> + Send>)
+        } else {
+            None
+        };
+
+        // Prove decoded MACs to the garbler.
+        let mac_proof = if !view.decode.is_empty() {
+            // CHANGED: send the output encoded into MACs instead.
+            let bits = view
+                .decode
+                .iter_ranges()
+                .flat_map(|range| {
+                    let slice = Slice::from_range_unchecked(range);
+                    self.mac_store.try_get(slice).unwrap().iter().map(|mac| {
+                        if *mac.as_block() == Block::ZERO {
+                            false
+                        } else if *mac.as_block() == Block::ONE {
+                            true
+                        } else {
+                            panic!("macs must be either 1 or 0")
+                        }
+                    })
+                })
+                .collect::<BitVec>();
+
+            // Send dummy hash.
+            let proof = Hash::from_bytes([0u8; 32]);
+
+            Some(MacProof { bits, proof })
+        } else {
+            None
+        };
+
+        let flush = EvaluatorFlush { mac_proof };
+
+        self.pending = Some(PendingFlush { cot });
+
+        Ok(flush)
+    }
+
+    /// Receives flush from the garbler.
+    ///
+    /// This expects that the COT receiver has been flushed.
+    pub fn receive_flush(&mut self, flush: GarblerFlush) -> Result<()> {
+        let Some(PendingFlush { cot }) = self.pending.take() else {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        };
+
+        let GarblerFlush {
+            macs,
+            key_bits,
+            mac_commitments,
+        } = flush;
+
+        // Receive the MACs.
+        if macs.len() != self.view.flush().macs.len() {
+            return Err(ErrorRepr::IncorrectMacCount {
+                expected: self.view.flush().macs.len(),
+                actual: macs.len(),
+            }
+            .into());
+        }
+
+        let mut i = 0;
+        for range in self.view.flush().macs.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.mac_store.try_set(slice, &macs[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        // Receive the MACs via COT.
+        if let Some(mut cot) = cot {
+            let COTReceiverOutput { msgs: macs, .. } = cot
+                .try_recv()
+                .map_err(Error::cot)?
+                .ok_or_else(|| Error::cot("COT output is not ready"))?;
+            let _macs = Mac::from_blocks(macs);
+
+            i = 0;
+            for range in self.view.flush().ot.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                // CHANGED: ignre received MACs and instead set them based
+                // on the choice bits.
+                let data = self.data_store.try_get(slice).expect("data was set");
+                let macs = data
+                    .into_iter()
+                    .map(|bit| {
+                        if bit == true {
+                            Mac::from(Block::ONE)
+                        } else {
+                            Mac::from(Block::ZERO)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                self.mac_store.try_set(slice, &macs)?;
+                i += slice.len();
+            }
+        }
+
+        // Receive the decode info.
+        if key_bits.len() != self.view.flush().decode_info.len() {
+            return Err(ErrorRepr::IncorrectDecodeCount {
+                expected: self.view.flush().decode_info.len(),
+                actual: key_bits.len(),
+            }
+            .into());
+        } else if mac_commitments.len() != self.view.flush().decode_info.len() {
+            return Err(ErrorRepr::IncorrectMacCommitmentCount {
+                expected: self.view.flush().decode_info.len(),
+                actual: mac_commitments.len(),
+            }
+            .into());
+        }
+
+        i = 0;
+        for range in self.view.flush().decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            self.key_bit_store
+                .try_set(slice, &key_bits[i..i + slice.len()])?;
+            self.commit_store
+                .try_set(slice, &mac_commitments[i..i + slice.len()])?;
+            i += slice.len();
+        }
+
+        self.view.complete_flush();
+        self.flush_decode()?;
+
+        Ok(())
+    }
+}
+
+impl<COT> Memory<Binary> for EvaluatorStore<COT> {
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.view.is_alloc(slice.to_range())
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.view.alloc_input(size);
+        self.mac_store.alloc(size);
+        self.commit_store.alloc(size);
+        self.key_bit_store.alloc(size);
+        let slice = self.data_store.alloc(size);
+
+        Ok(slice)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.data_store.is_set(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        Ok(())
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.view.decode(slice.to_range())?;
+
+        let (fut, mut op) = DecodeFuture::new(slice);
+        // If data is already decoded, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        Ok(fut)
+    }
+}
+
+impl<COT> ViewTrait<Binary> for EvaluatorStore<COT>
+where
+    COT: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate COTs for private data.
+        self.cot
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+/// Error for [`EvaluatorStore`].
+#[derive(Debug, thiserror::Error)]
+#[error("evaluator store error: {}", .0)]
+pub struct EvaluatorStoreError(#[from] ErrorRepr);
+
+impl EvaluatorStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("cot error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    MacStore(MacStoreError),
+    #[error(transparent)]
+    Store(StoreError),
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    #[error(transparent)]
+    View(#[from] ViewError),
+    #[error("store was not expecting a flush")]
+    UnexpectedFlush,
+    #[error("generator sent incorrect number of MACs, expected={expected}, actual={actual}")]
+    IncorrectMacCount { expected: usize, actual: usize },
+    #[error(
+        "generator sent incorrect number of MAC commitments, expected={expected}, actual={actual}"
+    )]
+    IncorrectMacCommitmentCount { expected: usize, actual: usize },
+    #[error(
+        "generator sent incorrect number of decoding bits, expected={expected}, actual={actual}"
+    )]
+    IncorrectDecodeCount { expected: usize, actual: usize },
+    #[error("invalid MAC commitment: {0}")]
+    MacCommitment(#[from] MacCommitmentError),
+}
+
+impl From<MacStoreError> for EvaluatorStoreError {
+    fn from(err: MacStoreError) -> Self {
+        Self(ErrorRepr::MacStore(err))
+    }
+}
+
+impl From<StoreError> for EvaluatorStoreError {
+    fn from(err: StoreError) -> Self {
+        Self(ErrorRepr::Store(err))
+    }
+}
+
+impl From<DecodeError> for EvaluatorStoreError {
+    fn from(err: DecodeError) -> Self {
+        Self(ErrorRepr::Decode(err))
+    }
+}
+
+impl From<ViewError> for EvaluatorStoreError {
+    fn from(err: ViewError) -> Self {
+        Self(ErrorRepr::View(err))
+    }
+}
+
+impl From<MacCommitmentError> for EvaluatorStoreError {
+    fn from(err: MacCommitmentError) -> Self {
+        Self(ErrorRepr::MacCommitment(err))
+    }
+}

--- a/crates/garble-core/src/store/mock/garbler.rs
+++ b/crates/garble-core/src/store/mock/garbler.rs
@@ -1,0 +1,391 @@
+use std::sync::Arc;
+
+use rand::Rng;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use mpz_core::{Block, bitvec::BitVec, prg::Prg};
+use mpz_memory_core::{
+    DecodeError, DecodeFuture, DecodeOp, Memory, Slice, View as ViewTrait,
+    binary::Binary,
+    correlated::{Delta, Key, KeyStore, KeyStoreError, Mac, MacCommitment},
+    store::{BitStore, StoreError},
+};
+use mpz_ot_core::cot::COTSender;
+
+use crate::{
+    FlushView,
+    store::{EvaluatorFlush, GarblerFlush, MacProof},
+    view::{View, ViewError},
+};
+
+type Error = GarblerStoreError;
+type Result<T> = core::result::Result<T, Error>;
+
+/// Garbler memory store.
+#[derive(Debug)]
+pub struct GarblerStore<COT> {
+    cot: Arc<Mutex<COT>>,
+    prg: Prg,
+    key_store: KeyStore,
+    data_store: BitStore,
+    view: View,
+    buffer_decode: Vec<DecodeOp<BitVec>>,
+    // Whether the store is waiting for a flush.
+    pending: bool,
+}
+
+impl<COT> GarblerStore<COT> {
+    /// Creates a new garbler store.
+    pub fn new(seed: [u8; 16], delta: Delta, cot: COT) -> Self {
+        Self {
+            cot: Arc::new(Mutex::new(cot)),
+            prg: Prg::new_with_seed(seed),
+            key_store: KeyStore::new(delta),
+            data_store: BitStore::new(),
+            view: View::new_garbler(),
+            buffer_decode: Vec::new(),
+            pending: false,
+        }
+    }
+
+    /// Returns delta.
+    pub fn delta(&self) -> &Delta {
+        self.key_store.delta()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        Mutex::try_lock_owned(self.cot.clone()).unwrap()
+    }
+
+    /// Returns the COT sender.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a lock to the sender is still held.
+    pub fn into_inner(self) -> COT {
+        Arc::try_unwrap(self.cot)
+            .map_err(|_| ())
+            .expect("sender lock should be dropped")
+            .into_inner()
+    }
+
+    /// Returns whether all the keys are set.
+    pub fn is_set_keys(&self, slice: Slice) -> bool {
+        self.key_store.is_set(slice)
+    }
+
+    /// Returns whether the slice is committed.
+    pub fn is_committed(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    /// Returns keys if they are set.
+    ///
+    /// # Security
+    ///
+    /// **Never** use this method to transfer MACs to the evaluator.
+    pub fn try_get_keys(&self, slice: Slice) -> Result<&[Key]> {
+        self.key_store.try_get(slice).map_err(Error::from)
+    }
+
+    /// Allocates uninitialized memory for output values.
+    pub fn alloc_output(&mut self, len: usize) -> Slice {
+        self.view.alloc_output(len);
+        self.key_store.alloc(len);
+        self.data_store.alloc(len)
+    }
+
+    /// Sets the keys for output data.
+    pub fn set_output(&mut self, slice: Slice, keys: &[Key]) -> Result<()> {
+        self.key_store.try_set(slice, keys)?;
+        self.view.set_preprocessed(slice.to_range())?;
+
+        Ok(())
+    }
+
+    /// Marks an output as executed.
+    ///
+    /// This indicates that both parties have *executed* the call which produces
+    /// this output.
+    pub fn mark_output_complete(&mut self, slice: Slice) -> Result<()> {
+        self.view.set_output(slice.to_range()).map_err(Error::from)
+    }
+
+    /// Returns `true` if the store wants to flush.
+    pub fn wants_flush(&self) -> bool {
+        self.view.wants_flush()
+    }
+
+    /// Flushes decode operations.
+    fn flush_decode(&mut self) -> Result<()> {
+        for mut op in self
+            .buffer_decode
+            .extract_if(.., |op| self.data_store.is_set(op.slice))
+        {
+            let data = self.data_store.try_get(op.slice)?;
+            op.send(data.to_bitvec())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<COT> GarblerStore<COT>
+where
+    COT: COTSender<Block>,
+{
+    /// Returns the flush view.
+    pub fn flush_view(&self) -> &FlushView {
+        self.view.flush()
+    }
+
+    /// Sends a flush to the evaluator.
+    ///
+    /// This queues any necessary COTs.
+    pub fn send_flush(&mut self) -> Result<GarblerFlush> {
+        if self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let view = self.view.flush().clone();
+
+        // Collect MACs.
+        let mut macs = Vec::with_capacity(view.macs.len());
+        for range in view.macs.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            let data = self.data_store.try_get(slice)?;
+
+            // CHANGED: encode the garbler's input into the MAC.
+            let slice_macs = data
+                .iter()
+                .map(|bit| {
+                    // Send the MAC corresponding to the input bit, so that
+                    // the evaluator could recover the input.
+                    if *bit {
+                        Block::ONE.into()
+                    } else {
+                        Block::ZERO.into()
+                    }
+                })
+                .collect::<Vec<Mac>>();
+
+            macs.extend(slice_macs);
+        }
+
+        // Send keys for OT.
+        if !view.ot.is_empty() {
+            let mut keys = Vec::with_capacity(view.ot.len());
+            for range in view.ot.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                keys.extend_from_slice(self.key_store.oblivious_transfer(slice)?);
+            }
+
+            // Queue COT, we don't need the output here.
+            _ = self
+                .cot
+                .try_lock()
+                .unwrap()
+                .queue_send_cot(Key::as_blocks(&keys))
+                .map_err(Error::cot)?;
+        }
+
+        // Collect key bits.
+        let mut key_bits = BitVec::with_capacity(view.decode_info.len());
+        for range in view.decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            key_bits.extend(self.key_store.try_get_bits(slice)?);
+        }
+
+        // Collect MAC commitments.
+        let mut mac_commitments = Vec::with_capacity(view.decode_info.len());
+        for range in view.decode_info.iter_ranges() {
+            let slice = Slice::from_range_unchecked(range);
+            // CHANGED: use dummy commitments.
+            let commitments =
+                vec![MacCommitment::from_blocks([Block::ZERO, Block::ONE]); slice.len()];
+            mac_commitments.extend(commitments);
+        }
+
+        let flush = GarblerFlush {
+            macs,
+            key_bits,
+            mac_commitments,
+        };
+
+        self.pending = true;
+
+        Ok(flush)
+    }
+
+    /// Receives a flush from the evaluator.
+    pub fn receive_flush(&mut self, flush: EvaluatorFlush) -> Result<()> {
+        if !self.pending {
+            return Err(ErrorRepr::UnexpectedFlush.into());
+        }
+
+        let EvaluatorFlush { mac_proof } = flush;
+
+        // Verify MACs and store the data.
+        if let Some(MacProof { mut bits, proof }) = mac_proof {
+            if bits.len() != self.view.flush().decode.len() {
+                return Err(ErrorRepr::IncorrectMacCount {
+                    expected: self.view.flush().decode.len(),
+                    actual: bits.len(),
+                }
+                .into());
+            }
+
+            // CHANGED: do not verify MACs.
+
+            let mut i = 0;
+            for range in self.view.flush().decode.iter_ranges() {
+                let slice = Slice::from_range_unchecked(range);
+                self.data_store.try_set(slice, &bits[i..i + slice.len()])?;
+                i += slice.len();
+            }
+        }
+
+        self.view.complete_flush();
+        self.flush_decode()?;
+        self.pending = false;
+
+        Ok(())
+    }
+}
+
+impl<COT> Memory<Binary> for GarblerStore<COT> {
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.view.is_alloc(slice.to_range())
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        let keys = (0..size).map(|_| self.prg.random()).collect::<Vec<_>>();
+        self.view.alloc_input(size);
+        self.key_store.alloc_with(&keys);
+        let slice = self.data_store.alloc(size);
+
+        Ok(slice)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.data_store.is_set(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<()> {
+        self.view.assign(slice.to_range())?;
+        self.data_store.try_set(slice, &data)?;
+
+        Ok(())
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.view.is_committed(slice.to_range())
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.commit(slice.to_range()).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        Ok(self.data_store.get(slice).map(|data| data.to_bitvec()))
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.view.decode(slice.to_range())?;
+
+        let (fut, mut op) = DecodeFuture::new(slice);
+        // If data is already available, send it immediately.
+        if let Ok(data) = self.data_store.try_get(slice) {
+            op.send(data.to_bitvec())?;
+        } else {
+            self.buffer_decode.push(op);
+        }
+
+        Ok(fut)
+    }
+}
+
+impl<COT> ViewTrait<Binary> for GarblerStore<COT>
+where
+    COT: COTSender<Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.view.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        // Allocate COTs for blind data.
+        self.cot
+            .try_lock()
+            .unwrap()
+            .alloc(slice.len())
+            .map_err(Error::cot)?;
+
+        self.view.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+/// Error for [`GarblerStore`].
+#[derive(Debug, thiserror::Error)]
+#[error("garbler store error: {}", .0)]
+pub struct GarblerStoreError(#[from] ErrorRepr);
+
+impl GarblerStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("cot error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    KeyStore(KeyStoreError),
+    #[error(transparent)]
+    Store(StoreError),
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    #[error(transparent)]
+    View(#[from] ViewError),
+    #[error("evaluator sent incorrect number of MAC bits, expected={expected}, actual={actual}")]
+    IncorrectMacCount { expected: usize, actual: usize },
+    #[error("store was not expecting a flush")]
+    UnexpectedFlush,
+}
+
+impl From<KeyStoreError> for GarblerStoreError {
+    fn from(err: KeyStoreError) -> Self {
+        Self(ErrorRepr::KeyStore(err))
+    }
+}
+
+impl From<StoreError> for GarblerStoreError {
+    fn from(err: StoreError) -> Self {
+        Self(ErrorRepr::Store(err))
+    }
+}
+
+impl From<DecodeError> for GarblerStoreError {
+    fn from(err: DecodeError) -> Self {
+        Self(ErrorRepr::Decode(err))
+    }
+}
+
+impl From<ViewError> for GarblerStoreError {
+    fn from(err: ViewError) -> Self {
+        Self(ErrorRepr::View(err))
+    }
+}

--- a/crates/garble-core/src/store/mock/mod.rs
+++ b/crates/garble-core/src/store/mock/mod.rs
@@ -1,0 +1,281 @@
+//! Copies of E and G with minimal modifications to remove all cryptography
+//! operations.
+//!
+//! Places in the code which were changed are marked with // CHANGED
+
+mod evaluator;
+mod garbler;
+
+pub use crate::store::mock::{
+    evaluator::{EvaluatorStore, EvaluatorStoreError},
+    garbler::{GarblerStore, GarblerStoreError},
+};
+
+// The tests make sure that the mock is consistent with the real impl.
+#[cfg(test)]
+mod tests {
+    use crate::store::{EvaluatorStore as RealEvaluatorStore, GarblerStore as RealGarblerStore};
+    use mpz_core::Block;
+    use mpz_memory_core::{
+        Array, Memory, MemoryExt, ViewExt,
+        binary::{Binary, U8},
+        correlated::{Delta, Key},
+    };
+    use mpz_ot_core::ideal::cot::IdealCOT;
+    use mpz_vm_core::Vm;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::*;
+
+    #[ignore = "verifies mock matches real implementation"]
+    #[test]
+    fn test_store_decode() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+        let cot = IdealCOT::new(delta.into_inner());
+
+        // ---------------- Obtain real impl's outputs.
+
+        let mut gb = RealGarblerStore::new(rng.random(), delta, cot.clone());
+        let mut ev = RealEvaluatorStore::new(cot.clone());
+
+        let val_a = [0u8; 16];
+        let val_b = [42u8; 16];
+        let val_c = [69u8; 16];
+
+        let ref_a_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_public(ref_a_gb).unwrap();
+        let ref_b_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_private(ref_b_gb).unwrap();
+        let ref_c_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_blind(ref_c_gb).unwrap();
+
+        let ref_a_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_public(ref_a_ev).unwrap();
+        let ref_b_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_blind(ref_b_ev).unwrap();
+        let ref_c_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_private(ref_c_ev).unwrap();
+
+        gb.assign(ref_a_gb, val_a).unwrap();
+        gb.assign(ref_b_gb, val_b).unwrap();
+
+        ev.assign(ref_a_ev, val_a).unwrap();
+        ev.assign(ref_c_ev, val_c).unwrap();
+
+        gb.commit(ref_a_gb).unwrap();
+        gb.commit(ref_b_gb).unwrap();
+        gb.commit(ref_c_gb).unwrap();
+
+        ev.commit(ref_a_ev).unwrap();
+        ev.commit(ref_b_ev).unwrap();
+        ev.commit(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.acquire_cot().flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        let mut fut_a_gb = gb.decode(ref_a_gb).unwrap();
+        let mut fut_b_gb = gb.decode(ref_b_gb).unwrap();
+        let mut fut_c_gb = gb.decode(ref_c_gb).unwrap();
+
+        let mut fut_a_ev = ev.decode(ref_a_ev).unwrap();
+        let mut fut_b_ev = ev.decode(ref_b_ev).unwrap();
+        let mut fut_c_ev = ev.decode(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        let (val_a_gb, val_b_gb, val_c_gb) = (
+            fut_a_gb.try_recv().unwrap().unwrap(),
+            fut_b_gb.try_recv().unwrap().unwrap(),
+            fut_c_gb.try_recv().unwrap().unwrap(),
+        );
+
+        let (val_a_ev, val_b_ev, val_c_ev) = (
+            fut_a_ev.try_recv().unwrap().unwrap(),
+            fut_b_ev.try_recv().unwrap().unwrap(),
+            fut_c_ev.try_recv().unwrap().unwrap(),
+        );
+
+        assert_eq!(val_a_gb, val_a_ev);
+        assert_eq!(val_b_gb, val_b_ev);
+        assert_eq!(val_c_gb, val_c_ev);
+        assert_eq!(val_a_gb, val_a);
+        assert_eq!(val_b_gb, val_b);
+        assert_eq!(val_c_gb, val_c);
+
+        let real_val_a_gb = val_a_gb;
+        let real_val_b_gb = val_b_gb;
+        let real_val_c_gb = val_c_gb;
+
+        // ----------------The same as above but for a mock impl.
+
+        let delta = Delta::random(&mut rng);
+        let cot = IdealCOT::new(delta.into_inner());
+
+        let mut gb = GarblerStore::new(rng.random(), delta, cot.clone());
+        let mut ev = EvaluatorStore::new(cot);
+
+        let ref_a_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_public(ref_a_gb).unwrap();
+        let ref_b_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_private(ref_b_gb).unwrap();
+        let ref_c_gb: Array<U8, 16> = gb.alloc().unwrap();
+        gb.mark_blind(ref_c_gb).unwrap();
+
+        let ref_a_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_public(ref_a_ev).unwrap();
+        let ref_b_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_blind(ref_b_ev).unwrap();
+        let ref_c_ev: Array<U8, 16> = ev.alloc().unwrap();
+        ev.mark_private(ref_c_ev).unwrap();
+
+        gb.assign(ref_a_gb, val_a).unwrap();
+        gb.assign(ref_b_gb, val_b).unwrap();
+
+        ev.assign(ref_a_ev, val_a).unwrap();
+        ev.assign(ref_c_ev, val_c).unwrap();
+
+        gb.commit(ref_a_gb).unwrap();
+        gb.commit(ref_b_gb).unwrap();
+        gb.commit(ref_c_gb).unwrap();
+
+        ev.commit(ref_a_ev).unwrap();
+        ev.commit(ref_b_ev).unwrap();
+        ev.commit(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.acquire_cot().flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        let mut fut_a_gb = gb.decode(ref_a_gb).unwrap();
+        let mut fut_b_gb = gb.decode(ref_b_gb).unwrap();
+        let mut fut_c_gb = gb.decode(ref_c_gb).unwrap();
+
+        let mut fut_a_ev = ev.decode(ref_a_ev).unwrap();
+        let mut fut_b_ev = ev.decode(ref_b_ev).unwrap();
+        let mut fut_c_ev = ev.decode(ref_c_ev).unwrap();
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        let (val_a_gb, val_b_gb, val_c_gb) = (
+            fut_a_gb.try_recv().unwrap().unwrap(),
+            fut_b_gb.try_recv().unwrap().unwrap(),
+            fut_c_gb.try_recv().unwrap().unwrap(),
+        );
+
+        let (val_a_ev, val_b_ev, val_c_ev) = (
+            fut_a_ev.try_recv().unwrap().unwrap(),
+            fut_b_ev.try_recv().unwrap().unwrap(),
+            fut_c_ev.try_recv().unwrap().unwrap(),
+        );
+
+        assert_eq!(val_a_gb, val_a_ev);
+        assert_eq!(val_b_gb, val_b_ev);
+        assert_eq!(val_c_gb, val_c_ev);
+        assert_eq!(val_a_gb, val_a);
+        assert_eq!(val_b_gb, val_b);
+        assert_eq!(val_c_gb, val_c);
+
+        // Make sure real and mock outputs match.
+
+        assert_eq!(val_a_gb, real_val_a_gb);
+        assert_eq!(val_b_gb, real_val_b_gb);
+        assert_eq!(val_c_gb, real_val_c_gb);
+    }
+
+    // Tests that calling decode on a preprocessed output twice behaves
+    // correctly.
+    #[ignore = "verifies mock matches real implementation"]
+    #[test]
+    fn test_store_decode_preprocessed() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+        let cot = IdealCOT::new(delta.into_inner());
+
+        let mut gb = RealGarblerStore::new(rng.random(), delta, cot.clone());
+        let mut ev = RealEvaluatorStore::new(cot);
+
+        let ref_out_gb = gb.alloc_output(16);
+        gb.set_output(ref_out_gb, &Key::from_blocks(vec![Block::ZERO; 16]))
+            .unwrap();
+        std::mem::drop(gb.decode_raw(ref_out_gb).unwrap());
+
+        let ref_out_ev = ev.alloc_output(16);
+        ev.mark_output_preprocessed(ref_out_ev).unwrap();
+        std::mem::drop(ev.decode_raw(ref_out_ev).unwrap());
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        std::mem::drop(gb.decode_raw(ref_out_gb).unwrap());
+        std::mem::drop(ev.decode_raw(ref_out_ev).unwrap());
+
+        // ---------------Same as above but with a mock.
+
+        let delta = Delta::random(&mut rng);
+        let cot = IdealCOT::new(delta.into_inner());
+
+        let mut gb = GarblerStore::new(rng.random(), delta, cot.clone());
+        let mut ev = EvaluatorStore::new(cot);
+
+        let ref_out_gb = gb.alloc_output(16);
+        gb.set_output(ref_out_gb, &Key::from_blocks(vec![Block::ZERO; 16]))
+            .unwrap();
+        std::mem::drop(gb.decode_raw(ref_out_gb).unwrap());
+
+        let ref_out_ev = ev.alloc_output(16);
+        ev.mark_output_preprocessed(ref_out_ev).unwrap();
+        std::mem::drop(ev.decode_raw(ref_out_ev).unwrap());
+
+        assert!(gb.wants_flush());
+        assert!(ev.wants_flush());
+
+        let gen_flush = gb.send_flush().unwrap();
+        let ev_flush = ev.send_flush().unwrap();
+
+        gb.receive_flush(ev_flush).unwrap();
+        ev.receive_flush(gen_flush).unwrap();
+
+        std::mem::drop(gb.decode_raw(ref_out_gb).unwrap());
+        std::mem::drop(ev.decode_raw(ref_out_ev).unwrap());
+
+        // There should be nothing to flush, since the decoding info
+        // has already been sent in the first flush.
+        assert!(!gb.wants_flush() && !ev.wants_flush());
+    }
+}

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -150,6 +150,8 @@ mod tests {
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
         let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
 
+        // There is a bug in IdealOT which makes this test hang when using a mock.
+        // Using a real impl for now.
         let mut gb = crate::protocol::semihonest::Garbler::new(cot_send, [0u8; 16], delta);
         let mut ev = crate::protocol::semihonest::Evaluator::new(cot_recv);
 

--- a/crates/garble/src/protocol/semihonest.rs
+++ b/crates/garble/src/protocol/semihonest.rs
@@ -2,6 +2,8 @@
 
 mod evaluator;
 mod garbler;
+/// Docs
+pub mod mock;
 
 pub use evaluator::Evaluator;
 pub use garbler::Garbler;
@@ -47,7 +49,7 @@ mod tests {
     use mpz_vm_core::{Call, CallableExt, Execute, Vm};
     use rand::{SeedableRng, rngs::StdRng};
 
-    use super::*;
+    use crate::protocol::semihonest::mock::{Evaluator, Garbler};
 
     #[test]
     fn test_semihonest_is_vm() {
@@ -148,8 +150,8 @@ mod tests {
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
         let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
 
-        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
-        let mut ev = Evaluator::new(cot_recv);
+        let mut gb = crate::protocol::semihonest::Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = crate::protocol::semihonest::Evaluator::new(cot_recv);
 
         let (gen_out, ev_out) = futures::join!(
             async {

--- a/crates/garble/src/protocol/semihonest/mock/evaluator.rs
+++ b/crates/garble/src/protocol/semihonest/mock/evaluator.rs
@@ -1,0 +1,399 @@
+use std::{iter, sync::Arc};
+
+use async_trait::async_trait;
+use futures::{StreamExt, stream::iter};
+use hashbrown::HashMap;
+use mpz_circuits::circuits;
+use tokio::sync::{Mutex, MutexGuard};
+
+use mpz_common::{Context, Flush};
+use mpz_core::{Block, bitvec::BitVec};
+use mpz_garble_core::{EvaluatorOutput, GarbledCircuit, Mac, evaluate_garbled_circuits};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
+use mpz_ot::cot::COTReceiver;
+use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
+
+use crate::{
+    evaluator::receive_garbled_circuit, protocol::semihonest::take_preprocess_calls,
+    store::mock::EvaluatorStore,
+};
+
+/// Semi-honest evaluator.
+#[derive(Debug)]
+pub struct Evaluator<COT> {
+    // CHANGED use a mock store.
+    store: Arc<Mutex<EvaluatorStore<COT>>>,
+    call_stack: Vec<(Call, Slice)>,
+    preprocessed: HashMap<Slice, (Call, GarbledCircuit)>,
+}
+
+impl<COT> Evaluator<COT> {
+    /// Creates a new evaluator.
+    pub fn new(cot: COT) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(EvaluatorStore::new(cot))),
+            call_stack: Vec::new(),
+            preprocessed: HashMap::new(),
+        }
+    }
+
+    fn take_execute_calls(&mut self) -> Vec<(Call, Slice)> {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            // Extract only a call which has all its inputs committed.
+            .extract_if(.., |(call, _)| {
+                call.inputs()
+                    .iter()
+                    .all(|input| store.is_committed_raw(*input))
+            })
+            .collect()
+    }
+
+    fn execute_preprocessed(&mut self) -> Result<()> {
+        loop {
+            let mut store = self.store.try_lock().unwrap();
+
+            let (calls, outputs): (Vec<_>, Vec<_>) = self
+                .preprocessed
+                .extract_if(|_, (call, _)| {
+                    call.inputs()
+                        .iter()
+                        .all(|input| store.is_committed_raw(*input))
+                })
+                .map(|(output, (call, _garbled_circuit))| {
+                    let (circ, inputs) = call.clone().into_parts();
+                    let mut input_macs = Vec::with_capacity(circ.inputs().len());
+                    for input in inputs {
+                        input_macs.extend_from_slice(
+                            store
+                                .try_get_macs(input)
+                                .expect("committed MACs should be set"),
+                        );
+                    }
+
+                    (call, output)
+                })
+                .unzip();
+
+            if calls.is_empty() {
+                break;
+            }
+
+            for (call, output) in calls.into_iter().zip(outputs) {
+                // CHANGED: don't use parallel evaluation.
+                evaluate(&mut store, call, output).unwrap();
+            }
+
+            store.flush_decode().map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn store(&self) -> Arc<Mutex<EvaluatorStore<COT>>> {
+        self.store.clone()
+    }
+}
+
+impl<COT> Memory<Binary> for Evaluator<COT> {
+    type Error = VmError;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .alloc_raw(size)
+            .map_err(VmError::memory)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, value: BitVec) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .assign_raw(slice, value)
+            .map_err(VmError::memory)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .commit_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .get_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .decode_raw(slice)
+            .map_err(VmError::memory)
+    }
+}
+
+impl<COT> View<Binary> for Evaluator<COT>
+where
+    COT: COTReceiver<bool, Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_public_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_private_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_blind_raw(slice)
+            .map_err(VmError::view)
+    }
+}
+
+impl<COT> Callable<Binary> for Evaluator<COT> {
+    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+        let output = self
+            .store
+            .try_lock()
+            .unwrap()
+            .alloc_output(call.circ().outputs().len());
+        self.call_stack.push((call, output));
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl<COT> Execute for Evaluator<COT>
+where
+    COT: COTReceiver<bool, Block> + Flush + Send + 'static,
+    COT::Future: Send + 'static,
+{
+    fn wants_flush(&self) -> bool {
+        self.store.try_lock().unwrap().wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+        let mut store = self.store.try_lock().unwrap();
+        if store.wants_flush() {
+            store.flush(ctx).await.map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    fn wants_preprocess(&self) -> bool {
+        // The first call in the call stack is always ready for preprocessing.
+        !self.call_stack.is_empty()
+    }
+
+    async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
+        let mut cot = self.store.try_lock().unwrap().acquire_cot();
+
+        let mut call_stack = std::mem::take(&mut self.call_stack);
+
+        let (_, preprocessed) = ctx
+            .try_join(
+                async move |ctx| {
+                    // This flush is primarily intended to perform OT setup
+                    // concurrently with preprocessing.
+                    // TODO: there is a bug in IdealOT which requires `cot.wants_flush()`
+                    // here to prevent a deadlock.
+                    if cot.wants_flush() {
+                        println!("evaluator before flush ");
+                        let r = cot.flush(ctx).await.map_err(VmError::execute);
+                        println!("evaluator after flush");
+                        return r;
+                    }
+                    Ok(())
+                },
+                async move |ctx| {
+                    let mut preprocessed = Vec::new();
+
+                    while !call_stack.is_empty() {
+                        let calls = take_preprocess_calls(&mut call_stack);
+
+                        // There must be at least one call ready for preprocessing
+                        // in a non-empty call stack.
+                        debug_assert!(!calls.is_empty());
+
+                        let mut outputs = ctx
+                            .map(
+                                calls,
+                                async move |ctx, (call, output): (Call, Slice)| {
+                                    // CHANGED: don't receive garbled circuits.
+
+                                    let garbled_circuit = GarbledCircuit { gates: Vec::new() };
+
+                                    Ok::<_, VmError>((call, output, garbled_circuit))
+                                },
+                                |(call, _)| call.circ().and_count(),
+                            )
+                            .await
+                            .map_err(VmError::execute)?;
+
+                        preprocessed.append(&mut outputs);
+                    }
+
+                    Ok::<_, VmError>(preprocessed)
+                },
+            )
+            .await
+            .map_err(VmError::execute)??;
+
+        let mut store = self.store.try_lock().unwrap();
+        for output in preprocessed {
+            let (call, output, garbled_circuit) = output?;
+
+            self.preprocessed.insert(output, (call, garbled_circuit));
+            store
+                .mark_output_preprocessed(output)
+                .map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    fn wants_execute(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        self.preprocessed.iter().any(|(_, (call, _))| {
+            call.inputs()
+                .iter()
+                .all(|input| store.is_committed_raw(*input))
+        }) || self.call_stack.iter().any(|(call, _)| {
+            call.inputs()
+                .iter()
+                .all(|input| store.is_committed_raw(*input))
+        })
+    }
+
+    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+        if !self.preprocessed.is_empty() {
+            self.execute_preprocessed()?;
+        }
+
+        while !self.call_stack.is_empty() {
+            let calls = self.take_execute_calls();
+
+            if calls.is_empty() {
+                break;
+            }
+
+            let store = self.store.clone();
+            let outputs = ctx
+                .map(
+                    calls,
+                    async move |ctx, (call, output): (Call, Slice)| {
+                        // CHANGED: use non-async `evaluate`.
+                        println!("will lock");
+                        let mut store = store.lock().await;
+                        println!("after lock");
+                        evaluate(&mut store, call, output)
+                    },
+                    |(call, _)| call.circ().and_count(),
+                )
+                .await
+                .map_err(VmError::execute)?;
+
+            outputs.into_iter().collect::<Result<()>>()?;
+        }
+
+        self.store
+            .try_lock()
+            .unwrap()
+            .flush_decode()
+            .map_err(VmError::memory)?;
+
+        Ok(())
+    }
+}
+
+// CHANGED: make `evaluate` non-async, passing in an already-locked store.
+// Evaluates the circuit on cleartext values.
+fn evaluate<COT>(
+    locked_store: &mut MutexGuard<'_, EvaluatorStore<COT>>,
+    call: Call,
+    output: Slice,
+) -> Result<()> {
+    let (circ, inputs) = call.into_parts();
+
+    let mut full_input: Vec<bool> = Vec::new();
+
+    for input in inputs {
+        // Check if this is our input.
+        let raw = locked_store.get_raw(input).unwrap();
+        let mut input = match raw {
+            Some(bits) => bits.iter().by_vals().collect::<Vec<bool>>(),
+            None => match locked_store.try_get_macs(input) {
+                // Try to recover the garbler input from MACs.
+                Ok(macs) => macs
+                    .iter()
+                    .map(|mac| {
+                        if *mac.as_block() == Block::ZERO {
+                            false
+                        } else if *mac.as_block() == Block::ONE {
+                            true
+                        } else {
+                            println!("MAC IS {:?}", mac);
+                            panic!("A MAC must have been set to either 0 or 1")
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+                Err(..) => panic!(""),
+            },
+        };
+
+        full_input.append(&mut input);
+    }
+
+    let res = circ.evaluate(full_input).unwrap();
+    let output_macs = res
+        .iter()
+        .map(|bit| {
+            //
+            if *bit {
+                Block::ONE.into()
+            } else {
+                Block::ZERO.into()
+            }
+        })
+        .collect::<Vec<Mac>>();
+
+    locked_store
+        .set_output(output, &output_macs)
+        .map_err(VmError::memory)?;
+
+    Ok(())
+}

--- a/crates/garble/src/protocol/semihonest/mock/garbler.rs
+++ b/crates/garble/src/protocol/semihonest/mock/garbler.rs
@@ -1,0 +1,335 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use mpz_common::{Context, Flush};
+use mpz_core::{Block, bitvec::BitVec};
+use mpz_garble_core::{GarblerOutput, Key};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary, correlated::Delta};
+use mpz_ot::cot::COTSender;
+use mpz_vm_core::{Call, Callable, Execute, Result, VmError};
+
+use crate::{protocol::semihonest::take_preprocess_calls, store::mock::GarblerStore};
+
+/// Semi-honest garbler.
+#[derive(Debug)]
+pub struct Garbler<COT> {
+    // CHANGED use a mock store.
+    store: Arc<Mutex<GarblerStore<COT>>>,
+    call_stack: Vec<(Call, Slice)>,
+    preprocessed: Vec<(Vec<Slice>, Slice)>,
+}
+
+impl<COT> Garbler<COT> {
+    /// Creates a new garbler.
+    pub fn new(cot: COT, seed: [u8; 16], delta: Delta) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(GarblerStore::new(seed, delta, cot))),
+            call_stack: Vec::new(),
+            preprocessed: Vec::new(),
+        }
+    }
+
+    fn take_execute_calls(&mut self) -> Vec<(Call, Slice)> {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            .extract_if(.., |(call, _)| {
+                call.inputs()
+                    .iter()
+                    .all(|slice| store.is_committed_raw(*slice))
+            })
+            .collect()
+    }
+
+    // Marks the outputs of preprocessed calls as executed.
+    fn mark_executed(&mut self) -> Result<()> {
+        let mut store = self.store.try_lock().unwrap();
+        loop {
+            let outputs = self
+                .preprocessed
+                .extract_if(.., |(inputs, _)| {
+                    inputs.iter().all(|input| store.is_committed_raw(*input))
+                })
+                .map(|(_, output)| output)
+                .collect::<Vec<_>>();
+
+            if outputs.is_empty() {
+                break;
+            }
+
+            for output in outputs {
+                store
+                    .mark_output_complete(output)
+                    .map_err(VmError::memory)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn store(&self) -> Arc<Mutex<GarblerStore<COT>>> {
+        self.store.clone()
+    }
+}
+
+impl<COT> Memory<Binary> for Garbler<COT> {
+    type Error = VmError;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .alloc_raw(size)
+            .map_err(VmError::memory)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, value: BitVec) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .assign_raw(slice, value)
+            .map_err(VmError::memory)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.store.try_lock().unwrap().is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .commit_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .get_raw(slice)
+            .map_err(VmError::memory)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .decode_raw(slice)
+            .map_err(VmError::memory)
+    }
+}
+
+impl<COT> View<Binary> for Garbler<COT>
+where
+    COT: COTSender<Block>,
+{
+    type Error = VmError;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_public_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_private_raw(slice)
+            .map_err(VmError::view)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<()> {
+        self.store
+            .try_lock()
+            .unwrap()
+            .mark_blind_raw(slice)
+            .map_err(VmError::view)
+    }
+}
+
+impl<COT> Callable<Binary> for Garbler<COT> {
+    fn call_raw(&mut self, call: Call) -> Result<Slice> {
+        let slice = self
+            .store
+            .try_lock()
+            .unwrap()
+            .alloc_output(call.circ().outputs().len());
+        self.call_stack.push((call, slice));
+        Ok(slice)
+    }
+}
+
+#[async_trait]
+impl<COT> Execute for Garbler<COT>
+where
+    COT: COTSender<Block> + Flush + Send + 'static,
+{
+    fn wants_flush(&self) -> bool {
+        self.store.try_lock().unwrap().wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<()> {
+        let mut store = self.store.try_lock().unwrap();
+        if store.wants_flush() {
+            store.flush(ctx).await.map_err(VmError::memory)?;
+        }
+
+        Ok(())
+    }
+
+    fn wants_preprocess(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        self.call_stack
+            .iter()
+            .any(|(call, _)| call.inputs().iter().all(|slice| store.is_set_keys(*slice)))
+    }
+
+    async fn preprocess(&mut self, ctx: &mut Context) -> Result<()> {
+        let (delta, mut cot) = {
+            let store = self.store.try_lock().unwrap();
+            (*store.delta(), store.acquire_cot())
+        };
+
+        let mut call_stack = std::mem::take(&mut self.call_stack);
+        let store = self.store.clone();
+
+        // All calls will be added to preprocessed once preprocessing completes.
+        let mut preprocessed = call_stack
+            .iter()
+            .map(|(call, output)| (call.inputs().to_vec(), *output))
+            .collect::<Vec<_>>();
+
+        ctx.try_join(
+            async move |ctx| {
+                // This flush is primarily intended to perform OT setup
+                // concurrently with preprocessing.
+                // TODO: there is a bug in IdealOT which requires `cot.wants_flush()`
+                // here to prevent a deadlock.
+                if cot.wants_flush() {
+                    println!("garbler before flush ");
+                    let r = cot.flush(ctx).await.map_err(VmError::execute);
+                    println!("garbler after flush ");
+                    return r;
+                }
+                Ok(())
+            },
+            async move |ctx| {
+                while !call_stack.is_empty() {
+                    let calls = take_preprocess_calls(&mut call_stack);
+
+                    // There must be at least one call ready for preprocessing
+                    // in a non-empty call stack.
+                    debug_assert!(!calls.is_empty());
+
+                    let store = store.clone();
+                    let outputs = ctx
+                        .map(
+                            calls,
+                            async move |ctx: &mut Context, (call, output): (Call, Slice)| {
+                                generate(ctx, store.clone(), delta, call, output, Mode::Preprocess)
+                                    .await
+                            },
+                            |(call, _)| call.circ().and_count(),
+                        )
+                        .await
+                        .map_err(VmError::execute)?;
+
+                    outputs.into_iter().collect::<Result<()>>()?;
+                }
+
+                Ok::<_, VmError>(())
+            },
+        )
+        .await
+        .map_err(VmError::execute)??;
+
+        self.preprocessed.append(&mut preprocessed);
+
+        Ok(())
+    }
+
+    fn wants_execute(&self) -> bool {
+        let store = self.store.try_lock().unwrap();
+        self.preprocessed
+            .iter()
+            .any(|(inputs, _)| inputs.iter().all(|input| store.is_committed_raw(*input)))
+            || self.call_stack.iter().any(|(call, _)| {
+                call.inputs()
+                    .iter()
+                    .all(|slice| store.is_committed_raw(*slice))
+            })
+    }
+
+    async fn execute(&mut self, ctx: &mut Context) -> Result<()> {
+        self.mark_executed()?;
+
+        let delta = *self.store.try_lock().unwrap().delta();
+
+        while !self.call_stack.is_empty() {
+            let calls = self.take_execute_calls();
+
+            if calls.is_empty() {
+                break;
+            }
+
+            let store = self.store.clone();
+            let outputs = ctx
+                .map(
+                    calls,
+                    async move |ctx: &mut Context, (call, output): (Call, Slice)| {
+                        generate(ctx, store.clone(), delta, call, output, Mode::Execute).await
+                    },
+                    |(call, _)| call.circ().and_count(),
+                )
+                .await
+                .map_err(VmError::execute)?;
+
+            outputs.into_iter().collect::<Result<()>>()?;
+        }
+
+        self.mark_executed()?;
+
+        Ok(())
+    }
+}
+
+enum Mode {
+    Preprocess,
+    Execute,
+}
+
+// CHANGED: do not generate the garbled circuits.
+async fn generate<COT>(
+    ctx: &mut Context,
+    store: Arc<Mutex<GarblerStore<COT>>>,
+    delta: Delta,
+    call: Call,
+    output: Slice,
+    mode: Mode,
+) -> Result<()> {
+    let output_keys = vec![Key::from(Block::ZERO); output.len()];
+
+    let mut lock = store.lock().await;
+    lock.set_output(output, &output_keys)
+        .map_err(VmError::memory)?;
+
+    if let Mode::Execute = mode {
+        lock.mark_output_complete(output).map_err(VmError::memory)?;
+    }
+
+    Ok(())
+}

--- a/crates/garble/src/protocol/semihonest/mock/mod.rs
+++ b/crates/garble/src/protocol/semihonest/mock/mod.rs
@@ -1,0 +1,492 @@
+//! Copies of Evaluator and Garbler with minimal modifications to remove all
+//! cryptography operations.
+//!
+//! Places in the code which were changed are marked with // CHANGED
+
+mod evaluator;
+mod garbler;
+
+pub use evaluator::Evaluator;
+pub use garbler::Garbler;
+
+// The tests make sure that the mock is consistent with the real impl.
+#[cfg(test)]
+mod tests {
+    use mpz_circuits::circuits::AES128;
+    use mpz_common::{Flush, context::test_st_context};
+    use mpz_core::Block;
+    use mpz_memory_core::{
+        Array, MemoryExt, ViewExt,
+        binary::{Binary, U8},
+        correlated::Delta,
+    };
+    use mpz_ot::{
+        cot::{COTReceiver, COTSender},
+        ideal::cot::{IdealCOTReceiver, IdealCOTSender, ideal_cot},
+    };
+    use mpz_vm_core::{Call, CallableExt, Execute, Vm};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use crate::protocol::semihonest::{
+        Evaluator as RealEvaluator, Garbler as RealGarbler,
+        mock::{Evaluator, Garbler},
+    };
+
+    #[ignore = "verifies mock matches real implementation"]
+    #[tokio::test]
+    async fn test_semihonest() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = RealGarbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = RealEvaluator::new(cot_recv);
+
+        let (gen_out, ev_out) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_blind(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(msg).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_private(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(msg).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            }
+        );
+
+        assert_eq!(gen_out, ev_out);
+
+        let real_gen_out = gen_out;
+
+        // --------- Same as above but with a mock.
+
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = Evaluator::new(cot_recv);
+
+        let (gen_out, ev_out) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_blind(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(msg).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_private(msg).unwrap();
+
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(msg).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            }
+        );
+
+        assert_eq!(gen_out, ev_out);
+
+        assert_eq!(real_gen_out, gen_out);
+    }
+
+    #[ignore = "verifies mock matches real implementation"]
+    #[tokio::test]
+    async fn test_semihonest_nothing_to_do() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = RealGarbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = RealEvaluator::new(cot_recv);
+
+        gb.flush(&mut ctx_a).await.unwrap();
+        ev.flush(&mut ctx_b).await.unwrap();
+
+        // --------- Same as above but with a mock.
+
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = Evaluator::new(cot_recv);
+
+        gb.flush(&mut ctx_a).await.unwrap();
+        ev.flush(&mut ctx_b).await.unwrap();
+    }
+
+    #[ignore = "verifies mock matches real implementation"]
+    #[tokio::test]
+    async fn test_semihonest_preprocess() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = RealGarbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = RealEvaluator::new(cot_recv);
+
+        let (gen_out, ev_out) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_blind(msg).unwrap();
+
+                let output: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+
+                assert!(gb.wants_preprocess());
+                gb.preprocess(&mut ctx_a).await.unwrap();
+
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(msg).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_private(msg).unwrap();
+
+                let output: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+
+                assert!(ev.wants_preprocess());
+                ev.preprocess(&mut ctx_b).await.unwrap();
+
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(msg).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            }
+        );
+
+        assert_eq!(gen_out, ev_out);
+
+        let real_gen_out = gen_out;
+
+        // --------- Same as above but with a mock.
+
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (cot_send, cot_recv) = ideal_cot(delta.into_inner());
+
+        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = Evaluator::new(cot_recv);
+
+        let (gb, ev) = futures::join!(
+            async {
+                let key: Array<U8, 16> = gb.alloc().unwrap();
+                let msg: Array<U8, 16> = gb.alloc().unwrap();
+
+                gb.mark_private(key).unwrap();
+                gb.mark_blind(msg).unwrap();
+
+                let output: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = gb
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = gb.decode(ciphertext).unwrap();
+
+                assert!(gb.wants_preprocess());
+                gb.preprocess(&mut ctx_a).await.unwrap();
+                (gb, key, msg, ciphertext)
+
+                // gb.assign(key, [0u8; 16]).unwrap();
+                // gb.commit(key).unwrap();
+                // gb.commit(msg).unwrap();
+
+                // gb.execute_all(&mut ctx_a).await.unwrap();
+                //ciphertext.try_recv().unwrap().unwrap()
+            },
+            async {
+                let key: Array<U8, 16> = ev.alloc().unwrap();
+                let msg: Array<U8, 16> = ev.alloc().unwrap();
+
+                ev.mark_blind(key).unwrap();
+                ev.mark_private(msg).unwrap();
+
+                let output: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(msg)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                // Chain the AES calls.
+                let ciphertext: Array<U8, 16> = ev
+                    .call(
+                        Call::builder(AES128.clone())
+                            .arg(key)
+                            .arg(output)
+                            .build()
+                            .unwrap(),
+                    )
+                    .unwrap();
+
+                let mut ciphertext = ev.decode(ciphertext).unwrap();
+
+                assert!(ev.wants_preprocess());
+                ev.preprocess(&mut ctx_b).await.unwrap();
+
+                (ev, key, msg, ciphertext)
+
+                // ev.assign(msg, [42u8; 16]).unwrap();
+                // ev.commit(key).unwrap();
+                // ev.commit(msg).unwrap();
+
+                // ev.execute_all(&mut ctx_b).await.unwrap();
+                //ciphertext.try_recv().unwrap().unwrap()
+            }
+        );
+
+        // TODO: there is  bug in IdealOT due to which we must not make any VM calls
+        // on either side until both parties finish preprocessing.
+
+        let (gen_out, ev_out) = futures::join!(
+            async {
+                let (mut gb, key, msg, mut ciphertext) = gb;
+                gb.assign(key, [0u8; 16]).unwrap();
+                gb.commit(key).unwrap();
+                gb.commit(msg).unwrap();
+
+                gb.execute_all(&mut ctx_a).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            },
+            async {
+                let (mut ev, key, msg, mut ciphertext) = ev;
+
+                ev.assign(msg, [42u8; 16]).unwrap();
+                ev.commit(key).unwrap();
+                ev.commit(msg).unwrap();
+
+                ev.execute_all(&mut ctx_b).await.unwrap();
+                ciphertext.try_recv().unwrap().unwrap()
+            }
+        );
+
+        assert_eq!(gen_out, ev_out);
+        assert_eq!(gen_out, real_gen_out);
+    }
+
+    #[ignore = "verifies mock matches real implementation"]
+    #[tokio::test]
+    // Tests that OT is flushed when `preprocess` is called.
+    async fn test_semihonest_concurrent_flush() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
+
+        // Put the sender and the receiver in a state where they want to flush.
+        drop(cot_send.queue_send_cot(&[Block::default()]).unwrap());
+        drop(cot_recv.queue_recv_cot(&[true]).unwrap());
+        assert!(cot_send.wants_flush());
+        assert!(cot_recv.wants_flush());
+
+        let mut gb = RealGarbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = RealEvaluator::new(cot_recv);
+
+        let (_, _) = futures::join!(
+            async {
+                gb.preprocess(&mut ctx_a).await.unwrap();
+            },
+            async {
+                ev.preprocess(&mut ctx_b).await.unwrap();
+            }
+        );
+
+        let gb_cot = gb.store().try_lock().unwrap().acquire_cot();
+        let ev_cot = ev.store().try_lock().unwrap().acquire_cot();
+        assert!(!gb_cot.wants_flush());
+        assert!(!ev_cot.wants_flush());
+
+        // --------- Same as above but with a mock.
+
+        let delta = Delta::random(&mut rng);
+
+        let (mut ctx_a, mut ctx_b) = test_st_context(8);
+        let (mut cot_send, mut cot_recv) = ideal_cot(delta.into_inner());
+
+        // Put the sender and the receiver in a state where they want to flush.
+        drop(cot_send.queue_send_cot(&[Block::default()]).unwrap());
+        drop(cot_recv.queue_recv_cot(&[true]).unwrap());
+        assert!(cot_send.wants_flush());
+        assert!(cot_recv.wants_flush());
+
+        let mut gb = Garbler::new(cot_send, [0u8; 16], delta);
+        let mut ev = Evaluator::new(cot_recv);
+
+        let (_, _) = futures::join!(
+            async {
+                gb.preprocess(&mut ctx_a).await.unwrap();
+            },
+            async {
+                ev.preprocess(&mut ctx_b).await.unwrap();
+            }
+        );
+
+        let gb_cot = gb.store().try_lock().unwrap().acquire_cot();
+        let ev_cot = ev.store().try_lock().unwrap().acquire_cot();
+        assert!(!gb_cot.wants_flush());
+        assert!(!ev_cot.wants_flush());
+    }
+}

--- a/crates/garble/src/store.rs
+++ b/crates/garble/src/store.rs
@@ -1,5 +1,7 @@
 mod evaluator;
 mod garbler;
+/// Docs
+pub(crate) mod mock;
 
 pub(crate) use evaluator::EvaluatorStore;
 pub(crate) use garbler::GarblerStore;

--- a/crates/garble/src/store/mock/evaluator.rs
+++ b/crates/garble/src/store/mock/evaluator.rs
@@ -1,0 +1,197 @@
+use async_trait::async_trait;
+use mpz_common::{Context, ContextError, Flush};
+use mpz_core::{Block, bitvec::BitVec};
+use mpz_garble_core::{
+    Mac,
+    store::mock::{EvaluatorStore as Core, EvaluatorStoreError as CoreError},
+};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
+use mpz_ot::cot::COTReceiver;
+use serio::{SinkExt, stream::IoStreamExt};
+use tokio::sync::OwnedMutexGuard;
+
+type Error = EvaluatorStoreError;
+type Result<T, E = Error> = core::result::Result<T, E>;
+
+#[derive(Debug)]
+pub(crate) struct EvaluatorStore<COT> {
+    core: Core<COT>,
+}
+
+impl<COT> EvaluatorStore<COT> {
+    /// Creates a new evaluator store.
+    pub(crate) fn new(cot: COT) -> Self {
+        Self {
+            // CHANGED: use a mock core store.
+            core: Core::new(cot),
+        }
+    }
+
+    /// Returns a lock on the COT receiver.
+    pub(crate) fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        self.core.acquire_cot()
+    }
+
+    pub(crate) fn try_get_macs(&self, slice: Slice) -> Result<&[Mac], Error> {
+        self.core.try_get_macs(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn alloc_output(&mut self, size: usize) -> Slice {
+        self.core.alloc_output(size)
+    }
+
+    pub(crate) fn mark_output_preprocessed(&mut self, slice: Slice) -> Result<(), Error> {
+        self.core
+            .mark_output_preprocessed(slice)
+            .map_err(Error::from)
+    }
+
+    pub(crate) fn set_output(&mut self, slice: Slice, macs: &[Mac]) -> Result<(), Error> {
+        self.core.set_output(slice, macs).map_err(Error::from)
+    }
+
+    pub(crate) fn flush_decode(&mut self) -> Result<(), Error> {
+        self.core.flush_decode().map_err(Error::from)
+    }
+}
+
+impl<COT> Memory<Binary> for EvaluatorStore<COT> {
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.core.is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice, Self::Error> {
+        self.core.alloc_raw(size).map_err(Error::from)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.core.is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<(), Self::Error> {
+        self.core.assign_raw(slice, data).map_err(Error::from)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.core.is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.commit_raw(slice).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>, Self::Error> {
+        self.core.get_raw(slice).map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>, Self::Error> {
+        self.core.decode_raw(slice).map_err(Error::from)
+    }
+}
+
+impl<COT> View<Binary> for EvaluatorStore<COT>
+where
+    COT: COTReceiver<bool, Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+#[async_trait]
+impl<COT> Flush for EvaluatorStore<COT>
+where
+    COT: COTReceiver<bool, Block> + Flush + Send + 'static,
+    COT::Future: Send + 'static,
+{
+    type Error = Error;
+
+    fn wants_flush(&self) -> bool {
+        self.core.wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        while self.core.wants_flush() {
+            let flush = self.core.send_flush()?;
+            let mut cot = self.core.acquire_cot();
+
+            let flush_size = self.core.flush_view().evaluator_flush_size();
+            let expected_size = self.core.flush_view().garbler_flush_size();
+            let (flush, ()) = ctx
+                .try_join(
+                    async move |ctx| {
+                        ctx.io_mut().with_limit(flush_size).send(flush).await?;
+
+                        // Adjust the limit to expected size.
+                        let limit = ctx.io().limit().max(expected_size);
+                        ctx.io_mut()
+                            .with_limit(limit)
+                            .expect_next()
+                            .await
+                            .map_err(Error::from)
+                    },
+                    async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
+                )
+                .await??;
+
+            self.core.receive_flush(flush)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct EvaluatorStoreError(#[from] ErrorRepr);
+
+impl EvaluatorStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] CoreError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("COT error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("context error: {0}")]
+    Context(#[from] ContextError),
+}
+
+impl From<CoreError> for EvaluatorStoreError {
+    fn from(value: CoreError) -> Self {
+        EvaluatorStoreError(ErrorRepr::Core(value))
+    }
+}
+
+impl From<std::io::Error> for EvaluatorStoreError {
+    fn from(value: std::io::Error) -> Self {
+        EvaluatorStoreError(ErrorRepr::Io(value))
+    }
+}
+
+impl From<ContextError> for EvaluatorStoreError {
+    fn from(value: ContextError) -> Self {
+        EvaluatorStoreError(ErrorRepr::Context(value))
+    }
+}

--- a/crates/garble/src/store/mock/garbler.rs
+++ b/crates/garble/src/store/mock/garbler.rs
@@ -1,0 +1,197 @@
+use async_trait::async_trait;
+use mpz_common::{Context, ContextError, Flush};
+use mpz_core::{Block, bitvec::BitVec};
+use mpz_garble_core::{
+    Delta, Key,
+    store::mock::{GarblerStore as Core, GarblerStoreError as CoreError},
+};
+use mpz_memory_core::{DecodeFuture, Memory, Slice, View, binary::Binary};
+use mpz_ot::cot::COTSender;
+use serio::{SinkExt, stream::IoStreamExt};
+use tokio::sync::OwnedMutexGuard;
+
+type Error = GarblerStoreError;
+
+#[derive(Debug)]
+pub(crate) struct GarblerStore<COT> {
+    // CHANGED: use a mock core store.
+    core: Core<COT>,
+}
+
+impl<COT> GarblerStore<COT> {
+    /// Creates a new garbler store.
+    pub(crate) fn new(seed: [u8; 16], delta: Delta, cot: COT) -> Self {
+        Self {
+            core: Core::new(seed, delta, cot),
+        }
+    }
+
+    pub(crate) fn delta(&self) -> &Delta {
+        self.core.delta()
+    }
+
+    /// Returns a lock on the COT sender.
+    pub(crate) fn acquire_cot(&self) -> OwnedMutexGuard<COT> {
+        self.core.acquire_cot()
+    }
+
+    pub(crate) fn is_set_keys(&self, slice: Slice) -> bool {
+        self.core.is_set_keys(slice)
+    }
+
+    pub(crate) fn try_get_keys(&self, slice: Slice) -> Result<&[Key], Error> {
+        self.core.try_get_keys(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn alloc_output(&mut self, size: usize) -> Slice {
+        self.core.alloc_output(size)
+    }
+
+    pub(crate) fn mark_output_complete(&mut self, slice: Slice) -> Result<(), Error> {
+        self.core.mark_output_complete(slice).map_err(Error::from)
+    }
+
+    pub(crate) fn set_output(&mut self, slice: Slice, keys: &[Key]) -> Result<(), Error> {
+        self.core.set_output(slice, keys).map_err(Error::from)
+    }
+}
+
+impl<COT> Memory<Binary> for GarblerStore<COT> {
+    type Error = Error;
+
+    fn is_alloc_raw(&self, slice: Slice) -> bool {
+        self.core.is_alloc_raw(slice)
+    }
+
+    fn alloc_raw(&mut self, size: usize) -> Result<Slice, Self::Error> {
+        self.core.alloc_raw(size).map_err(Error::from)
+    }
+
+    fn is_assigned_raw(&self, slice: Slice) -> bool {
+        self.core.is_assigned_raw(slice)
+    }
+
+    fn assign_raw(&mut self, slice: Slice, data: BitVec) -> Result<(), Self::Error> {
+        self.core.assign_raw(slice, data).map_err(Error::from)
+    }
+
+    fn is_committed_raw(&self, slice: Slice) -> bool {
+        self.core.is_committed_raw(slice)
+    }
+
+    fn commit_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.commit_raw(slice).map_err(Error::from)
+    }
+
+    fn get_raw(&self, slice: Slice) -> Result<Option<BitVec>, Self::Error> {
+        self.core.get_raw(slice).map_err(Error::from)
+    }
+
+    fn decode_raw(&mut self, slice: Slice) -> Result<DecodeFuture<BitVec>, Self::Error> {
+        self.core.decode_raw(slice).map_err(Error::from)
+    }
+}
+
+impl<COT> View<Binary> for GarblerStore<COT>
+where
+    COT: COTSender<Block>,
+{
+    type Error = Error;
+
+    fn mark_public_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_public_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_private_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_private_raw(slice).map_err(Error::from)
+    }
+
+    fn mark_blind_raw(&mut self, slice: Slice) -> Result<(), Self::Error> {
+        self.core.mark_blind_raw(slice).map_err(Error::from)
+    }
+}
+
+#[async_trait]
+impl<COT> Flush for GarblerStore<COT>
+where
+    COT: COTSender<Block> + Flush + Send + 'static,
+{
+    type Error = Error;
+
+    fn wants_flush(&self) -> bool {
+        self.core.wants_flush()
+    }
+
+    async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
+        while self.core.wants_flush() {
+            let flush = self.core.send_flush()?;
+            let mut cot = self.core.acquire_cot();
+
+            let flush_size = self.core.flush_view().garbler_flush_size();
+            let expected_size = self.core.flush_view().evaluator_flush_size();
+            let (flush, ()) = ctx
+                .try_join(
+                    async move |ctx| {
+                        ctx.io_mut().with_limit(flush_size).send(flush).await?;
+
+                        // Adjust the limit to expected size.
+                        let limit = ctx.io().limit().max(expected_size);
+                        ctx.io_mut()
+                            .with_limit(limit)
+                            .expect_next()
+                            .await
+                            .map_err(Error::from)
+                    },
+                    async move |ctx| cot.flush(ctx).await.map_err(Error::cot),
+                )
+                .await??;
+
+            self.core.receive_flush(flush)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub(crate) struct GarblerStoreError(#[from] ErrorRepr);
+
+impl GarblerStoreError {
+    fn cot<E>(err: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        Self(ErrorRepr::Cot(err.into()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorRepr {
+    #[error("core error: {0}")]
+    Core(#[from] CoreError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("COT error: {0}")]
+    Cot(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("context error: {0}")]
+    Context(#[from] ContextError),
+}
+
+impl From<CoreError> for GarblerStoreError {
+    fn from(value: CoreError) -> Self {
+        GarblerStoreError(ErrorRepr::Core(value))
+    }
+}
+
+impl From<std::io::Error> for GarblerStoreError {
+    fn from(value: std::io::Error) -> Self {
+        GarblerStoreError(ErrorRepr::Io(value))
+    }
+}
+
+impl From<ContextError> for GarblerStoreError {
+    fn from(value: ContextError) -> Self {
+        GarblerStoreError(ErrorRepr::Context(value))
+    }
+}

--- a/crates/garble/src/store/mock/mod.rs
+++ b/crates/garble/src/store/mock/mod.rs
@@ -1,0 +1,12 @@
+//! Copies of EvaluatorStore and GarblerStore with minimal modifications to
+//! remove all cryptography operations.
+//!
+//! Places in the code which were changed are marked with // CHANGED
+
+mod evaluator;
+mod garbler;
+
+pub(crate) use crate::store::mock::{
+    evaluator::{EvaluatorStore, EvaluatorStoreError},
+    garbler::{GarblerStore, GarblerStoreError},
+};

--- a/crates/memory-core/src/correlated.rs
+++ b/crates/memory-core/src/correlated.rs
@@ -228,6 +228,11 @@ impl MacCommitment {
 
         Ok(())
     }
+
+    // TODO: put behind mock flag
+    pub fn from_blocks(blocks: [Block; 2]) -> Self {
+        MacCommitment(blocks)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
This is a draft PR to align on how mocks should be implemented and tested.

I implemented mocks for semihonest garbler and evaluator by removing all expensive cryptographic operations.

I tested each mock against the real implementation by copying existing tests, running them against real and mock impls and comparing the results.

All changes in the mocks are marked with // CHANGED, so it is easier to ctrl-f and find the changes.