### PR TITLE
fix(wasm-bench): enable web-sys Worker feature for web-spawn

### DIFF
--- a/crates/wasm-bench/Cargo.toml
+++ b/crates/wasm-bench/Cargo.toml
@@ -29,7 +29,14 @@ rand = { workspace = true }
 futures = { workspace = true }
 web-spawn = { version = "0.2", features = ["no-bundler"] }
 rayon = { workspace = true }
-web-sys = { version = "0.3", features = ["console", "Window", "Performance"] }
+web-sys = { version = "0.3", features = [
+    "console",
+    "Window",
+    "Performance",
+    "Worker",
+    "WorkerOptions",
+    "WorkerType",
+] }
 serio = { workspace = true }
 aes-wasm = "0.1"
 aes = { workspace = true }


### PR DESCRIPTION
web-spawn 0.2.1 uses web_sys::Worker but relies on downstream crates
  to enable the "Worker" cargo feature of web-sys. Adding it (along with
  WorkerOptions and WorkerType, which Worker::new_with_options needs)
  restores the wasm32 clippy build which is currently failing. 

