### PR TITLE
feat(memory-core): add Bool type

### DIFF
--- a/crates/memory-core/src/binary.rs
+++ b/crates/memory-core/src/binary.rs
@@ -86,6 +86,74 @@ impl_uint!(u32, U32, 32);
 impl_uint!(u64, U64, 64);
 impl_uint!(u128, U128, 128);
 
+/// A single bit (boolean) type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bool(Ptr);
+
+impl Repr<Binary> for Bool {
+    type Clear = bool;
+}
+
+impl StaticSize<Binary> for bool {
+    const SIZE: usize = 1;
+}
+
+impl<const N: usize> StaticSize<Binary> for [bool; N] {
+    const SIZE: usize = N;
+}
+
+impl StaticSize<Binary> for Bool {
+    const SIZE: usize = 1;
+}
+
+impl<const N: usize> StaticSize<Binary> for [Bool; N] {
+    const SIZE: usize = N;
+}
+
+impl FromRaw<Binary> for Bool {
+    fn from_raw(slice: Slice) -> Self {
+        Self(slice.ptr)
+    }
+}
+
+impl ToRaw for Bool {
+    fn to_raw(&self) -> Slice {
+        Slice::new_unchecked(self.0, Self::SIZE)
+    }
+}
+
+impl ClearValue<Binary> for bool {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(std::iter::once(self))
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        debug_assert_eq!(value.len(), 1);
+        value[0]
+    }
+}
+
+impl<const N: usize> ClearValue<Binary> for [bool; N] {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(self)
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        debug_assert_eq!(value.len(), N);
+        std::array::from_fn(|i| value[i])
+    }
+}
+
+impl ClearValue<Binary> for Vec<bool> {
+    fn into_clear(self) -> BitVec {
+        BitVec::from_iter(self)
+    }
+
+    fn from_clear(value: BitVec) -> Self {
+        value.iter().by_vals().collect()
+    }
+}
+
 macro_rules! impl_clear_value_for_tuples {
     // Macro for generating implementations for tuples with element identifiers and indices.
     ($($name:ident : $index:tt),+) => {

--- a/crates/memory-core/src/lib.rs
+++ b/crates/memory-core/src/lib.rs
@@ -700,7 +700,7 @@ impl_repr_for_tuples!(T0, T1, T2, T3, T4, T5, T6, T7);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::binary::U8;
+    use crate::binary::{Bool, U8};
 
     #[test]
     fn test_slice_split_at() {
@@ -743,5 +743,57 @@ mod tests {
 
         // Shouldn't be able to get a [30..34] slice.
         assert!(arr.get::<4>(30).is_none());
+    }
+
+    #[test]
+    fn test_bool_type() {
+        use crate::binary::Binary;
+
+        // Test Bool size
+        assert_eq!(Bool::SIZE, 1);
+        assert_eq!(<bool as StaticSize<Binary>>::SIZE, 1);
+
+        // Test ClearValue for bool
+        let value = true;
+        let bits = value.into_clear();
+        assert_eq!(bits.len(), 1);
+        assert!(bits[0]);
+
+        let recovered = bool::from_clear(bits);
+        assert!(recovered);
+
+        let value = false;
+        let bits = value.into_clear();
+        assert_eq!(bits.len(), 1);
+        assert!(!bits[0]);
+
+        let recovered = bool::from_clear(bits);
+        assert!(!recovered);
+
+        // Test ClearValue for [bool; N]
+        let arr = [true, false, true, false];
+        let bits = arr.into_clear();
+        assert_eq!(bits.len(), 4);
+        let recovered: [bool; 4] = <[bool; 4] as ClearValue<Binary>>::from_clear(bits);
+        assert_eq!(recovered, [true, false, true, false]);
+
+        // Test ClearValue for Vec<bool>
+        let vec = vec![false, true, true, false, true];
+        let bits = vec.clone().into_clear();
+        assert_eq!(bits.len(), 5);
+        let recovered: Vec<bool> = <Vec<bool> as ClearValue<Binary>>::from_clear(bits);
+        assert_eq!(recovered, vec);
+
+        // Test Bool FromRaw/ToRaw roundtrip
+        let slice = Slice::from_range_unchecked(42..43);
+        let b = Bool::from_raw(slice);
+        let recovered_slice = b.to_raw();
+        assert_eq!(recovered_slice.ptr().as_usize(), 42);
+        assert_eq!(recovered_slice.len(), 1);
+
+        // Test Vector<Bool>
+        let slice = Slice::from_range_unchecked(0..8);
+        let vec: Vector<Bool> = Vector::from_raw(slice);
+        assert_eq!(vec.len(), 8);
     }
 }


### PR DESCRIPTION
This PR adds a VM memory bool type which is useful when checking that a predicate evaluates to true or false. 