### PR TITLE
feat: add permutation proof protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ mpz-vole-core = { path = "crates/vole-core" }
 mpz-poly-proof-core = { path = "crates/poly-proof-core" }
 mpz-poly-proof-lifter = { path = "crates/poly-proof-lifter" }
 mpz-poly-proof-macros = { path = "crates/poly-proof-macros" }
+mpz-perm-proof-core = { path = "crates/perm-proof-core" }
 clmul = { path = "crates/clmul" }
 matrix-transpose = { path = "crates/matrix-transpose" }
 rangeset = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/poly-proof-core",
     "crates/poly-proof-lifter",
     "crates/poly-proof-macros",
+    "crates/perm-proof-core",
 ]
 exclude = ["crates/lpn-estimator"]
 resolver = "2"
@@ -127,6 +128,7 @@ ark-serialize = "0.4"
 serde = "1.0"
 serde_yaml = "0.9"
 serde_arrays = "0.1"
+bcs = "0.1.5"
 bincode = "1.3.3"
 bytes = "1"
 yamux = "0.10"

--- a/crates/perm-proof-core/Cargo.toml
+++ b/crates/perm-proof-core/Cargo.toml
@@ -16,14 +16,16 @@ test-utils = []
 bcs = { workspace = true }
 blake3 = { workspace = true }
 hybrid-array = { workspace = true }
+mpz-circuits-new = { workspace = true }
 mpz-common = { workspace = true, features = ["future"] }
 mpz-fields = { workspace = true }
 mpz-vole-core = { workspace = true }
-poly-proof-core = { workspace = true }
+mpz-poly-proof-core = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+zerocopy = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/perm-proof-core/Cargo.toml
+++ b/crates/perm-proof-core/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "perm-proof-core"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "perm_proof_core"
+
+[lints]
+workspace = true
+
+[features]
+test-utils = []
+
+[dependencies]
+bcs = { workspace = true }
+blake3 = { workspace = true }
+hybrid-array = { workspace = true }
+mpz-common = { workspace = true, features = ["future"] }
+mpz-fields = { workspace = true }
+mpz-vole-core = { workspace = true }
+poly-proof-core = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[test]]
+name = "api"
+path = "tests/api.rs"
+required-features = ["test-utils"]
+
+[[bench]]
+name = "prover"
+path = "benches/prover.rs"
+harness = false
+required-features = ["test-utils"]
+
+[[bench]]
+name = "verifier"
+path = "benches/verifier.rs"
+harness = false
+required-features = ["test-utils"]

--- a/crates/perm-proof-core/Cargo.toml
+++ b/crates/perm-proof-core/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
-name = "perm-proof-core"
+name = "mpz-perm-proof-core"
 version = "0.1.0"
 edition = "2024"
-
-[lib]
-name = "perm_proof_core"
 
 [lints]
 workspace = true
@@ -21,6 +18,8 @@ mpz-common = { workspace = true, features = ["future"] }
 mpz-fields = { workspace = true }
 mpz-vole-core = { workspace = true }
 mpz-poly-proof-core = { workspace = true }
+mpz-poly-proof-macros = { workspace = true }
+paste = "1"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/perm-proof-core/benches/prover.rs
+++ b/crates/perm-proof-core/benches/prover.rs
@@ -44,27 +44,27 @@ type ProverBackend = VoleZkProverBackend<
 /// Per-`(n, L)` data that's immutable across bench iterations: the
 /// shared MAC secret, the input permutation, its authenticated wires,
 /// and the transcript state from the ideal-VOLE commit.
-struct Fixture<const L: usize> {
+struct Fixture {
     delta: Gf2_64,
-    x_values: Vec<[Gf2_64; L]>,
-    x_macs: Vec<[Gf2_64; L]>,
-    y_values: Vec<[Gf2_64; L]>,
-    y_macs: Vec<[Gf2_64; L]>,
+    x_values: Vec<Vec<Gf2_64>>,
+    x_macs: Vec<Vec<Gf2_64>>,
+    y_values: Vec<Vec<Gf2_64>>,
+    y_macs: Vec<Vec<Gf2_64>>,
     transcript: Hasher,
 }
 
 /// One-shot: pick `delta`, generate the input permutation, authenticate
 /// both vectors via the ideal-VOLE `commit_values` helper, and bundle
 /// the result. Called once per `(n, L)` bench point.
-fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture<L> {
+fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture {
     let delta: Gf2_64 = rng.random();
 
-    let x_values: Vec<[Gf2_64; L]> = (0..n)
-        .map(|_| std::array::from_fn(|_| rng.random()))
+    let x_values: Vec<Vec<Gf2_64>> = (0..n)
+        .map(|_| (0..L).map(|_| rng.random()).collect())
         .collect();
     let mut perm_indices: Vec<usize> = (0..n).collect();
     perm_indices.shuffle(rng);
-    let y_values: Vec<[Gf2_64; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+    let y_values: Vec<Vec<Gf2_64>> = perm_indices.iter().map(|&i| x_values[i].clone()).collect();
 
     let Committed {
         macs: [x_macs, y_macs],
@@ -136,7 +136,7 @@ fn bench_prove(c: &mut Criterion) {
                 },
                 |(prover, transcript)| {
                     let (_preparation, prover) = prover
-                        .prepare::<L>(
+                        .prepare(
                             transcript,
                             (&fixture.x_values, &fixture.x_macs),
                             (&fixture.y_values, &fixture.y_macs),

--- a/crates/perm-proof-core/benches/prover.rs
+++ b/crates/perm-proof-core/benches/prover.rs
@@ -5,36 +5,29 @@
 //! isolation from any concrete VOLE construction.
 
 use blake3::Hasher;
-use criterion::{
-    BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
-};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use mpz_fields::gf2_64::Gf2_64;
+use mpz_perm_proof_core::{
+    Prover,
+    backend::vole_zk::VoleZkProverBackend,
+    test_utils::{
+        Committed, commit_values, vole_zk_rvole_pregenerate_count, vole_zk_rvope_pregenerate_degree,
+    },
+};
 use mpz_vole_core::ideal::{
     rvole::{IdealRVOLEReceiver, IdealRVOLESender, ideal_rvole},
     rvope::{IdealRVOPEReceiver, IdealRVOPESender, ideal_rvope},
 };
-use perm_proof_core::{
-    Prover,
-    backend::vole_zk::VoleZkProverBackend,
-    test_utils::{
-        Committed, commit_values, vole_zk_rvole_pregenerate_count,
-        vole_zk_rvope_pregenerate_degree,
-    },
-};
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_chacha::ChaCha8Rng;
 
-/// Fan-in of the product circuit. 
-const EPS: usize = 16;
+const EPS: usize = 8;
 
-/// Criterion reports per-element throughput via `Throughput::Elements(n)`.
-const INPUT_SIZES: &[usize] = &[10_000, 100_000, 200_000];
+const INPUT_SIZES: &[usize] = &[100_000, 200_000];
 
-/// Seed for the driver RNG. Fixed so input distributions and ideal
-/// correlations are reproducible run-to-run.
 const BENCH_SEED: u64 = 0x5E1F_B0FB_1F15_D00D;
 
-type ProverBackend = VoleZkProverBackend<
+type ProverBackendT = VoleZkProverBackend<
     Gf2_64,
     Gf2_64,
     IdealRVOLEReceiver<Gf2_64, Gf2_64>,
@@ -89,7 +82,7 @@ fn build_correlations_and_prover(
     rng: &mut ChaCha8Rng,
     delta: Gf2_64,
     n: usize,
-) -> Prover<Gf2_64, Gf2_64, ProverBackend> {
+) -> Prover<Gf2_64, Gf2_64, ProverBackendT> {
     let rvole_seed: u64 = rng.random();
     let rvope_seed: u64 = rng.random();
 
@@ -107,8 +100,6 @@ fn build_correlations_and_prover(
     rvope_s.pregenerate(1, rvope_degree);
     rvope_r.pregenerate(1, rvope_degree);
 
-    // Keep the senders alive to the end of setup so they materialize
-    // the receiver-side pool via shared seed; drop once done.
     drop(rvole_s);
     drop(rvope_s);
 
@@ -134,15 +125,15 @@ fn bench_prove(c: &mut Criterion) {
                     let prover = build_correlations_and_prover(&mut rng, fixture.delta, n);
                     (prover, fixture.transcript.clone())
                 },
-                |(prover, transcript)| {
-                    let (_preparation, prover) = prover
+                |(mut prover, mut transcript)| {
+                    let _preparation = prover
                         .prepare(
-                            transcript,
+                            &mut transcript,
                             (&fixture.x_values, &fixture.x_macs),
                             (&fixture.y_values, &fixture.y_macs),
                         )
                         .expect("prepare must succeed");
-                    let proof = prover.prove().expect("prove must succeed");
+                    let proof = prover.prove(&mut transcript).expect("prove must succeed");
                     black_box(proof);
                 },
                 criterion::BatchSize::PerIteration,
@@ -150,7 +141,7 @@ fn bench_prove(c: &mut Criterion) {
         });
     }
 
-    let mut group = c.benchmark_group("prove");
+    let mut group = c.benchmark_group("prover");
     group.sample_size(10);
     for &n in INPUT_SIZES {
         group.throughput(Throughput::Elements(n as u64));

--- a/crates/perm-proof-core/benches/prover.rs
+++ b/crates/perm-proof-core/benches/prover.rs
@@ -1,0 +1,164 @@
+//! Prover-side benchmark for the permutation-proof protocol.
+//!
+//! Uses the [`VoleZkProverBackend`] with the ideal RVOLE / RVOPE
+//! functionalities, so the numbers measure protocol overhead in
+//! isolation from any concrete VOLE construction.
+
+use blake3::Hasher;
+use criterion::{
+    BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use mpz_fields::gf2_64::Gf2_64;
+use mpz_vole_core::ideal::{
+    rvole::{IdealRVOLEReceiver, IdealRVOLESender, ideal_rvole},
+    rvope::{IdealRVOPEReceiver, IdealRVOPESender, ideal_rvope},
+};
+use perm_proof_core::{
+    Prover,
+    backend::vole_zk::VoleZkProverBackend,
+    test_utils::{
+        Committed, commit_values, vole_zk_rvole_pregenerate_count,
+        vole_zk_rvope_pregenerate_degree,
+    },
+};
+use rand::{Rng, SeedableRng, seq::SliceRandom};
+use rand_chacha::ChaCha8Rng;
+
+/// Fan-in of the product circuit. 
+const EPS: usize = 16;
+
+/// Criterion reports per-element throughput via `Throughput::Elements(n)`.
+const INPUT_SIZES: &[usize] = &[10_000, 100_000, 200_000];
+
+/// Seed for the driver RNG. Fixed so input distributions and ideal
+/// correlations are reproducible run-to-run.
+const BENCH_SEED: u64 = 0x5E1F_B0FB_1F15_D00D;
+
+type ProverBackend = VoleZkProverBackend<
+    Gf2_64,
+    Gf2_64,
+    IdealRVOLEReceiver<Gf2_64, Gf2_64>,
+    IdealRVOPEReceiver<Gf2_64>,
+>;
+
+/// Per-`(n, L)` data that's immutable across bench iterations: the
+/// shared MAC secret, the input permutation, its authenticated wires,
+/// and the transcript state from the ideal-VOLE commit.
+struct Fixture<const L: usize> {
+    delta: Gf2_64,
+    x_values: Vec<[Gf2_64; L]>,
+    x_macs: Vec<[Gf2_64; L]>,
+    y_values: Vec<[Gf2_64; L]>,
+    y_macs: Vec<[Gf2_64; L]>,
+    transcript: Hasher,
+}
+
+/// One-shot: pick `delta`, generate the input permutation, authenticate
+/// both vectors via the ideal-VOLE `commit_values` helper, and bundle
+/// the result. Called once per `(n, L)` bench point.
+fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture<L> {
+    let delta: Gf2_64 = rng.random();
+
+    let x_values: Vec<[Gf2_64; L]> = (0..n)
+        .map(|_| std::array::from_fn(|_| rng.random()))
+        .collect();
+    let mut perm_indices: Vec<usize> = (0..n).collect();
+    perm_indices.shuffle(rng);
+    let y_values: Vec<[Gf2_64; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+
+    let Committed {
+        macs: [x_macs, y_macs],
+        keys: _,
+        transcript,
+    } = commit_values([&x_values[..], &y_values[..]], delta, rng);
+
+    Fixture {
+        delta,
+        x_values,
+        x_macs,
+        y_values,
+        y_macs,
+        transcript,
+    }
+}
+
+/// Per-iter: build a fresh ideal RVOLE / RVOPE pair under the fixture's
+/// `delta`, pregenerate enough correlations for exactly one prover run,
+/// and wire a new `Prover` to the receiver halves.
+fn build_correlations_and_prover(
+    rng: &mut ChaCha8Rng,
+    delta: Gf2_64,
+    n: usize,
+) -> Prover<Gf2_64, Gf2_64, ProverBackend> {
+    let rvole_seed: u64 = rng.random();
+    let rvope_seed: u64 = rng.random();
+
+    let rvole_count = vole_zk_rvole_pregenerate_count(n, EPS);
+    let (mut rvole_s, mut rvole_r): (IdealRVOLESender<Gf2_64>, _) =
+        ideal_rvole::<Gf2_64, Gf2_64>(rvole_seed, delta);
+    rvole_s.pregenerate(rvole_count);
+    rvole_r
+        .pregenerate(rvole_count, delta)
+        .expect("ideal RVOLE receiver pregenerate");
+
+    let rvope_degree = vole_zk_rvope_pregenerate_degree::<Gf2_64>(EPS);
+    let (mut rvope_s, mut rvope_r): (IdealRVOPESender<Gf2_64>, _) =
+        ideal_rvope::<Gf2_64>(rvope_seed, delta);
+    rvope_s.pregenerate(1, rvope_degree);
+    rvope_r.pregenerate(1, rvope_degree);
+
+    // Keep the senders alive to the end of setup so they materialize
+    // the receiver-side pool via shared seed; drop once done.
+    drop(rvole_s);
+    drop(rvope_s);
+
+    let mut prover = Prover::new(
+        VoleZkProverBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, rvole_r, rvope_r).unwrap(),
+    );
+    prover.alloc(n).expect("prover alloc must succeed");
+    prover
+}
+
+/// Bench `n` inputs of tuple width `L`.
+fn bench_prove(c: &mut Criterion) {
+    fn case<const L: usize>(
+        group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+        n: usize,
+    ) {
+        let id = BenchmarkId::new(format!("L={L}"), n);
+        group.bench_with_input(id, &n, |b, &n| {
+            let mut rng = ChaCha8Rng::seed_from_u64(BENCH_SEED ^ (n as u64) ^ (L as u64));
+            let fixture = build_fixture::<L>(&mut rng, n);
+            b.iter_batched(
+                || {
+                    let prover = build_correlations_and_prover(&mut rng, fixture.delta, n);
+                    (prover, fixture.transcript.clone())
+                },
+                |(prover, transcript)| {
+                    let (_preparation, prover) = prover
+                        .prepare::<L>(
+                            transcript,
+                            (&fixture.x_values, &fixture.x_macs),
+                            (&fixture.y_values, &fixture.y_macs),
+                        )
+                        .expect("prepare must succeed");
+                    let proof = prover.prove().expect("prove must succeed");
+                    black_box(proof);
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    let mut group = c.benchmark_group("prove");
+    group.sample_size(10);
+    for &n in INPUT_SIZES {
+        group.throughput(Throughput::Elements(n as u64));
+        case::<1>(&mut group, n);
+        case::<2>(&mut group, n);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_prove);
+criterion_main!(benches);

--- a/crates/perm-proof-core/benches/verifier.rs
+++ b/crates/perm-proof-core/benches/verifier.rs
@@ -1,0 +1,216 @@
+//! Verifier-side benchmark for the permutation-proof protocol.
+//!
+//! Uses the [`VoleZkVerifierBackend`] with the ideal RVOLE / RVOPE
+//! functionalities, so the numbers measure protocol overhead in
+//! isolation from any concrete VOLE construction.
+
+use blake3::Hasher;
+use criterion::{
+    BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
+use mpz_fields::gf2_64::Gf2_64;
+use mpz_vole_core::ideal::{
+    rvole::{IdealRVOLESender, ideal_rvole},
+    rvope::{IdealRVOPESender, ideal_rvope},
+};
+use perm_proof_core::{
+    KeyTuple, Proof as Envelope, Prover, Verifier,
+    backend::vole_zk::{
+        Preparation, Proof as BackendProof, VoleZkProverBackend, VoleZkVerifierBackend,
+    },
+    test_utils::{
+        Committed, commit_values, vole_zk_rvole_pregenerate_count,
+        vole_zk_rvope_pregenerate_degree,
+    },
+};
+use rand::{Rng, SeedableRng, seq::SliceRandom};
+use rand_chacha::ChaCha8Rng;
+
+const EPS: usize = 16;
+
+const INPUT_SIZES: &[usize] = &[10_000, 100_000, 200_000];
+
+const BENCH_SEED: u64 = 0x5E1F_B0FB_1F15_D00D;
+
+type VerifierBackendT = VoleZkVerifierBackend<
+    Gf2_64,
+    Gf2_64,
+    IdealRVOLESender<Gf2_64>,
+    IdealRVOPESender<Gf2_64>,
+>;
+
+type FullProof = Envelope<Gf2_64, BackendProof<Gf2_64>>;
+
+/// Per-`(n, L)` data that's immutable across iterations: the verifier
+/// inputs (keys + transcript), the prover-produced DTOs the verifier
+/// consumes, and the RVOLE/RVOPE seeds so per-iter setup can rebuild
+/// matching senders. Generated once per bench point.
+struct Fixture<const L: usize> {
+    delta: Gf2_64,
+    x_keys: Vec<KeyTuple<Gf2_64, L>>,
+    y_keys: Vec<KeyTuple<Gf2_64, L>>,
+    transcript: Hasher,
+    preparation: Preparation<Gf2_64>,
+    proof: FullProof,
+    rvole_seed: u64,
+    rvope_seed: u64,
+}
+
+/// One-shot: generate inputs, authenticate them via `commit_values`,
+/// then run an honest prover through `prepare` + `prove` to produce the
+/// `preparation` and `Proof` the verifier will consume.
+fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture<L> {
+    let delta: Gf2_64 = rng.random();
+
+    let x_values: Vec<[Gf2_64; L]> = (0..n)
+        .map(|_| std::array::from_fn(|_| rng.random()))
+        .collect();
+    let mut perm_indices: Vec<usize> = (0..n).collect();
+    perm_indices.shuffle(rng);
+    let y_values: Vec<[Gf2_64; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+
+    let Committed {
+        macs: [x_macs, y_macs],
+        keys: [x_keys, y_keys],
+        transcript,
+    } = commit_values([&x_values[..], &y_values[..]], delta, rng);
+
+    let rvole_seed: u64 = rng.random();
+    let rvope_seed: u64 = rng.random();
+
+    // Build the prover's correlation receivers (senders are only kept
+    // alive long enough to materialize the matching pool via shared
+    // seed, then dropped — their per-iter counterpart is rebuilt in
+    // `build_verifier` below).
+    let rvole_count = vole_zk_rvole_pregenerate_count(n, EPS);
+    let (mut rvole_s, mut rvole_r): (IdealRVOLESender<Gf2_64>, _) =
+        ideal_rvole::<Gf2_64, Gf2_64>(rvole_seed, delta);
+    rvole_s.pregenerate(rvole_count);
+    rvole_r
+        .pregenerate(rvole_count, delta)
+        .expect("ideal RVOLE receiver pregenerate");
+
+    let rvope_degree = vole_zk_rvope_pregenerate_degree::<Gf2_64>(EPS);
+    let (mut rvope_s, mut rvope_r): (IdealRVOPESender<Gf2_64>, _) =
+        ideal_rvope::<Gf2_64>(rvope_seed, delta);
+    rvope_s.pregenerate(1, rvope_degree);
+    rvope_r.pregenerate(1, rvope_degree);
+
+    drop(rvole_s);
+    drop(rvope_s);
+
+    let mut prover = Prover::new(
+        VoleZkProverBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, rvole_r, rvope_r).unwrap(),
+    );
+    prover.alloc(n).expect("prover alloc must succeed");
+    let (preparation, prover) = prover
+        .prepare::<L>(
+            transcript.clone(),
+            (&x_values, &x_macs),
+            (&y_values, &y_macs),
+        )
+        .expect("prover prepare must succeed");
+    let proof = prover.prove().expect("prover prove must succeed");
+
+    Fixture {
+        delta,
+        x_keys,
+        y_keys,
+        transcript,
+        preparation,
+        proof,
+        rvole_seed,
+        rvope_seed,
+    }
+}
+
+/// Per-iter: rebuild the verifier side under the fixture's `delta` and
+/// seeds. The sender pool pregenerated here matches the receiver pool
+/// the prover consumed in `build_fixture` (shared `(seed, delta)` →
+/// identical correlations), so the adjustments in the prover's
+/// `preparation` apply correctly.
+///
+/// The receiver halves are pregenerated but immediately dropped; the
+/// prover bench's comment applies here inverted: keep both halves alive
+/// through pregenerate so the pair materializes consistently, then
+/// discard the one we don't need.
+fn build_verifier(
+    delta: Gf2_64,
+    rvole_seed: u64,
+    rvope_seed: u64,
+    n: usize,
+) -> Verifier<Gf2_64, Gf2_64, VerifierBackendT> {
+    let rvole_count = vole_zk_rvole_pregenerate_count(n, EPS);
+    let (mut rvole_s, mut rvole_r): (IdealRVOLESender<Gf2_64>, _) =
+        ideal_rvole::<Gf2_64, Gf2_64>(rvole_seed, delta);
+    rvole_s.pregenerate(rvole_count);
+    rvole_r
+        .pregenerate(rvole_count, delta)
+        .expect("ideal RVOLE receiver pregenerate");
+
+    let rvope_degree = vole_zk_rvope_pregenerate_degree::<Gf2_64>(EPS);
+    let (mut rvope_s, mut rvope_r): (IdealRVOPESender<Gf2_64>, _) =
+        ideal_rvope::<Gf2_64>(rvope_seed, delta);
+    rvope_s.pregenerate(1, rvope_degree);
+    rvope_r.pregenerate(1, rvope_degree);
+
+    drop(rvole_r);
+    drop(rvope_r);
+
+    let mut verifier = Verifier::new(
+        VoleZkVerifierBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, delta, rvole_s, rvope_s)
+            .unwrap(),
+    );
+    verifier.alloc(n).expect("verifier alloc must succeed");
+    verifier
+}
+
+/// Bench `n` inputs of tuple width `L`.
+fn bench_verify(c: &mut Criterion) {
+    fn case<const L: usize>(
+        group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+        n: usize,
+    ) {
+        let id = BenchmarkId::new(format!("L={L}"), n);
+        group.bench_with_input(id, &n, |b, &n| {
+            let mut rng = ChaCha8Rng::seed_from_u64(BENCH_SEED ^ (n as u64) ^ (L as u64));
+            let fixture = build_fixture::<L>(&mut rng, n);
+            b.iter_batched(
+                || {
+                    let verifier = build_verifier(
+                        fixture.delta,
+                        fixture.rvole_seed,
+                        fixture.rvope_seed,
+                        n,
+                    );
+                    (
+                        verifier,
+                        fixture.transcript.clone(),
+                        fixture.preparation.clone(),
+                        fixture.proof.clone(),
+                    )
+                },
+                |(verifier, transcript, preparation, proof)| {
+                    let verifier = verifier
+                        .prepare::<L>(transcript, &fixture.x_keys, &fixture.y_keys, preparation)
+                        .expect("verifier prepare must succeed");
+                    verifier.verify(proof).expect("verify must succeed");
+                    black_box(());
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    let mut group = c.benchmark_group("verify");
+    group.sample_size(10);
+    for &n in INPUT_SIZES {
+        group.throughput(Throughput::Elements(n as u64));
+        case::<1>(&mut group, n);
+        case::<2>(&mut group, n);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_verify);
+criterion_main!(benches);

--- a/crates/perm-proof-core/benches/verifier.rs
+++ b/crates/perm-proof-core/benches/verifier.rs
@@ -5,39 +5,32 @@
 //! isolation from any concrete VOLE construction.
 
 use blake3::Hasher;
-use criterion::{
-    BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
-};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use mpz_fields::gf2_64::Gf2_64;
-use mpz_vole_core::ideal::{
-    rvole::{IdealRVOLESender, ideal_rvole},
-    rvope::{IdealRVOPESender, ideal_rvope},
-};
-use perm_proof_core::{
+use mpz_perm_proof_core::{
     Proof as Envelope, Prover, Verifier,
     backend::vole_zk::{
         Preparation, Proof as BackendProof, VoleZkProverBackend, VoleZkVerifierBackend,
     },
     test_utils::{
-        Committed, commit_values, vole_zk_rvole_pregenerate_count,
-        vole_zk_rvope_pregenerate_degree,
+        Committed, commit_values, vole_zk_rvole_pregenerate_count, vole_zk_rvope_pregenerate_degree,
     },
+};
+use mpz_vole_core::ideal::{
+    rvole::{IdealRVOLESender, ideal_rvole},
+    rvope::{IdealRVOPESender, ideal_rvope},
 };
 use rand::{Rng, SeedableRng, seq::SliceRandom};
 use rand_chacha::ChaCha8Rng;
 
-const EPS: usize = 16;
+const EPS: usize = 8;
 
-const INPUT_SIZES: &[usize] = &[10_000, 100_000, 200_000];
+const INPUT_SIZES: &[usize] = &[100_000, 200_000];
 
 const BENCH_SEED: u64 = 0x5E1F_B0FB_1F15_D00D;
 
-type VerifierBackendT = VoleZkVerifierBackend<
-    Gf2_64,
-    Gf2_64,
-    IdealRVOLESender<Gf2_64>,
-    IdealRVOPESender<Gf2_64>,
->;
+type VerifierBackendT =
+    VoleZkVerifierBackend<Gf2_64, Gf2_64, IdealRVOLESender<Gf2_64>, IdealRVOPESender<Gf2_64>>;
 
 type FullProof = Envelope<Gf2_64, BackendProof<Gf2_64>>;
 
@@ -104,14 +97,11 @@ fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture {
     );
     prover.alloc(n).expect("prover alloc must succeed");
 
-    let (preparation, prover) = prover
-        .prepare(
-            transcript.clone(),
-            (&x_values, &x_macs),
-            (&y_values, &y_macs),
-        )
+    let mut tp = transcript.clone();
+    let preparation = prover
+        .prepare(&mut tp, (&x_values, &x_macs), (&y_values, &y_macs))
         .expect("prover prepare must succeed");
-    let proof = prover.prove().expect("prover prove must succeed");
+    let proof = prover.prove(&mut tp).expect("prover prove must succeed");
 
     Fixture {
         delta,
@@ -159,8 +149,7 @@ fn build_verifier(
     drop(rvope_r);
 
     let mut verifier = Verifier::new(
-        VoleZkVerifierBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, delta, rvole_s, rvope_s)
-            .unwrap(),
+        VoleZkVerifierBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, delta, rvole_s, rvope_s).unwrap(),
     );
     verifier.alloc(n).expect("verifier alloc must succeed");
     verifier
@@ -178,12 +167,8 @@ fn bench_verify(c: &mut Criterion) {
             let fixture = build_fixture::<L>(&mut rng, n);
             b.iter_batched(
                 || {
-                    let verifier = build_verifier(
-                        fixture.delta,
-                        fixture.rvole_seed,
-                        fixture.rvope_seed,
-                        n,
-                    );
+                    let verifier =
+                        build_verifier(fixture.delta, fixture.rvole_seed, fixture.rvope_seed, n);
                     (
                         verifier,
                         fixture.transcript.clone(),
@@ -191,11 +176,18 @@ fn bench_verify(c: &mut Criterion) {
                         fixture.proof.clone(),
                     )
                 },
-                |(verifier, transcript, preparation, proof)| {
-                    let verifier = verifier
-                        .prepare(transcript, &fixture.x_keys, &fixture.y_keys, preparation)
+                |(mut verifier, mut transcript, preparation, proof)| {
+                    verifier
+                        .prepare(
+                            &mut transcript,
+                            &fixture.x_keys,
+                            &fixture.y_keys,
+                            preparation,
+                        )
                         .expect("verifier prepare must succeed");
-                    verifier.verify(proof).expect("verify must succeed");
+                    verifier
+                        .verify(proof, &mut transcript)
+                        .expect("verify must succeed");
                     black_box(());
                 },
                 criterion::BatchSize::PerIteration,
@@ -203,7 +195,7 @@ fn bench_verify(c: &mut Criterion) {
         });
     }
 
-    let mut group = c.benchmark_group("verify");
+    let mut group = c.benchmark_group("verifier");
     group.sample_size(10);
     for &n in INPUT_SIZES {
         group.throughput(Throughput::Elements(n as u64));

--- a/crates/perm-proof-core/benches/verifier.rs
+++ b/crates/perm-proof-core/benches/verifier.rs
@@ -14,7 +14,7 @@ use mpz_vole_core::ideal::{
     rvope::{IdealRVOPESender, ideal_rvope},
 };
 use perm_proof_core::{
-    KeyTuple, Proof as Envelope, Prover, Verifier,
+    Proof as Envelope, Prover, Verifier,
     backend::vole_zk::{
         Preparation, Proof as BackendProof, VoleZkProverBackend, VoleZkVerifierBackend,
     },
@@ -45,10 +45,10 @@ type FullProof = Envelope<Gf2_64, BackendProof<Gf2_64>>;
 /// inputs (keys + transcript), the prover-produced DTOs the verifier
 /// consumes, and the RVOLE/RVOPE seeds so per-iter setup can rebuild
 /// matching senders. Generated once per bench point.
-struct Fixture<const L: usize> {
+struct Fixture {
     delta: Gf2_64,
-    x_keys: Vec<KeyTuple<Gf2_64, L>>,
-    y_keys: Vec<KeyTuple<Gf2_64, L>>,
+    x_keys: Vec<Vec<Gf2_64>>,
+    y_keys: Vec<Vec<Gf2_64>>,
     transcript: Hasher,
     preparation: Preparation<Gf2_64>,
     proof: FullProof,
@@ -59,15 +59,15 @@ struct Fixture<const L: usize> {
 /// One-shot: generate inputs, authenticate them via `commit_values`,
 /// then run an honest prover through `prepare` + `prove` to produce the
 /// `preparation` and `Proof` the verifier will consume.
-fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture<L> {
+fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture {
     let delta: Gf2_64 = rng.random();
 
-    let x_values: Vec<[Gf2_64; L]> = (0..n)
-        .map(|_| std::array::from_fn(|_| rng.random()))
+    let x_values: Vec<Vec<Gf2_64>> = (0..n)
+        .map(|_| (0..L).map(|_| rng.random()).collect())
         .collect();
     let mut perm_indices: Vec<usize> = (0..n).collect();
     perm_indices.shuffle(rng);
-    let y_values: Vec<[Gf2_64; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+    let y_values: Vec<Vec<Gf2_64>> = perm_indices.iter().map(|&i| x_values[i].clone()).collect();
 
     let Committed {
         macs: [x_macs, y_macs],
@@ -103,8 +103,9 @@ fn build_fixture<const L: usize>(rng: &mut ChaCha8Rng, n: usize) -> Fixture<L> {
         VoleZkProverBackend::<Gf2_64, Gf2_64, _, _>::new(EPS, rvole_r, rvope_r).unwrap(),
     );
     prover.alloc(n).expect("prover alloc must succeed");
+
     let (preparation, prover) = prover
-        .prepare::<L>(
+        .prepare(
             transcript.clone(),
             (&x_values, &x_macs),
             (&y_values, &y_macs),
@@ -192,7 +193,7 @@ fn bench_verify(c: &mut Criterion) {
                 },
                 |(verifier, transcript, preparation, proof)| {
                     let verifier = verifier
-                        .prepare::<L>(transcript, &fixture.x_keys, &fixture.y_keys, preparation)
+                        .prepare(transcript, &fixture.x_keys, &fixture.y_keys, preparation)
                         .expect("verifier prepare must succeed");
                     verifier.verify(proof).expect("verify must succeed");
                     black_box(());

--- a/crates/perm-proof-core/src/backend/mock/mod.rs
+++ b/crates/perm-proof-core/src/backend/mock/mod.rs
@@ -1,0 +1,35 @@
+//! Mock backend.
+
+use mpz_fields::Field;
+use serde::{Deserialize, Serialize};
+
+pub mod prover;
+pub mod verifier;
+
+pub use prover::MockProverBackend;
+pub use verifier::MockVerifierBackend;
+
+/// Preparation DTO for the mock backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preparation<E: Field> {
+    /// Verifier-side IT-MAC keys for product wires, declared by the
+    /// prover (legal here because the mock prover knows `Δ`), one per
+    /// `product` call, in emission order.
+    pub prod_keys: Vec<E>,
+}
+
+/// Error produced by the mock prover / verifier.
+#[derive(Debug, thiserror::Error)]
+pub enum MockError {
+    /// The verifier ran out of buffered prod_keys.
+    #[error("ran out of prod_keys at product")]
+    ProdKeyUnderflow,
+}
+
+/// Build a paired mock prover and verifier sharing `delta`.
+pub fn mock_pair<W, E: Field>(delta: E) -> (MockProverBackend<W, E>, MockVerifierBackend<W, E>) {
+    (
+        MockProverBackend::new(delta),
+        MockVerifierBackend::new(delta),
+    )
+}

--- a/crates/perm-proof-core/src/backend/mock/prover.rs
+++ b/crates/perm-proof-core/src/backend/mock/prover.rs
@@ -3,8 +3,7 @@
 use std::marker::PhantomData;
 
 use blake3::Hasher;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 
 use super::{MockError, Preparation};
 use crate::backend::{Backend, ProverBackend};
@@ -32,13 +31,13 @@ impl<W, E: Field> MockProverBackend<W, E> {
     }
 }
 
-impl<W: SubfieldOf<E>, E: Field> Backend<W, E> for MockProverBackend<W, E> {
+impl<W: Field, E: ExtensionField<W>> Backend<W, E> for MockProverBackend<W, E> {
     type Error = MockError;
     type Preparation = Preparation<E>;
     type BackendProof = ();
 }
 
-impl<W: SubfieldOf<E>, E: Field> ProverBackend<W, E> for MockProverBackend<W, E> {
+impl<W: Field, E: ExtensionField<W>> ProverBackend<W, E> for MockProverBackend<W, E> {
     fn drain_preparation(&mut self) -> Result<Self::Preparation, Self::Error> {
         Ok(Preparation {
             prod_keys: std::mem::take(&mut self.prod_keys),

--- a/crates/perm-proof-core/src/backend/mock/prover.rs
+++ b/crates/perm-proof-core/src/backend/mock/prover.rs
@@ -44,17 +44,12 @@ impl<W: Field, E: ExtensionField<W>> ProverBackend<W, E> for MockProverBackend<W
         })
     }
 
-    fn prove(self) -> Result<Self::BackendProof, Self::Error> {
+    fn prove(self, _transcript: &mut Hasher) -> Result<Self::BackendProof, Self::Error> {
         // Mock contributes no supplementary proof.
         Ok(())
     }
 
-    fn product(
-        &mut self,
-        _transcript: &mut Hasher,
-        factor_values: &[E],
-        factor_macs: &[E],
-    ) -> Result<(E, E), Self::Error> {
+    fn product(&mut self, factor_values: &[E], factor_macs: &[E]) -> Result<(E, E), Self::Error> {
         assert_eq!(
             factor_values.len(),
             factor_macs.len(),

--- a/crates/perm-proof-core/src/backend/mock/prover.rs
+++ b/crates/perm-proof-core/src/backend/mock/prover.rs
@@ -1,0 +1,76 @@
+//! Mock prover backend.
+
+use std::marker::PhantomData;
+
+use blake3::Hasher;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+
+use super::{MockError, Preparation};
+use crate::backend::{Backend, ProverBackend};
+
+/// Mock prover backend.
+pub struct MockProverBackend<W, E: Field> {
+    /// Global key. Must match the verifier's.
+    delta: E,
+
+    /// Buffered product-wire keys emitted by
+    /// [`product`](ProverBackend::product).
+    prod_keys: Vec<E>,
+
+    _phantom: PhantomData<W>,
+}
+
+impl<W, E: Field> MockProverBackend<W, E> {
+    /// Build a new mock prover holding `delta`.
+    pub fn new(delta: E) -> Self {
+        Self {
+            delta,
+            prod_keys: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<W: SubfieldOf<E>, E: Field> Backend<W, E> for MockProverBackend<W, E> {
+    type Error = MockError;
+    type Preparation = Preparation<E>;
+    type BackendProof = ();
+}
+
+impl<W: SubfieldOf<E>, E: Field> ProverBackend<W, E> for MockProverBackend<W, E> {
+    fn drain_preparation(&mut self) -> Result<Self::Preparation, Self::Error> {
+        Ok(Preparation {
+            prod_keys: std::mem::take(&mut self.prod_keys),
+        })
+    }
+
+    fn prove(self) -> Result<Self::BackendProof, Self::Error> {
+        // Mock contributes no supplementary proof.
+        Ok(())
+    }
+
+    fn product(
+        &mut self,
+        _transcript: &mut Hasher,
+        factor_values: &[E],
+        factor_macs: &[E],
+    ) -> Result<(E, E), Self::Error> {
+        assert_eq!(
+            factor_values.len(),
+            factor_macs.len(),
+            "factor_values and factor_macs must be equal length"
+        );
+
+        // Cleartext product.
+        let prod_value = factor_values.iter().copied().fold(E::one(), |a, b| a * b);
+
+        // Any prod_mac satisfies the IT-MAC invariant.
+        let prod_mac = E::rand(&mut rand::rng());
+
+        let prod_key = prod_mac - self.delta * prod_value;
+
+        self.prod_keys.push(prod_key);
+        Ok((prod_value, prod_mac))
+    }
+}

--- a/crates/perm-proof-core/src/backend/mock/verifier.rs
+++ b/crates/perm-proof-core/src/backend/mock/verifier.rs
@@ -46,16 +46,16 @@ impl<W: Field, E: ExtensionField<W>> VerifierBackend<W, E> for MockVerifierBacke
         self.prod_keys = preparation.prod_keys.into();
     }
 
-    fn verify(self, _proof: Self::BackendProof) -> Result<(), Self::Error> {
+    fn verify(
+        self,
+        _proof: Self::BackendProof,
+        _transcript: &mut Hasher,
+    ) -> Result<(), Self::Error> {
         // Mock contributes no supplementary check.
         Ok(())
     }
 
-    fn product(
-        &mut self,
-        _transcript: &mut Hasher,
-        _factor_keys: &[E],
-    ) -> Result<E, Self::Error> {
+    fn product(&mut self, _factor_keys: &[E]) -> Result<E, Self::Error> {
         self.prod_keys
             .pop_front()
             .ok_or(MockError::ProdKeyUnderflow)

--- a/crates/perm-proof-core/src/backend/mock/verifier.rs
+++ b/crates/perm-proof-core/src/backend/mock/verifier.rs
@@ -1,0 +1,64 @@
+//! Mock verifier backend.
+
+use std::{collections::VecDeque, marker::PhantomData};
+
+use blake3::Hasher;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+
+use super::{MockError, Preparation};
+use crate::backend::{Backend, VerifierBackend};
+
+/// Mock verifier backend.
+pub struct MockVerifierBackend<W, E: Field> {
+    /// Global key. Must match the prover's.
+    delta: E,
+
+    /// Product-wire keys loaded from a [`Preparation`], drained FIFO by
+    /// [`product`](VerifierBackend::product).
+    prod_keys: VecDeque<E>,
+
+    _phantom: PhantomData<W>,
+}
+
+impl<W, E: Field> MockVerifierBackend<W, E> {
+    /// Build a new mock verifier holding `delta`.
+    pub fn new(delta: E) -> Self {
+        Self {
+            delta,
+            prod_keys: VecDeque::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<W: SubfieldOf<E>, E: Field> Backend<W, E> for MockVerifierBackend<W, E> {
+    type Error = MockError;
+    type Preparation = Preparation<E>;
+    type BackendProof = ();
+}
+
+impl<W: SubfieldOf<E>, E: Field> VerifierBackend<W, E> for MockVerifierBackend<W, E> {
+    fn delta(&self) -> E {
+        self.delta
+    }
+
+    fn load_preparation(&mut self, preparation: Self::Preparation) {
+        self.prod_keys = preparation.prod_keys.into();
+    }
+
+    fn verify(self, _proof: Self::BackendProof) -> Result<(), Self::Error> {
+        // Mock contributes no supplementary check.
+        Ok(())
+    }
+
+    fn product(
+        &mut self,
+        _transcript: &mut Hasher,
+        _factor_keys: &[E],
+    ) -> Result<E, Self::Error> {
+        self.prod_keys
+            .pop_front()
+            .ok_or(MockError::ProdKeyUnderflow)
+    }
+}

--- a/crates/perm-proof-core/src/backend/mock/verifier.rs
+++ b/crates/perm-proof-core/src/backend/mock/verifier.rs
@@ -3,8 +3,7 @@
 use std::{collections::VecDeque, marker::PhantomData};
 
 use blake3::Hasher;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 
 use super::{MockError, Preparation};
 use crate::backend::{Backend, VerifierBackend};
@@ -32,13 +31,13 @@ impl<W, E: Field> MockVerifierBackend<W, E> {
     }
 }
 
-impl<W: SubfieldOf<E>, E: Field> Backend<W, E> for MockVerifierBackend<W, E> {
+impl<W: Field, E: ExtensionField<W>> Backend<W, E> for MockVerifierBackend<W, E> {
     type Error = MockError;
     type Preparation = Preparation<E>;
     type BackendProof = ();
 }
 
-impl<W: SubfieldOf<E>, E: Field> VerifierBackend<W, E> for MockVerifierBackend<W, E> {
+impl<W: Field, E: ExtensionField<W>> VerifierBackend<W, E> for MockVerifierBackend<W, E> {
     fn delta(&self) -> E {
         self.delta
     }

--- a/crates/perm-proof-core/src/backend/mod.rs
+++ b/crates/perm-proof-core/src/backend/mod.rs
@@ -1,0 +1,109 @@
+//! Backend traits for the permutation proof.
+
+use blake3::Hasher;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod mock;
+pub mod vole_zk;
+
+/// Types shared by a paired prover/verifier backend.
+pub trait Backend<W: SubfieldOf<E>, E: Field> {
+    /// Error type produced by fallible backend operations.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Preparation DTO: data the verifier can start processing the
+    /// moment the prover's `product` calls are done.
+    type Preparation;
+
+    /// Backend-specific supplementary proof.
+    type BackendProof;
+}
+
+/// Prover backend for the permutation proof.
+pub trait ProverBackend<W: SubfieldOf<E>, E: Field>: Backend<W, E> + Sized {
+    /// Allocate capacity for proving a permutation of size `n`.
+    ///
+    /// May be called multiple times: each call allocates additional
+    /// capacity on top of prior calls.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Size of the permutation to prove.
+    fn alloc(&mut self, _n: usize) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Authenticated product of `n` factors. Returns the
+    /// `(value, MAC)` of the product wire.
+    ///
+    /// On entry, `transcript` is guaranteed to have absorbed
+    /// `factor_values` and `factor_macs`. On return, the
+    /// implementation must have absorbed any on-wire bytes it
+    /// emitted during the call into `transcript`.
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - Shared session transcript.
+    /// * `factor_values` - Cleartext values of the factor wires.
+    /// * `factor_macs` - Per-position MACs matching `factor_values`.
+    fn product(
+        &mut self,
+        transcript: &mut Hasher,
+        factor_values: &[E],
+        factor_macs: &[E],
+    ) -> Result<(E, E), Self::Error>;
+
+    /// Drain the buffered preparation DTO.
+    fn drain_preparation(&mut self) -> Result<Self::Preparation, Self::Error>;
+
+    /// Produce the backend-specific proof.
+    fn prove(self) -> Result<Self::BackendProof, Self::Error>;
+}
+
+/// Verifier backend for the permutation proof.
+pub trait VerifierBackend<W: SubfieldOf<E>, E: Field>: Backend<W, E> + Sized {
+    /// Verifier's global key `Δ`.
+    fn delta(&self) -> E;
+
+    /// Allocate capacity for verifying a permutation of size `n`.
+    ///
+    /// May be called multiple times: each call allocates additional
+    /// capacity on top of prior calls.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Size of the permutation to verify.
+    fn alloc(&mut self, _n: usize) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Consumes the keys for `n` authenticated factors and returns
+    /// the key for the product wire.
+    ///
+    /// On entry, `transcript` is guaranteed to have absorbed
+    /// `factor_keys`. On return, the implementation must have
+    /// absorbed any on-wire bytes it received during the call into
+    /// `transcript`.
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - Shared session transcript.
+    /// * `factor_keys` - Per-position keys for the factor wires.
+    fn product(&mut self, transcript: &mut Hasher, factor_keys: &[E]) -> Result<E, Self::Error>;
+
+    /// Install the preparation DTO.
+    ///
+    /// # Arguments
+    ///
+    /// * `preparation` - The prover-emitted preparation DTO.
+    fn load_preparation(&mut self, preparation: Self::Preparation);
+
+    /// Verify the backend-specific proof.
+    ///
+    /// # Arguments
+    ///
+    /// * `proof` - The prover-emitted backend proof DTO.
+    fn verify(self, proof: Self::BackendProof) -> Result<(), Self::Error>;
+}

--- a/crates/perm-proof-core/src/backend/mod.rs
+++ b/crates/perm-proof-core/src/backend/mod.rs
@@ -36,29 +36,26 @@ pub trait ProverBackend<W: Field, E: ExtensionField<W>>: Backend<W, E> + Sized {
 
     /// Authenticated product of `n` factors. Returns the
     /// `(value, MAC)` of the product wire.
-    ///
-    /// On entry, `transcript` is guaranteed to have absorbed
-    /// `factor_values` and `factor_macs`. On return, the
-    /// implementation must have absorbed any on-wire bytes it
-    /// emitted during the call into `transcript`.
+
     ///
     /// # Arguments
     ///
-    /// * `transcript` - Shared session transcript.
     /// * `factor_values` - Cleartext values of the factor wires.
     /// * `factor_macs` - Per-position MACs matching `factor_values`.
-    fn product(
-        &mut self,
-        transcript: &mut Hasher,
-        factor_values: &[E],
-        factor_macs: &[E],
-    ) -> Result<(E, E), Self::Error>;
+    fn product(&mut self, factor_values: &[E], factor_macs: &[E]) -> Result<(E, E), Self::Error>;
 
     /// Drain the buffered preparation DTO.
     fn drain_preparation(&mut self) -> Result<Self::Preparation, Self::Error>;
 
     /// Produce the backend-specific proof.
-    fn prove(self) -> Result<Self::BackendProof, Self::Error>;
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`product`](Self::product) before this call —
+    /// otherwise the protocol's soundness guarantee no longer holds.
+    fn prove(self, transcript: &mut Hasher) -> Result<Self::BackendProof, Self::Error>;
 }
 
 /// Verifier backend for the permutation proof.
@@ -81,16 +78,17 @@ pub trait VerifierBackend<W: Field, E: ExtensionField<W>>: Backend<W, E> + Sized
     /// Consumes the keys for `n` authenticated factors and returns
     /// the key for the product wire.
     ///
-    /// On entry, `transcript` is guaranteed to have absorbed
-    /// `factor_keys`. On return, the implementation must have
-    /// absorbed any on-wire bytes it received during the call into
-    /// `transcript`.
+    /// Any on-wire bytes the backend processes during the call are
+    /// absorbed into the backend's own internal transcript, not into
+    /// the caller's external transcript. [`verify`](Self::verify)
+    /// folds that internal transcript into the caller's external
+    /// transcript before drawing any challenges. Mirrors the
+    /// prover-side [`ProverBackend::product`].
     ///
     /// # Arguments
     ///
-    /// * `transcript` - Shared session transcript.
     /// * `factor_keys` - Per-position keys for the factor wires.
-    fn product(&mut self, transcript: &mut Hasher, factor_keys: &[E]) -> Result<E, Self::Error>;
+    fn product(&mut self, factor_keys: &[E]) -> Result<E, Self::Error>;
 
     /// Install the preparation DTO.
     ///
@@ -100,9 +98,14 @@ pub trait VerifierBackend<W: Field, E: ExtensionField<W>>: Backend<W, E> + Sized
     fn load_preparation(&mut self, preparation: Self::Preparation);
 
     /// Verify the backend-specific proof.
+
     ///
     /// # Arguments
     ///
     /// * `proof` - The prover-emitted backend proof DTO.
-    fn verify(self, proof: Self::BackendProof) -> Result<(), Self::Error>;
+    /// * `transcript` - the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`product`](Self::product) before this call —
+    /// otherwise the protocol's soundness guarantee no longer holds.
+    fn verify(self, proof: Self::BackendProof, transcript: &mut Hasher) -> Result<(), Self::Error>;
 }

--- a/crates/perm-proof-core/src/backend/mod.rs
+++ b/crates/perm-proof-core/src/backend/mod.rs
@@ -1,15 +1,14 @@
 //! Backend traits for the permutation proof.
 
 use blake3::Hasher;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock;
 pub mod vole_zk;
 
 /// Types shared by a paired prover/verifier backend.
-pub trait Backend<W: SubfieldOf<E>, E: Field> {
+pub trait Backend<W: Field, E: ExtensionField<W>> {
     /// Error type produced by fallible backend operations.
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -22,7 +21,7 @@ pub trait Backend<W: SubfieldOf<E>, E: Field> {
 }
 
 /// Prover backend for the permutation proof.
-pub trait ProverBackend<W: SubfieldOf<E>, E: Field>: Backend<W, E> + Sized {
+pub trait ProverBackend<W: Field, E: ExtensionField<W>>: Backend<W, E> + Sized {
     /// Allocate capacity for proving a permutation of size `n`.
     ///
     /// May be called multiple times: each call allocates additional
@@ -63,7 +62,7 @@ pub trait ProverBackend<W: SubfieldOf<E>, E: Field>: Backend<W, E> + Sized {
 }
 
 /// Verifier backend for the permutation proof.
-pub trait VerifierBackend<W: SubfieldOf<E>, E: Field>: Backend<W, E> + Sized {
+pub trait VerifierBackend<W: Field, E: ExtensionField<W>>: Backend<W, E> + Sized {
     /// Verifier's global key `Δ`.
     fn delta(&self) -> E;
 

--- a/crates/perm-proof-core/src/backend/vole_zk/kernels.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/kernels.rs
@@ -1,0 +1,100 @@
+//! Fan-in-product kernels.
+//!
+//! One kernel per supported fan-in in [`super::SUPPORTED_FAN_IN`];
+
+use mpz_circuits_new::Context;
+use mpz_fields::{ExtensionField, Field};
+use mpz_poly_proof_core::{ConstraintId, ConstraintsBuilder};
+use mpz_poly_proof_macros::poly_kernel;
+
+/// Returned by [`add_product_kernel`] when the requested fan-in has no
+/// pre-expanded kernel.
+#[derive(Debug, thiserror::Error)]
+#[error("fan-in {0} is outside the supported range")]
+pub(crate) struct UnsupportedFanIn(pub usize);
+
+// `len` is `n + 1`; passed explicitly because `#[poly_kernel]` requires
+// the array length to be an integer literal, not a const expression.
+macro_rules! product_kernel {
+    ($n:literal, $len:literal) => {
+        paste::paste! {
+            #[poly_kernel]
+            // The fn body is read by `#[poly_kernel]` at macro-expansion time
+            // (lifted into a `ConstraintDef` impl) but never called at runtime.
+            #[allow(dead_code)]
+            pub fn [<product_ $n>]<C, E>(
+                ctx: &mut C,
+                vars: [C::Wire; $len],
+            ) -> Result<(), C::Error>
+            where
+                C: Context<Field = E>,
+                E: Field,
+            {
+                let mut p = vars[0];
+                for i in 1..$n {
+                    p = ctx.mul(p, vars[i]);
+                }
+                let diff = ctx.sub(p, vars[$n]);
+                ctx.assert_const(diff, E::zero())
+            }
+        }
+    };
+}
+
+macro_rules! product_kernels {
+    ($(($n:literal, $len:literal)),+ $(,)?) => {
+        $( product_kernel!($n, $len); )+
+
+        /// Register the product-kernel matching `arity` on `b` and
+        /// return the new constraint's id, or [`UnsupportedFanIn`] if
+        /// no pre-expanded kernel exists for that fan-in.
+        pub(crate) fn add_product_kernel<E: Field + ExtensionField<E>>(
+            b: &mut ConstraintsBuilder<E>,
+            arity: usize,
+        ) -> Result<ConstraintId, UnsupportedFanIn> {
+            paste::paste! {
+                match arity {
+                    $(
+                        $n => Ok(
+                            b.add::<[<Product $n>]>()
+                                .expect("kernel registration is infallible"),
+                        ),
+                    )+
+                    _ => Err(UnsupportedFanIn(arity)),
+                }
+            }
+        }
+    };
+}
+
+product_kernels!(
+    (4, 5),
+    (5, 6),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+    (10, 11),
+    (11, 12),
+    (12, 13),
+    (13, 14),
+    (14, 15),
+    (15, 16),
+    (16, 17),
+    (17, 18),
+    (18, 19),
+    (19, 20),
+    (20, 21),
+    (21, 22),
+    (22, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 28),
+    (28, 29),
+    (29, 30),
+    (30, 31),
+    (31, 32),
+    (32, 33),
+);

--- a/crates/perm-proof-core/src/backend/vole_zk/mod.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/mod.rs
@@ -2,18 +2,15 @@
 //! authentication with a QuickSilver polynomial proof for fan-in
 //! multiplications.
 
+use mpz_circuits_new::Context;
 use mpz_fields::Field;
-use poly_proof_core::circuit::{Circuit, CircuitBuilder};
+use mpz_poly_proof_core::{ConstraintId, Constraints};
 
 pub mod prover;
 pub mod verifier;
 
 pub use prover::{Preparation, Proof, VoleZkProverBackend, VoleZkProverError};
 pub use verifier::{VoleZkVerifierBackend, VoleZkVerifierError};
-
-/// Poly-id of the only QS circuit this backend registers (the
-/// fan-in-`fan_in_degree` product circuit).
-pub(crate) const PRODUCT_POLY_ID: usize = 0;
 
 /// Internal-node count of a fan-in-`d` tree over `n` leaves —
 /// `⌈(n−1)/(d−1)⌉`, since each merge takes `d` items into 1 and
@@ -30,20 +27,28 @@ pub(crate) fn chunk_ranges_and_leftover(n: usize, d: usize) -> (Vec<(usize, usiz
     (chunks, leftover)
 }
 
-/// Build a circuit computing `(x_0 · x_1 · … · x_{n-1}) − prod`.
+/// Build a `Constraints` set holding the single fan-in-product
+/// constraint `(x_0 · x_1 · … · x_{n-1}) − prod = 0`.
+///
 /// Variable layout: `var(0)…var(n−1)` are the factors, `var(n)` is
-/// `prod`.
-pub(crate) fn build_circuit<E: Field>(factor_count: usize) -> Circuit<E> {
+/// `prod`. Returns the set alongside the constraint's id.
+pub(crate) fn build_product_constraints<E: Field>(
+    factor_count: usize,
+) -> (Constraints<E>, ConstraintId) {
     assert!(factor_count >= 1);
-    let mut cb = CircuitBuilder::new();
-    let factors: Vec<_> = (0..factor_count).map(|i| cb.var(i)).collect();
-    let prod = cb.var(factor_count);
-    let mut product = factors[0];
-    for &f in &factors[1..] {
-        product = cb.mul(product, f);
-    }
-    let out = cb.sub(product, prod);
-    cb.build(out)
+    let mut b = Constraints::<E>::builder();
+    let id = b
+        .add_dynamic(factor_count + 1, |ctx, vars| {
+            // `add_dynamic(factor_count + 1, …)` allocates exactly that
+            // many wires, so the indices below are always in bounds.
+            let mut product = vars[0];
+            for &f in &vars[1..factor_count] {
+                product = ctx.mul(product, f);
+            }
+            ctx.assert_eq(product, vars[factor_count])
+        })
+        .expect("product constraint shape is well-formed");
+    (b.build(), id)
 }
 
 #[cfg(test)]
@@ -54,8 +59,10 @@ mod tests {
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
-    use crate::backend::{ProverBackend, VerifierBackend};
-    use crate::test_utils::{Committed, commit_values};
+    use crate::{
+        backend::{ProverBackend, VerifierBackend},
+        test_utils::{Committed, commit_values},
+    };
     use mpz_vole_core::{
         RVOLEReceiver, RVOLESender, RVOPEReceiver, RVOPESender,
         ideal::{
@@ -100,8 +107,8 @@ mod tests {
         }
 
         // Pre-fill RVOPE — query a throwaway QS prover.
-        let circuit = build_circuit::<Gf2_128>(eps);
-        let tmp_qs = poly_proof_core::prover::Prover::<Gf2_128>::new(vec![circuit]);
+        let (constraints, _) = build_product_constraints::<Gf2_128>(eps);
+        let tmp_qs = mpz_poly_proof_core::prover::Prover::<Gf2_128>::new(&constraints);
         let required_vopes = tmp_qs.required_vopes();
 
         let (mut rvope_s, mut rvope_r) = ideal_rvope::<Gf2_128>(rvope_seed, delta);
@@ -140,7 +147,8 @@ mod tests {
         let (delta, mut prover, mut verifier) = build_pair(rng_seed, n, eps);
 
         let mut rng = ChaCha8Rng::seed_from_u64(rng_seed ^ 0xABCD_EF01);
-        let mut values: Vec<[Gf2_128; 1]> = (0..n).map(|_| [rng.random()]).collect();
+        // Width-1 tuples: each position is a singleton Vec.
+        let mut values: Vec<Vec<Gf2_128>> = (0..n).map(|_| vec![rng.random()]).collect();
         let Committed {
             macs: [macs],
             keys: [keys],
@@ -159,12 +167,15 @@ mod tests {
         let mut tp = transcript.clone();
         let mut tv = transcript;
 
-        let (prod_value, prod_mac) = prover
-            .product(&mut tp, values.as_flattened(), macs.as_flattened())
-            .unwrap();
+        // Flatten width-1 tuples into plain slices for the backend.
+        let flat_values: Vec<Gf2_128> = values.iter().flatten().copied().collect();
+        let flat_macs: Vec<Gf2_128> = macs.iter().flatten().copied().collect();
+        let flat_keys: Vec<Gf2_128> = keys.iter().flatten().copied().collect();
+
+        let (prod_value, prod_mac) = prover.product(&mut tp, &flat_values, &flat_macs).unwrap();
         let prep = prover.drain_preparation().unwrap();
         verifier.load_preparation(prep);
-        let prod_key = verifier.product(&mut tv, keys.as_flattened()).unwrap();
+        let prod_key = verifier.product(&mut tv, &flat_keys).unwrap();
 
         if matches!(mode, Mode::Honest) {
             assert_eq!(

--- a/crates/perm-proof-core/src/backend/vole_zk/mod.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/mod.rs
@@ -1,0 +1,229 @@
+//! VOLE-ZK backend (prover and verifier) built on top of VOLE-ZK
+//! authentication with a QuickSilver polynomial proof for fan-in
+//! multiplications.
+
+use mpz_fields::Field;
+use poly_proof_core::circuit::{Circuit, CircuitBuilder};
+
+pub mod prover;
+pub mod verifier;
+
+pub use prover::{Preparation, Proof, VoleZkProverBackend, VoleZkProverError};
+pub use verifier::{VoleZkVerifierBackend, VoleZkVerifierError};
+
+/// Poly-id of the only QS circuit this backend registers (the
+/// fan-in-`fan_in_degree` product circuit).
+pub(crate) const PRODUCT_POLY_ID: usize = 0;
+
+/// Internal-node count of a fan-in-`d` tree over `n` leaves —
+/// `⌈(n−1)/(d−1)⌉`, since each merge takes `d` items into 1 and
+/// reducing `n` to `1` requires `n−1` removals.
+pub(crate) fn fan_in_tree_internal_nodes(n: usize, d: usize) -> usize {
+    n.saturating_sub(1).div_ceil(d - 1)
+}
+
+/// Split `[0, n)` into `d`-sized chunks plus the trailing leftover.
+pub(crate) fn chunk_ranges_and_leftover(n: usize, d: usize) -> (Vec<(usize, usize)>, Vec<usize>) {
+    let full = n / d;
+    let chunks: Vec<(usize, usize)> = (0..full).map(|i| (i * d, (i + 1) * d)).collect();
+    let leftover: Vec<usize> = (full * d..n).collect();
+    (chunks, leftover)
+}
+
+/// Build a circuit computing `(x_0 · x_1 · … · x_{n-1}) − prod`.
+/// Variable layout: `var(0)…var(n−1)` are the factors, `var(n)` is
+/// `prod`.
+pub(crate) fn build_circuit<E: Field>(factor_count: usize) -> Circuit<E> {
+    assert!(factor_count >= 1);
+    let mut cb = CircuitBuilder::new();
+    let factors: Vec<_> = (0..factor_count).map(|i| cb.var(i)).collect();
+    let prod = cb.var(factor_count);
+    let mut product = factors[0];
+    for &f in &factors[1..] {
+        product = cb.mul(product, f);
+    }
+    let out = cb.sub(product, prod);
+    cb.build(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::backend::{ProverBackend, VerifierBackend};
+    use crate::test_utils::{Committed, commit_values};
+    use mpz_vole_core::{
+        RVOLEReceiver, RVOLESender, RVOPEReceiver, RVOPESender,
+        ideal::{
+            rvole::{IdealRVOLEReceiver, IdealRVOLESender, ideal_rvole},
+            rvope::{IdealRVOPEReceiver, IdealRVOPESender, ideal_rvope},
+        },
+    };
+
+    /// Build both VOLE-ZK backends wired to pre-filled ideal correlation
+    /// providers, sized for a proof of running size `n` with fan-in `eps`.
+    fn build_pair(
+        rng_seed: u64,
+        n: usize,
+        eps: usize,
+    ) -> (
+        Gf2_128,
+        VoleZkProverBackend<
+            Gf2_128,
+            Gf2_128,
+            IdealRVOLEReceiver<Gf2_128, Gf2_128>,
+            IdealRVOPEReceiver<Gf2_128>,
+        >,
+        VoleZkVerifierBackend<
+            Gf2_128,
+            Gf2_128,
+            IdealRVOLESender<Gf2_128>,
+            IdealRVOPESender<Gf2_128>,
+        >,
+    ) {
+        let mut rng = ChaCha8Rng::seed_from_u64(rng_seed);
+        let delta: Gf2_128 = rng.random();
+        let rvole_seed: u64 = rng.random();
+        let rvope_seed: u64 = rng.random();
+
+        // Match what the backend's own `alloc` reserves.
+        let rvole_count = 2 * fan_in_tree_internal_nodes(n, eps);
+        let (mut rvole_s, mut rvole_r) = ideal_rvole::<Gf2_128, Gf2_128>(rvole_seed, delta);
+        <_ as RVOLESender<Gf2_128>>::alloc(&mut rvole_s, rvole_count).unwrap();
+        <_ as RVOLEReceiver<Gf2_128, Gf2_128>>::alloc(&mut rvole_r, rvole_count).unwrap();
+        if let Some(msg) = rvole_s.flush() {
+            rvole_r.flush(msg).unwrap();
+        }
+
+        // Pre-fill RVOPE — query a throwaway QS prover.
+        let circuit = build_circuit::<Gf2_128>(eps);
+        let tmp_qs = poly_proof_core::prover::Prover::<Gf2_128>::new(vec![circuit]);
+        let required_vopes = tmp_qs.required_vopes();
+
+        let (mut rvope_s, mut rvope_r) = ideal_rvope::<Gf2_128>(rvope_seed, delta);
+        <_ as RVOPESender<Gf2_128>>::alloc(&mut rvope_s, 1, required_vopes).unwrap();
+        <_ as RVOPEReceiver<Gf2_128>>::alloc(&mut rvope_r, 1, required_vopes).unwrap();
+        for msg in rvope_s.flush() {
+            rvope_r.flush(msg).unwrap();
+        }
+
+        let prover =
+            VoleZkProverBackend::<Gf2_128, Gf2_128, _, _>::new(eps, rvole_r, rvope_r).unwrap();
+        let verifier =
+            VoleZkVerifierBackend::<Gf2_128, Gf2_128, _, _>::new(eps, delta, rvole_s, rvope_s)
+                .unwrap();
+
+        (delta, prover, verifier)
+    }
+
+    /// Mode toggle for [`run_pair`].
+    #[derive(Clone, Copy)]
+    enum Mode {
+        /// Honest prover.
+        Honest,
+        /// Dishonest prover.
+        Dishonest,
+    }
+
+    /// Drive a prover/verifier pair through the full backend lifecycle
+    /// against `n` factors with fan-in `eps`.
+    fn run_pair(
+        rng_seed: u64,
+        n: usize,
+        eps: usize,
+        mode: Mode,
+    ) -> Result<(), VoleZkVerifierError> {
+        let (delta, mut prover, mut verifier) = build_pair(rng_seed, n, eps);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(rng_seed ^ 0xABCD_EF01);
+        let mut values: Vec<[Gf2_128; 1]> = (0..n).map(|_| [rng.random()]).collect();
+        let Committed {
+            macs: [macs],
+            keys: [keys],
+            transcript,
+        } = commit_values([&values[..]], delta, &mut rng);
+
+        // Tamper AFTER authentication.
+        if matches!(mode, Mode::Dishonest) {
+            values[0][0] = values[0][0] + Gf2_128::one();
+        }
+
+        prover.alloc(n).unwrap();
+        verifier.alloc(n).unwrap();
+
+        // Transcript is bound to committed values.
+        let mut tp = transcript.clone();
+        let mut tv = transcript;
+
+        let (prod_value, prod_mac) = prover
+            .product(&mut tp, values.as_flattened(), macs.as_flattened())
+            .unwrap();
+        let prep = prover.drain_preparation().unwrap();
+        verifier.load_preparation(prep);
+        let prod_key = verifier.product(&mut tv, keys.as_flattened()).unwrap();
+
+        if matches!(mode, Mode::Honest) {
+            assert_eq!(
+                prod_mac,
+                prod_key + delta * prod_value,
+                "IT-MAC invariant violated at fan-in-product root"
+            );
+        }
+
+        let proof = prover.prove().unwrap();
+        verifier.verify(proof)
+    }
+
+    /// Honest prover: each shape exercises a different path through the
+    /// fan-in tree.
+    #[test]
+    fn accepts() {
+        // Multi-level walk with leftover passthroughs and a terminal short chunk.
+        run_pair(0xA1, 100, 8, Mode::Honest).expect("honest must accept");
+        // ε=2: tightest tree, many small levels.
+        run_pair(0xC3, 9, 2, Mode::Honest).expect("honest must accept");
+        // n == ε: one-level tree, single chunk, no leftover.
+        run_pair(0xD4, 4, 4, Mode::Honest).expect("honest must accept");
+    }
+
+    /// Dishonest prover: tampered input is rejected.
+    #[test]
+    fn rejects_tampered_input() {
+        let err =
+            run_pair(0xA1, 100, 8, Mode::Dishonest).expect_err("tampered input must be rejected");
+        assert!(
+            matches!(err, VoleZkVerifierError::QsVerify(_)),
+            "expected QsVerify, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_fan_in_tree_internal_nodes() {
+        assert_eq!(fan_in_tree_internal_nodes(1, 2), 0); // single leaf, no merge
+        assert_eq!(fan_in_tree_internal_nodes(8, 2), 7); // 8-leaf binary tree
+        assert_eq!(fan_in_tree_internal_nodes(8, 8), 1); // one merge of all 8
+        assert_eq!(fan_in_tree_internal_nodes(9, 8), 2); // 8 merge + 2-merge
+    }
+
+    #[test]
+    fn test_chunk_ranges_and_leftover() {
+        // Clean split: n is a multiple of d.
+        assert_eq!(
+            chunk_ranges_and_leftover(8, 4),
+            (vec![(0, 4), (4, 8)], vec![])
+        );
+        // Two full chunks + trailing leftover.
+        assert_eq!(
+            chunk_ranges_and_leftover(10, 4),
+            (vec![(0, 4), (4, 8)], vec![8, 9])
+        );
+        // n < d: no full chunk fits, everything is leftover.
+        assert_eq!(chunk_ranges_and_leftover(3, 4), (vec![], vec![0, 1, 2]));
+        // Single index → single leftover.
+        assert_eq!(chunk_ranges_and_leftover(1, 4), (vec![], vec![0]));
+    }
+}

--- a/crates/perm-proof-core/src/backend/vole_zk/mod.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/mod.rs
@@ -2,15 +2,22 @@
 //! authentication with a QuickSilver polynomial proof for fan-in
 //! multiplications.
 
-use mpz_circuits_new::Context;
-use mpz_fields::Field;
-use mpz_poly_proof_core::{ConstraintId, Constraints};
+use std::ops::RangeInclusive;
 
+use mpz_fields::{ExtensionField, Field};
+use mpz_poly_proof_core::{
+    ConstraintId, ConstraintsBuilder, ProverConstraints, VerifierConstraints,
+};
+
+mod kernels;
 pub mod prover;
 pub mod verifier;
 
 pub use prover::{Preparation, Proof, VoleZkProverBackend, VoleZkProverError};
 pub use verifier::{VoleZkVerifierBackend, VoleZkVerifierError};
+
+/// Fan-in degrees the VOLE-ZK backend supports.
+pub const SUPPORTED_FAN_IN: RangeInclusive<usize> = 4..=32;
 
 /// Internal-node count of a fan-in-`d` tree over `n` leaves —
 /// `⌈(n−1)/(d−1)⌉`, since each merge takes `d` items into 1 and
@@ -27,28 +34,19 @@ pub(crate) fn chunk_ranges_and_leftover(n: usize, d: usize) -> (Vec<(usize, usiz
     (chunks, leftover)
 }
 
-/// Build a `Constraints` set holding the single fan-in-product
+/// Build the constraint set holding the single fan-in-product
 /// constraint `(x_0 · x_1 · … · x_{n-1}) − prod = 0`.
 ///
 /// Variable layout: `var(0)…var(n−1)` are the factors, `var(n)` is
-/// `prod`. Returns the set alongside the constraint's id.
-pub(crate) fn build_product_constraints<E: Field>(
+/// `prod`.
+pub(crate) fn build_product_constraints<E: Field + ExtensionField<E>>(
     factor_count: usize,
-) -> (Constraints<E>, ConstraintId) {
-    assert!(factor_count >= 1);
-    let mut b = Constraints::<E>::builder();
-    let id = b
-        .add_dynamic(factor_count + 1, |ctx, vars| {
-            // `add_dynamic(factor_count + 1, …)` allocates exactly that
-            // many wires, so the indices below are always in bounds.
-            let mut product = vars[0];
-            for &f in &vars[1..factor_count] {
-                product = ctx.mul(product, f);
-            }
-            ctx.assert_eq(product, vars[factor_count])
-        })
-        .expect("product constraint shape is well-formed");
-    (b.build(), id)
+) -> Result<(ProverConstraints<E>, VerifierConstraints<E>, ConstraintId), kernels::UnsupportedFanIn>
+{
+    let mut b = ConstraintsBuilder::<E>::new();
+    let id = kernels::add_product_kernel(&mut b, factor_count)?;
+    let (pc, vc) = b.build();
+    Ok((pc, vc, id))
 }
 
 #[cfg(test)]
@@ -107,8 +105,8 @@ mod tests {
         }
 
         // Pre-fill RVOPE — query a throwaway QS prover.
-        let (constraints, _) = build_product_constraints::<Gf2_128>(eps);
-        let tmp_qs = mpz_poly_proof_core::prover::Prover::<Gf2_128>::new(&constraints);
+        let (pc, _, _) = build_product_constraints::<Gf2_128>(eps).unwrap();
+        let tmp_qs = mpz_poly_proof_core::prover::Prover::<Gf2_128>::new(&pc);
         let required_vopes = tmp_qs.required_vopes();
 
         let (mut rvope_s, mut rvope_r) = ideal_rvope::<Gf2_128>(rvope_seed, delta);
@@ -172,10 +170,10 @@ mod tests {
         let flat_macs: Vec<Gf2_128> = macs.iter().flatten().copied().collect();
         let flat_keys: Vec<Gf2_128> = keys.iter().flatten().copied().collect();
 
-        let (prod_value, prod_mac) = prover.product(&mut tp, &flat_values, &flat_macs).unwrap();
+        let (prod_value, prod_mac) = prover.product(&flat_values, &flat_macs).unwrap();
         let prep = prover.drain_preparation().unwrap();
         verifier.load_preparation(prep);
-        let prod_key = verifier.product(&mut tv, &flat_keys).unwrap();
+        let prod_key = verifier.product(&flat_keys).unwrap();
 
         if matches!(mode, Mode::Honest) {
             assert_eq!(
@@ -185,8 +183,8 @@ mod tests {
             );
         }
 
-        let proof = prover.prove().unwrap();
-        verifier.verify(proof)
+        let proof = prover.prove(&mut tp).unwrap();
+        verifier.verify(proof, &mut tv)
     }
 
     /// Honest prover: each shape exercises a different path through the
@@ -195,10 +193,10 @@ mod tests {
     fn accepts() {
         // Multi-level walk with leftover passthroughs and a terminal short chunk.
         run_pair(0xA1, 100, 8, Mode::Honest).expect("honest must accept");
-        // ε=2: tightest tree, many small levels.
-        run_pair(0xC3, 9, 2, Mode::Honest).expect("honest must accept");
+        // Smallest supported ε, multi-level walk with leftover.
+        run_pair(0xC3, 9, 6, Mode::Honest).expect("honest must accept");
         // n == ε: one-level tree, single chunk, no leftover.
-        run_pair(0xD4, 4, 4, Mode::Honest).expect("honest must accept");
+        run_pair(0xD4, 6, 6, Mode::Honest).expect("honest must accept");
     }
 
     /// Dishonest prover: tampered input is rejected.

--- a/crates/perm-proof-core/src/backend/vole_zk/prover.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/prover.rs
@@ -50,9 +50,13 @@ where
     /// the order the verifier expects.
     pending_adjustments: Vec<VoleAdjustment<E>>,
 
-    /// QuickSilver `accumulate` arguments, one per tree level,
-    /// replayed at finalize.
-    pending_qs_accumulate: Vec<DeferredAccumulate<E>>,
+    /// QuickSilver evaluations accumulated across every tree level
+    /// of every `product` call.
+    pending_qs_evaluations: Vec<(ConstraintId, Vec<E>, Vec<E>)>,
+
+    /// Fiat-Shamir transcript: absorbs every VoleAdjustment emitted as it's
+    /// produced.
+    transcript: blake3::Hasher,
 
     _phantom: PhantomData<W>,
 }
@@ -69,15 +73,13 @@ where
     /// # Arguments
     ///
     /// * `fan_in_degree` - Fan-in of the product tree (must be ≥ 1).
-    /// * `rvole` - Random VOLE receiver for committing intermediate
-    ///   product wires.
-    /// * `rvope` - Random VOPE receiver for the mask consumed at QS
-    ///   finalize time.
+    /// * `rvole` - Random VOLE receiver for committing intermediate product
+    ///   wires.
+    /// * `rvope` - Random VOPE receiver for the mask consumed at QS finalize
+    ///   time.
     pub fn new(fan_in_degree: usize, rvole: VL, mut rvope: VP) -> Result<Self, VoleZkProverError> {
-        if fan_in_degree < 2 {
-            return Err(VoleZkProverError::InvalidFanIn(fan_in_degree));
-        }
-        let (constraints, product_constraint) = build_product_constraints::<E>(fan_in_degree);
+        let (constraints, _, product_constraint) = build_product_constraints::<E>(fan_in_degree)
+            .map_err(|_| VoleZkProverError::InvalidFanIn(fan_in_degree))?;
         let qs = mpz_poly_proof_core::prover::Prover::new(&constraints);
 
         rvope
@@ -93,7 +95,8 @@ where
             total_count: 0,
             rvoles_alloced: 0,
             pending_adjustments: Vec::new(),
-            pending_qs_accumulate: Vec::new(),
+            pending_qs_evaluations: Vec::new(),
+            transcript: blake3::Hasher::new(),
             _phantom: PhantomData,
         })
     }
@@ -153,25 +156,24 @@ where
         })
     }
 
-    fn prove(mut self) -> Result<Self::BackendProof, Self::Error> {
-        // Step 1: replay the QS accumulate calls that `product`
-        // buffered earlier.
-        for DeferredAccumulate { seed, evaluations } in
-            std::mem::take(&mut self.pending_qs_accumulate)
-        {
-            let refs: Vec<(ConstraintId, &[E], &[E])> = evaluations
-                .iter()
-                .map(|(id, m, v)| (*id, m.as_slice(), v.as_slice()))
-                .collect();
-            // W = E here: tree-walk wires are already extension-field
-            // elements (post-`prepare` collapse), so the `accumulate`
-            // generic uses the trivial `E: ExtensionField<E>` impl.
-            self.qs
-                .accumulate::<E>(&refs, seed)
-                .map_err(|e| VoleZkProverError::QsAccumulate(Box::new(e)))?;
-        }
+    fn prove(mut self, transcript: &mut blake3::Hasher) -> Result<Self::BackendProof, Self::Error> {
+        // Absorb internal transcript.
+        let internal_hash = std::mem::take(&mut self.transcript).finalize();
+        transcript.update(internal_hash.as_bytes());
+        let qs_seed = crate::draw_seed(transcript, b"permutation-proof::qs-end-seed");
 
-        // Step 2: consume the single RVOPE correlation.
+        // Drain every buffered evaluation product.
+        let evaluations = std::mem::take(&mut self.pending_qs_evaluations);
+        let refs: Vec<(ConstraintId, &[E], &[E])> = evaluations
+            .iter()
+            .map(|(id, m, v)| (*id, m.as_slice(), v.as_slice()))
+            .collect();
+
+        self.qs
+            .accumulate(&refs, qs_seed)
+            .map_err(|e| VoleZkProverError::QsAccumulate(Box::new(e)))?;
+
+        // Consume the single RVOPE correlation.
         let rvope_out = self
             .rvope
             .try_recv_vope(1)
@@ -208,12 +210,7 @@ where
         Ok(())
     }
 
-    fn product(
-        &mut self,
-        transcript: &mut blake3::Hasher,
-        factor_values: &[E],
-        factor_macs: &[E],
-    ) -> Result<(E, E), Self::Error> {
+    fn product(&mut self, factor_values: &[E], factor_macs: &[E]) -> Result<(E, E), Self::Error> {
         if factor_values.len() != factor_macs.len() {
             return Err(VoleZkProverError::FactorLengthMismatch {
                 values: factor_values.len(),
@@ -236,6 +233,9 @@ where
         let mut current_values: Cow<'_, [E]> = Cow::Borrowed(factor_values);
         let mut current_macs: Cow<'_, [E]> = Cow::Borrowed(factor_macs);
         let eps = self.fan_in_degree;
+
+        // Collected this-call adjustments.
+        let mut call_adjustments: Vec<VoleAdjustment<E>> = Vec::new();
 
         // Walk the tree bottom-up until a single root wire remains.
         while current_values.len() > 1 {
@@ -278,11 +278,7 @@ where
                 .expect("VOLE future should resolve after adjust() returns")
                 .macs;
 
-            transcript.update(b"permutation-proof::vole-adjustment");
-            transcript.update(&bcs::to_bytes(&adjustment).expect("serialize"));
-
-            // Buffer the DTO for transport.
-            self.pending_adjustments.push(adjustment);
+            call_adjustments.push(adjustment);
 
             // Build the QS accumulate inputs. For each chunk, assemble
             // one evaluation with `ε + 1` variables: ε factor slots
@@ -311,15 +307,12 @@ where
                 chunk_values_store.push(values);
             }
 
-            // Draw a fresh PRG seed for this tree-walk level.
-            let seed = crate::draw_seed(transcript, b"permutation-proof::qs-seed");
-            let evaluations: Vec<(ConstraintId, Vec<E>, Vec<E>)> = chunk_macs_store
-                .into_iter()
-                .zip(chunk_values_store)
-                .map(|(m, v)| (self.product_constraint, m, v))
-                .collect();
-            self.pending_qs_accumulate
-                .push(DeferredAccumulate { seed, evaluations });
+            self.pending_qs_evaluations.extend(
+                chunk_macs_store
+                    .into_iter()
+                    .zip(chunk_values_store)
+                    .map(|(m, v)| (self.product_constraint, m, v)),
+            );
 
             // Assemble the next level.
             chunk_products.extend(passthroughs.iter().map(|&idx| current_values[idx]));
@@ -329,16 +322,14 @@ where
             current_macs = Cow::Owned(prod_macs);
         }
 
+        // Bulk-absorb every adjustment into the transcript.
+        self.transcript
+            .update(&bcs::to_bytes(&call_adjustments).expect("serialize"));
+
+        self.pending_adjustments.extend(call_adjustments);
+
         Ok((current_values[0], current_macs[0]))
     }
-}
-
-/// One tree-walk level's deferred QuickSilver accumulate call.
-struct DeferredAccumulate<E: Field> {
-    /// PRG seed drawn from the transcript.
-    seed: [u8; 32],
-    /// Per-chunk `(constraint_id, macs, values)` tuples.
-    evaluations: Vec<(ConstraintId, Vec<E>, Vec<E>)>,
 }
 
 /// Errors produced by [`VoleZkProverBackend`].
@@ -365,8 +356,9 @@ pub enum VoleZkProverError {
     #[error("QuickSilver finalize failed: {0}")]
     QsFinalize(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// `fan_in_degree` was less than the minimum supported value (2).
-    #[error("fan_in_degree must be at least 2; got {0}")]
+    /// `fan_in_degree` was outside the kernel-supported range
+    /// (see [`super::SUPPORTED_FAN_IN`]).
+    #[error("unsupported fan_in_degree: {0}")]
     InvalidFanIn(usize),
 
     /// `factor_values` and `factor_macs` lengths disagree at `product`.
@@ -471,9 +463,8 @@ mod tests {
     #[test]
     fn product_rejects_empty_input() {
         let mut prover = build_prover_only(0xE6, 8);
-        let mut transcript = blake3::Hasher::new();
         let err = prover
-            .product(&mut transcript, &[], &[])
+            .product(&[], &[])
             .expect_err("empty input must surface an error");
         assert!(
             matches!(err, VoleZkProverError::EmptyInput),
@@ -489,9 +480,8 @@ mod tests {
         let v: Gf2_128 = rng.random();
         let m: Gf2_128 = rng.random();
 
-        let mut transcript = blake3::Hasher::new();
         let (ret_v, ret_m) = prover
-            .product(&mut transcript, &[v], &[m])
+            .product(&[v], &[m])
             .expect("singleton passthrough must succeed");
         assert_eq!(ret_v, v);
         assert_eq!(ret_m, m);
@@ -508,11 +498,11 @@ mod tests {
     #[test]
     fn product_computes_correct_root() {
         let cases = [
-            (2, 2),   // minimal tree
-            (10, 2),  // multi-level tight tree
-            (10, 3),  // leftover=1 at leaves
-            (10, 4),  // leftover=2 at leaves, padded
-            (27, 3),  // clean power-of-3 tree, every level splits exactly
+            (6, 6),   // minimal tree (n == ε)
+            (60, 6),  // multi-level tight tree (clean ε² factor)
+            (10, 6),  // leftover=4 at leaves
+            (10, 7),  // leftover=3 at leaves
+            (49, 7),  // clean power-of-7 tree, every level splits exactly
             (100, 8), // moderate size matching a pair-test shape
         ];
 
@@ -529,9 +519,8 @@ mod tests {
             let macs: Vec<Gf2_128> = (0..n).map(|_| rng.random()).collect();
 
             prover.alloc(n).unwrap();
-            let mut transcript = blake3::Hasher::new();
             let (prod_value, _prod_mac) = prover
-                .product(&mut transcript, &values, &macs)
+                .product(&values, &macs)
                 .unwrap_or_else(|e| panic!("(n={n}, eps={eps}): {e:?}"));
 
             let expected = values

--- a/crates/perm-proof-core/src/backend/vole_zk/prover.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/prover.rs
@@ -1,0 +1,538 @@
+//! VOLE-ZK prover backend.
+
+use std::{borrow::Cow, marker::PhantomData};
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    PRODUCT_POLY_ID, build_circuit, chunk_ranges_and_leftover, fan_in_tree_internal_nodes,
+};
+use crate::backend::{Backend, ProverBackend};
+use mpz_vole_core::{
+    DerandVOLEReceiver, RVOLEReceiver, RVOPEReceiver, VOLEReceiver, VoleAdjustment,
+};
+
+/// VOLE-ZK prover backend.
+pub struct VoleZkProverBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLEReceiver<E, E>,
+    VP: RVOPEReceiver<E>,
+{
+    /// Fan-in of the product tree: each tree level
+    /// merges `fan_in_degree` factors into one product wire.
+    fan_in_degree: usize,
+
+    /// Derandomized full-field VOLE receiver for committing the
+    /// intermediate product wires.
+    rvole: DerandVOLEReceiver<VL, E, E>,
+
+    /// RVOPE receiver for the mask(s) consumed at finalization.
+    rvope: VP,
+
+    /// QuickSilver polynomial-proof prover.
+    qs: poly_proof_core::prover::Prover<E>,
+
+    /// Running size of the permutation vector this backend will prove
+    /// over.
+    total_count: usize,
+
+    /// Total RVOLE correlations the backend will consume across its
+    /// lifecycle.
+    rvoles_alloced: usize,
+
+    /// VoleAdjustments emitted by the tree walk, one per level, in
+    /// the order the verifier expects.
+    pending_adjustments: Vec<VoleAdjustment<E>>,
+
+    /// QuickSilver `accumulate` arguments, one per tree level,
+    /// replayed at finalize.
+    pending_qs_accumulate: Vec<DeferredAccumulate<E>>,
+
+    _phantom: PhantomData<W>,
+}
+
+impl<W, E, VL, VP> VoleZkProverBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLEReceiver<E, E>,
+    VP: RVOPEReceiver<E>,
+{
+    /// Build a new prover backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `fan_in_degree` - Fan-in of the product tree (must be ≥ 1).
+    /// * `rvole` - Random VOLE receiver for committing intermediate
+    ///   product wires.
+    /// * `rvope` - Random VOPE receiver for the mask consumed at QS
+    ///   finalize time.
+    pub fn new(fan_in_degree: usize, rvole: VL, mut rvope: VP) -> Result<Self, VoleZkProverError> {
+        if fan_in_degree < 2 {
+            return Err(VoleZkProverError::InvalidFanIn(fan_in_degree));
+        }
+        let circuit = build_circuit(fan_in_degree);
+        let qs = poly_proof_core::prover::Prover::new(vec![circuit]);
+
+        rvope
+            .alloc(1, qs.required_vopes())
+            .map_err(|e| VoleZkProverError::RvopeAlloc(Box::new(e)))?;
+
+        Ok(Self {
+            fan_in_degree,
+            rvole: DerandVOLEReceiver::new(rvole),
+            rvope,
+            qs,
+            total_count: 0,
+            rvoles_alloced: 0,
+            pending_adjustments: Vec::new(),
+            pending_qs_accumulate: Vec::new(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Configured fan-in degree.
+    pub fn fan_in_degree(&self) -> usize {
+        self.fan_in_degree
+    }
+
+    /// Running total of RVOLE correlations.
+    #[cfg(test)]
+    pub(super) fn rvoles_alloced(&self) -> usize {
+        self.rvoles_alloced
+    }
+}
+
+/// Preparation message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preparation<E: Field> {
+    /// Per-level VoleAdjustment DTOs, in emission order.
+    pub adjustments: Vec<VoleAdjustment<E>>,
+}
+
+/// Proof message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proof<E: Field> {
+    /// QuickSilver polynomial-proof message.
+    pub qs_proof: poly_proof_core::ProofMessage<E>,
+}
+
+impl<W, E, VL, VP> Backend<W, E> for VoleZkProverBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLEReceiver<E, E>,
+    VP: RVOPEReceiver<E>,
+{
+    type Error = VoleZkProverError;
+    type Preparation = Preparation<E>;
+    type BackendProof = Proof<E>;
+}
+
+impl<W, E, VL, VP> ProverBackend<W, E> for VoleZkProverBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field + Serialize,
+    VL: RVOLEReceiver<E, E>,
+    VP: RVOPEReceiver<E>,
+{
+    fn drain_preparation(&mut self) -> Result<Self::Preparation, Self::Error> {
+        Ok(Preparation {
+            adjustments: std::mem::take(&mut self.pending_adjustments),
+        })
+    }
+
+    fn prove(mut self) -> Result<Self::BackendProof, Self::Error> {
+        // Step 1: replay the QS accumulate calls that `product`
+        // buffered earlier.
+        for DeferredAccumulate { chi, evaluations } in
+            std::mem::take(&mut self.pending_qs_accumulate)
+        {
+            let refs: Vec<(usize, &[E], &[E])> = evaluations
+                .iter()
+                .map(|(id, m, v)| (*id, m.as_slice(), v.as_slice()))
+                .collect();
+            self.qs
+                .accumulate(&refs, chi)
+                .map_err(|e| VoleZkProverError::QsAccumulate(Box::new(e)))?;
+        }
+
+        // Step 2: consume the single RVOPE correlation.
+        let rvope_out = self
+            .rvope
+            .try_recv_vope(1)
+            .map_err(|e| VoleZkProverError::RvopeConsume(Box::new(e)))?;
+        // Move the coefficients out.
+        let coeffs = rvope_out
+            .polynomials
+            .into_iter()
+            .next()
+            .expect("RVOPE try_recv_vope(1) should return exactly one polynomial");
+        let vope = poly_proof_core::ProverVope { coeffs };
+
+        // Step 3: run QS finalize.
+        let qs_proof = self
+            .qs
+            .finalize(&vope)
+            .map_err(|e| VoleZkProverError::QsFinalize(Box::new(e)))?;
+
+        Ok(Proof { qs_proof })
+    }
+
+    fn alloc(&mut self, n: usize) -> Result<(), Self::Error> {
+        self.total_count = self.total_count.saturating_add(n);
+        // 2× because the product is computed for each of the two
+        // permutation vectors.
+        let target = 2 * fan_in_tree_internal_nodes(self.total_count, self.fan_in_degree);
+        let delta = target - self.rvoles_alloced;
+        if delta > 0 {
+            self.rvole
+                .alloc(delta)
+                .map_err(|e| VoleZkProverError::RvoleAlloc(Box::new(e)))?;
+            self.rvoles_alloced = target;
+        }
+        Ok(())
+    }
+
+    fn product(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+        factor_values: &[E],
+        factor_macs: &[E],
+    ) -> Result<(E, E), Self::Error> {
+        if factor_values.len() != factor_macs.len() {
+            return Err(VoleZkProverError::FactorLengthMismatch {
+                values: factor_values.len(),
+                macs: factor_macs.len(),
+            });
+        }
+
+        let n = factor_values.len();
+        if n == 0 {
+            return Err(VoleZkProverError::EmptyInput);
+        }
+        if n == 1 {
+            // Singleton: no chunk to commit, just pass the wire through.
+            return Ok((factor_values[0], factor_macs[0]));
+        }
+
+        // Working set for the current tree level. Borrowed from the
+        // input on iter 0, replaced with an owned Vec at the end of
+        // every iter — so no upfront copy of the leaves.
+        let mut current_values: Cow<'_, [E]> = Cow::Borrowed(factor_values);
+        let mut current_macs: Cow<'_, [E]> = Cow::Borrowed(factor_macs);
+        let eps = self.fan_in_degree;
+
+        // Walk the tree bottom-up until a single root wire remains.
+        while current_values.len() > 1 {
+            let level_size = current_values.len();
+            let (mut chunk_ranges, mut passthroughs) = chunk_ranges_and_leftover(level_size, eps);
+            // Terminal level (`level_size < eps`): no next iteration to
+            // defer leftover to, so commit it here as a single short
+            // chunk.
+            if chunk_ranges.is_empty() {
+                chunk_ranges = vec![(0, level_size)];
+                passthroughs = Vec::new();
+            }
+
+            // Compute each chunk's cleartext product. Pre-sized to fit
+            // the trailing passthroughs we'll append at end-of-iter,
+            // so the next-level assembly is realloc-free.
+            let mut chunk_products: Vec<E> =
+                Vec::with_capacity(chunk_ranges.len() + passthroughs.len());
+            chunk_products.extend(chunk_ranges.iter().map(|&(start, end)| {
+                current_values[start..end]
+                    .iter()
+                    .copied()
+                    .fold(E::one(), |acc, x| acc * x)
+            }));
+
+            // Commit products.
+            let mut batch_fut = self
+                .rvole
+                .queue_recv_vole(&chunk_products)
+                .map_err(|e| VoleZkProverError::RvoleAlloc(Box::new(e)))?;
+
+            let adjustment = self
+                .rvole
+                .adjust()
+                .map_err(|e| VoleZkProverError::RvoleAlloc(Box::new(e)))?;
+
+            let mut prod_macs: Vec<E> = batch_fut
+                .try_recv()
+                .expect("VOLE adjust() should not cancel queued futures")
+                .expect("VOLE future should resolve after adjust() returns")
+                .macs;
+
+            transcript.update(b"permutation-proof::vole-adjustment");
+            transcript.update(&bcs::to_bytes(&adjustment).expect("serialize"));
+
+            // Buffer the DTO for transport.
+            self.pending_adjustments.push(adjustment);
+
+            // Build the QS accumulate inputs. For each chunk, assemble
+            // one evaluation with `ε + 1` variables: ε factor slots
+            // followed by the prod slot.
+            let mut chunk_macs_store: Vec<Vec<E>> = Vec::with_capacity(chunk_ranges.len());
+            let mut chunk_values_store: Vec<Vec<E>> = Vec::with_capacity(chunk_ranges.len());
+            for (i, &(start, end)) in chunk_ranges.iter().enumerate() {
+                let real_count = end - start;
+                let mut macs = Vec::with_capacity(eps + 1);
+                let mut values = Vec::with_capacity(eps + 1);
+                macs.extend_from_slice(&current_macs[start..end]);
+                values.extend_from_slice(&current_values[start..end]);
+                // Pad short chunks up to ε with the public-coefficient
+                // 1: value = 1 leaves the circuit's product unchanged
+                // (1 is the multiplicative identity); MAC = 0 is the
+                // IT-MAC encoding, pinned by `key = -Δ` on the verifier
+                // side. Only ever fires for the last chunk — full
+                // chunks have `real_count == ε` and the loop is empty.
+                for _ in real_count..eps {
+                    macs.push(E::zero());
+                    values.push(E::one());
+                }
+                macs.push(prod_macs[i]);
+                values.push(chunk_products[i]);
+                chunk_macs_store.push(macs);
+                chunk_values_store.push(values);
+            }
+
+            // Draw a fresh challenge for this tree-walk level.
+            let chi = crate::draw_field::<E>(transcript, b"permutation-proof::qs-chi");
+            let evaluations: Vec<(usize, Vec<E>, Vec<E>)> = chunk_macs_store
+                .into_iter()
+                .zip(chunk_values_store)
+                .map(|(m, v)| (PRODUCT_POLY_ID, m, v))
+                .collect();
+            self.pending_qs_accumulate
+                .push(DeferredAccumulate { chi, evaluations });
+
+            // Assemble the next level.
+            chunk_products.extend(passthroughs.iter().map(|&idx| current_values[idx]));
+            prod_macs.extend(passthroughs.iter().map(|&idx| current_macs[idx]));
+
+            current_values = Cow::Owned(chunk_products);
+            current_macs = Cow::Owned(prod_macs);
+        }
+
+        Ok((current_values[0], current_macs[0]))
+    }
+}
+
+/// One tre-walk level's deferred QuickSilver accumulate call.
+struct DeferredAccumulate<E: Field> {
+    /// Challenge drawn from the transcript.
+    chi: E,
+    /// Per-chunk `(poly_id, macs, values)` tuples.
+    evaluations: Vec<(usize, Vec<E>, Vec<E>)>,
+}
+
+/// Errors produced by [`VoleZkProverBackend`].
+#[derive(Debug, thiserror::Error)]
+pub enum VoleZkProverError {
+    /// The underlying RVOLE provider's `alloc` rejected the request.
+    #[error("RVOLE alloc failed: {0}")]
+    RvoleAlloc(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The underlying RVOPE provider's `alloc` rejected the request.
+    #[error("RVOPE alloc failed: {0}")]
+    RvopeAlloc(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The QuickSilver prover rejected an `accumulate` call.
+    #[error("QuickSilver accumulate failed: {0}")]
+    QsAccumulate(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The RVOPE provider failed to deliver the pre-allocated correlation
+    /// when QS finalize tried to consume it.
+    #[error("RVOPE consume failed: {0}")]
+    RvopeConsume(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The QuickSilver prover rejected the `finalize` call.
+    #[error("QuickSilver finalize failed: {0}")]
+    QsFinalize(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// `fan_in_degree` was less than the minimum supported value (2).
+    #[error("fan_in_degree must be at least 2; got {0}")]
+    InvalidFanIn(usize),
+
+    /// `factor_values` and `factor_macs` lengths disagree at `product`.
+    #[error("factor_values and factor_macs lengths disagree: values={values}, macs={macs}")]
+    FactorLengthMismatch {
+        /// Length of the `factor_values` slice.
+        values: usize,
+        /// Length of the `factor_macs` slice.
+        macs: usize,
+    },
+
+    /// `product` was called with empty factor slices.
+    #[error("product called with empty factor slices")]
+    EmptyInput,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::backend::ProverBackend;
+    use mpz_vole_core::{
+        RVOLEReceiver, RVOLESender,
+        ideal::{
+            rvole::{IdealRVOLEReceiver, ideal_rvole},
+            rvope::IdealRVOPEReceiver,
+        },
+    };
+
+    /// Build a prover-only backend with no pre-filled correlations.
+    /// For tests that exercise bookkeeping.
+    fn build_prover_only(
+        rng_seed: u64,
+        eps: usize,
+    ) -> VoleZkProverBackend<
+        Gf2_128,
+        Gf2_128,
+        IdealRVOLEReceiver<Gf2_128, Gf2_128>,
+        IdealRVOPEReceiver<Gf2_128>,
+    > {
+        let mut rng = ChaCha8Rng::seed_from_u64(rng_seed);
+        let delta: Gf2_128 = rng.random();
+        let rvole_seed: u64 = rng.random();
+        let rvope_seed: u64 = rng.random();
+        let (_rvole_s, rvole_r) = ideal_rvole::<Gf2_128, Gf2_128>(rvole_seed, delta);
+        let rvope_r = IdealRVOPEReceiver::<Gf2_128>::new(rvope_seed);
+        VoleZkProverBackend::<Gf2_128, Gf2_128, _, _>::new(eps, rvole_r, rvope_r).unwrap()
+    }
+
+    /// Build a prover-only backend with RVOLE pre-filled.
+    fn build_prover_with_correlations(
+        rng_seed: u64,
+        n: usize,
+        eps: usize,
+    ) -> VoleZkProverBackend<
+        Gf2_128,
+        Gf2_128,
+        IdealRVOLEReceiver<Gf2_128, Gf2_128>,
+        IdealRVOPEReceiver<Gf2_128>,
+    > {
+        let mut rng = ChaCha8Rng::seed_from_u64(rng_seed);
+        let delta: Gf2_128 = rng.random();
+        let rvole_seed: u64 = rng.random();
+        let rvope_seed: u64 = rng.random();
+
+        let rvole_count = 2 * fan_in_tree_internal_nodes(n, eps);
+        let (mut rvole_s, mut rvole_r) = ideal_rvole::<Gf2_128, Gf2_128>(rvole_seed, delta);
+        <_ as RVOLESender<Gf2_128>>::alloc(&mut rvole_s, rvole_count).unwrap();
+        <_ as RVOLEReceiver<Gf2_128, Gf2_128>>::alloc(&mut rvole_r, rvole_count).unwrap();
+        if let Some(msg) = rvole_s.flush() {
+            rvole_r.flush(msg).unwrap();
+        }
+
+        let rvope_r = IdealRVOPEReceiver::<Gf2_128>::new(rvope_seed);
+        VoleZkProverBackend::<Gf2_128, Gf2_128, _, _>::new(eps, rvole_r, rvope_r).unwrap()
+    }
+
+    /// Test cumulative-alloc contract.
+    #[test]
+    fn alloc_forwards_cumulative_deltas() {
+        let mut prover = build_prover_only(0xE5, 8);
+        assert_eq!(prover.rvoles_alloced(), 0);
+
+        // running n=5  → internal_nodes(5,8)=1,  target=2, delta=+2
+        prover.alloc(5).unwrap();
+        assert_eq!(prover.rvoles_alloced(), 2);
+
+        // running n=12 → internal_nodes(12,8)=2, target=4, delta=+2
+        prover.alloc(7).unwrap();
+        assert_eq!(prover.rvoles_alloced(), 4);
+
+        // running n=16 → internal_nodes(16,8)=3, target=6, delta=+2
+        prover.alloc(4).unwrap();
+        assert_eq!(prover.rvoles_alloced(), 6);
+    }
+
+    /// Empty-input short-circuit.
+    #[test]
+    fn product_rejects_empty_input() {
+        let mut prover = build_prover_only(0xE6, 8);
+        let mut transcript = blake3::Hasher::new();
+        let err = prover
+            .product(&mut transcript, &[], &[])
+            .expect_err("empty input must surface an error");
+        assert!(
+            matches!(err, VoleZkProverError::EmptyInput),
+            "expected EmptyInput, got {err:?}"
+        );
+    }
+
+    /// Singleton short-circuit.
+    #[test]
+    fn product_passes_through_singleton() {
+        let mut prover = build_prover_only(0xE7, 8);
+        let mut rng = ChaCha8Rng::seed_from_u64(0xE7_1234);
+        let v: Gf2_128 = rng.random();
+        let m: Gf2_128 = rng.random();
+
+        let mut transcript = blake3::Hasher::new();
+        let (ret_v, ret_m) = prover
+            .product(&mut transcript, &[v], &[m])
+            .expect("singleton passthrough must succeed");
+        assert_eq!(ret_v, v);
+        assert_eq!(ret_m, m);
+
+        let prep = prover.drain_preparation().unwrap();
+        assert!(
+            prep.adjustments.is_empty(),
+            "singleton passthrough must not buffer any adjustments"
+        );
+    }
+
+    /// `product`'s root value must equal the total plaintext
+    /// product of its input factors.
+    #[test]
+    fn product_computes_correct_root() {
+        let cases = [
+            (2, 2),   // minimal tree
+            (10, 2),  // multi-level tight tree
+            (10, 3),  // leftover=1 at leaves
+            (10, 4),  // leftover=2 at leaves, padded
+            (27, 3),  // clean power-of-3 tree, every level splits exactly
+            (100, 8), // moderate size matching a pair-test shape
+        ];
+
+        for (n, eps) in cases {
+            let mut prover = build_prover_with_correlations(
+                0xF00D_u64.wrapping_add((n as u64) * 31 + eps as u64),
+                n,
+                eps,
+            );
+
+            let mut rng =
+                ChaCha8Rng::seed_from_u64(0xBEEF_u64.wrapping_add((n as u64) * 17 + eps as u64));
+            let values: Vec<Gf2_128> = (0..n).map(|_| rng.random()).collect();
+            let macs: Vec<Gf2_128> = (0..n).map(|_| rng.random()).collect();
+
+            prover.alloc(n).unwrap();
+            let mut transcript = blake3::Hasher::new();
+            let (prod_value, _prod_mac) = prover
+                .product(&mut transcript, &values, &macs)
+                .unwrap_or_else(|e| panic!("(n={n}, eps={eps}): {e:?}"));
+
+            let expected = values
+                .iter()
+                .copied()
+                .fold(Gf2_128::one(), |acc, x| acc * x);
+            assert_eq!(
+                prod_value, expected,
+                "(n={n}, eps={eps}): root value must equal the total product"
+            );
+        }
+    }
+}

--- a/crates/perm-proof-core/src/backend/vole_zk/prover.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/prover.rs
@@ -3,13 +3,11 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use mpz_common::future::Output;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
+use mpz_poly_proof_core::ConstraintId;
 use serde::{Deserialize, Serialize};
 
-use super::{
-    PRODUCT_POLY_ID, build_circuit, chunk_ranges_and_leftover, fan_in_tree_internal_nodes,
-};
+use super::{build_product_constraints, chunk_ranges_and_leftover, fan_in_tree_internal_nodes};
 use crate::backend::{Backend, ProverBackend};
 use mpz_vole_core::{
     DerandVOLEReceiver, RVOLEReceiver, RVOPEReceiver, VOLEReceiver, VoleAdjustment,
@@ -18,8 +16,8 @@ use mpz_vole_core::{
 /// VOLE-ZK prover backend.
 pub struct VoleZkProverBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLEReceiver<E, E>,
     VP: RVOPEReceiver<E>,
 {
@@ -35,7 +33,10 @@ where
     rvope: VP,
 
     /// QuickSilver polynomial-proof prover.
-    qs: poly_proof_core::prover::Prover<E>,
+    qs: mpz_poly_proof_core::prover::Prover<E>,
+
+    /// Id of the single product constraint registered with `qs`.
+    product_constraint: ConstraintId,
 
     /// Running size of the permutation vector this backend will prove
     /// over.
@@ -58,8 +59,8 @@ where
 
 impl<W, E, VL, VP> VoleZkProverBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLEReceiver<E, E>,
     VP: RVOPEReceiver<E>,
 {
@@ -76,8 +77,8 @@ where
         if fan_in_degree < 2 {
             return Err(VoleZkProverError::InvalidFanIn(fan_in_degree));
         }
-        let circuit = build_circuit(fan_in_degree);
-        let qs = poly_proof_core::prover::Prover::new(vec![circuit]);
+        let (constraints, product_constraint) = build_product_constraints::<E>(fan_in_degree);
+        let qs = mpz_poly_proof_core::prover::Prover::new(&constraints);
 
         rvope
             .alloc(1, qs.required_vopes())
@@ -88,6 +89,7 @@ where
             rvole: DerandVOLEReceiver::new(rvole),
             rvope,
             qs,
+            product_constraint,
             total_count: 0,
             rvoles_alloced: 0,
             pending_adjustments: Vec::new(),
@@ -119,13 +121,13 @@ pub struct Preparation<E: Field> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proof<E: Field> {
     /// QuickSilver polynomial-proof message.
-    pub qs_proof: poly_proof_core::ProofMessage<E>,
+    pub qs_proof: mpz_poly_proof_core::ProofMessage<E>,
 }
 
 impl<W, E, VL, VP> Backend<W, E> for VoleZkProverBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLEReceiver<E, E>,
     VP: RVOPEReceiver<E>,
 {
@@ -136,8 +138,12 @@ where
 
 impl<W, E, VL, VP> ProverBackend<W, E> for VoleZkProverBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field + Serialize,
+    W: Field,
+    E: ExtensionField<W>
+        + ExtensionField<E>
+        + Serialize
+        + zerocopy::IntoBytes
+        + zerocopy::FromBytes,
     VL: RVOLEReceiver<E, E>,
     VP: RVOPEReceiver<E>,
 {
@@ -150,15 +156,18 @@ where
     fn prove(mut self) -> Result<Self::BackendProof, Self::Error> {
         // Step 1: replay the QS accumulate calls that `product`
         // buffered earlier.
-        for DeferredAccumulate { chi, evaluations } in
+        for DeferredAccumulate { seed, evaluations } in
             std::mem::take(&mut self.pending_qs_accumulate)
         {
-            let refs: Vec<(usize, &[E], &[E])> = evaluations
+            let refs: Vec<(ConstraintId, &[E], &[E])> = evaluations
                 .iter()
                 .map(|(id, m, v)| (*id, m.as_slice(), v.as_slice()))
                 .collect();
+            // W = E here: tree-walk wires are already extension-field
+            // elements (post-`prepare` collapse), so the `accumulate`
+            // generic uses the trivial `E: ExtensionField<E>` impl.
             self.qs
-                .accumulate(&refs, chi)
+                .accumulate::<E>(&refs, seed)
                 .map_err(|e| VoleZkProverError::QsAccumulate(Box::new(e)))?;
         }
 
@@ -173,7 +182,7 @@ where
             .into_iter()
             .next()
             .expect("RVOPE try_recv_vope(1) should return exactly one polynomial");
-        let vope = poly_proof_core::ProverVope { coeffs };
+        let vope = mpz_poly_proof_core::ProverVope { coeffs };
 
         // Step 3: run QS finalize.
         let qs_proof = self
@@ -293,8 +302,8 @@ where
                 // side. Only ever fires for the last chunk — full
                 // chunks have `real_count == ε` and the loop is empty.
                 for _ in real_count..eps {
-                    macs.push(E::zero());
-                    values.push(E::one());
+                    macs.push(<E as Field>::zero());
+                    values.push(<E as Field>::one());
                 }
                 macs.push(prod_macs[i]);
                 values.push(chunk_products[i]);
@@ -302,15 +311,15 @@ where
                 chunk_values_store.push(values);
             }
 
-            // Draw a fresh challenge for this tree-walk level.
-            let chi = crate::draw_field::<E>(transcript, b"permutation-proof::qs-chi");
-            let evaluations: Vec<(usize, Vec<E>, Vec<E>)> = chunk_macs_store
+            // Draw a fresh PRG seed for this tree-walk level.
+            let seed = crate::draw_seed(transcript, b"permutation-proof::qs-seed");
+            let evaluations: Vec<(ConstraintId, Vec<E>, Vec<E>)> = chunk_macs_store
                 .into_iter()
                 .zip(chunk_values_store)
-                .map(|(m, v)| (PRODUCT_POLY_ID, m, v))
+                .map(|(m, v)| (self.product_constraint, m, v))
                 .collect();
             self.pending_qs_accumulate
-                .push(DeferredAccumulate { chi, evaluations });
+                .push(DeferredAccumulate { seed, evaluations });
 
             // Assemble the next level.
             chunk_products.extend(passthroughs.iter().map(|&idx| current_values[idx]));
@@ -324,12 +333,12 @@ where
     }
 }
 
-/// One tre-walk level's deferred QuickSilver accumulate call.
+/// One tree-walk level's deferred QuickSilver accumulate call.
 struct DeferredAccumulate<E: Field> {
-    /// Challenge drawn from the transcript.
-    chi: E,
-    /// Per-chunk `(poly_id, macs, values)` tuples.
-    evaluations: Vec<(usize, Vec<E>, Vec<E>)>,
+    /// PRG seed drawn from the transcript.
+    seed: [u8; 32],
+    /// Per-chunk `(constraint_id, macs, values)` tuples.
+    evaluations: Vec<(ConstraintId, Vec<E>, Vec<E>)>,
 }
 
 /// Errors produced by [`VoleZkProverBackend`].

--- a/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
@@ -2,12 +2,12 @@
 
 use std::{borrow::Cow, collections::VecDeque, marker::PhantomData};
 
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
+use mpz_poly_proof_core::ConstraintId;
 use serde::Serialize;
 
 use super::{
-    PRODUCT_POLY_ID, Preparation, Proof, build_circuit, chunk_ranges_and_leftover,
+    Preparation, Proof, build_product_constraints, chunk_ranges_and_leftover,
     fan_in_tree_internal_nodes,
 };
 use crate::backend::{Backend, VerifierBackend};
@@ -16,8 +16,8 @@ use mpz_vole_core::{RVOLESender, RVOPESender, VoleAdjustment};
 /// VOLE-ZK verifier backend.
 pub struct VoleZkVerifierBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLESender<E>,
     VP: RVOPESender<E>,
 {
@@ -37,7 +37,10 @@ where
     rvope: VP,
 
     /// QuickSilver polynomial-proof verifier.
-    qs: poly_proof_core::verifier::Verifier<E>,
+    qs: mpz_poly_proof_core::verifier::Verifier<E>,
+
+    /// Id of the single product constraint registered with `qs`.
+    product_constraint: ConstraintId,
 
     /// Running size of the permutation vector this backend will verify
     /// over.
@@ -55,8 +58,8 @@ where
 
 impl<W, E, VL, VP> VoleZkVerifierBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLESender<E>,
     VP: RVOPESender<E>,
 {
@@ -79,8 +82,8 @@ where
         if fan_in_degree < 2 {
             return Err(VoleZkVerifierError::InvalidFanIn(fan_in_degree));
         }
-        let circuit = build_circuit(fan_in_degree);
-        let qs = poly_proof_core::verifier::Verifier::new(delta, vec![circuit]);
+        let (constraints, product_constraint) = build_product_constraints::<E>(fan_in_degree);
+        let qs = mpz_poly_proof_core::verifier::Verifier::new(delta, &constraints);
 
         rvope
             .alloc(1, qs.required_vopes())
@@ -92,6 +95,7 @@ where
             rvole,
             rvope,
             qs,
+            product_constraint,
             total_count: 0,
             rvoles_alloced: 0,
             adjustments: VecDeque::new(),
@@ -118,8 +122,8 @@ where
 
 impl<W, E, VL, VP> Backend<W, E> for VoleZkVerifierBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W> + ExtensionField<E>,
     VL: RVOLESender<E>,
     VP: RVOPESender<E>,
 {
@@ -130,8 +134,12 @@ where
 
 impl<W, E, VL, VP> VerifierBackend<W, E> for VoleZkVerifierBackend<W, E, VL, VP>
 where
-    W: SubfieldOf<E>,
-    E: Field + Serialize,
+    W: Field,
+    E: ExtensionField<W>
+        + ExtensionField<E>
+        + Serialize
+        + zerocopy::IntoBytes
+        + zerocopy::FromBytes,
     VL: RVOLESender<E>,
     VP: RVOPESender<E>,
 {
@@ -156,7 +164,7 @@ where
             .into_iter()
             .next()
             .expect("RVOPE try_send_vope(1) should return exactly one evaluation");
-        let vope = poly_proof_core::VerifierVope { sum };
+        let vope = mpz_poly_proof_core::VerifierVope { sum };
 
         // Step 2: run QS finalize.
         self.qs
@@ -263,14 +271,14 @@ where
                 chunk_keys_store.push(keys);
             }
 
-            // Draw a fresh challenge for this tree-walk level.
-            let chi = crate::draw_field::<E>(transcript, b"permutation-proof::qs-chi");
-            let evaluations: Vec<(usize, &[E])> = chunk_keys_store
+            // Draw a fresh PRG seed for this tree-walk level.
+            let seed = crate::draw_seed(transcript, b"permutation-proof::qs-seed");
+            let evaluations: Vec<(ConstraintId, &[E])> = chunk_keys_store
                 .iter()
-                .map(|k| (PRODUCT_POLY_ID, k.as_slice()))
+                .map(|k| (self.product_constraint, k.as_slice()))
                 .collect();
             self.qs
-                .accumulate(&evaluations, chi)
+                .accumulate(&evaluations, seed)
                 .map_err(|e| VoleZkVerifierError::QsAccumulate(Box::new(e)))?;
 
             // Assemble the next level.

--- a/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
@@ -1,0 +1,476 @@
+//! VOLE-ZK verifier backend.
+
+use std::{borrow::Cow, collections::VecDeque, marker::PhantomData};
+
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+use serde::Serialize;
+
+use super::{
+    PRODUCT_POLY_ID, Preparation, Proof, build_circuit, chunk_ranges_and_leftover,
+    fan_in_tree_internal_nodes,
+};
+use crate::backend::{Backend, VerifierBackend};
+use mpz_vole_core::{RVOLESender, RVOPESender, VoleAdjustment};
+
+/// VOLE-ZK verifier backend.
+pub struct VoleZkVerifierBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLESender<E>,
+    VP: RVOPESender<E>,
+{
+    /// Fan-in of the product tree: each tree level
+    /// merges `fan_in_degree` factors into one product wire.
+    ///
+    /// Must match the prover's setting or the proof will fail.
+    fan_in_degree: usize,
+
+    /// Verifier's global key.
+    delta: E,
+
+    /// RVOLE sender.
+    rvole: VL,
+
+    /// RVOPE sender for the mask(s) consumed at finalization.
+    rvope: VP,
+
+    /// QuickSilver polynomial-proof verifier.
+    qs: poly_proof_core::verifier::Verifier<E>,
+
+    /// Running size of the permutation vector this backend will verify
+    /// over.
+    total_count: usize,
+
+    /// Total RVOLE correlations the backend will consume across its
+    /// lifecycle.
+    rvoles_alloced: usize,
+
+    /// VoleAdjustments loaded from the prover's [`Preparation`].
+    adjustments: VecDeque<VoleAdjustment<E>>,
+
+    _phantom: PhantomData<W>,
+}
+
+impl<W, E, VL, VP> VoleZkVerifierBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLESender<E>,
+    VP: RVOPESender<E>,
+{
+    /// Build a new verifier backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `fan_in_degree` - Fan-in of the product tree (must be ≥ 1).
+    /// * `delta` - Verifier's global key.
+    /// * `rvole` - Random VOLE sender for committing intermediate
+    ///   product wires.
+    /// * `rvope` - Random VOPE sender for the mask consumed at QS
+    ///   finalize time.
+    pub fn new(
+        fan_in_degree: usize,
+        delta: E,
+        rvole: VL,
+        mut rvope: VP,
+    ) -> Result<Self, VoleZkVerifierError> {
+        if fan_in_degree < 2 {
+            return Err(VoleZkVerifierError::InvalidFanIn(fan_in_degree));
+        }
+        let circuit = build_circuit(fan_in_degree);
+        let qs = poly_proof_core::verifier::Verifier::new(delta, vec![circuit]);
+
+        rvope
+            .alloc(1, qs.required_vopes())
+            .map_err(|e| VoleZkVerifierError::RvopeAlloc(Box::new(e)))?;
+
+        Ok(Self {
+            fan_in_degree,
+            delta,
+            rvole,
+            rvope,
+            qs,
+            total_count: 0,
+            rvoles_alloced: 0,
+            adjustments: VecDeque::new(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Configured fan-in degree.
+    pub fn fan_in_degree(&self) -> usize {
+        self.fan_in_degree
+    }
+
+    /// Verifier's `Δ`.
+    pub fn delta_value(&self) -> E {
+        self.delta
+    }
+
+    /// Running total of RVOLE correlations.
+    #[cfg(test)]
+    pub(super) fn rvoles_alloced(&self) -> usize {
+        self.rvoles_alloced
+    }
+}
+
+impl<W, E, VL, VP> Backend<W, E> for VoleZkVerifierBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    VL: RVOLESender<E>,
+    VP: RVOPESender<E>,
+{
+    type Error = VoleZkVerifierError;
+    type Preparation = Preparation<E>;
+    type BackendProof = Proof<E>;
+}
+
+impl<W, E, VL, VP> VerifierBackend<W, E> for VoleZkVerifierBackend<W, E, VL, VP>
+where
+    W: SubfieldOf<E>,
+    E: Field + Serialize,
+    VL: RVOLESender<E>,
+    VP: RVOPESender<E>,
+{
+    fn delta(&self) -> E {
+        self.delta
+    }
+
+    fn load_preparation(&mut self, preparation: Self::Preparation) {
+        self.adjustments = preparation.adjustments.into();
+    }
+
+    fn verify(mut self, proof: Self::BackendProof) -> Result<(), Self::Error> {
+        let Proof { qs_proof } = proof;
+
+        // Step 1: consume the single pre-alloc'd RVOPE correlation.
+        let rvope_out = self
+            .rvope
+            .try_send_vope(1)
+            .map_err(|e| VoleZkVerifierError::RvopeConsume(Box::new(e)))?;
+        let sum = rvope_out
+            .evaluations
+            .into_iter()
+            .next()
+            .expect("RVOPE try_send_vope(1) should return exactly one evaluation");
+        let vope = poly_proof_core::VerifierVope { sum };
+
+        // Step 2: run QS finalize.
+        self.qs
+            .finalize(&qs_proof, &vope)
+            .map_err(|e| VoleZkVerifierError::QsVerify(Box::new(e)))
+    }
+
+    fn alloc(&mut self, n: usize) -> Result<(), Self::Error> {
+        self.total_count = self.total_count.saturating_add(n);
+        // 2× because the product is computed for each of the two
+        // permutation vectors.
+        let target = 2 * fan_in_tree_internal_nodes(self.total_count, self.fan_in_degree);
+        let delta = target - self.rvoles_alloced;
+        if delta > 0 {
+            self.rvole
+                .alloc(delta)
+                .map_err(|e| VoleZkVerifierError::RvoleAlloc(Box::new(e)))?;
+            self.rvoles_alloced = target;
+        }
+        Ok(())
+    }
+
+    fn product(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+        factor_keys: &[E],
+    ) -> Result<E, Self::Error> {
+        let n = factor_keys.len();
+        if n == 0 {
+            return Err(VoleZkVerifierError::EmptyInput);
+        }
+        if n == 1 {
+            return Ok(factor_keys[0]);
+        }
+
+        // Working set for the current tree level. Borrowed from the
+        // input on iter 0, replaced with an owned Vec at the end of
+        // every iter — so no upfront copy of the leaves.
+        let mut current_keys: Cow<'_, [E]> = Cow::Borrowed(factor_keys);
+        let eps = self.fan_in_degree;
+
+        while current_keys.len() > 1 {
+            let level_size = current_keys.len();
+            let (mut chunk_ranges, mut passthroughs) = chunk_ranges_and_leftover(level_size, eps);
+            // Terminal level (`level_size < eps`): no next iteration to
+            // defer leftover to, so commit it here as a single short
+            // chunk.
+            if chunk_ranges.is_empty() {
+                chunk_ranges = vec![(0, level_size)];
+                passthroughs = Vec::new();
+            }
+            let n_chunks = chunk_ranges.len();
+
+            // Consume the prover's adjustment for this level.
+            let adjustment = self
+                .adjustments
+                .pop_front()
+                .ok_or(VoleZkVerifierError::AdjustmentUnderflow)?;
+            if adjustment.diffs.len() != n_chunks {
+                return Err(VoleZkVerifierError::AdjustmentShapeMismatch {
+                    expected: n_chunks,
+                    actual: adjustment.diffs.len(),
+                });
+            }
+
+            // Absorb into the transcript.
+            transcript.update(b"permutation-proof::vole-adjustment");
+            transcript.update(&bcs::to_bytes(&adjustment).expect("serialize"));
+
+            // Consume and derandomize random VOLEs.
+            let rvole_out = self
+                .rvole
+                .try_send_vole(n_chunks)
+                .map_err(|e| VoleZkVerifierError::RvoleConsume(Box::new(e)))?;
+
+            // Pre-sized to fit the trailing passthroughs we'll append at
+            // end-of-iter, so the next-level assembly is realloc-free.
+            let mut prod_keys: Vec<E> = Vec::with_capacity(n_chunks + passthroughs.len());
+            prod_keys.extend(
+                rvole_out
+                    .keys
+                    .iter()
+                    .zip(&adjustment.diffs)
+                    .map(|(k, d)| *k - self.delta * *d),
+            );
+
+            // Build the QS accumulate inputs for this level, one
+            // evaluation per chunk with ε+1 keys.
+            let neg_delta = -self.delta;
+            let mut chunk_keys_store: Vec<Vec<E>> = Vec::with_capacity(n_chunks);
+            for (i, &(start, end)) in chunk_ranges.iter().enumerate() {
+                let real_count = end - start;
+                let mut keys = Vec::with_capacity(eps + 1);
+                keys.extend_from_slice(&current_keys[start..end]);
+                for _ in real_count..eps {
+                    // Padding convention: the prover uses (value=1, mac=0).
+                    // Under the invariant `mac = key + Δ·value`, that forces
+                    // the matching key to `mac − Δ·value = −Δ·1 = −Δ`.
+                    // Only ever fires for the last chunk — full
+                    // chunks have `real_count == ε` and the loop is empty.
+                    keys.push(neg_delta);
+                }
+                keys.push(prod_keys[i]);
+                chunk_keys_store.push(keys);
+            }
+
+            // Draw a fresh challenge for this tree-walk level.
+            let chi = crate::draw_field::<E>(transcript, b"permutation-proof::qs-chi");
+            let evaluations: Vec<(usize, &[E])> = chunk_keys_store
+                .iter()
+                .map(|k| (PRODUCT_POLY_ID, k.as_slice()))
+                .collect();
+            self.qs
+                .accumulate(&evaluations, chi)
+                .map_err(|e| VoleZkVerifierError::QsAccumulate(Box::new(e)))?;
+
+            // Assemble the next level.
+            prod_keys.extend(passthroughs.iter().map(|&idx| current_keys[idx]));
+
+            current_keys = Cow::Owned(prod_keys);
+        }
+
+        Ok(current_keys[0])
+    }
+}
+
+/// Errors produced by [`VoleZkVerifierBackend`].
+#[derive(Debug, thiserror::Error)]
+pub enum VoleZkVerifierError {
+    /// The underlying RVOLE provider's `alloc` rejected the request.
+    #[error("RVOLE alloc failed: {0}")]
+    RvoleAlloc(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The underlying RVOPE provider's `alloc` rejected the request.
+    #[error("RVOPE alloc failed: {0}")]
+    RvopeAlloc(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The QuickSilver verifier rejected an `accumulate` call.
+    #[error("QuickSilver accumulate failed: {0}")]
+    QsAccumulate(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The RVOPE provider failed to deliver the pre-allocated correlation.
+    #[error("RVOPE consume failed: {0}")]
+    RvopeConsume(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The underlying RVOLE provider failed to produce preprocessed
+    /// correlations.
+    #[error("RVOLE consume failed: {0}")]
+    RvoleConsume(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The QuickSilver polynomial-proof verifier rejected the `finalize`
+    /// call.
+    #[error("QuickSilver verify failed: {0}")]
+    QsVerify(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// The verifier's tree walk needed another VoleAdjustment but the
+    /// loaded proof had none left.
+    #[error("ran out of VoleAdjustments while walking the fan-in tree")]
+    AdjustmentUnderflow,
+
+    /// A consumed VoleAdjustment's `diffs` length disagreed with the
+    /// number of chunks the verifier expected at this tree level.
+    #[error(
+        "VoleAdjustment shape mismatch: expected {expected} diffs for this level, got {actual}"
+    )]
+    AdjustmentShapeMismatch {
+        /// Number of chunks the verifier expected at this level.
+        expected: usize,
+        /// Number of diffs actually present in the adjustment.
+        actual: usize,
+    },
+
+    /// `fan_in_degree` was less than the minimum supported value (2).
+    #[error("fan_in_degree must be at least 2; got {0}")]
+    InvalidFanIn(usize),
+
+    /// `product` was called with an empty factor-keys slice.
+    #[error("product called with empty factor-keys slice")]
+    EmptyInput,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::backend::VerifierBackend;
+    use mpz_vole_core::ideal::{
+        rvole::{IdealRVOLESender, ideal_rvole},
+        rvope::IdealRVOPESender,
+    };
+
+    /// Build a verifier-only backend with no pre-filled correlations.
+    /// For tests that exercise bookkeeping.
+    fn build_verifier_only(
+        rng_seed: u64,
+        eps: usize,
+    ) -> VoleZkVerifierBackend<Gf2_128, Gf2_128, IdealRVOLESender<Gf2_128>, IdealRVOPESender<Gf2_128>>
+    {
+        let mut rng = ChaCha8Rng::seed_from_u64(rng_seed);
+        let delta: Gf2_128 = rng.random();
+        let rvole_seed: u64 = rng.random();
+        let rvope_seed: u64 = rng.random();
+        let (rvole_s, _rvole_r) = ideal_rvole::<Gf2_128, Gf2_128>(rvole_seed, delta);
+        let rvope_s = IdealRVOPESender::<Gf2_128>::new(rvope_seed, delta);
+        VoleZkVerifierBackend::<Gf2_128, Gf2_128, _, _>::new(eps, delta, rvole_s, rvope_s).unwrap()
+    }
+
+    /// Test cumulative-alloc contract.
+    #[test]
+    fn alloc_forwards_cumulative_deltas() {
+        let mut verifier = build_verifier_only(0xE5, 8);
+        assert_eq!(verifier.rvoles_alloced(), 0);
+
+        // running n=5  → internal_nodes(5,8)=1,  target=2, delta=+2
+        verifier.alloc(5).unwrap();
+        assert_eq!(verifier.rvoles_alloced(), 2);
+
+        // running n=12 → internal_nodes(12,8)=2, target=4, delta=+2
+        verifier.alloc(7).unwrap();
+        assert_eq!(verifier.rvoles_alloced(), 4);
+
+        // running n=16 → internal_nodes(16,8)=3, target=6, delta=+2
+        verifier.alloc(4).unwrap();
+        assert_eq!(verifier.rvoles_alloced(), 6);
+    }
+
+    /// Empty-input short-circuit.
+    #[test]
+    fn product_rejects_empty_input() {
+        let mut verifier = build_verifier_only(0xE6, 8);
+        let mut transcript = blake3::Hasher::new();
+        let err = verifier
+            .product(&mut transcript, &[])
+            .expect_err("empty input must surface an error");
+        assert!(
+            matches!(err, VoleZkVerifierError::EmptyInput),
+            "expected EmptyInput, got {err:?}"
+        );
+    }
+
+    /// Singleton short-circuit.
+    #[test]
+    fn product_passes_through_singleton() {
+        let mut verifier = build_verifier_only(0xE7, 8);
+        let mut rng = ChaCha8Rng::seed_from_u64(0xE7_1234);
+        let k: Gf2_128 = rng.random();
+
+        // Load an empty `Preparation` — the singleton path must not
+        // pop any adjustments off the queue.
+        verifier.load_preparation(Preparation {
+            adjustments: vec![],
+        });
+
+        let mut transcript = blake3::Hasher::new();
+        let ret_k = verifier
+            .product(&mut transcript, &[k])
+            .expect("singleton passthrough must succeed");
+        assert_eq!(ret_k, k);
+    }
+
+    /// Test `VoleAdjustment` underflow.
+    #[test]
+    fn product_underflow_on_short_preparation() {
+        let mut verifier = build_verifier_only(0xE8, 4);
+        // `n = 4, eps = 4`: tree walks exactly one level (one chunk).
+        // Loading an empty Preparation means the first `pop_front` at
+        // level 0 returns `None` → AdjustmentUnderflow.
+        verifier.load_preparation(Preparation {
+            adjustments: vec![],
+        });
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0xE8_1234);
+        let keys: Vec<Gf2_128> = (0..4).map(|_| rng.random()).collect();
+
+        let mut transcript = blake3::Hasher::new();
+        let err = verifier
+            .product(&mut transcript, &keys)
+            .expect_err("short Preparation must surface an error");
+        assert!(
+            matches!(err, VoleZkVerifierError::AdjustmentUnderflow),
+            "expected AdjustmentUnderflow, got {err:?}"
+        );
+    }
+
+    /// Per-level shape check.
+    #[test]
+    fn product_shape_mismatch_on_wrong_diffs_length() {
+        let mut verifier = build_verifier_only(0xE9, 4);
+        // `n = 4, eps = 4`: level 0 has exactly one chunk, so the
+        // matching adjustment must carry `diffs.len() == 1`. Load one
+        // with 2 diffs to trip the shape check.
+        verifier.load_preparation(Preparation {
+            adjustments: vec![mpz_vole_core::VoleAdjustment {
+                diffs: vec![Gf2_128::one(), Gf2_128::one()],
+            }],
+        });
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0xE9_1234);
+        let keys: Vec<Gf2_128> = (0..4).map(|_| rng.random()).collect();
+
+        let mut transcript = blake3::Hasher::new();
+        let err = verifier
+            .product(&mut transcript, &keys)
+            .expect_err("wrong-shape adjustment must surface an error");
+        match err {
+            VoleZkVerifierError::AdjustmentShapeMismatch { expected, actual } => {
+                assert_eq!(expected, 1, "expected 1 chunk at level 0");
+                assert_eq!(actual, 2, "loaded adjustment had 2 diffs");
+            }
+            other => panic!("expected AdjustmentShapeMismatch, got {other:?}"),
+        }
+    }
+}

--- a/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
+++ b/crates/perm-proof-core/src/backend/vole_zk/verifier.rs
@@ -53,6 +53,9 @@ where
     /// VoleAdjustments loaded from the prover's [`Preparation`].
     adjustments: VecDeque<VoleAdjustment<E>>,
 
+    /// Fiat-Shamir transcript: absorbs every VoleAdjustment received.
+    internal_transcript: blake3::Hasher,
+
     _phantom: PhantomData<W>,
 }
 
@@ -69,20 +72,18 @@ where
     ///
     /// * `fan_in_degree` - Fan-in of the product tree (must be ≥ 1).
     /// * `delta` - Verifier's global key.
-    /// * `rvole` - Random VOLE sender for committing intermediate
-    ///   product wires.
-    /// * `rvope` - Random VOPE sender for the mask consumed at QS
-    ///   finalize time.
+    /// * `rvole` - Random VOLE sender for committing intermediate product
+    ///   wires.
+    /// * `rvope` - Random VOPE sender for the mask consumed at QS finalize
+    ///   time.
     pub fn new(
         fan_in_degree: usize,
         delta: E,
         rvole: VL,
         mut rvope: VP,
     ) -> Result<Self, VoleZkVerifierError> {
-        if fan_in_degree < 2 {
-            return Err(VoleZkVerifierError::InvalidFanIn(fan_in_degree));
-        }
-        let (constraints, product_constraint) = build_product_constraints::<E>(fan_in_degree);
+        let (_, constraints, product_constraint) = build_product_constraints::<E>(fan_in_degree)
+            .map_err(|_| VoleZkVerifierError::InvalidFanIn(fan_in_degree))?;
         let qs = mpz_poly_proof_core::verifier::Verifier::new(delta, &constraints);
 
         rvope
@@ -99,6 +100,7 @@ where
             total_count: 0,
             rvoles_alloced: 0,
             adjustments: VecDeque::new(),
+            internal_transcript: blake3::Hasher::new(),
             _phantom: PhantomData,
         })
     }
@@ -151,10 +153,19 @@ where
         self.adjustments = preparation.adjustments.into();
     }
 
-    fn verify(mut self, proof: Self::BackendProof) -> Result<(), Self::Error> {
+    fn verify(
+        mut self,
+        proof: Self::BackendProof,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<(), Self::Error> {
         let Proof { qs_proof } = proof;
 
-        // Step 1: consume the single pre-alloc'd RVOPE correlation.
+        // Absorb internal transcript.
+        let internal_hash = std::mem::take(&mut self.internal_transcript).finalize();
+        transcript.update(internal_hash.as_bytes());
+        let qs_seed = crate::draw_seed(transcript, b"permutation-proof::qs-end-seed");
+
+        // Consume the single pre-alloc'd RVOPE correlation.
         let rvope_out = self
             .rvope
             .try_send_vope(1)
@@ -166,9 +177,9 @@ where
             .expect("RVOPE try_send_vope(1) should return exactly one evaluation");
         let vope = mpz_poly_proof_core::VerifierVope { sum };
 
-        // Step 2: run QS finalize.
+        // Run QS finalize.
         self.qs
-            .finalize(&qs_proof, &vope)
+            .finalize(&qs_proof, &vope, qs_seed)
             .map_err(|e| VoleZkVerifierError::QsVerify(Box::new(e)))
     }
 
@@ -187,11 +198,7 @@ where
         Ok(())
     }
 
-    fn product(
-        &mut self,
-        transcript: &mut blake3::Hasher,
-        factor_keys: &[E],
-    ) -> Result<E, Self::Error> {
+    fn product(&mut self, factor_keys: &[E]) -> Result<E, Self::Error> {
         let n = factor_keys.len();
         if n == 0 {
             return Err(VoleZkVerifierError::EmptyInput);
@@ -205,6 +212,9 @@ where
         // every iter — so no upfront copy of the leaves.
         let mut current_keys: Cow<'_, [E]> = Cow::Borrowed(factor_keys);
         let eps = self.fan_in_degree;
+
+        // Collected this-call adjustments.
+        let mut call_adjustments: Vec<VoleAdjustment<E>> = Vec::new();
 
         while current_keys.len() > 1 {
             let level_size = current_keys.len();
@@ -229,10 +239,6 @@ where
                     actual: adjustment.diffs.len(),
                 });
             }
-
-            // Absorb into the transcript.
-            transcript.update(b"permutation-proof::vole-adjustment");
-            transcript.update(&bcs::to_bytes(&adjustment).expect("serialize"));
 
             // Consume and derandomize random VOLEs.
             let rvole_out = self
@@ -271,21 +277,27 @@ where
                 chunk_keys_store.push(keys);
             }
 
-            // Draw a fresh PRG seed for this tree-walk level.
-            let seed = crate::draw_seed(transcript, b"permutation-proof::qs-seed");
+            // Stream this level's evaluations into the QS verifier's
+            // pending-b buffer.
             let evaluations: Vec<(ConstraintId, &[E])> = chunk_keys_store
                 .iter()
                 .map(|k| (self.product_constraint, k.as_slice()))
                 .collect();
             self.qs
-                .accumulate(&evaluations, seed)
+                .accumulate(&evaluations)
                 .map_err(|e| VoleZkVerifierError::QsAccumulate(Box::new(e)))?;
 
             // Assemble the next level.
             prod_keys.extend(passthroughs.iter().map(|&idx| current_keys[idx]));
 
             current_keys = Cow::Owned(prod_keys);
+
+            call_adjustments.push(adjustment);
         }
+
+        // Bulk-absorb every adjustment into transcript.
+        self.internal_transcript
+            .update(&bcs::to_bytes(&call_adjustments).expect("serialize"));
 
         Ok(current_keys[0])
     }
@@ -337,8 +349,9 @@ pub enum VoleZkVerifierError {
         actual: usize,
     },
 
-    /// `fan_in_degree` was less than the minimum supported value (2).
-    #[error("fan_in_degree must be at least 2; got {0}")]
+    /// `fan_in_degree` was outside the kernel-supported range
+    /// (see [`super::SUPPORTED_FAN_IN`]).
+    #[error("unsupported fan_in_degree: {0}")]
     InvalidFanIn(usize),
 
     /// `product` was called with an empty factor-keys slice.
@@ -399,9 +412,8 @@ mod tests {
     #[test]
     fn product_rejects_empty_input() {
         let mut verifier = build_verifier_only(0xE6, 8);
-        let mut transcript = blake3::Hasher::new();
         let err = verifier
-            .product(&mut transcript, &[])
+            .product(&[])
             .expect_err("empty input must surface an error");
         assert!(
             matches!(err, VoleZkVerifierError::EmptyInput),
@@ -422,9 +434,8 @@ mod tests {
             adjustments: vec![],
         });
 
-        let mut transcript = blake3::Hasher::new();
         let ret_k = verifier
-            .product(&mut transcript, &[k])
+            .product(&[k])
             .expect("singleton passthrough must succeed");
         assert_eq!(ret_k, k);
     }
@@ -432,8 +443,8 @@ mod tests {
     /// Test `VoleAdjustment` underflow.
     #[test]
     fn product_underflow_on_short_preparation() {
-        let mut verifier = build_verifier_only(0xE8, 4);
-        // `n = 4, eps = 4`: tree walks exactly one level (one chunk).
+        let mut verifier = build_verifier_only(0xE8, 6);
+        // `n = 6, eps = 6`: tree walks exactly one level (one chunk).
         // Loading an empty Preparation means the first `pop_front` at
         // level 0 returns `None` → AdjustmentUnderflow.
         verifier.load_preparation(Preparation {
@@ -441,11 +452,10 @@ mod tests {
         });
 
         let mut rng = ChaCha8Rng::seed_from_u64(0xE8_1234);
-        let keys: Vec<Gf2_128> = (0..4).map(|_| rng.random()).collect();
+        let keys: Vec<Gf2_128> = (0..6).map(|_| rng.random()).collect();
 
-        let mut transcript = blake3::Hasher::new();
         let err = verifier
-            .product(&mut transcript, &keys)
+            .product(&keys)
             .expect_err("short Preparation must surface an error");
         assert!(
             matches!(err, VoleZkVerifierError::AdjustmentUnderflow),
@@ -456,8 +466,8 @@ mod tests {
     /// Per-level shape check.
     #[test]
     fn product_shape_mismatch_on_wrong_diffs_length() {
-        let mut verifier = build_verifier_only(0xE9, 4);
-        // `n = 4, eps = 4`: level 0 has exactly one chunk, so the
+        let mut verifier = build_verifier_only(0xE9, 6);
+        // `n = 6, eps = 6`: level 0 has exactly one chunk, so the
         // matching adjustment must carry `diffs.len() == 1`. Load one
         // with 2 diffs to trip the shape check.
         verifier.load_preparation(Preparation {
@@ -467,11 +477,10 @@ mod tests {
         });
 
         let mut rng = ChaCha8Rng::seed_from_u64(0xE9_1234);
-        let keys: Vec<Gf2_128> = (0..4).map(|_| rng.random()).collect();
+        let keys: Vec<Gf2_128> = (0..6).map(|_| rng.random()).collect();
 
-        let mut transcript = blake3::Hasher::new();
         let err = verifier
-            .product(&mut transcript, &keys)
+            .product(&keys)
             .expect_err("wrong-shape adjustment must surface an error");
         match err {
             VoleZkVerifierError::AdjustmentShapeMismatch { expected, actual } => {

--- a/crates/perm-proof-core/src/lib.rs
+++ b/crates/perm-proof-core/src/lib.rs
@@ -24,24 +24,13 @@ pub use backend::{
     ProverBackend, VerifierBackend,
     vole_zk::{VoleZkProverBackend, VoleZkProverError, VoleZkVerifierBackend, VoleZkVerifierError},
 };
+pub use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, RVOLEReceiverOutput, RVOLESender,
+    RVOLESenderOutput, RVOPEReceiver, RVOPEReceiverOutput, RVOPESender, RVOPESenderOutput,
+    VOLEReceiver, VOLEReceiverOutput, VoleAdjustment,
+};
 pub use prover::{ProveError, Prover};
 pub use verifier::{Verifier, VerifyError};
-
-/// One position's worth of cleartext values: an `L`-element tuple.
-///
-/// The permutation proof operates on vectors of `L`-tuples of field
-/// elements. `L = 1` is a degenerate scalar case — callers with a
-/// plain vector of single values wrap each in a one-element array
-/// (`[value]`) and proceed.
-pub type ValueTuple<W, const L: usize> = [W; L];
-
-/// One position's worth of prover-side MACs — an `L`-element tuple
-/// matching the shape of [`ValueTuple`].
-pub type MacTuple<E, const L: usize> = [E; L];
-
-/// One position's worth of verifier-side keys — an `L`-element tuple
-/// matching the shape of [`ValueTuple`].
-pub type KeyTuple<E, const L: usize> = [E; L];
 
 /// Bundle of proof data the prover ships to the verifier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -53,12 +42,6 @@ pub struct Proof<E: Field, BackendProof> {
     pub backend_proof: BackendProof,
 }
 
-pub use mpz_vole_core::{
-    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, RVOLEReceiverOutput, RVOLESender,
-    RVOLESenderOutput, RVOPEReceiver, RVOPEReceiverOutput, RVOPESender, RVOPESenderOutput,
-    VOLEReceiver, VOLEReceiverOutput, VoleAdjustment,
-};
-
 /// Draw a uniform extension-field element from the transcript under a
 /// domain-separation label.
 pub(crate) fn draw_field<E: Field>(transcript: &mut Hasher, label: &[u8]) -> E {
@@ -68,10 +51,13 @@ pub(crate) fn draw_field<E: Field>(transcript: &mut Hasher, label: &[u8]) -> E {
     E::try_from(buf).expect("uniform bytes are a field element")
 }
 
-/// Inner product of two E-valued `L`-tuples:
-/// `Σ_j coeffs[j] · terms[j]`.
-pub(crate) fn inner_product<E: Field, const L: usize>(coeffs: &[E; L], terms: &[E; L]) -> E {
-    (0..L).fold(E::zero(), |acc, j| acc + coeffs[j] * terms[j])
+/// Draw a 32-byte PRG seed from the transcript under a
+/// domain-separation label.
+pub(crate) fn draw_seed(transcript: &mut Hasher, label: &[u8]) -> [u8; 32] {
+    transcript.update(label);
+    let mut buf = [0u8; 32];
+    transcript.finalize_xof().fill(&mut buf);
+    buf
 }
 
 #[cfg(test)]
@@ -128,62 +114,6 @@ mod tests {
         assert_ne!(
             x, y,
             "consecutive draws under same label must still diverge"
-        );
-    }
-
-    /// `inner_product` must compute `Σ_j coeffs[j] · terms[j]` for
-    /// hand-traceable cases.
-    #[test]
-    fn inner_product_matches_hand_traced_cases() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha8Rng;
-
-        let mut rng = ChaCha8Rng::seed_from_u64(0x1234);
-        let one = Gf2_128::one();
-        let zero = Gf2_128::zero();
-
-        // L = 1: `<[c], [t]> = c · t`.
-        let t: Gf2_128 = rng.random();
-        assert_eq!(inner_product::<Gf2_128, 1>(&[one], &[t]), t);
-        assert_eq!(inner_product::<Gf2_128, 1>(&[zero], &[t]), zero);
-
-        // L = 3 with coefficients [1, 0, 1]: zeros in `coeffs` project
-        // out the corresponding terms, leaving `a + c`.
-        let a: Gf2_128 = rng.random();
-        let b: Gf2_128 = rng.random();
-        let c: Gf2_128 = rng.random();
-        assert_eq!(inner_product(&[one, zero, one], &[a, b, c]), a + c);
-
-        // L = 3 general case: compare against the explicit sum.
-        let s: [Gf2_128; 3] = std::array::from_fn(|_| rng.random());
-        let ts: [Gf2_128; 3] = std::array::from_fn(|_| rng.random());
-        let expected = s[0] * ts[0] + s[1] * ts[1] + s[2] * ts[2];
-        assert_eq!(inner_product(&s, &ts), expected);
-    }
-
-    /// IT-MAC preservation under `inner_product` with public coefficients.
-    #[test]
-    fn inner_product_preserves_it_mac_invariant() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha8Rng;
-
-        let mut rng = ChaCha8Rng::seed_from_u64(0xCAFE);
-        let delta: Gf2_128 = rng.random();
-
-        const L: usize = 3;
-        let s: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
-        let values: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
-        let keys: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
-        let macs: [Gf2_128; L] = std::array::from_fn(|j| keys[j] + delta * values[j]);
-
-        let value_z = inner_product(&s, &values);
-        let key_z = inner_product(&s, &keys);
-        let mac_z = inner_product(&s, &macs);
-
-        assert_eq!(
-            mac_z,
-            key_z + delta * value_z,
-            "inner_product must preserve mac = key + Δ·value under public s"
         );
     }
 }

--- a/crates/perm-proof-core/src/lib.rs
+++ b/crates/perm-proof-core/src/lib.rs
@@ -1,0 +1,189 @@
+//! Permutation proof protocol.
+//!
+//! Given two vectors `x, y ∈ Eⁿ` of authenticated wires, this crate
+//! proves `x ~ y` (i.e. that one is a permutation of the other) using
+//! the standard polynomial identity test over a random challenge drawn
+//! from the verifier.
+
+#![deny(missing_docs)]
+
+use blake3::Hasher;
+use hybrid_array::Array;
+use mpz_fields::Field;
+use serde::{Deserialize, Serialize};
+
+pub mod backend;
+pub mod prover;
+pub mod verifier;
+
+/// Test-support utilities.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
+pub use backend::{
+    ProverBackend, VerifierBackend,
+    vole_zk::{VoleZkProverBackend, VoleZkProverError, VoleZkVerifierBackend, VoleZkVerifierError},
+};
+pub use prover::{ProveError, Prover};
+pub use verifier::{Verifier, VerifyError};
+
+/// One position's worth of cleartext values: an `L`-element tuple.
+///
+/// The permutation proof operates on vectors of `L`-tuples of field
+/// elements. `L = 1` is a degenerate scalar case — callers with a
+/// plain vector of single values wrap each in a one-element array
+/// (`[value]`) and proceed.
+pub type ValueTuple<W, const L: usize> = [W; L];
+
+/// One position's worth of prover-side MACs — an `L`-element tuple
+/// matching the shape of [`ValueTuple`].
+pub type MacTuple<E, const L: usize> = [E; L];
+
+/// One position's worth of verifier-side keys — an `L`-element tuple
+/// matching the shape of [`ValueTuple`].
+pub type KeyTuple<E, const L: usize> = [E; L];
+
+/// Bundle of proof data the prover ships to the verifier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proof<E: Field, BackendProof> {
+    /// MAC opening for the (single) zero-check the protocol runs over
+    /// the difference of the two authenticated product wires.
+    pub zero_proof: E,
+    /// Backend-specific supplementary proof.
+    pub backend_proof: BackendProof,
+}
+
+pub use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, RVOLEReceiverOutput, RVOLESender,
+    RVOLESenderOutput, RVOPEReceiver, RVOPEReceiverOutput, RVOPESender, RVOPESenderOutput,
+    VOLEReceiver, VOLEReceiverOutput, VoleAdjustment,
+};
+
+/// Draw a uniform extension-field element from the transcript under a
+/// domain-separation label.
+pub(crate) fn draw_field<E: Field>(transcript: &mut Hasher, label: &[u8]) -> E {
+    transcript.update(label);
+    let mut buf: Array<u8, E::ByteSize> = Array::default();
+    transcript.finalize_xof().fill(buf.as_mut_slice());
+    E::try_from(buf).expect("uniform bytes are a field element")
+}
+
+/// Inner product of two E-valued `L`-tuples:
+/// `Σ_j coeffs[j] · terms[j]`.
+pub(crate) fn inner_product<E: Field, const L: usize>(coeffs: &[E; L], terms: &[E; L]) -> E {
+    (0..L).fold(E::zero(), |acc, j| acc + coeffs[j] * terms[j])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+
+    /// Determinism: two hashers in identical state, drawn with the
+    /// same label, must produce the same field element.
+    #[test]
+    fn draw_field_is_deterministic_on_identical_transcripts() {
+        let mut a = Hasher::new();
+        let mut b = Hasher::new();
+        a.update(b"shared-prefix");
+        b.update(b"shared-prefix");
+
+        let x: Gf2_128 = draw_field(&mut a, b"label");
+        let y: Gf2_128 = draw_field(&mut b, b"label");
+        assert_eq!(
+            x, y,
+            "same transcript state + same label must yield same draw"
+        );
+    }
+
+    /// Domain separation: two draws from identical starting state but
+    /// under different labels must produce different field elements
+    /// with overwhelming probability.
+    #[test]
+    fn draw_field_separates_domains_by_label() {
+        let mut a = Hasher::new();
+        let mut b = Hasher::new();
+        a.update(b"shared-prefix");
+        b.update(b"shared-prefix");
+
+        let x: Gf2_128 = draw_field(&mut a, b"label-one");
+        let y: Gf2_128 = draw_field(&mut b, b"label-two");
+        assert_ne!(
+            x, y,
+            "different labels on same state must yield different draws"
+        );
+    }
+
+    /// Sequential uniqueness: two consecutive draws with the *same*
+    /// label on the same transcript must produce different field
+    /// elements.
+    #[test]
+    fn draw_field_is_sequentially_unique_under_same_label() {
+        let mut transcript = Hasher::new();
+        transcript.update(b"shared-prefix");
+
+        let x: Gf2_128 = draw_field(&mut transcript, b"label");
+        let y: Gf2_128 = draw_field(&mut transcript, b"label");
+        assert_ne!(
+            x, y,
+            "consecutive draws under same label must still diverge"
+        );
+    }
+
+    /// `inner_product` must compute `Σ_j coeffs[j] · terms[j]` for
+    /// hand-traceable cases.
+    #[test]
+    fn inner_product_matches_hand_traced_cases() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0x1234);
+        let one = Gf2_128::one();
+        let zero = Gf2_128::zero();
+
+        // L = 1: `<[c], [t]> = c · t`.
+        let t: Gf2_128 = rng.random();
+        assert_eq!(inner_product::<Gf2_128, 1>(&[one], &[t]), t);
+        assert_eq!(inner_product::<Gf2_128, 1>(&[zero], &[t]), zero);
+
+        // L = 3 with coefficients [1, 0, 1]: zeros in `coeffs` project
+        // out the corresponding terms, leaving `a + c`.
+        let a: Gf2_128 = rng.random();
+        let b: Gf2_128 = rng.random();
+        let c: Gf2_128 = rng.random();
+        assert_eq!(inner_product(&[one, zero, one], &[a, b, c]), a + c);
+
+        // L = 3 general case: compare against the explicit sum.
+        let s: [Gf2_128; 3] = std::array::from_fn(|_| rng.random());
+        let ts: [Gf2_128; 3] = std::array::from_fn(|_| rng.random());
+        let expected = s[0] * ts[0] + s[1] * ts[1] + s[2] * ts[2];
+        assert_eq!(inner_product(&s, &ts), expected);
+    }
+
+    /// IT-MAC preservation under `inner_product` with public coefficients.
+    #[test]
+    fn inner_product_preserves_it_mac_invariant() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0xCAFE);
+        let delta: Gf2_128 = rng.random();
+
+        const L: usize = 3;
+        let s: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
+        let values: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
+        let keys: [Gf2_128; L] = std::array::from_fn(|_| rng.random());
+        let macs: [Gf2_128; L] = std::array::from_fn(|j| keys[j] + delta * values[j]);
+
+        let value_z = inner_product(&s, &values);
+        let key_z = inner_product(&s, &keys);
+        let mac_z = inner_product(&s, &macs);
+
+        assert_eq!(
+            mac_z,
+            key_z + delta * value_z,
+            "inner_product must preserve mac = key + Δ·value under public s"
+        );
+    }
+}

--- a/crates/perm-proof-core/src/prover.rs
+++ b/crates/perm-proof-core/src/prover.rs
@@ -1,0 +1,405 @@
+//! Permutation protocol prover.
+
+use blake3::Hasher;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+use serde::Serialize;
+
+use crate::{MacTuple, Proof, ValueTuple, backend::ProverBackend, draw_field, inner_product};
+
+/// Permutation protocol prover.
+pub struct Prover<W, E, B, S = prover_state::Initialized>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: ProverBackend<W, E>,
+    S: prover_state::State,
+{
+    backend: B,
+    state: S,
+    _phantom: std::marker::PhantomData<(W, E)>,
+}
+
+impl<W, E, B> Prover<W, E, B, prover_state::Initialized>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: ProverBackend<W, E>,
+{
+    /// Build a new prover around `backend`.
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            state: prover_state::Initialized,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Announce that a permutation proof of size `n` will run through
+    /// this prover.
+    ///
+    /// Multiple calls accumulate.
+    pub fn alloc(&mut self, n: usize) -> Result<(), B::Error> {
+        self.backend.alloc(n)
+    }
+
+    /// Compute the preparation message for phase 1 of the protocol.
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - Shared session transcript.
+    /// * `x` - Pair `(values, macs)` for the first input vector.
+    /// * `y` - Pair `(values, macs)` for the second input vector.
+    ///
+    /// # Security
+    ///
+    /// It is crucial that `transcript` has absorbed the input vectors
+    /// `x` and `y` before this method is invoked. The protocol's
+    /// soundness depends on this binding.
+    pub fn prepare<const L: usize>(
+        mut self,
+        mut transcript: Hasher,
+        x: (&[ValueTuple<W, L>], &[MacTuple<E, L>]),
+        y: (&[ValueTuple<W, L>], &[MacTuple<E, L>]),
+    ) -> Result<(B::Preparation, Prover<W, E, B, prover_state::Prepared<E>>), ProveError<B::Error>>
+    {
+        let (x_values, x_macs) = x;
+        let (y_values, y_macs) = y;
+
+        let xv = x_values.len();
+        let xm = x_macs.len();
+        let yv = y_values.len();
+        let ym = y_macs.len();
+        if xv != xm || yv != ym || xv != yv {
+            return Err(ProveError::LengthMismatch { xv, xm, yv, ym });
+        }
+        let n = xv;
+        if n == 0 || L == 0 {
+            return Err(ProveError::EmptyInputs);
+        }
+
+        // Draw the random challenge `r`.
+        let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
+
+        // Draw the tuple-collapse challenge `s ∈ E^L`.
+        let s: [E; L] = std::array::from_fn(|_| {
+            draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s")
+        });
+
+        // Compute per-position collapsed factors.
+        //
+        //   z_val  = Σ_j s[j] · values[i][j].embed()    (in E)
+        //   z_mac  = Σ_j s[j] · macs[i][j]              (in E)
+        //   factor_value = r − z_val
+        //   factor_mac   = −z_mac    // r contributes no MAC; the `−` carries through.
+        let mut fx_values: Vec<E> = Vec::with_capacity(n);
+        let mut fx_macs: Vec<E> = Vec::with_capacity(n);
+        let mut fy_values: Vec<E> = Vec::with_capacity(n);
+        let mut fy_macs: Vec<E> = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let (zx_val, zx_mac) = collapse_tuple(&s, &x_values[i], &x_macs[i]);
+            let (zy_val, zy_mac) = collapse_tuple(&s, &y_values[i], &y_macs[i]);
+            fx_values.push(r - zx_val);
+            fx_macs.push(-zx_mac);
+            fy_values.push(r - zy_val);
+            fy_macs.push(-zy_mac);
+        }
+
+        // Commit the authenticated product of each vectors's factors.
+        let (_, px_m) = self
+            .backend
+            .product(&mut transcript, &fx_values, &fx_macs)
+            .map_err(ProveError::Backend)?;
+        let (_, py_m) = self
+            .backend
+            .product(&mut transcript, &fy_values, &fy_macs)
+            .map_err(ProveError::Backend)?;
+
+        // Drain the preparation message now so the caller can ship it
+        // to the verifier immediately.
+        let preparation = self
+            .backend
+            .drain_preparation()
+            .map_err(ProveError::Backend)?;
+
+        Ok((
+            preparation,
+            Prover {
+                backend: self.backend,
+                state: prover_state::Prepared {
+                    transcript,
+                    px_m,
+                    py_m,
+                },
+                _phantom: std::marker::PhantomData,
+            },
+        ))
+    }
+}
+
+impl<W, E, B> Prover<W, E, B, prover_state::Prepared<E>>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: ProverBackend<W, E>,
+{
+    /// Return the proof message for phase 2 of the protocol.
+    pub fn prove(self) -> Result<Proof<E, B::BackendProof>, ProveError<B::Error>>
+    where
+        E: Serialize,
+        B::BackendProof: Serialize,
+    {
+        let Prover { backend, state, .. } = self;
+        let prover_state::Prepared {
+            mut transcript,
+            px_m,
+            py_m,
+        } = state;
+
+        // Materialize the zero-check: the difference MAC is what the
+        // verifier checks against its own diff_k. Under an honest
+        // permutation, the underlying value diff is zero.
+        let zero_proof = px_m - py_m;
+
+        // Absorb the proof into the transcript so any subsequent proof
+        // sharing this transcript stays bound to this one.
+        let backend_proof = backend.prove().map_err(ProveError::Backend)?;
+        let proof = Proof {
+            zero_proof,
+            backend_proof,
+        };
+        transcript.update(b"permutation-proof::proof");
+        transcript.update(&bcs::to_bytes(&proof).expect("serialize"));
+
+        Ok(proof)
+    }
+}
+
+/// Type-state markers for [`Prover`]'s phase.
+pub mod prover_state {
+    use mpz_fields::Field;
+
+    mod sealed {
+        pub trait Sealed {}
+    }
+
+    /// Marker trait implemented by every legal [`Prover`](super::Prover)
+    /// phase. Sealed: external crates cannot add new phases.
+    pub trait State: sealed::Sealed {}
+
+    /// Phase right after [`Prover::new`](super::Prover::new): `alloc`
+    /// and `prepare` are callable; `prove` is not.
+    pub struct Initialized;
+
+    /// Phase right after a successful
+    /// [`prepare`](super::Prover::<_, _, _, Initialized>::prepare):
+    /// `prove` is callable.
+    pub struct Prepared<E: Field> {
+        pub(super) transcript: blake3::Hasher,
+        pub(super) px_m: E,
+        pub(super) py_m: E,
+    }
+
+    impl sealed::Sealed for Initialized {}
+    impl State for Initialized {}
+    impl<E: Field> sealed::Sealed for Prepared<E> {}
+    impl<E: Field> State for Prepared<E> {}
+}
+
+/// Collapse one `L`-tuple of authenticated wires into a single
+/// `(value, MAC)` pair via the inner product with `s`:
+///
+/// ```text
+/// z_val = Σ_j s[j] · values[j].embed()
+/// z_mac = Σ_j s[j] · macs[j]
+/// ```
+pub(crate) fn collapse_tuple<W, E, const L: usize>(
+    s: &[E; L],
+    values: &[W; L],
+    macs: &[E; L],
+) -> (E, E)
+where
+    W: SubfieldOf<E>,
+    E: Field,
+{
+    let embedded: [E; L] = std::array::from_fn(|j| values[j].embed());
+    (inner_product(s, &embedded), inner_product(s, macs))
+}
+
+/// Error produced by protocol prover.
+#[derive(Debug, thiserror::Error)]
+pub enum ProveError<E: std::error::Error + Send + Sync + 'static> {
+    /// The four input slices did not all have the same length.
+    #[error("length mismatch: x_values={xv}, x_macs={xm}, y_values={yv}, y_macs={ym}")]
+    LengthMismatch {
+        /// Length of `x.0` (values).
+        xv: usize,
+        /// Length of `x.1` (macs).
+        xm: usize,
+        /// Length of `y.0` (values).
+        yv: usize,
+        /// Length of `y.1` (macs).
+        ym: usize,
+    },
+
+    /// Input vectors had length zero.
+    #[error("empty inputs: permutation proof requires at least one wire per side")]
+    EmptyInputs,
+
+    /// The backend reported an error.
+    #[error("backend error: {0}")]
+    Backend(#[source] E),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::backend::mock::MockProverBackend;
+
+    /// Build a mock-backed prover.
+    fn build_mock_prover() -> Prover<Gf2_128, Gf2_128, MockProverBackend<Gf2_128, Gf2_128>> {
+        let delta = Gf2_128::one();
+        Prover::new(MockProverBackend::<Gf2_128, Gf2_128>::new(delta))
+    }
+
+    /// Mismatched `x_values.len()` vs `x_macs.len()` must surface as
+    /// `LengthMismatch`.
+    #[test]
+    fn prepare_rejects_x_values_x_macs_length_mismatch() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 2]; // short by 1
+        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+
+        let err = prover
+            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .err()
+            .expect("x-side length mismatch must surface an error");
+        match err {
+            ProveError::LengthMismatch { xv, xm, yv, ym } => {
+                assert_eq!((xv, xm, yv, ym), (3, 2, 3, 3));
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    /// Mismatched `y_values.len()` vs `y_macs.len()` trips the second
+    /// disjunct of the length check.
+    #[test]
+    fn prepare_rejects_y_values_y_macs_length_mismatch() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
+        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
+        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
+        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3]; // short by 1
+
+        let err = prover
+            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .err()
+            .expect("y-side length mismatch must surface an error");
+        match err {
+            ProveError::LengthMismatch { xv, xm, yv, ym } => {
+                assert_eq!((xv, xm, yv, ym), (4, 4, 4, 3));
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    /// With each side internally consistent but `x.len() != y.len()`,
+    /// the third disjunct of the length check trips.
+    #[test]
+    fn prepare_rejects_x_vs_y_length_mismatch() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
+        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
+
+        let err = prover
+            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .err()
+            .expect("x-vs-y length mismatch must surface an error");
+        match err {
+            ProveError::LengthMismatch { xv, xm, yv, ym } => {
+                assert_eq!((xv, xm, yv, ym), (3, 3, 5, 5));
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    /// A permutation proof over zero positions is vacuous.
+    #[test]
+    fn prepare_rejects_empty_vectors() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        let empty: Vec<[Gf2_128; 1]> = Vec::new();
+
+        let err = prover
+            .prepare::<1>(transcript, (&empty, &empty), (&empty, &empty))
+            .err()
+            .expect("empty inputs must surface an error");
+        assert!(
+            matches!(err, ProveError::EmptyInputs),
+            "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// Zero-width tuples (`L = 0`) rejected.
+    #[test]
+    fn prepare_rejects_zero_width_tuples() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        // n = 1, L = 0: one position, zero-width tuple.
+        let x_values: Vec<[Gf2_128; 0]> = vec![[]];
+        let x_macs: Vec<[Gf2_128; 0]> = vec![[]];
+        let y_values: Vec<[Gf2_128; 0]> = vec![[]];
+        let y_macs: Vec<[Gf2_128; 0]> = vec![[]];
+
+        let err = prover
+            .prepare::<0>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .err()
+            .expect("zero-width tuples must surface an error");
+        assert!(
+            matches!(err, ProveError::EmptyInputs),
+            "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// `prove` materializes the zero-check opening as
+    /// `zero_proof = px_m − py_m`.
+    #[test]
+    fn prove_materializes_zero_proof_as_px_minus_py() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0xF00F);
+        let delta: Gf2_128 = rng.random();
+        let px_m: Gf2_128 = rng.random();
+        let py_m: Gf2_128 = rng.random();
+
+        // Construct the Prepared state directly — bypasses `prepare`
+        // so this test pins `prove` in isolation from the rest of the
+        // lifecycle. `pub(super)` fields on `Prepared` make this
+        // accessible from inside `prover.rs`'s test submodule.
+        let prover = Prover {
+            backend: MockProverBackend::<Gf2_128, Gf2_128>::new(delta),
+            state: prover_state::Prepared {
+                transcript: Hasher::new(),
+                px_m,
+                py_m,
+            },
+            _phantom: std::marker::PhantomData,
+        };
+
+        let proof = prover.prove().expect("mock prove must succeed");
+        assert_eq!(proof.zero_proof, px_m - py_m);
+        assert_eq!(proof.backend_proof, ());
+    }
+}

--- a/crates/perm-proof-core/src/prover.rs
+++ b/crates/perm-proof-core/src/prover.rs
@@ -1,17 +1,16 @@
 //! Permutation protocol prover.
 
 use blake3::Hasher;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 use serde::Serialize;
 
-use crate::{MacTuple, Proof, ValueTuple, backend::ProverBackend, draw_field, inner_product};
+use crate::{Proof, backend::ProverBackend, draw_field};
 
 /// Permutation protocol prover.
 pub struct Prover<W, E, B, S = prover_state::Initialized>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: ProverBackend<W, E>,
     S: prover_state::State,
 {
@@ -22,8 +21,8 @@ where
 
 impl<W, E, B> Prover<W, E, B, prover_state::Initialized>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: ProverBackend<W, E>,
 {
     /// Build a new prover around `backend`.
@@ -56,11 +55,11 @@ where
     /// It is crucial that `transcript` has absorbed the input vectors
     /// `x` and `y` before this method is invoked. The protocol's
     /// soundness depends on this binding.
-    pub fn prepare<const L: usize>(
+    pub fn prepare(
         mut self,
         mut transcript: Hasher,
-        x: (&[ValueTuple<W, L>], &[MacTuple<E, L>]),
-        y: (&[ValueTuple<W, L>], &[MacTuple<E, L>]),
+        x: (&[Vec<W>], &[Vec<E>]),
+        y: (&[Vec<W>], &[Vec<E>]),
     ) -> Result<(B::Preparation, Prover<W, E, B, prover_state::Prepared<E>>), ProveError<B::Error>>
     {
         let (x_values, x_macs) = x;
@@ -74,17 +73,33 @@ where
             return Err(ProveError::LengthMismatch { xv, xm, yv, ym });
         }
         let n = xv;
-        if n == 0 || L == 0 {
+        if n == 0 {
             return Err(ProveError::EmptyInputs);
+        }
+
+        // Tuple width: read from the first input tuple.
+        let tuple_width = x_values[0].len();
+        if tuple_width == 0 {
+            return Err(ProveError::EmptyInputs);
+        }
+
+        // Uniformity: every tuple (across both x and y, values and
+        // macs) must have the same width.
+        let all_uniform = x_values.iter().all(|v| v.len() == tuple_width)
+            && x_macs.iter().all(|m| m.len() == tuple_width)
+            && y_values.iter().all(|v| v.len() == tuple_width)
+            && y_macs.iter().all(|m| m.len() == tuple_width);
+        if !all_uniform {
+            return Err(ProveError::TupleWidthMismatch);
         }
 
         // Draw the random challenge `r`.
         let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
 
-        // Draw the tuple-collapse challenge `s ∈ E^L`.
-        let s: [E; L] = std::array::from_fn(|_| {
-            draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s")
-        });
+        // Draw the tuple-collapse challenge `s ∈ E^tuple_width`.
+        let s: Vec<E> = (0..tuple_width)
+            .map(|_| draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s"))
+            .collect();
 
         // Compute per-position collapsed factors.
         //
@@ -140,8 +155,8 @@ where
 
 impl<W, E, B> Prover<W, E, B, prover_state::Prepared<E>>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: ProverBackend<W, E>,
 {
     /// Return the proof message for phase 2 of the protocol.
@@ -207,24 +222,18 @@ pub mod prover_state {
     impl<E: Field> State for Prepared<E> {}
 }
 
-/// Collapse one `L`-tuple of authenticated wires into a single
-/// `(value, MAC)` pair via the inner product with `s`:
+/// Collapse one tuple of authenticated wires into a single
+/// `(value, MAC)` pair via the inner product with `s`.
 ///
-/// ```text
-/// z_val = Σ_j s[j] · values[j].embed()
-/// z_mac = Σ_j s[j] · macs[j]
-/// ```
-pub(crate) fn collapse_tuple<W, E, const L: usize>(
-    s: &[E; L],
-    values: &[W; L],
-    macs: &[E; L],
-) -> (E, E)
+/// `s.len()`, `values.len()`, and `macs.len()` are expected to be
+/// equal; the inner product extends only as far as the shortest slice.
+pub(crate) fn collapse_tuple<W, E>(s: &[E], values: &[W], macs: &[E]) -> (E, E)
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
 {
-    let embedded: [E; L] = std::array::from_fn(|j| values[j].embed());
-    (inner_product(s, &embedded), inner_product(s, macs))
+    let embedded: Vec<E> = values.iter().map(|v| E::embed(*v)).collect();
+    (E::inner_product(s, &embedded), E::inner_product(s, macs))
 }
 
 /// Error produced by protocol prover.
@@ -243,9 +252,13 @@ pub enum ProveError<E: std::error::Error + Send + Sync + 'static> {
         ym: usize,
     },
 
-    /// Input vectors had length zero.
+    /// Input vectors had length zero, or the tuple width was zero.
     #[error("empty inputs: permutation proof requires at least one wire per side")]
     EmptyInputs,
+
+    /// Not all input tuples had the same width.
+    #[error("tuple width mismatch across input vectors")]
+    TupleWidthMismatch,
 
     /// The backend reported an error.
     #[error("backend error: {0}")]
@@ -268,19 +281,24 @@ mod tests {
         Prover::new(MockProverBackend::<Gf2_128, Gf2_128>::new(delta))
     }
 
+    /// Construct a uniform-width tuple Vec for tests.
+    fn ones(n: usize, width: usize) -> Vec<Vec<Gf2_128>> {
+        (0..n).map(|_| vec![Gf2_128::one(); width]).collect()
+    }
+
     /// Mismatched `x_values.len()` vs `x_macs.len()` must surface as
     /// `LengthMismatch`.
     #[test]
     fn prepare_rejects_x_values_x_macs_length_mismatch() {
         let prover = build_mock_prover();
         let transcript = Hasher::new();
-        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
-        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 2]; // short by 1
-        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
-        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let x_values = ones(3, 1);
+        let x_macs = ones(2, 1); // short by 1
+        let y_values = ones(3, 1);
+        let y_macs = ones(3, 1);
 
         let err = prover
-            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("x-side length mismatch must surface an error");
         match err {
@@ -297,13 +315,13 @@ mod tests {
     fn prepare_rejects_y_values_y_macs_length_mismatch() {
         let prover = build_mock_prover();
         let transcript = Hasher::new();
-        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
-        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
-        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 4];
-        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3]; // short by 1
+        let x_values = ones(4, 1);
+        let x_macs = ones(4, 1);
+        let y_values = ones(4, 1);
+        let y_macs = ones(3, 1); // short by 1
 
         let err = prover
-            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("y-side length mismatch must surface an error");
         match err {
@@ -320,13 +338,13 @@ mod tests {
     fn prepare_rejects_x_vs_y_length_mismatch() {
         let prover = build_mock_prover();
         let transcript = Hasher::new();
-        let x_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
-        let x_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
-        let y_values: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
-        let y_macs: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
+        let x_values = ones(3, 1);
+        let x_macs = ones(3, 1);
+        let y_values = ones(5, 1);
+        let y_macs = ones(5, 1);
 
         let err = prover
-            .prepare::<1>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("x-vs-y length mismatch must surface an error");
         match err {
@@ -342,10 +360,10 @@ mod tests {
     fn prepare_rejects_empty_vectors() {
         let prover = build_mock_prover();
         let transcript = Hasher::new();
-        let empty: Vec<[Gf2_128; 1]> = Vec::new();
+        let empty: Vec<Vec<Gf2_128>> = Vec::new();
 
         let err = prover
-            .prepare::<1>(transcript, (&empty, &empty), (&empty, &empty))
+            .prepare(transcript, (&empty, &empty), (&empty, &empty))
             .err()
             .expect("empty inputs must surface an error");
         assert!(
@@ -354,24 +372,45 @@ mod tests {
         );
     }
 
-    /// Zero-width tuples (`L = 0`) rejected.
+    /// Zero-width tuples rejected.
     #[test]
     fn prepare_rejects_zero_width_tuples() {
         let prover = build_mock_prover();
         let transcript = Hasher::new();
-        // n = 1, L = 0: one position, zero-width tuple.
-        let x_values: Vec<[Gf2_128; 0]> = vec![[]];
-        let x_macs: Vec<[Gf2_128; 0]> = vec![[]];
-        let y_values: Vec<[Gf2_128; 0]> = vec![[]];
-        let y_macs: Vec<[Gf2_128; 0]> = vec![[]];
+        // n = 1, tuple_width = 0.
+        let x_values = ones(1, 0);
+        let x_macs = ones(1, 0);
+        let y_values = ones(1, 0);
+        let y_macs = ones(1, 0);
 
         let err = prover
-            .prepare::<0>(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("zero-width tuples must surface an error");
         assert!(
             matches!(err, ProveError::EmptyInputs),
             "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// Non-uniform tuple widths rejected.
+    #[test]
+    fn prepare_rejects_tuple_width_mismatch() {
+        let prover = build_mock_prover();
+        let transcript = Hasher::new();
+        // n = 2: first tuple width 2, second tuple width 3.
+        let x_values: Vec<Vec<Gf2_128>> = vec![vec![Gf2_128::one(); 2], vec![Gf2_128::one(); 3]];
+        let x_macs: Vec<Vec<Gf2_128>> = vec![vec![Gf2_128::one(); 2], vec![Gf2_128::one(); 3]];
+        let y_values = x_values.clone();
+        let y_macs = x_macs.clone();
+
+        let err = prover
+            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .err()
+            .expect("non-uniform tuple width must surface an error");
+        assert!(
+            matches!(err, ProveError::TupleWidthMismatch),
+            "expected TupleWidthMismatch, got {err:?}"
         );
     }
 

--- a/crates/perm-proof-core/src/prover.rs
+++ b/crates/perm-proof-core/src/prover.rs
@@ -7,19 +7,18 @@ use serde::Serialize;
 use crate::{Proof, backend::ProverBackend, draw_field};
 
 /// Permutation protocol prover.
-pub struct Prover<W, E, B, S = prover_state::Initialized>
+pub struct Prover<W, E, B>
 where
     W: Field,
     E: ExtensionField<W>,
     B: ProverBackend<W, E>,
-    S: prover_state::State,
 {
     backend: B,
-    state: S,
+    state: ProverState<E>,
     _phantom: std::marker::PhantomData<(W, E)>,
 }
 
-impl<W, E, B> Prover<W, E, B, prover_state::Initialized>
+impl<W, E, B> Prover<W, E, B>
 where
     W: Field,
     E: ExtensionField<W>,
@@ -29,7 +28,7 @@ where
     pub fn new(backend: B) -> Self {
         Self {
             backend,
-            state: prover_state::Initialized,
+            state: ProverState::Initialized,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -38,15 +37,18 @@ where
     /// this prover.
     ///
     /// Multiple calls accumulate.
-    pub fn alloc(&mut self, n: usize) -> Result<(), B::Error> {
-        self.backend.alloc(n)
+    pub fn alloc(&mut self, n: usize) -> Result<(), ProveError<B::Error>> {
+        match &self.state {
+            ProverState::Initialized => self.backend.alloc(n).map_err(ProveError::Backend),
+            _ => Err(ProveError::WrongPhase),
+        }
     }
 
     /// Compute the preparation message for phase 1 of the protocol.
     ///
     /// # Arguments
     ///
-    /// * `transcript` - Shared session transcript.
+    /// * `transcript` - Fiat-Shamir transcript.
     /// * `x` - Pair `(values, macs)` for the first input vector.
     /// * `y` - Pair `(values, macs)` for the second input vector.
     ///
@@ -56,12 +58,16 @@ where
     /// `x` and `y` before this method is invoked. The protocol's
     /// soundness depends on this binding.
     pub fn prepare(
-        mut self,
-        mut transcript: Hasher,
+        &mut self,
+        transcript: &mut Hasher,
         x: (&[Vec<W>], &[Vec<E>]),
         y: (&[Vec<W>], &[Vec<E>]),
-    ) -> Result<(B::Preparation, Prover<W, E, B, prover_state::Prepared<E>>), ProveError<B::Error>>
-    {
+    ) -> Result<B::Preparation, ProveError<B::Error>> {
+        match &self.state {
+            ProverState::Initialized => {}
+            _ => return Err(ProveError::WrongPhase),
+        }
+
         let (x_values, x_macs) = x;
         let (y_values, y_macs) = y;
 
@@ -94,11 +100,11 @@ where
         }
 
         // Draw the random challenge `r`.
-        let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
+        let r = draw_field::<E>(transcript, b"permutation-proof::challenge_r");
 
         // Draw the tuple-collapse challenge `s ∈ E^tuple_width`.
         let s: Vec<E> = (0..tuple_width)
-            .map(|_| draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s"))
+            .map(|_| draw_field::<E>(transcript, b"permutation-proof::challenge_s"))
             .collect();
 
         // Compute per-position collapsed factors.
@@ -121,14 +127,14 @@ where
             fy_macs.push(-zy_mac);
         }
 
-        // Commit the authenticated product of each vectors's factors.
+        // Commit the authenticated product of each vector's factors.
         let (_, px_m) = self
             .backend
-            .product(&mut transcript, &fx_values, &fx_macs)
+            .product(&fx_values, &fx_macs)
             .map_err(ProveError::Backend)?;
         let (_, py_m) = self
             .backend
-            .product(&mut transcript, &fy_values, &fy_macs)
+            .product(&fy_values, &fy_macs)
             .map_err(ProveError::Backend)?;
 
         // Drain the preparation message now so the caller can ship it
@@ -138,88 +144,54 @@ where
             .drain_preparation()
             .map_err(ProveError::Backend)?;
 
-        Ok((
-            preparation,
-            Prover {
-                backend: self.backend,
-                state: prover_state::Prepared {
-                    transcript,
-                    px_m,
-                    py_m,
-                },
-                _phantom: std::marker::PhantomData,
-            },
-        ))
-    }
-}
+        self.state = ProverState::Prepared { px_m, py_m };
 
-impl<W, E, B> Prover<W, E, B, prover_state::Prepared<E>>
-where
-    W: Field,
-    E: ExtensionField<W>,
-    B: ProverBackend<W, E>,
-{
+        Ok(preparation)
+    }
+
     /// Return the proof message for phase 2 of the protocol.
-    pub fn prove(self) -> Result<Proof<E, B::BackendProof>, ProveError<B::Error>>
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - Fiat-Shamir transcript. Must be the same instance as in
+    ///   [`prepare`](Self::prepare).
+    pub fn prove(
+        self,
+        transcript: &mut Hasher,
+    ) -> Result<Proof<E, B::BackendProof>, ProveError<B::Error>>
     where
         E: Serialize,
         B::BackendProof: Serialize,
     {
         let Prover { backend, state, .. } = self;
-        let prover_state::Prepared {
-            mut transcript,
-            px_m,
-            py_m,
-        } = state;
+        let (px_m, py_m) = match state {
+            ProverState::Prepared { px_m, py_m } => (px_m, py_m),
+            _ => return Err(ProveError::WrongPhase),
+        };
 
         // Materialize the zero-check: the difference MAC is what the
         // verifier checks against its own diff_k. Under an honest
         // permutation, the underlying value diff is zero.
         let zero_proof = px_m - py_m;
 
-        // Absorb the proof into the transcript so any subsequent proof
-        // sharing this transcript stays bound to this one.
-        let backend_proof = backend.prove().map_err(ProveError::Backend)?;
+        let backend_proof = backend.prove(transcript).map_err(ProveError::Backend)?;
         let proof = Proof {
             zero_proof,
             backend_proof,
         };
-        transcript.update(b"permutation-proof::proof");
+
+        // Absorb the proof into the transcript so any subsequent proof
+        // sharing this transcript stays bound to this one.
         transcript.update(&bcs::to_bytes(&proof).expect("serialize"));
 
         Ok(proof)
     }
 }
 
-/// Type-state markers for [`Prover`]'s phase.
-pub mod prover_state {
-    use mpz_fields::Field;
-
-    mod sealed {
-        pub trait Sealed {}
-    }
-
-    /// Marker trait implemented by every legal [`Prover`](super::Prover)
-    /// phase. Sealed: external crates cannot add new phases.
-    pub trait State: sealed::Sealed {}
-
-    /// Phase right after [`Prover::new`](super::Prover::new): `alloc`
-    /// and `prepare` are callable; `prove` is not.
-    pub struct Initialized;
-
-    /// Phase right after a successful
-    /// [`prepare`](super::Prover::<_, _, _, Initialized>::prepare):
-    /// `prove` is callable.
-    pub struct Prepared<E: Field> {
-        pub(super) transcript: blake3::Hasher,
-        pub(super) px_m: E,
-        pub(super) py_m: E,
-    }
-
-    impl sealed::Sealed for Initialized {}
-    impl State for Initialized {}
-    impl<E: Field> sealed::Sealed for Prepared<E> {}
-    impl<E: Field> State for Prepared<E> {}
+/// Internal state machine for [`Prover`].
+enum ProverState<E> {
+    Initialized,
+    Prepared { px_m: E, py_m: E },
 }
 
 /// Collapse one tuple of authenticated wires into a single
@@ -239,6 +211,10 @@ where
 /// Error produced by protocol prover.
 #[derive(Debug, thiserror::Error)]
 pub enum ProveError<E: std::error::Error + Send + Sync + 'static> {
+    /// A method was called while the prover was in the wrong phase.
+    #[error("prover called in the wrong phase")]
+    WrongPhase,
+
     /// The four input slices did not all have the same length.
     #[error("length mismatch: x_values={xv}, x_macs={xm}, y_values={yv}, y_macs={ym}")]
     LengthMismatch {
@@ -290,15 +266,15 @@ mod tests {
     /// `LengthMismatch`.
     #[test]
     fn prepare_rejects_x_values_x_macs_length_mismatch() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         let x_values = ones(3, 1);
         let x_macs = ones(2, 1); // short by 1
         let y_values = ones(3, 1);
         let y_macs = ones(3, 1);
 
         let err = prover
-            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(&mut transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("x-side length mismatch must surface an error");
         match err {
@@ -313,15 +289,15 @@ mod tests {
     /// disjunct of the length check.
     #[test]
     fn prepare_rejects_y_values_y_macs_length_mismatch() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         let x_values = ones(4, 1);
         let x_macs = ones(4, 1);
         let y_values = ones(4, 1);
         let y_macs = ones(3, 1); // short by 1
 
         let err = prover
-            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(&mut transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("y-side length mismatch must surface an error");
         match err {
@@ -336,15 +312,15 @@ mod tests {
     /// the third disjunct of the length check trips.
     #[test]
     fn prepare_rejects_x_vs_y_length_mismatch() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         let x_values = ones(3, 1);
         let x_macs = ones(3, 1);
         let y_values = ones(5, 1);
         let y_macs = ones(5, 1);
 
         let err = prover
-            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(&mut transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("x-vs-y length mismatch must surface an error");
         match err {
@@ -358,12 +334,12 @@ mod tests {
     /// A permutation proof over zero positions is vacuous.
     #[test]
     fn prepare_rejects_empty_vectors() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         let empty: Vec<Vec<Gf2_128>> = Vec::new();
 
         let err = prover
-            .prepare(transcript, (&empty, &empty), (&empty, &empty))
+            .prepare(&mut transcript, (&empty, &empty), (&empty, &empty))
             .err()
             .expect("empty inputs must surface an error");
         assert!(
@@ -375,8 +351,8 @@ mod tests {
     /// Zero-width tuples rejected.
     #[test]
     fn prepare_rejects_zero_width_tuples() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         // n = 1, tuple_width = 0.
         let x_values = ones(1, 0);
         let x_macs = ones(1, 0);
@@ -384,7 +360,7 @@ mod tests {
         let y_macs = ones(1, 0);
 
         let err = prover
-            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(&mut transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("zero-width tuples must surface an error");
         assert!(
@@ -396,8 +372,8 @@ mod tests {
     /// Non-uniform tuple widths rejected.
     #[test]
     fn prepare_rejects_tuple_width_mismatch() {
-        let prover = build_mock_prover();
-        let transcript = Hasher::new();
+        let mut prover = build_mock_prover();
+        let mut transcript = Hasher::new();
         // n = 2: first tuple width 2, second tuple width 3.
         let x_values: Vec<Vec<Gf2_128>> = vec![vec![Gf2_128::one(); 2], vec![Gf2_128::one(); 3]];
         let x_macs: Vec<Vec<Gf2_128>> = vec![vec![Gf2_128::one(); 2], vec![Gf2_128::one(); 3]];
@@ -405,7 +381,7 @@ mod tests {
         let y_macs = x_macs.clone();
 
         let err = prover
-            .prepare(transcript, (&x_values, &x_macs), (&y_values, &y_macs))
+            .prepare(&mut transcript, (&x_values, &x_macs), (&y_values, &y_macs))
             .err()
             .expect("non-uniform tuple width must surface an error");
         assert!(
@@ -425,20 +401,31 @@ mod tests {
 
         // Construct the Prepared state directly — bypasses `prepare`
         // so this test pins `prove` in isolation from the rest of the
-        // lifecycle. `pub(super)` fields on `Prepared` make this
-        // accessible from inside `prover.rs`'s test submodule.
+        // lifecycle.
         let prover = Prover {
             backend: MockProverBackend::<Gf2_128, Gf2_128>::new(delta),
-            state: prover_state::Prepared {
-                transcript: Hasher::new(),
-                px_m,
-                py_m,
-            },
+            state: ProverState::Prepared { px_m, py_m },
             _phantom: std::marker::PhantomData,
         };
 
-        let proof = prover.prove().expect("mock prove must succeed");
+        let mut transcript = Hasher::new();
+        let proof = prover
+            .prove(&mut transcript)
+            .expect("mock prove must succeed");
         assert_eq!(proof.zero_proof, px_m - py_m);
         assert_eq!(proof.backend_proof, ());
+    }
+
+    /// `prove` errors with `WrongPhase` if `prepare` hasn't been
+    /// called.
+    #[test]
+    fn prove_rejects_initialized_phase() {
+        let prover = build_mock_prover();
+        let mut transcript = Hasher::new();
+        let err = prover
+            .prove(&mut transcript)
+            .err()
+            .expect("prove without prepare must fail");
+        assert!(matches!(err, ProveError::WrongPhase));
     }
 }

--- a/crates/perm-proof-core/src/test_utils.rs
+++ b/crates/perm-proof-core/src/test_utils.rs
@@ -1,0 +1,125 @@
+//! Test utilities for the permutation-proof protocol.
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+use rand::Rng;
+
+use crate::{KeyTuple, MacTuple, ValueTuple};
+use mpz_vole_core::{
+    RVOLESender, VOLEReceiver,
+    ideal::vole::{FlushMsg, ideal_vole},
+};
+
+/// Tight bundle of what [`commit_values`] produces: per-vector
+/// prover-side [`MacTuple`]s and verifier-side [`KeyTuple`]s plus
+/// the transcript carrying a binding to all of them.
+#[derive(Debug)]
+pub struct Committed<E: Field, const L: usize, const N: usize> {
+    /// Prover-side MAC tuples, one `Vec` per input vector, in
+    /// submission order.
+    pub macs: [Vec<MacTuple<E, L>>; N],
+    /// Verifier-side key tuples, one `Vec` per input vector, in
+    /// submission order.
+    pub keys: [Vec<KeyTuple<E, L>>; N],
+    /// Transcript with the on-wire setup message absorbed under a
+    /// fixed label.
+    pub transcript: blake3::Hasher,
+}
+
+/// Commit `vectors` of `L`-tuples as authenticated wires via a
+/// single ideal chosen-VOLE session.
+pub fn commit_values<W, E, const L: usize, const N: usize>(
+    vectors: [&[ValueTuple<W, L>]; N],
+    delta: E,
+    rng: &mut impl Rng,
+) -> Committed<E, L, N>
+where
+    W: SubfieldOf<E>,
+    E: Field + serde::Serialize,
+{
+    assert!(L >= 1, "commit_values: L must be at least 1");
+
+    let seed: u64 = rng.random();
+    let total_scalars: usize = vectors.iter().map(|v| v.len() * L).sum();
+
+    let (mut sender, mut receiver) = ideal_vole::<W, E>(seed, delta);
+    <_ as RVOLESender<E>>::alloc(&mut sender, total_scalars).expect("sender alloc");
+    <_ as VOLEReceiver<W, E>>::alloc(&mut receiver, total_scalars).expect("receiver alloc");
+
+    let mut futs: [_; N] = std::array::from_fn(|i| {
+        Some(
+            receiver
+                .queue_recv_vole(vectors[i].as_flattened())
+                .expect("queue"),
+        )
+    });
+
+    // Single flush covers every queued wire.
+    let flush = sender.flush().expect("flush must produce a message");
+    let mut transcript = blake3::Hasher::new();
+    absorb_vole_flush(&mut transcript, &flush);
+    receiver.flush(flush).expect("receiver flush");
+
+    // Re-bundle the returned flat MACs / keys back into `L`-tuples so
+    // the layout matches the input shape vector for vector.
+    let macs: [Vec<MacTuple<E, L>>; N] = std::array::from_fn(|i| {
+        let flat = futs[i]
+            .take()
+            .expect("future slot populated")
+            .try_recv()
+            .expect("future must not cancel")
+            .expect("future must resolve after flush")
+            .macs;
+        bundle_into_tuples::<E, L>(flat)
+    });
+    let keys: [Vec<KeyTuple<E, L>>; N] = std::array::from_fn(|i| {
+        let flat = sender
+            .try_send_vole(vectors[i].len() * L)
+            .expect("sender keys")
+            .keys;
+        bundle_into_tuples::<E, L>(flat)
+    });
+
+    Committed {
+        macs,
+        keys,
+        transcript,
+    }
+}
+
+/// Reshape a flat `Vec<E>` of length `n · L` into a `Vec<[E; L]>` of
+/// length `n`. Panics if the length isn't a multiple of `L`.
+fn bundle_into_tuples<E: Field, const L: usize>(flat: Vec<E>) -> Vec<[E; L]> {
+    assert!(
+        flat.len() % L == 0,
+        "flat length {} not divisible by tuple width {}",
+        flat.len(),
+        L
+    );
+    flat.chunks_exact(L)
+        .map(|chunk| <[E; L]>::try_from(chunk).expect("exact-length chunk"))
+        .collect()
+}
+
+/// Absorb the bytes of an ideal-VOLE [`FlushMsg`] into a transcript.
+fn absorb_vole_flush<E: Field + serde::Serialize>(
+    transcript: &mut blake3::Hasher,
+    msg: &FlushMsg<E>,
+) {
+    transcript.update(b"permutation-proof::test::ideal-vole-flush");
+    transcript.update(&bcs::to_bytes(msg).expect("serialize"));
+}
+
+/// Number of RVOLE correlations the `vole_zk` backend consumes across
+/// one prover/verifier pair running on `n` inputs with fan-in `eps`.
+pub fn vole_zk_rvole_pregenerate_count(n: usize, eps: usize) -> usize {
+    2 * crate::backend::vole_zk::fan_in_tree_internal_nodes(n, eps)
+}
+
+/// Polynomial degree the `vole_zk` backend's QS finalize expects from
+/// its single RVOPE correlation, for fan-in `eps` over field `E`.
+pub fn vole_zk_rvope_pregenerate_degree<E: Field>(eps: usize) -> usize {
+    let circuit = crate::backend::vole_zk::build_circuit::<E>(eps);
+    poly_proof_core::prover::Prover::<E>::new(vec![circuit]).required_vopes()
+}

--- a/crates/perm-proof-core/src/test_utils.rs
+++ b/crates/perm-proof-core/src/test_utils.rs
@@ -28,6 +28,55 @@ pub type IdealVoleZkPermProver<E> =
 pub type IdealVoleZkPermVerifier<E> =
     Verifier<E, E, VoleZkVerifierBackend<E, E, IdealRVOLESender<E>, IdealRVOPESender<E>>>;
 
+/// Build an ideal RVOLE `(sender, receiver)` pair, allocated and
+/// flushed for exactly one perm-proof prover run over `n_perm` rows at
+/// the given `fan_in`. The returned halves are ready to be passed to
+/// [`VoleZkProverBackend::new`] / [`VoleZkVerifierBackend::new`].
+pub fn ideal_perm_proof_rvole_pair<E>(
+    rng: &mut impl Rng,
+    delta: E,
+    n_perm: usize,
+    fan_in: usize,
+) -> (IdealRVOLESender<E>, IdealRVOLEReceiver<E, E>)
+where
+    E: Field + ExtensionField<E>,
+    rand::distr::StandardUniform: rand::distr::Distribution<E>,
+{
+    let seed = rand::Rng::random::<u64>(rng);
+    let count = vole_zk_rvole_pregenerate_count(n_perm, fan_in);
+    let (mut sender, mut receiver) = ideal_rvole::<E, E>(seed, delta);
+    <_ as RVOLESender<E>>::alloc(&mut sender, count).expect("rvole sender alloc");
+    <_ as RVOLEReceiver<E, E>>::alloc(&mut receiver, count).expect("rvole receiver alloc");
+    if let Some(msg) = sender.flush() {
+        receiver.flush(msg).expect("rvole flush");
+    }
+    (sender, receiver)
+}
+
+/// Build an ideal RVOPE `(sender, receiver)` pair, allocated and
+/// flushed for exactly one perm-proof prover run at the given `fan_in`.
+/// One polynomial; degree is derived from `fan_in` via
+/// [`vole_zk_rvope_pregenerate_degree`].
+pub fn ideal_perm_proof_rvope_pair<E>(
+    rng: &mut impl Rng,
+    delta: E,
+    fan_in: usize,
+) -> (IdealRVOPESender<E>, IdealRVOPEReceiver<E>)
+where
+    E: Field + ExtensionField<E>,
+    rand::distr::StandardUniform: rand::distr::Distribution<E>,
+{
+    let seed = rand::Rng::random::<u64>(rng);
+    let degree = vole_zk_rvope_pregenerate_degree::<E>(fan_in);
+    let (mut sender, mut receiver) = ideal_rvope::<E>(seed, delta);
+    <_ as RVOPESender<E>>::alloc(&mut sender, 1, degree).expect("rvope sender alloc");
+    <_ as RVOPEReceiver<E>>::alloc(&mut receiver, 1, degree).expect("rvope receiver alloc");
+    for msg in sender.flush() {
+        receiver.flush(msg).expect("rvope flush");
+    }
+    (sender, receiver)
+}
+
 /// Build a `vole_zk` perm-proof `(Prover, Verifier)` pair backed by
 /// ideal RVOLE / RVOPE correlations sized for `n_perm` rows with the
 /// given `fan_in`.
@@ -46,26 +95,8 @@ where
         + zerocopy::FromBytes,
     rand::distr::StandardUniform: rand::distr::Distribution<E>,
 {
-    let rvole_seed = rand::Rng::random::<u64>(rng);
-    let rvope_seed = rand::Rng::random::<u64>(rng);
-
-    // ---- full-field RVOLE ----
-    let rvole_count = vole_zk_rvole_pregenerate_count(n_perm, fan_in);
-    let (mut rvole_s, mut rvole_r) = ideal_rvole::<E, E>(rvole_seed, delta);
-    <_ as RVOLESender<E>>::alloc(&mut rvole_s, rvole_count).expect("rvole sender alloc");
-    <_ as RVOLEReceiver<E, E>>::alloc(&mut rvole_r, rvole_count).expect("rvole receiver alloc");
-    if let Some(msg) = rvole_s.flush() {
-        rvole_r.flush(msg).expect("rvole flush");
-    }
-
-    // ---- lifted-VOPE RVOPE ----
-    let required_vopes = vole_zk_rvope_pregenerate_degree::<E>(fan_in);
-    let (mut rvope_s, mut rvope_r) = ideal_rvope::<E>(rvope_seed, delta);
-    <_ as RVOPESender<E>>::alloc(&mut rvope_s, 1, required_vopes).expect("rvope sender alloc");
-    <_ as RVOPEReceiver<E>>::alloc(&mut rvope_r, 1, required_vopes).expect("rvope receiver alloc");
-    for msg in rvope_s.flush() {
-        rvope_r.flush(msg).expect("rvope flush");
-    }
+    let (rvole_s, rvole_r) = ideal_perm_proof_rvole_pair::<E>(rng, delta, n_perm, fan_in);
+    let (rvope_s, rvope_r) = ideal_perm_proof_rvope_pair::<E>(rng, delta, fan_in);
 
     let prover_backend = VoleZkProverBackend::<E, E, _, _>::new(fan_in, rvole_r, rvope_r)
         .expect("vole-zk prover backend");

--- a/crates/perm-proof-core/src/test_utils.rs
+++ b/crates/perm-proof-core/src/test_utils.rs
@@ -5,9 +5,76 @@ use mpz_fields::{ExtensionField, Field};
 use rand::Rng;
 
 use mpz_vole_core::{
-    RVOLESender, VOLEReceiver,
-    ideal::vole::{FlushMsg, ideal_vole},
+    RVOLEReceiver, RVOLESender, RVOPEReceiver, RVOPESender, VOLEReceiver,
+    ideal::{
+        rvole::{IdealRVOLEReceiver, IdealRVOLESender, ideal_rvole},
+        rvope::{IdealRVOPEReceiver, IdealRVOPESender, ideal_rvope},
+        vole::{FlushMsg, ideal_vole},
+    },
 };
+
+use crate::{
+    Prover, Verifier,
+    backend::vole_zk::{VoleZkProverBackend, VoleZkVerifierBackend},
+};
+
+/// `vole_zk` perm-proof prover backed by ideal RVOLE / RVOPE
+/// correlations over field `E`.
+pub type IdealVoleZkPermProver<E> =
+    Prover<E, E, VoleZkProverBackend<E, E, IdealRVOLEReceiver<E, E>, IdealRVOPEReceiver<E>>>;
+
+/// `vole_zk` perm-proof verifier backed by ideal RVOLE / RVOPE
+/// correlations over field `E`.
+pub type IdealVoleZkPermVerifier<E> =
+    Verifier<E, E, VoleZkVerifierBackend<E, E, IdealRVOLESender<E>, IdealRVOPESender<E>>>;
+
+/// Build a `vole_zk` perm-proof `(Prover, Verifier)` pair backed by
+/// ideal RVOLE / RVOPE correlations sized for `n_perm` rows with the
+/// given `fan_in`.
+pub fn build_ideal_perm_proof_pair<E>(
+    rng: &mut impl Rng,
+    delta: E,
+    n_perm: usize,
+    fan_in: usize,
+) -> (IdealVoleZkPermProver<E>, IdealVoleZkPermVerifier<E>)
+where
+    E: Field
+        + ExtensionField<E>
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + zerocopy::IntoBytes
+        + zerocopy::FromBytes,
+    rand::distr::StandardUniform: rand::distr::Distribution<E>,
+{
+    let rvole_seed = rand::Rng::random::<u64>(rng);
+    let rvope_seed = rand::Rng::random::<u64>(rng);
+
+    // ---- full-field RVOLE ----
+    let rvole_count = vole_zk_rvole_pregenerate_count(n_perm, fan_in);
+    let (mut rvole_s, mut rvole_r) = ideal_rvole::<E, E>(rvole_seed, delta);
+    <_ as RVOLESender<E>>::alloc(&mut rvole_s, rvole_count).expect("rvole sender alloc");
+    <_ as RVOLEReceiver<E, E>>::alloc(&mut rvole_r, rvole_count).expect("rvole receiver alloc");
+    if let Some(msg) = rvole_s.flush() {
+        rvole_r.flush(msg).expect("rvole flush");
+    }
+
+    // ---- lifted-VOPE RVOPE ----
+    let required_vopes = vole_zk_rvope_pregenerate_degree::<E>(fan_in);
+    let (mut rvope_s, mut rvope_r) = ideal_rvope::<E>(rvope_seed, delta);
+    <_ as RVOPESender<E>>::alloc(&mut rvope_s, 1, required_vopes).expect("rvope sender alloc");
+    <_ as RVOPEReceiver<E>>::alloc(&mut rvope_r, 1, required_vopes).expect("rvope receiver alloc");
+    for msg in rvope_s.flush() {
+        rvope_r.flush(msg).expect("rvope flush");
+    }
+
+    let prover_backend = VoleZkProverBackend::<E, E, _, _>::new(fan_in, rvole_r, rvope_r)
+        .expect("vole-zk prover backend");
+    let verifier_backend =
+        VoleZkVerifierBackend::<E, E, _, _>::new(fan_in, delta, rvole_s, rvope_s)
+            .expect("vole-zk verifier backend");
+
+    (Prover::new(prover_backend), Verifier::new(verifier_backend))
+}
 
 /// Tight bundle of what [`commit_values`] produces: per-vector
 /// prover-side MAC tuples and verifier-side key tuples plus the
@@ -51,7 +118,11 @@ where
             "commit_values: input {i} has non-uniform tuple widths",
         );
     }
-    let total_scalars: usize = vectors.iter().enumerate().map(|(i, v)| v.len() * widths[i]).sum();
+    let total_scalars: usize = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| v.len() * widths[i])
+        .sum();
 
     let (mut sender, mut receiver) = ideal_vole::<W, E>(seed, delta);
     <_ as RVOLESender<E>>::alloc(&mut sender, total_scalars).expect("sender alloc");
@@ -59,13 +130,8 @@ where
 
     let flat_inputs: [Vec<W>; N] =
         std::array::from_fn(|i| vectors[i].iter().flatten().copied().collect());
-    let mut futs: [_; N] = std::array::from_fn(|i| {
-        Some(
-            receiver
-                .queue_recv_vole(&flat_inputs[i])
-                .expect("queue"),
-        )
-    });
+    let mut futs: [_; N] =
+        std::array::from_fn(|i| Some(receiver.queue_recv_vole(&flat_inputs[i]).expect("queue")));
 
     // Single flush covers every queued wire.
     let flush = sender.flush().expect("flush must produce a message");
@@ -113,7 +179,9 @@ fn chunk_into_vecs<E: Field>(flat: Vec<E>, width: usize) -> Vec<Vec<E>> {
         flat.len(),
         width
     );
-    flat.chunks_exact(width).map(|chunk| chunk.to_vec()).collect()
+    flat.chunks_exact(width)
+        .map(|chunk| chunk.to_vec())
+        .collect()
 }
 
 /// Absorb the bytes of an ideal-VOLE [`FlushMsg`] into a transcript.
@@ -133,7 +201,10 @@ pub fn vole_zk_rvole_pregenerate_count(n: usize, eps: usize) -> usize {
 
 /// Polynomial degree the `vole_zk` backend's QS finalize expects from
 /// its single RVOPE correlation, for fan-in `eps` over field `E`.
-pub fn vole_zk_rvope_pregenerate_degree<E: Field>(eps: usize) -> usize {
-    let (constraints, _) = crate::backend::vole_zk::build_product_constraints::<E>(eps);
+pub fn vole_zk_rvope_pregenerate_degree<E: Field + mpz_fields::ExtensionField<E>>(
+    eps: usize,
+) -> usize {
+    let (constraints, _, _) = crate::backend::vole_zk::build_product_constraints::<E>(eps)
+        .expect("eps must be in SUPPORTED_FAN_IN");
     mpz_poly_proof_core::prover::Prover::<E>::new(&constraints).required_vopes()
 }

--- a/crates/perm-proof-core/src/test_utils.rs
+++ b/crates/perm-proof-core/src/test_utils.rs
@@ -1,56 +1,68 @@
 //! Test utilities for the permutation-proof protocol.
 
 use mpz_common::future::Output;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 use rand::Rng;
 
-use crate::{KeyTuple, MacTuple, ValueTuple};
 use mpz_vole_core::{
     RVOLESender, VOLEReceiver,
     ideal::vole::{FlushMsg, ideal_vole},
 };
 
 /// Tight bundle of what [`commit_values`] produces: per-vector
-/// prover-side [`MacTuple`]s and verifier-side [`KeyTuple`]s plus
-/// the transcript carrying a binding to all of them.
+/// prover-side MAC tuples and verifier-side key tuples plus the
+/// transcript carrying a binding to all of them. Each inner `Vec<E>`
+/// is one tuple-position; outer `Vec` is one entry per input vector.
 #[derive(Debug)]
-pub struct Committed<E: Field, const L: usize, const N: usize> {
+pub struct Committed<E: Field, const N: usize> {
     /// Prover-side MAC tuples, one `Vec` per input vector, in
     /// submission order.
-    pub macs: [Vec<MacTuple<E, L>>; N],
+    pub macs: [Vec<Vec<E>>; N],
     /// Verifier-side key tuples, one `Vec` per input vector, in
     /// submission order.
-    pub keys: [Vec<KeyTuple<E, L>>; N],
+    pub keys: [Vec<Vec<E>>; N],
     /// Transcript with the on-wire setup message absorbed under a
     /// fixed label.
     pub transcript: blake3::Hasher,
 }
 
-/// Commit `vectors` of `L`-tuples as authenticated wires via a
-/// single ideal chosen-VOLE session.
-pub fn commit_values<W, E, const L: usize, const N: usize>(
-    vectors: [&[ValueTuple<W, L>]; N],
+/// Commit `vectors` of runtime-width tuples as authenticated wires
+/// via a single ideal chosen-VOLE session.
+///
+/// Each input `&[Vec<W>]` is a slice of tuples; every tuple within a
+/// given input must have the same width. Across inputs, tuple widths
+/// may differ — the per-input width is read from the first tuple.
+pub fn commit_values<W, E, const N: usize>(
+    vectors: [&[Vec<W>]; N],
     delta: E,
     rng: &mut impl Rng,
-) -> Committed<E, L, N>
+) -> Committed<E, N>
 where
-    W: SubfieldOf<E>,
-    E: Field + serde::Serialize,
+    W: Field,
+    E: ExtensionField<W> + serde::Serialize,
 {
-    assert!(L >= 1, "commit_values: L must be at least 1");
-
     let seed: u64 = rng.random();
-    let total_scalars: usize = vectors.iter().map(|v| v.len() * L).sum();
+
+    // Per-input tuple widths and flat counts.
+    let widths: [usize; N] = std::array::from_fn(|i| vectors[i].first().map_or(0, |t| t.len()));
+    for (i, v) in vectors.iter().enumerate() {
+        assert!(
+            v.iter().all(|t| t.len() == widths[i]),
+            "commit_values: input {i} has non-uniform tuple widths",
+        );
+    }
+    let total_scalars: usize = vectors.iter().enumerate().map(|(i, v)| v.len() * widths[i]).sum();
 
     let (mut sender, mut receiver) = ideal_vole::<W, E>(seed, delta);
     <_ as RVOLESender<E>>::alloc(&mut sender, total_scalars).expect("sender alloc");
     <_ as VOLEReceiver<W, E>>::alloc(&mut receiver, total_scalars).expect("receiver alloc");
 
+    let flat_inputs: [Vec<W>; N] =
+        std::array::from_fn(|i| vectors[i].iter().flatten().copied().collect());
     let mut futs: [_; N] = std::array::from_fn(|i| {
         Some(
             receiver
-                .queue_recv_vole(vectors[i].as_flattened())
+                .queue_recv_vole(&flat_inputs[i])
                 .expect("queue"),
         )
     });
@@ -61,9 +73,9 @@ where
     absorb_vole_flush(&mut transcript, &flush);
     receiver.flush(flush).expect("receiver flush");
 
-    // Re-bundle the returned flat MACs / keys back into `L`-tuples so
-    // the layout matches the input shape vector for vector.
-    let macs: [Vec<MacTuple<E, L>>; N] = std::array::from_fn(|i| {
+    // Re-bundle the returned flat MACs / keys into per-vector tuple
+    // shapes matching the input.
+    let macs: [Vec<Vec<E>>; N] = std::array::from_fn(|i| {
         let flat = futs[i]
             .take()
             .expect("future slot populated")
@@ -71,14 +83,14 @@ where
             .expect("future must not cancel")
             .expect("future must resolve after flush")
             .macs;
-        bundle_into_tuples::<E, L>(flat)
+        chunk_into_vecs(flat, widths[i])
     });
-    let keys: [Vec<KeyTuple<E, L>>; N] = std::array::from_fn(|i| {
+    let keys: [Vec<Vec<E>>; N] = std::array::from_fn(|i| {
         let flat = sender
-            .try_send_vole(vectors[i].len() * L)
+            .try_send_vole(vectors[i].len() * widths[i])
             .expect("sender keys")
             .keys;
-        bundle_into_tuples::<E, L>(flat)
+        chunk_into_vecs(flat, widths[i])
     });
 
     Committed {
@@ -88,18 +100,20 @@ where
     }
 }
 
-/// Reshape a flat `Vec<E>` of length `n · L` into a `Vec<[E; L]>` of
-/// length `n`. Panics if the length isn't a multiple of `L`.
-fn bundle_into_tuples<E: Field, const L: usize>(flat: Vec<E>) -> Vec<[E; L]> {
+/// Reshape a flat `Vec<E>` into a `Vec<Vec<E>>` where each inner vec
+/// holds `width` consecutive elements. With `width == 0` returns an
+/// empty outer vec.
+fn chunk_into_vecs<E: Field>(flat: Vec<E>, width: usize) -> Vec<Vec<E>> {
+    if width == 0 {
+        return Vec::new();
+    }
     assert!(
-        flat.len() % L == 0,
+        flat.len() % width == 0,
         "flat length {} not divisible by tuple width {}",
         flat.len(),
-        L
+        width
     );
-    flat.chunks_exact(L)
-        .map(|chunk| <[E; L]>::try_from(chunk).expect("exact-length chunk"))
-        .collect()
+    flat.chunks_exact(width).map(|chunk| chunk.to_vec()).collect()
 }
 
 /// Absorb the bytes of an ideal-VOLE [`FlushMsg`] into a transcript.
@@ -120,6 +134,6 @@ pub fn vole_zk_rvole_pregenerate_count(n: usize, eps: usize) -> usize {
 /// Polynomial degree the `vole_zk` backend's QS finalize expects from
 /// its single RVOPE correlation, for fan-in `eps` over field `E`.
 pub fn vole_zk_rvope_pregenerate_degree<E: Field>(eps: usize) -> usize {
-    let circuit = crate::backend::vole_zk::build_circuit::<E>(eps);
-    poly_proof_core::prover::Prover::<E>::new(vec![circuit]).required_vopes()
+    let (constraints, _) = crate::backend::vole_zk::build_product_constraints::<E>(eps);
+    mpz_poly_proof_core::prover::Prover::<E>::new(&constraints).required_vopes()
 }

--- a/crates/perm-proof-core/src/verifier.rs
+++ b/crates/perm-proof-core/src/verifier.rs
@@ -1,0 +1,361 @@
+//! Permutation protocol verifier.
+
+use blake3::Hasher;
+use mpz_fields::Field;
+use poly_proof_core::SubfieldOf;
+use serde::Serialize;
+
+use crate::{KeyTuple, Proof, backend::VerifierBackend, draw_field, inner_product};
+
+/// Permutation protocol verifier.
+pub struct Verifier<W, E, B, S = verifier_state::Initialized>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: VerifierBackend<W, E>,
+    S: verifier_state::State,
+{
+    backend: B,
+    state: S,
+    _phantom: std::marker::PhantomData<(W, E)>,
+}
+
+impl<W, E, B> Verifier<W, E, B, verifier_state::Initialized>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: VerifierBackend<W, E>,
+{
+    /// Build a new verifier around `backend`.
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            state: verifier_state::Initialized,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Announce that a permutation proof of size `n` will run through
+    /// this verifier.
+    ///
+    /// Multiple calls accumulate.
+    pub fn alloc(&mut self, n: usize) -> Result<(), B::Error> {
+        self.backend.alloc(n)
+    }
+
+    /// Compute the preparation phase of the protocol.
+    ///
+    /// # Arguments
+    ///
+    /// * `transcript` - Shared session transcript.
+    /// * `x_keys` - Verifier-side keys for the first input vector.
+    /// * `y_keys` - Verifier-side keys for the second input vector.
+    /// * `preparation` - The prover-emitted preparation DTO.
+    ///
+    /// # Security
+    ///
+    /// It is crucial that `transcript` has absorbed `x_keys` and
+    /// `y_keys` before this method is invoked. The protocol's soundness
+    /// depends on this binding.
+    pub fn prepare<const L: usize>(
+        mut self,
+        mut transcript: Hasher,
+        x_keys: &[KeyTuple<E, L>],
+        y_keys: &[KeyTuple<E, L>],
+        preparation: B::Preparation,
+    ) -> Result<Verifier<W, E, B, verifier_state::Prepared<E>>, VerifyError<B::Error>> {
+        let xn = x_keys.len();
+        let yn = y_keys.len();
+        if xn != yn {
+            return Err(VerifyError::LengthMismatch { xn, yn });
+        }
+        if xn == 0 || L == 0 {
+            return Err(VerifyError::EmptyInputs);
+        }
+
+        // Draw the random challenge `r`.
+        let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
+
+        // Draw the tuple-collapse challenge `s ∈ E^L`.
+        let s: [E; L] = std::array::from_fn(|_| {
+            draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s")
+        });
+
+        // Compute per-position collapsed factors.
+        //
+        //   z_key  = Σ_j s[j] · keys[i][j]              (in E)
+        //   factor_key = −Δ·r − z_key    // r's key is −Δ·r; the `−` carries through.
+        let delta = self.backend.delta();
+        let minus_delta_r = -(delta * r);
+        let fx_keys: Vec<E> = x_keys
+            .iter()
+            .map(|k| minus_delta_r - inner_product(&s, k))
+            .collect();
+        let fy_keys: Vec<E> = y_keys
+            .iter()
+            .map(|k| minus_delta_r - inner_product(&s, k))
+            .collect();
+
+        // Install the preparation DTOs.
+        self.backend.load_preparation(preparation);
+
+        let px_k = self
+            .backend
+            .product(&mut transcript, &fx_keys)
+            .map_err(VerifyError::Backend)?;
+        let py_k = self
+            .backend
+            .product(&mut transcript, &fy_keys)
+            .map_err(VerifyError::Backend)?;
+
+        Ok(Verifier {
+            backend: self.backend,
+            state: verifier_state::Prepared {
+                transcript,
+                px_k,
+                py_k,
+            },
+            _phantom: std::marker::PhantomData,
+        })
+    }
+}
+
+impl<W, E, B> Verifier<W, E, B, verifier_state::Prepared<E>>
+where
+    W: SubfieldOf<E>,
+    E: Field,
+    B: VerifierBackend<W, E>,
+{
+    /// Verify the proof.
+    ///
+    /// # Arguments
+    ///
+    /// * `proof` - The prover-emitted proof.
+    pub fn verify(self, proof: Proof<E, B::BackendProof>) -> Result<(), VerifyError<B::Error>>
+    where
+        E: Serialize,
+        B::BackendProof: Serialize,
+    {
+        let Verifier { backend, state, .. } = self;
+        let verifier_state::Prepared {
+            mut transcript,
+            px_k,
+            py_k,
+        } = state;
+
+        transcript.update(b"permutation-proof::proof");
+        transcript.update(&bcs::to_bytes(&proof).expect("serialize"));
+
+        let Proof {
+            zero_proof,
+            backend_proof,
+        } = proof;
+
+        // Zero-check: diff_k is the key for the difference wire. Under
+        // `mac = key + Δ · value`, value-zero forces mac == key, so
+        // the prover's opened mac (zero_proof) must equal this
+        // locally-computed key.
+        let diff_k = px_k - py_k;
+        if zero_proof != diff_k {
+            return Err(VerifyError::ZeroCheckFailed);
+        }
+
+        // Backend's supplementary check.
+        backend.verify(backend_proof).map_err(VerifyError::Backend)
+    }
+}
+
+/// Error produced by protocol verifier.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError<E: std::error::Error + Send + Sync + 'static> {
+    /// The two key slices did not have the same length.
+    #[error("length mismatch: x_keys={xn}, y_keys={yn}")]
+    LengthMismatch {
+        /// Length of `x_keys`.
+        xn: usize,
+        /// Length of `y_keys`.
+        yn: usize,
+    },
+
+    /// Input key slices had length zero.
+    #[error("empty inputs: permutation proof requires at least one wire per side")]
+    EmptyInputs,
+
+    /// The prover's opened MAC disagreed with the verifier's
+    /// locally-computed key.
+    #[error("zero-check rejected: zero_proof does not match verifier's diff key")]
+    ZeroCheckFailed,
+
+    /// The backend reported an error.
+    #[error("backend error: {0}")]
+    Backend(#[source] E),
+}
+
+/// Type-state markers for [`Verifier`]'s phase.
+pub mod verifier_state {
+    use mpz_fields::Field;
+
+    mod sealed {
+        pub trait Sealed {}
+    }
+
+    /// Marker trait implemented by every legal
+    /// [`Verifier`](super::Verifier) phase. Sealed: external crates
+    /// cannot add new phases.
+    pub trait State: sealed::Sealed {}
+
+    /// Phase right after [`Verifier::new`](super::Verifier::new):
+    /// `alloc` and `prepare` are callable; `verify` is not.
+    pub struct Initialized;
+
+    /// Phase right after a successful
+    /// [`prepare`](super::Verifier::<_, _, _, Initialized>::prepare):
+    /// `verify` is callable.
+    pub struct Prepared<E: Field> {
+        pub(super) transcript: blake3::Hasher,
+        pub(super) px_k: E,
+        pub(super) py_k: E,
+    }
+
+    impl sealed::Sealed for Initialized {}
+    impl State for Initialized {}
+    impl<E: Field> sealed::Sealed for Prepared<E> {}
+    impl<E: Field> State for Prepared<E> {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mpz_fields::gf2_128::Gf2_128;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::backend::mock::{MockVerifierBackend, Preparation};
+
+    /// Build a mock-backed verifier.
+    fn build_mock_verifier() -> Verifier<Gf2_128, Gf2_128, MockVerifierBackend<Gf2_128, Gf2_128>> {
+        let delta = Gf2_128::one();
+        Verifier::new(MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta))
+    }
+
+    /// Mismatched `x_keys.len()` vs `y_keys.len()` must surface as
+    /// `LengthMismatch`.
+    #[test]
+    fn prepare_rejects_length_mismatch() {
+        let verifier = build_mock_verifier();
+        let transcript = Hasher::new();
+        let x_keys: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
+        let y_keys: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
+        let preparation = Preparation { prod_keys: vec![] };
+
+        let err = verifier
+            .prepare::<1>(transcript, &x_keys, &y_keys, preparation)
+            .err()
+            .expect("length mismatch must surface an error");
+        match err {
+            VerifyError::LengthMismatch { xn, yn } => {
+                assert_eq!((xn, yn), (3, 5));
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    /// A permutation proof over zero positions is vacuous.
+    #[test]
+    fn prepare_rejects_empty_vectors() {
+        let verifier = build_mock_verifier();
+        let transcript = Hasher::new();
+        let empty: Vec<[Gf2_128; 1]> = Vec::new();
+        let preparation = Preparation { prod_keys: vec![] };
+
+        let err = verifier
+            .prepare::<1>(transcript, &empty, &empty, preparation)
+            .err()
+            .expect("empty inputs must surface an error");
+        assert!(
+            matches!(err, VerifyError::EmptyInputs),
+            "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// Zero-width tuples (`L = 0`) are rejected.
+    #[test]
+    fn prepare_rejects_zero_width_tuples() {
+        let verifier = build_mock_verifier();
+        let transcript = Hasher::new();
+        let x_keys: Vec<[Gf2_128; 0]> = vec![[]];
+        let y_keys: Vec<[Gf2_128; 0]> = vec![[]];
+        let preparation = Preparation { prod_keys: vec![] };
+
+        let err = verifier
+            .prepare::<0>(transcript, &x_keys, &y_keys, preparation)
+            .err()
+            .expect("zero-width tuples must surface an error");
+        assert!(
+            matches!(err, VerifyError::EmptyInputs),
+            "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// `verify` accepts iff `zero_proof == px_k − py_k`.
+    #[test]
+    fn verify_accepts_matching_zero_proof() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0xDEAD);
+        let delta: Gf2_128 = rng.random();
+        let px_k: Gf2_128 = rng.random();
+        let py_k: Gf2_128 = rng.random();
+
+        let verifier = Verifier {
+            backend: MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta),
+            state: verifier_state::Prepared {
+                transcript: Hasher::new(),
+                px_k,
+                py_k,
+            },
+            _phantom: std::marker::PhantomData,
+        };
+
+        let proof = Proof {
+            zero_proof: px_k - py_k,
+            backend_proof: (),
+        };
+
+        verifier
+            .verify(proof)
+            .expect("matching zero_proof must be accepted");
+    }
+
+    /// `verify` rejects when `zero_proof != px_k − py_k`.
+    #[test]
+    fn verify_rejects_mismatched_zero_proof() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0xBEEF);
+        let delta: Gf2_128 = rng.random();
+        let px_k: Gf2_128 = rng.random();
+        let py_k: Gf2_128 = rng.random();
+
+        let verifier = Verifier {
+            backend: MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta),
+            state: verifier_state::Prepared {
+                transcript: Hasher::new(),
+                px_k,
+                py_k,
+            },
+            _phantom: std::marker::PhantomData,
+        };
+
+        let tampered = Proof {
+            zero_proof: (px_k - py_k) + Gf2_128::one(),
+            backend_proof: (),
+        };
+
+        let err = verifier
+            .verify(tampered)
+            .err()
+            .expect("tampered zero_proof must be rejected");
+        assert!(
+            matches!(err, VerifyError::ZeroCheckFailed),
+            "expected ZeroCheckFailed, got {err:?}"
+        );
+    }
+}

--- a/crates/perm-proof-core/src/verifier.rs
+++ b/crates/perm-proof-core/src/verifier.rs
@@ -1,17 +1,16 @@
 //! Permutation protocol verifier.
 
 use blake3::Hasher;
-use mpz_fields::Field;
-use poly_proof_core::SubfieldOf;
+use mpz_fields::{ExtensionField, Field};
 use serde::Serialize;
 
-use crate::{KeyTuple, Proof, backend::VerifierBackend, draw_field, inner_product};
+use crate::{Proof, backend::VerifierBackend, draw_field};
 
 /// Permutation protocol verifier.
 pub struct Verifier<W, E, B, S = verifier_state::Initialized>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: VerifierBackend<W, E>,
     S: verifier_state::State,
 {
@@ -22,8 +21,8 @@ where
 
 impl<W, E, B> Verifier<W, E, B, verifier_state::Initialized>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: VerifierBackend<W, E>,
 {
     /// Build a new verifier around `backend`.
@@ -57,11 +56,11 @@ where
     /// It is crucial that `transcript` has absorbed `x_keys` and
     /// `y_keys` before this method is invoked. The protocol's soundness
     /// depends on this binding.
-    pub fn prepare<const L: usize>(
+    pub fn prepare(
         mut self,
         mut transcript: Hasher,
-        x_keys: &[KeyTuple<E, L>],
-        y_keys: &[KeyTuple<E, L>],
+        x_keys: &[Vec<E>],
+        y_keys: &[Vec<E>],
         preparation: B::Preparation,
     ) -> Result<Verifier<W, E, B, verifier_state::Prepared<E>>, VerifyError<B::Error>> {
         let xn = x_keys.len();
@@ -69,17 +68,31 @@ where
         if xn != yn {
             return Err(VerifyError::LengthMismatch { xn, yn });
         }
-        if xn == 0 || L == 0 {
+        if xn == 0 {
             return Err(VerifyError::EmptyInputs);
+        }
+
+        // Tuple width: read from the first input tuple.
+        let tuple_width = x_keys[0].len();
+        if tuple_width == 0 {
+            return Err(VerifyError::EmptyInputs);
+        }
+
+        // Uniformity: every tuple (across both x and y) must have the
+        // same width.
+        let all_uniform = x_keys.iter().all(|k| k.len() == tuple_width)
+            && y_keys.iter().all(|k| k.len() == tuple_width);
+        if !all_uniform {
+            return Err(VerifyError::TupleWidthMismatch);
         }
 
         // Draw the random challenge `r`.
         let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
 
-        // Draw the tuple-collapse challenge `s ∈ E^L`.
-        let s: [E; L] = std::array::from_fn(|_| {
-            draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s")
-        });
+        // Draw the tuple-collapse challenge `s ∈ E^tuple_width`.
+        let s: Vec<E> = (0..tuple_width)
+            .map(|_| draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s"))
+            .collect();
 
         // Compute per-position collapsed factors.
         //
@@ -89,11 +102,11 @@ where
         let minus_delta_r = -(delta * r);
         let fx_keys: Vec<E> = x_keys
             .iter()
-            .map(|k| minus_delta_r - inner_product(&s, k))
+            .map(|k| minus_delta_r - E::inner_product(&s, k))
             .collect();
         let fy_keys: Vec<E> = y_keys
             .iter()
-            .map(|k| minus_delta_r - inner_product(&s, k))
+            .map(|k| minus_delta_r - E::inner_product(&s, k))
             .collect();
 
         // Install the preparation DTOs.
@@ -122,8 +135,8 @@ where
 
 impl<W, E, B> Verifier<W, E, B, verifier_state::Prepared<E>>
 where
-    W: SubfieldOf<E>,
-    E: Field,
+    W: Field,
+    E: ExtensionField<W>,
     B: VerifierBackend<W, E>,
 {
     /// Verify the proof.
@@ -177,9 +190,13 @@ pub enum VerifyError<E: std::error::Error + Send + Sync + 'static> {
         yn: usize,
     },
 
-    /// Input key slices had length zero.
+    /// Input key slices had length zero, or the tuple width was zero.
     #[error("empty inputs: permutation proof requires at least one wire per side")]
     EmptyInputs,
+
+    /// Not all input tuples had the same width.
+    #[error("tuple width mismatch across input vectors")]
+    TupleWidthMismatch,
 
     /// The prover's opened MAC disagreed with the verifier's
     /// locally-computed key.
@@ -239,18 +256,23 @@ mod tests {
         Verifier::new(MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta))
     }
 
+    /// Construct a uniform-width key Vec for tests.
+    fn key_ones(n: usize, width: usize) -> Vec<Vec<Gf2_128>> {
+        (0..n).map(|_| vec![Gf2_128::one(); width]).collect()
+    }
+
     /// Mismatched `x_keys.len()` vs `y_keys.len()` must surface as
     /// `LengthMismatch`.
     #[test]
     fn prepare_rejects_length_mismatch() {
         let verifier = build_mock_verifier();
         let transcript = Hasher::new();
-        let x_keys: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 3];
-        let y_keys: Vec<[Gf2_128; 1]> = vec![[Gf2_128::one()]; 5];
+        let x_keys = key_ones(3, 1);
+        let y_keys = key_ones(5, 1);
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare::<1>(transcript, &x_keys, &y_keys, preparation)
+            .prepare(transcript, &x_keys, &y_keys, preparation)
             .err()
             .expect("length mismatch must surface an error");
         match err {
@@ -266,11 +288,11 @@ mod tests {
     fn prepare_rejects_empty_vectors() {
         let verifier = build_mock_verifier();
         let transcript = Hasher::new();
-        let empty: Vec<[Gf2_128; 1]> = Vec::new();
+        let empty: Vec<Vec<Gf2_128>> = Vec::new();
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare::<1>(transcript, &empty, &empty, preparation)
+            .prepare(transcript, &empty, &empty, preparation)
             .err()
             .expect("empty inputs must surface an error");
         assert!(
@@ -279,22 +301,44 @@ mod tests {
         );
     }
 
-    /// Zero-width tuples (`L = 0`) are rejected.
+    /// Zero-width tuples are rejected.
     #[test]
     fn prepare_rejects_zero_width_tuples() {
         let verifier = build_mock_verifier();
         let transcript = Hasher::new();
-        let x_keys: Vec<[Gf2_128; 0]> = vec![[]];
-        let y_keys: Vec<[Gf2_128; 0]> = vec![[]];
+        let x_keys = key_ones(1, 0);
+        let y_keys = key_ones(1, 0);
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare::<0>(transcript, &x_keys, &y_keys, preparation)
+            .prepare(transcript, &x_keys, &y_keys, preparation)
             .err()
             .expect("zero-width tuples must surface an error");
         assert!(
             matches!(err, VerifyError::EmptyInputs),
             "expected EmptyInputs, got {err:?}"
+        );
+    }
+
+    /// Non-uniform tuple widths rejected.
+    #[test]
+    fn prepare_rejects_tuple_width_mismatch() {
+        let verifier = build_mock_verifier();
+        let transcript = Hasher::new();
+        let x_keys: Vec<Vec<Gf2_128>> = vec![
+            vec![Gf2_128::one(); 2],
+            vec![Gf2_128::one(); 3],
+        ];
+        let y_keys = x_keys.clone();
+        let preparation = Preparation { prod_keys: vec![] };
+
+        let err = verifier
+            .prepare(transcript, &x_keys, &y_keys, preparation)
+            .err()
+            .expect("non-uniform tuple width must surface an error");
+        assert!(
+            matches!(err, VerifyError::TupleWidthMismatch),
+            "expected TupleWidthMismatch, got {err:?}"
         );
     }
 

--- a/crates/perm-proof-core/src/verifier.rs
+++ b/crates/perm-proof-core/src/verifier.rs
@@ -7,19 +7,18 @@ use serde::Serialize;
 use crate::{Proof, backend::VerifierBackend, draw_field};
 
 /// Permutation protocol verifier.
-pub struct Verifier<W, E, B, S = verifier_state::Initialized>
+pub struct Verifier<W, E, B>
 where
     W: Field,
     E: ExtensionField<W>,
     B: VerifierBackend<W, E>,
-    S: verifier_state::State,
 {
     backend: B,
-    state: S,
+    state: VerifierState<E>,
     _phantom: std::marker::PhantomData<(W, E)>,
 }
 
-impl<W, E, B> Verifier<W, E, B, verifier_state::Initialized>
+impl<W, E, B> Verifier<W, E, B>
 where
     W: Field,
     E: ExtensionField<W>,
@@ -29,7 +28,7 @@ where
     pub fn new(backend: B) -> Self {
         Self {
             backend,
-            state: verifier_state::Initialized,
+            state: VerifierState::Initialized,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -38,15 +37,18 @@ where
     /// this verifier.
     ///
     /// Multiple calls accumulate.
-    pub fn alloc(&mut self, n: usize) -> Result<(), B::Error> {
-        self.backend.alloc(n)
+    pub fn alloc(&mut self, n: usize) -> Result<(), VerifyError<B::Error>> {
+        match &self.state {
+            VerifierState::Initialized => self.backend.alloc(n).map_err(VerifyError::Backend),
+            _ => Err(VerifyError::WrongPhase),
+        }
     }
 
     /// Compute the preparation phase of the protocol.
     ///
     /// # Arguments
     ///
-    /// * `transcript` - Shared session transcript.
+    /// * `transcript` -  Fiat-Shamir transcript..
     /// * `x_keys` - Verifier-side keys for the first input vector.
     /// * `y_keys` - Verifier-side keys for the second input vector.
     /// * `preparation` - The prover-emitted preparation DTO.
@@ -57,12 +59,17 @@ where
     /// `y_keys` before this method is invoked. The protocol's soundness
     /// depends on this binding.
     pub fn prepare(
-        mut self,
-        mut transcript: Hasher,
+        &mut self,
+        transcript: &mut Hasher,
         x_keys: &[Vec<E>],
         y_keys: &[Vec<E>],
         preparation: B::Preparation,
-    ) -> Result<Verifier<W, E, B, verifier_state::Prepared<E>>, VerifyError<B::Error>> {
+    ) -> Result<(), VerifyError<B::Error>> {
+        match &self.state {
+            VerifierState::Initialized => {}
+            _ => return Err(VerifyError::WrongPhase),
+        }
+
         let xn = x_keys.len();
         let yn = y_keys.len();
         if xn != yn {
@@ -87,11 +94,11 @@ where
         }
 
         // Draw the random challenge `r`.
-        let r = draw_field::<E>(&mut transcript, b"permutation-proof::challenge_r");
+        let r = draw_field::<E>(transcript, b"permutation-proof::challenge_r");
 
         // Draw the tuple-collapse challenge `s ∈ E^tuple_width`.
         let s: Vec<E> = (0..tuple_width)
-            .map(|_| draw_field::<E>(&mut transcript, b"permutation-proof::challenge_s"))
+            .map(|_| draw_field::<E>(transcript, b"permutation-proof::challenge_s"))
             .collect();
 
         // Compute per-position collapsed factors.
@@ -114,50 +121,41 @@ where
 
         let px_k = self
             .backend
-            .product(&mut transcript, &fx_keys)
+            .product(&fx_keys)
             .map_err(VerifyError::Backend)?;
         let py_k = self
             .backend
-            .product(&mut transcript, &fy_keys)
+            .product(&fy_keys)
             .map_err(VerifyError::Backend)?;
 
-        Ok(Verifier {
-            backend: self.backend,
-            state: verifier_state::Prepared {
-                transcript,
-                px_k,
-                py_k,
-            },
-            _phantom: std::marker::PhantomData,
-        })
-    }
-}
+        self.state = VerifierState::Prepared { px_k, py_k };
 
-impl<W, E, B> Verifier<W, E, B, verifier_state::Prepared<E>>
-where
-    W: Field,
-    E: ExtensionField<W>,
-    B: VerifierBackend<W, E>,
-{
+        Ok(())
+    }
+
     /// Verify the proof.
     ///
     /// # Arguments
     ///
     /// * `proof` - The prover-emitted proof.
-    pub fn verify(self, proof: Proof<E, B::BackendProof>) -> Result<(), VerifyError<B::Error>>
+    /// * `transcript` - Fiat-Shamir transcript. Must be the same instance as in
+    ///   [`prepare`](Self::prepare).
+    pub fn verify(
+        self,
+        proof: Proof<E, B::BackendProof>,
+        transcript: &mut Hasher,
+    ) -> Result<(), VerifyError<B::Error>>
     where
         E: Serialize,
         B::BackendProof: Serialize,
     {
         let Verifier { backend, state, .. } = self;
-        let verifier_state::Prepared {
-            mut transcript,
-            px_k,
-            py_k,
-        } = state;
+        let (px_k, py_k) = match state {
+            VerifierState::Prepared { px_k, py_k } => (px_k, py_k),
+            _ => return Err(VerifyError::WrongPhase),
+        };
 
-        transcript.update(b"permutation-proof::proof");
-        transcript.update(&bcs::to_bytes(&proof).expect("serialize"));
+        let proof_bytes = bcs::to_bytes(&proof).expect("serialize");
 
         let Proof {
             zero_proof,
@@ -173,14 +171,31 @@ where
             return Err(VerifyError::ZeroCheckFailed);
         }
 
-        // Backend's supplementary check.
-        backend.verify(backend_proof).map_err(VerifyError::Backend)
+        backend
+            .verify(backend_proof, transcript)
+            .map_err(VerifyError::Backend)?;
+
+        // Absorb the proof into the transcript so any subsequent proof
+        // sharing this transcript stays bound to this one.
+        transcript.update(&proof_bytes);
+
+        Ok(())
     }
+}
+
+/// Internal state machine for [`Verifier`].
+enum VerifierState<E> {
+    Initialized,
+    Prepared { px_k: E, py_k: E },
 }
 
 /// Error produced by protocol verifier.
 #[derive(Debug, thiserror::Error)]
 pub enum VerifyError<E: std::error::Error + Send + Sync + 'static> {
+    /// A method was called while the verifier was in the wrong phase.
+    #[error("verifier called in the wrong phase")]
+    WrongPhase,
+
     /// The two key slices did not have the same length.
     #[error("length mismatch: x_keys={xn}, y_keys={yn}")]
     LengthMismatch {
@@ -208,38 +223,6 @@ pub enum VerifyError<E: std::error::Error + Send + Sync + 'static> {
     Backend(#[source] E),
 }
 
-/// Type-state markers for [`Verifier`]'s phase.
-pub mod verifier_state {
-    use mpz_fields::Field;
-
-    mod sealed {
-        pub trait Sealed {}
-    }
-
-    /// Marker trait implemented by every legal
-    /// [`Verifier`](super::Verifier) phase. Sealed: external crates
-    /// cannot add new phases.
-    pub trait State: sealed::Sealed {}
-
-    /// Phase right after [`Verifier::new`](super::Verifier::new):
-    /// `alloc` and `prepare` are callable; `verify` is not.
-    pub struct Initialized;
-
-    /// Phase right after a successful
-    /// [`prepare`](super::Verifier::<_, _, _, Initialized>::prepare):
-    /// `verify` is callable.
-    pub struct Prepared<E: Field> {
-        pub(super) transcript: blake3::Hasher,
-        pub(super) px_k: E,
-        pub(super) py_k: E,
-    }
-
-    impl sealed::Sealed for Initialized {}
-    impl State for Initialized {}
-    impl<E: Field> sealed::Sealed for Prepared<E> {}
-    impl<E: Field> State for Prepared<E> {}
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,14 +248,14 @@ mod tests {
     /// `LengthMismatch`.
     #[test]
     fn prepare_rejects_length_mismatch() {
-        let verifier = build_mock_verifier();
-        let transcript = Hasher::new();
+        let mut verifier = build_mock_verifier();
+        let mut transcript = Hasher::new();
         let x_keys = key_ones(3, 1);
         let y_keys = key_ones(5, 1);
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare(transcript, &x_keys, &y_keys, preparation)
+            .prepare(&mut transcript, &x_keys, &y_keys, preparation)
             .err()
             .expect("length mismatch must surface an error");
         match err {
@@ -286,13 +269,13 @@ mod tests {
     /// A permutation proof over zero positions is vacuous.
     #[test]
     fn prepare_rejects_empty_vectors() {
-        let verifier = build_mock_verifier();
-        let transcript = Hasher::new();
+        let mut verifier = build_mock_verifier();
+        let mut transcript = Hasher::new();
         let empty: Vec<Vec<Gf2_128>> = Vec::new();
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare(transcript, &empty, &empty, preparation)
+            .prepare(&mut transcript, &empty, &empty, preparation)
             .err()
             .expect("empty inputs must surface an error");
         assert!(
@@ -304,14 +287,14 @@ mod tests {
     /// Zero-width tuples are rejected.
     #[test]
     fn prepare_rejects_zero_width_tuples() {
-        let verifier = build_mock_verifier();
-        let transcript = Hasher::new();
+        let mut verifier = build_mock_verifier();
+        let mut transcript = Hasher::new();
         let x_keys = key_ones(1, 0);
         let y_keys = key_ones(1, 0);
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare(transcript, &x_keys, &y_keys, preparation)
+            .prepare(&mut transcript, &x_keys, &y_keys, preparation)
             .err()
             .expect("zero-width tuples must surface an error");
         assert!(
@@ -323,17 +306,14 @@ mod tests {
     /// Non-uniform tuple widths rejected.
     #[test]
     fn prepare_rejects_tuple_width_mismatch() {
-        let verifier = build_mock_verifier();
-        let transcript = Hasher::new();
-        let x_keys: Vec<Vec<Gf2_128>> = vec![
-            vec![Gf2_128::one(); 2],
-            vec![Gf2_128::one(); 3],
-        ];
+        let mut verifier = build_mock_verifier();
+        let mut transcript = Hasher::new();
+        let x_keys: Vec<Vec<Gf2_128>> = vec![vec![Gf2_128::one(); 2], vec![Gf2_128::one(); 3]];
         let y_keys = x_keys.clone();
         let preparation = Preparation { prod_keys: vec![] };
 
         let err = verifier
-            .prepare(transcript, &x_keys, &y_keys, preparation)
+            .prepare(&mut transcript, &x_keys, &y_keys, preparation)
             .err()
             .expect("non-uniform tuple width must surface an error");
         assert!(
@@ -352,11 +332,7 @@ mod tests {
 
         let verifier = Verifier {
             backend: MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta),
-            state: verifier_state::Prepared {
-                transcript: Hasher::new(),
-                px_k,
-                py_k,
-            },
+            state: VerifierState::Prepared { px_k, py_k },
             _phantom: std::marker::PhantomData,
         };
 
@@ -365,8 +341,9 @@ mod tests {
             backend_proof: (),
         };
 
+        let mut transcript = Hasher::new();
         verifier
-            .verify(proof)
+            .verify(proof, &mut transcript)
             .expect("matching zero_proof must be accepted");
     }
 
@@ -380,11 +357,7 @@ mod tests {
 
         let verifier = Verifier {
             backend: MockVerifierBackend::<Gf2_128, Gf2_128>::new(delta),
-            state: verifier_state::Prepared {
-                transcript: Hasher::new(),
-                px_k,
-                py_k,
-            },
+            state: VerifierState::Prepared { px_k, py_k },
             _phantom: std::marker::PhantomData,
         };
 
@@ -393,13 +366,31 @@ mod tests {
             backend_proof: (),
         };
 
+        let mut transcript = Hasher::new();
         let err = verifier
-            .verify(tampered)
+            .verify(tampered, &mut transcript)
             .err()
             .expect("tampered zero_proof must be rejected");
         assert!(
             matches!(err, VerifyError::ZeroCheckFailed),
             "expected ZeroCheckFailed, got {err:?}"
         );
+    }
+
+    /// `verify` errors with `WrongPhase` if `prepare` hasn't been
+    /// called.
+    #[test]
+    fn verify_rejects_initialized_phase() {
+        let verifier = build_mock_verifier();
+        let proof = Proof {
+            zero_proof: Gf2_128::one(),
+            backend_proof: (),
+        };
+        let mut transcript = Hasher::new();
+        let err = verifier
+            .verify(proof, &mut transcript)
+            .err()
+            .expect("verify without prepare must fail");
+        assert!(matches!(err, VerifyError::WrongPhase));
     }
 }

--- a/crates/perm-proof-core/tests/api.rs
+++ b/crates/perm-proof-core/tests/api.rs
@@ -1,14 +1,14 @@
-//! End-to-end tests for the permutation proof protocol public API.
-//!
-//! These tests drive the full `Prover` → `Verifier` lifecycle against
-//! the non-cryptographic [`mock`](mpz_perm_proof_core::backend::mock)
-//! backend.
+//! End-to-end tests for the permutation-proof public API against the
+//! production [`vole_zk`](mpz_perm_proof_core::backend::vole_zk)
+//! backend, with the ideal VOLE functionalities.
 
 use mpz_fields::{Field, gf2_128::Gf2_128};
 use mpz_perm_proof_core::{
     Prover, Verifier,
-    backend::mock::{MockError, mock_pair},
-    test_utils::{Committed, commit_values},
+    backend::vole_zk::{VoleZkProverBackend, VoleZkVerifierBackend, VoleZkVerifierError},
+    test_utils::{
+        Committed, commit_values, ideal_perm_proof_rvole_pair, ideal_perm_proof_rvope_pair,
+    },
     verifier::VerifyError,
 };
 use rand::{Rng, SeedableRng, seq::SliceRandom};
@@ -19,57 +19,79 @@ use rand_chacha::ChaCha8Rng;
 enum Mode {
     /// Honest prover.
     Honest,
-    /// Dishonest prover.
+    /// Dishonest prover: tampers an input AFTER authentication, so the
+    /// MACs/keys still bind to the original value and the IT-MAC
+    /// invariant on that wire is broken.
     Dishonest,
 }
 
-/// Drive the full two-round Prover → Verifier lifecycle over
-/// `n = 100` tuples of width `L` and return the verifier's result.
-fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockError>> {
+/// Fan-in of the product tree the vole-zk backend uses.
+const FAN_IN: usize = 8;
+
+/// Permutation size.
+const N: usize = 100;
+
+/// Drive the full two-round Prover → Verifier lifecycle over `N` tuples
+/// of width `L` and return the verifier's result.
+fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<VoleZkVerifierError>> {
     let mut rng = ChaCha8Rng::seed_from_u64(0xA1);
     let delta: Gf2_128 = rng.random();
 
-    // Input tuples: `n` positions, each an `L`-wide tuple of random
-    // field elements. `y` is a random permutation of `x`.
-    let mut x_values: Vec<Vec<Gf2_128>> = (0..100)
+    // Inputs: `x` is random; `y` is `x` permuted via Fisher-Yates.
+    let mut x_values: Vec<Vec<Gf2_128>> = (0..N)
         .map(|_| (0..L).map(|_| rng.random()).collect())
         .collect();
-    // Fisher-Yates permutation on index vector; apply to build y.
     let mut perm_indices: Vec<usize> = (0..x_values.len()).collect();
     perm_indices.shuffle(&mut rng);
     let y_values: Vec<Vec<Gf2_128>> = perm_indices.iter().map(|&i| x_values[i].clone()).collect();
 
-    // Commit both vectors as authenticated tuple-wires in a single
-    // VOLE session.
+    // Authenticate both vectors via a single ideal VOLE session. Returns
+    // prover-side MACs, verifier-side keys, and a transcript bound to the
+    // on-wire commit. Both parties start their Fiat-Shamir transcripts
+    // from this committed state.
     let Committed {
         macs: [x_macs, y_macs],
         keys: [x_keys, y_keys],
         transcript,
     } = commit_values([&x_values[..], &y_values[..]], delta, &mut rng);
-    let mut tp = transcript.clone();
-    let mut tv = transcript;
 
+    // Ideal RVOLE / RVOPE correlations, allocated + flushed for one run.
+    let (rvole_s, rvole_r) = ideal_perm_proof_rvole_pair::<Gf2_128>(&mut rng, delta, N, FAN_IN);
+    let (rvope_s, rvope_r) = ideal_perm_proof_rvope_pair::<Gf2_128>(&mut rng, delta, FAN_IN);
+
+    // Construct the production vole-zk backends and wrap them in the
+    // `Prover` / `Verifier` state machine.
+    let prover_backend =
+        VoleZkProverBackend::<Gf2_128, Gf2_128, _, _>::new(FAN_IN, rvole_r, rvope_r)
+            .expect("vole-zk prover backend");
+    let verifier_backend =
+        VoleZkVerifierBackend::<Gf2_128, Gf2_128, _, _>::new(FAN_IN, delta, rvole_s, rvope_s)
+            .expect("vole-zk verifier backend");
+    let mut prover = Prover::new(prover_backend);
+    let mut verifier = Verifier::new(verifier_backend);
+    prover.alloc(N).expect("prover alloc");
+    verifier.alloc(N).expect("verifier alloc");
+
+    // Dishonest case: tamper AFTER authentication is locked in. The
+    // MACs/keys still bind to the original value, so the verifier
+    // rejects.
     if matches!(mode, Mode::Dishonest) {
-        // Tamper AFTER authentication.
         x_values[0][0] = x_values[0][0] + Gf2_128::one();
     }
 
-    let (pb, vb) = mock_pair::<Gf2_128, Gf2_128>(delta);
-    let mut prover = Prover::new(pb);
-    let mut verifier = Verifier::new(vb);
+    // The transcript is cloned so each party advances its own copy from the
+    // committed state.
+    let mut tp = transcript.clone();
+    let mut tv = transcript;
 
-    // --- Round 1: prover -> verifier ---
     let preparation = prover
         .prepare(&mut tp, (&x_values, &x_macs), (&y_values, &y_macs))
-        .expect("prover prepare must succeed");
+        .expect("prover prepare");
     verifier
         .prepare(&mut tv, &x_keys, &y_keys, preparation)
-        .expect("verifier prepare must succeed");
+        .expect("verifier prepare");
 
-    // --- Round 2: prover -> verifier ---
-    let proof = prover
-        .prove(&mut tp)
-        .expect("prover prove must succeed");
+    let proof = prover.prove(&mut tp).expect("prover prove");
     verifier.verify(proof, &mut tv)
 }
 
@@ -84,6 +106,9 @@ fn accepts_honest_permutation_scalar_n100() {
 fn rejects_non_permutation_scalar_n100() {
     let err =
         run_end_to_end::<1>(Mode::Dishonest).expect_err("dishonest scalar case must be rejected");
+    // Wrapper-level zero check (prover's opened MAC vs verifier's diff
+    // key) fires before the backend's QS verify gets a chance, so this
+    // is the expected reject path for tampered-after-auth inputs.
     assert!(
         matches!(err, VerifyError::ZeroCheckFailed),
         "expected ZeroCheckFailed, got {err:?}"
@@ -101,6 +126,9 @@ fn accepts_honest_permutation_tuples3_n100() {
 fn rejects_non_permutation_tuples3_n100() {
     let err =
         run_end_to_end::<3>(Mode::Dishonest).expect_err("dishonest tuple case must be rejected");
+    // Wrapper-level zero check (prover's opened MAC vs verifier's diff
+    // key) fires before the backend's QS verify gets a chance, so this
+    // is the expected reject path for tampered-after-auth inputs.
     assert!(
         matches!(err, VerifyError::ZeroCheckFailed),
         "expected ZeroCheckFailed, got {err:?}"

--- a/crates/perm-proof-core/tests/api.rs
+++ b/crates/perm-proof-core/tests/api.rs
@@ -1,0 +1,106 @@
+//! End-to-end tests for the permutation proof protocol public API.
+//!
+//! These tests drive the full `Prover` → `Verifier` lifecycle against
+//! the non-cryptographic [`mock`](perm_proof_core::backend::mock)
+//! backend.
+
+use mpz_fields::{Field, gf2_128::Gf2_128};
+use perm_proof_core::{
+    Prover, Verifier,
+    backend::mock::{MockError, mock_pair},
+    test_utils::{Committed, commit_values},
+    verifier::VerifyError,
+};
+use rand::{Rng, SeedableRng, seq::SliceRandom};
+use rand_chacha::ChaCha8Rng;
+
+/// Mode toggle for the end-to-end runners.
+#[derive(Clone, Copy)]
+enum Mode {
+    /// Honest prover.
+    Honest,
+    /// Dishonest prover.
+    Dishonest,
+}
+
+/// Drive the full two-round Prover → Verifier lifecycle over
+/// `n = 100` tuples of width `L` and return the verifier's result.
+fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockError>> {
+    let mut rng = ChaCha8Rng::seed_from_u64(0xA1);
+    let delta: Gf2_128 = rng.random();
+
+    // Input tuples: `n` positions, each an `L`-wide tuple of random
+    // field elements. `y` is a random permutation of `x`.
+    let mut x_values: Vec<[Gf2_128; L]> = (0..100)
+        .map(|_| std::array::from_fn(|_| rng.random()))
+        .collect();
+    // Fisher-Yates permutation on index vector; apply to build y.
+    let mut perm_indices: Vec<usize> = (0..x_values.len()).collect();
+    perm_indices.shuffle(&mut rng);
+    let y_values: Vec<[Gf2_128; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+
+    // Commit both vectors as authenticated tuple-wires in a single
+    // VOLE session.
+    let Committed {
+        macs: [x_macs, y_macs],
+        keys: [x_keys, y_keys],
+        transcript,
+    } = commit_values([&x_values[..], &y_values[..]], delta, &mut rng);
+    let tp = transcript.clone();
+    let tv = transcript;
+
+    if matches!(mode, Mode::Dishonest) {
+        // Tamper AFTER authentication.
+        x_values[0][0] = x_values[0][0] + Gf2_128::one();
+    }
+
+    let (pb, vb) = mock_pair::<Gf2_128, Gf2_128>(delta);
+    let prover = Prover::new(pb);
+    let verifier = Verifier::new(vb);
+
+    // --- Round 1: prover -> verifier ---
+    let (preparation, prover) = prover
+        .prepare::<L>(tp, (&x_values, &x_macs), (&y_values, &y_macs))
+        .expect("prover prepare must succeed");
+    let verifier = verifier
+        .prepare::<L>(tv, &x_keys, &y_keys, preparation)
+        .expect("verifier prepare must succeed");
+
+    // --- Round 2: prover -> verifier ---
+    let proof = prover.prove().expect("prover prove must succeed");
+    verifier.verify(proof)
+}
+
+/// Honest end-to-end with scalar inputs (`L = 1`).
+#[test]
+fn accepts_honest_permutation_scalar_n100() {
+    run_end_to_end::<1>(Mode::Honest).expect("honest case must accept");
+}
+
+/// Dishonest end-to-end with scalar inputs.
+#[test]
+fn rejects_non_permutation_scalar_n100() {
+    let err =
+        run_end_to_end::<1>(Mode::Dishonest).expect_err("dishonest scalar case must be rejected");
+    assert!(
+        matches!(err, VerifyError::ZeroCheckFailed),
+        "expected ZeroCheckFailed, got {err:?}"
+    );
+}
+
+/// Honest end-to-end with 3-tuple inputs.
+#[test]
+fn accepts_honest_permutation_tuples3_n100() {
+    run_end_to_end::<3>(Mode::Honest).expect("honest tuple case must accept");
+}
+
+/// Dishonest end-to-end with 3-tuple inputs.
+#[test]
+fn rejects_non_permutation_tuples3_n100() {
+    let err =
+        run_end_to_end::<3>(Mode::Dishonest).expect_err("dishonest tuple case must be rejected");
+    assert!(
+        matches!(err, VerifyError::ZeroCheckFailed),
+        "expected ZeroCheckFailed, got {err:?}"
+    );
+}

--- a/crates/perm-proof-core/tests/api.rs
+++ b/crates/perm-proof-core/tests/api.rs
@@ -31,13 +31,13 @@ fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockErro
 
     // Input tuples: `n` positions, each an `L`-wide tuple of random
     // field elements. `y` is a random permutation of `x`.
-    let mut x_values: Vec<[Gf2_128; L]> = (0..100)
-        .map(|_| std::array::from_fn(|_| rng.random()))
+    let mut x_values: Vec<Vec<Gf2_128>> = (0..100)
+        .map(|_| (0..L).map(|_| rng.random()).collect())
         .collect();
     // Fisher-Yates permutation on index vector; apply to build y.
     let mut perm_indices: Vec<usize> = (0..x_values.len()).collect();
     perm_indices.shuffle(&mut rng);
-    let y_values: Vec<[Gf2_128; L]> = perm_indices.iter().map(|&i| x_values[i]).collect();
+    let y_values: Vec<Vec<Gf2_128>> = perm_indices.iter().map(|&i| x_values[i].clone()).collect();
 
     // Commit both vectors as authenticated tuple-wires in a single
     // VOLE session.
@@ -60,10 +60,10 @@ fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockErro
 
     // --- Round 1: prover -> verifier ---
     let (preparation, prover) = prover
-        .prepare::<L>(tp, (&x_values, &x_macs), (&y_values, &y_macs))
+        .prepare(tp, (&x_values, &x_macs), (&y_values, &y_macs))
         .expect("prover prepare must succeed");
     let verifier = verifier
-        .prepare::<L>(tv, &x_keys, &y_keys, preparation)
+        .prepare(tv, &x_keys, &y_keys, preparation)
         .expect("verifier prepare must succeed");
 
     // --- Round 2: prover -> verifier ---

--- a/crates/perm-proof-core/tests/api.rs
+++ b/crates/perm-proof-core/tests/api.rs
@@ -1,11 +1,11 @@
 //! End-to-end tests for the permutation proof protocol public API.
 //!
 //! These tests drive the full `Prover` → `Verifier` lifecycle against
-//! the non-cryptographic [`mock`](perm_proof_core::backend::mock)
+//! the non-cryptographic [`mock`](mpz_perm_proof_core::backend::mock)
 //! backend.
 
 use mpz_fields::{Field, gf2_128::Gf2_128};
-use perm_proof_core::{
+use mpz_perm_proof_core::{
     Prover, Verifier,
     backend::mock::{MockError, mock_pair},
     test_utils::{Committed, commit_values},
@@ -46,8 +46,8 @@ fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockErro
         keys: [x_keys, y_keys],
         transcript,
     } = commit_values([&x_values[..], &y_values[..]], delta, &mut rng);
-    let tp = transcript.clone();
-    let tv = transcript;
+    let mut tp = transcript.clone();
+    let mut tv = transcript;
 
     if matches!(mode, Mode::Dishonest) {
         // Tamper AFTER authentication.
@@ -55,20 +55,22 @@ fn run_end_to_end<const L: usize>(mode: Mode) -> Result<(), VerifyError<MockErro
     }
 
     let (pb, vb) = mock_pair::<Gf2_128, Gf2_128>(delta);
-    let prover = Prover::new(pb);
-    let verifier = Verifier::new(vb);
+    let mut prover = Prover::new(pb);
+    let mut verifier = Verifier::new(vb);
 
     // --- Round 1: prover -> verifier ---
-    let (preparation, prover) = prover
-        .prepare(tp, (&x_values, &x_macs), (&y_values, &y_macs))
+    let preparation = prover
+        .prepare(&mut tp, (&x_values, &x_macs), (&y_values, &y_macs))
         .expect("prover prepare must succeed");
-    let verifier = verifier
-        .prepare(tv, &x_keys, &y_keys, preparation)
+    verifier
+        .prepare(&mut tv, &x_keys, &y_keys, preparation)
         .expect("verifier prepare must succeed");
 
     // --- Round 2: prover -> verifier ---
-    let proof = prover.prove().expect("prover prove must succeed");
-    verifier.verify(proof)
+    let proof = prover
+        .prove(&mut tp)
+        .expect("prover prove must succeed");
+    verifier.verify(proof, &mut tv)
 }
 
 /// Honest end-to-end with scalar inputs (`L = 1`).


### PR DESCRIPTION
This PR adds a permutation proof protocol.

### Benchmark

  *`n` = size of the permutation (number of elements). Native column is `target-cpu=native` (hardware-accelerated CLMUL etc.). 
  WASM column is `wasm32-wasip1-threads` under V8. All runs are single-threaded.*

  | Role | n | native | wasm |
  |---|---|---|---|
  | Prover   | 100K | 16.26 ms | 105.64 ms |
  | Prover   | 200K | 33.51 ms | 211.95 ms |
  | Verifier | 100K |  4.75 ms |  22.03 ms |
  | Verifier | 200K | 10.04 ms |  44.02 ms |
