### PR TITLE
Convert otp.rs test to compile-time API check

### DIFF
--- a/crates/vm-core/src/otp.rs
+++ b/crates/vm-core/src/otp.rs
@@ -78,9 +78,10 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    #[allow(dead_code)]
-    fn test_otp() {
+    // Compile-time API conformance check for OneTimePad::mask_private over U8 and
+    // Vector<U8>. Intentionally not a runtime test; ensures the generic bounds
+    // and signatures remain valid.
+    fn compile_check_otp() {
         fn single<Vm: OneTimePad<Binary>>(vm: &mut Vm, value: U8) {
             vm.mask_private(value, 0u8).unwrap();
         }


### PR DESCRIPTION
Replace a vacuous #[test] in crates/vm-core/src/otp.rs with a compile-time API conformance check. The previous test defined inner functions that were never called and contained no assertions, producing a misleading green test without runtime verification. This change preserves the intended compile-time validation of OneTimePad::mask_private for U8 and Vector<U8> while avoiding false test coverage and aligning with repository testing practices.