### PR TITLE
chore: fix CI clippy and update nightly compatibility

### DIFF
--- a/crates/common/src/load_balance.rs
+++ b/crates/common/src/load_balance.rs
@@ -23,7 +23,7 @@ where
         .collect();
 
     // Sort in decreasing order of weight
-    items_with_weights.sort_by(|a, b| b.1.cmp(&a.1));
+    items_with_weights.sort_by_key(|item| std::cmp::Reverse(item.1));
 
     let mut lanes: Vec<Vec<T>> = (0..num_lanes).map(|_| Vec::new()).collect();
     let mut lane_weights = vec![0; num_lanes];

--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -201,10 +201,7 @@ mod tests {
             test_field_compute_product_repeated,
         },
     };
-    use ghash_rc::{
-        GHash,
-        universal_hash::{KeyInit, UniversalHash},
-    };
+    use ghash_rc::{GHash, universal_hash::UniversalHash};
     use mpz_core::{Block, prg::Prg};
     use rand::SeedableRng;
 

--- a/crates/matrix-transpose/src/lib.rs
+++ b/crates/matrix-transpose/src/lib.rs
@@ -1,8 +1,4 @@
-#![cfg_attr(
-    feature = "simd-transpose",
-    feature(portable_simd),
-    feature(stmt_expr_attributes)
-)]
+#![cfg_attr(feature = "simd-transpose", feature(portable_simd))]
 
 #[cfg(feature = "simd-transpose")]
 #[cfg(target_arch = "x86_64")]

--- a/crates/matrix-transpose/src/simd.rs
+++ b/crates/matrix-transpose/src/simd.rs
@@ -1,7 +1,7 @@
 use super::{LANE_COUNT, TransposeError};
 use std::{
     ops::ShlAssign,
-    simd::{LaneCount, Simd, SimdElement, SupportedLaneCount},
+    simd::{Simd, SimdElement},
 };
 
 /// SIMD version for bit-level transposition
@@ -49,7 +49,6 @@ pub fn transpose_bits(matrix: &mut [u8], rows: usize) -> Result<(), TransposeErr
 #[inline]
 pub unsafe fn transpose_unchecked<const N: usize, T>(matrix: &mut [T], rounds: usize)
 where
-    LaneCount<N>: SupportedLaneCount,
     T: SimdElement + Copy,
 {
     let half = matrix.len() >> 1;

--- a/crates/wasm-bench/src/bin/runner.rs
+++ b/crates/wasm-bench/src/bin/runner.rs
@@ -233,10 +233,10 @@ async fn run_benchmarks_with_concurrency(
         let logs_check = page
             .evaluate("window.__consoleLogs ? JSON.stringify(window.__consoleLogs) : '[]'")
             .await?;
-        if let Ok(logs_json) = logs_check.into_value::<String>() {
-            if let Ok(logs) = serde_json::from_str::<Vec<String>>(&logs_json) {
-                let _ = logs.len();
-            }
+        if let Ok(logs_json) = logs_check.into_value::<String>()
+            && let Ok(logs) = serde_json::from_str::<Vec<String>>(&logs_json)
+        {
+            let _ = logs.len();
         }
 
         // Check for errors
@@ -247,13 +247,13 @@ async fn run_benchmarks_with_concurrency(
 
         // Check progress
         let progress_check = page.evaluate("window.__benchProgress || null").await?;
-        if let Ok(Some(progress)) = progress_check.into_value::<Option<String>>() {
-            if progress != last_status {
-                print!("\r\x1b[K{}", progress);
-                use std::io::Write;
-                std::io::stdout().flush().ok();
-                last_status = progress;
-            }
+        if let Ok(Some(progress)) = progress_check.into_value::<Option<String>>()
+            && progress != last_status
+        {
+            print!("\r\x1b[K{}", progress);
+            use std::io::Write;
+            std::io::stdout().flush().ok();
+            last_status = progress;
         }
 
         // Check if results are available
@@ -499,12 +499,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Validate concurrency for MT benchmarks (need at least 2 threads)
     let has_mt_benchmarks = benchmarks.iter().any(|b| is_mt_benchmark(b));
-    if has_mt_benchmarks {
-        if let Some(c) = concurrency {
-            if c < 2 {
-                return Err("MT benchmarks require at least 2 threads (garbler uses try_join). Use -c 2 or higher.".into());
-            }
-        }
+    if has_mt_benchmarks
+        && let Some(c) = concurrency
+        && c < 2
+    {
+        return Err(
+            "MT benchmarks require at least 2 threads (garbler uses try_join). Use -c 2 or higher."
+                .into(),
+        );
     }
 
     let crate_dir = get_crate_dir();

--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -9,8 +9,8 @@ set -e
 # Check formatting
 cargo +nightly fmt --check --all
 
-# Check clippy (excluding wasm-bench which requires wasm32 target)
+# Check clippy
 cargo +nightly clippy --workspace --exclude mpz-wasm-bench --all-targets --all-features -- -D warnings
 
-# To check wasm-bench lib, run separately with wasm32 target (from crates/wasm-bench/):
-# cargo +nightly clippy --lib --target wasm32-unknown-unknown -- -D warnings
+# Check clippy on wasm-bench (requires wasm32 target: rustup target add wasm32-unknown-unknown)
+(cd crates/wasm-bench && cargo +nightly clippy --lib --target wasm32-unknown-unknown -- -D warnings)


### PR DESCRIPTION
## Summary

- Fix `matrix-transpose` for current nightly: remove `LaneCount`/`SupportedLaneCount` (removed from `portable_simd` API) and `stmt_expr_attributes` feature gate (stabilized)
- Fix clippy lints: `sort_by` → `sort_by_key` in `load_balance.rs`, unused `KeyInit` import in `gf2_128.rs`
- Enable wasm-bench clippy in `pre-commit-check.sh` (was previously commented out)

## Test plan

- [x] `cargo +nightly clippy --workspace --exclude mpz-wasm-bench --all-targets --all-features -- -D warnings` passes
- [x] `cargo +nightly clippy --lib --target wasm32-unknown-unknown -- -D warnings` passes (from `crates/wasm-bench/`)
- [x] `cargo +nightly fmt --check --all` passes
- [x] `cargo +nightly test -p matrix-transpose --all-features` — all 4 tests pass
- [x] `pre-commit-check.sh` passes end-to-end
- [x] CI passes