### PR TITLE
chore(fields): remove redundant trait bounds from Field

### DIFF
--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -26,15 +26,11 @@ pub trait Field:
     + Mul<Output = Self>
     + Neg<Output = Self>
     + Copy
-    + Clone
     + Debug
     + 'static
     + Send
     + Sync
     + UniformRand
-    + PartialOrd
-    + Ord
-    + PartialEq
     + Eq
     + FromBitIterator
     + GetBit<Lsb0>


### PR DESCRIPTION
Removed Clone because Copy: Clone in Rust, so Clone was redundant for F: Field.
Removed Ord and PartialOrd because the codebase never relies on ordering for F: Field (no BTreeMap/BTreeSet keys of F, no sorting of Vec<F>, no T: Field + Ord constraints). Keeping ordering would enforce an arbitrary total order with no value and make the trait harder to implement.
Removed PartialEq while keeping Eq because Eq: PartialEq. Finite fields have exact equality, so Eq is the correct and sufficient constraint.
This simplifies implementing Field for new types, reduces unnecessary constraints, and does not change behavior. Existing implementations (Gf2_128, P256) already satisfy stricter bounds, so compatibility is preserved.