### PR TITLE
chore: fix clippy warnings and enforce them in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         run: cargo +nightly fmt --check --all
 
       - name: Run Clippy
-        run: cargo +nightly clippy --all-targets --all-features
+        run: cargo +nightly clippy --all-targets --all-features -- -D warnings
 
   miri:
     if: ( ! github.event.pull_request.draft )

--- a/crates/hash/src/blake3.rs
+++ b/crates/hash/src/blake3.rs
@@ -531,7 +531,7 @@ impl fmt::Display for Blake3Error {
         }
 
         if let Some(source) = &self.source {
-            write!(f, " caused by: {}", source)?;
+            write!(f, " caused by: {source}")?;
         }
 
         Ok(())
@@ -567,7 +567,7 @@ mod test {
     #[test]
     fn test_serialize_output() {
         let output: [u8; 32] = evaluate!(SERIALIZE_OUTPUT, IV).unwrap();
-        let expected: Vec<_> = IV.iter().map(|word| word.to_le_bytes()).flatten().collect();
+        let expected: Vec<_> = IV.iter().flat_map(|word| word.to_le_bytes()).collect();
         assert_eq!(&output, expected.as_slice());
     }
 


### PR DESCRIPTION
This PR fixes clippy warnings and enforces them in CI.