### PR TITLE
fix(zk): account for non-executable circuits

### DIFF
--- a/crates/zk/src/prover.rs
+++ b/crates/zk/src/prover.rs
@@ -220,6 +220,12 @@ where
             ctx.io_mut().send(uv).await?;
         }
 
+        // Pre-allocate OTs for the next execute() call's final check
+        // if circuits remain in the callstack.
+        if !self.callstack.is_empty() {
+            self.ot.alloc(128).map_err(VmError::execute)?;
+        }
+
         Ok(())
     }
 }

--- a/crates/zk/src/verifier.rs
+++ b/crates/zk/src/verifier.rs
@@ -210,6 +210,12 @@ where
                 .map_err(VmError::execute)?;
         }
 
+        // Pre-allocate OTs for the next execute() call's final check
+        // if circuits remain in the callstack.
+        if !self.callstack.is_empty() {
+            self.ot.alloc(128).map_err(VmError::execute)?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes the OT allocation in `crates/zk` for `prover` and `verifier`.

Currently the OT allocation for the quicksilver check assumes that all circuits are executable, but in practice we allocate circuits, whose inputs are committed at a later stage of the program flow and thus are not executable when `execute` is called.

The consequence is that a check for the AND gates is done every time `execute` is called, although all of them would have nicely fit into a single `batchsize`. This leads to an excess consumption of OTs, more than calculated on the basis that all circuits are executable. We get an OT allocation error.

The fix is to reallocate those OTs if this case happens.