### PR TITLE
chore: update pre-commit-check.sh

### DIFF
--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -10,7 +10,7 @@ set -e
 cargo +nightly fmt --check --all
 
 # Check clippy (excluding wasm-bench which requires wasm32 target)
-cargo +nightly clippy --workspace --exclude mpz-wasm-bench --all-targets --all-features --locked -- -D warnings
+cargo +nightly clippy --workspace --exclude mpz-wasm-bench --all-targets --all-features -- -D warnings
 
 # To check wasm-bench lib, run separately with wasm32 target (from crates/wasm-bench/):
 # cargo +nightly clippy --lib --target wasm32-unknown-unknown -- -D warnings


### PR DESCRIPTION
This PR removes the `--locked` arg from pre commit check. We do not need it since we do not commit the lockfile in `mpz`.