### PR TITLE
chore(fields): set MSRV to 1.95 for cfg_select!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ members = [
 exclude = ["crates/lpn-estimator"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.95"
+
 [profile.release]
 lto = true
 

--- a/crates/fields/Cargo.toml
+++ b/crates/fields/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mpz-fields"
 version = "0.1.0-alpha.5"
 edition = "2024"
+rust-version = "1.95"
 
 [lints]
 workspace = true

--- a/crates/fields/Cargo.toml
+++ b/crates/fields/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpz-fields"
 version = "0.1.0-alpha.5"
 edition = "2024"
-rust-version = "1.95"
+rust-version.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- The `cfg_select!` macro used in `mpz-fields` (in `gf2_64.rs`, `gf2_128.rs`, `lib.rs`) was stabilized in Rust 1.95.
- Declare `rust-version = "1.95"` in `crates/fields/Cargo.toml` so builds fail fast with a clear MSRV error on older toolchains instead of confusing macro errors.

## Test plan
- [x] `cargo check -p mpz-fields` succeeds