### PR TITLE
perf(zk-core): do not use union in View::is_committed

### DIFF
--- a/crates/zk-core/src/view.rs
+++ b/crates/zk-core/src/view.rs
@@ -1,5 +1,5 @@
 use mpz_memory_core::{Slice, View as ViewTrait, binary::Binary, view::VisibilityView};
-use rangeset::{Difference, Disjoint, Intersection, Subset, Union};
+use rangeset::{Difference, Disjoint, Intersection, Subset};
 use serde::{Deserialize, Serialize};
 
 type Range = std::ops::Range<usize>;
@@ -196,7 +196,7 @@ impl View {
     }
 
     pub(crate) fn is_committed(&self, range: Range) -> bool {
-        range.is_subset(&self.input.complete.union(&self.output.complete))
+        range.is_subset(&self.input.complete) || range.is_subset(&self.output.complete)
     }
 
     pub(crate) fn commit(&mut self, range: Range) -> Result<()> {


### PR DESCRIPTION
This PR significantly improves zk performance by avoiding the use of set union in View::is_committed.

The improvement was confirmed by running
> cargo bench --bench=zk -- --sample-size=10

and adjusting `BLOCK_COUNT` in crates/zk/benches/zk.rs

Below are the results before and after this PR


// const BLOCK_COUNT: usize = 2000; //

before:
zk/aes128               time:   [7.1492 s 7.2068 s 7.2695 s]
                        thrpt:  [4.2988 KiB/s 4.3362 KiB/s 4.3711 KiB/s]

after:

zk/aes128               time:   [2.7436 s 2.7583 s 2.7726 s]
                        thrpt:  [11.271 KiB/s 11.330 KiB/s 11.390 KiB/s]

// const BLOCK_COUNT: usize = 1000; //

before:
zk/aes128               time:   [1.8994 s 1.9207 s 1.9447 s]
                        thrpt:  [8.0347 KiB/s 8.1352 KiB/s 8.2262 KiB/s]

after:
zk/aes128               time:   [1.3038 s 1.3116 s 1.3202 s]
                        thrpt:  [11.835 KiB/s 11.913 KiB/s 11.984 KiB/s]


// const BLOCK_COUNT: usize = 100; //

before:
zk/aes128               time:   [152.44 ms 156.46 ms 160.10 ms]
                        thrpt:  [9.7595 KiB/s 9.9868 KiB/s 10.250 KiB/s]

after:
zk/aes128               time:   [127.94 ms 129.75 ms 134.08 ms]
                        thrpt:  [11.653 KiB/s 12.042 KiB/s 12.212 KiB/s]

