### PR TITLE
feat(mpz-fields): inner products, ExtensionField

### DIFF
--- a/crates/fields/benches/fields.rs
+++ b/crates/fields/benches/fields.rs
@@ -11,6 +11,13 @@ fn naive_inner_product<T: Field>(a: &[T], b: &[T]) -> T {
         .fold(T::zero(), |acc, (x, y)| acc + *x * *y)
 }
 
+fn naive_double_inner_product<T: Field>(a: &[T], b: &[T], c: &[T]) -> T {
+    a.iter()
+        .zip(b.iter())
+        .zip(c.iter())
+        .fold(T::zero(), |acc, ((x, y), z)| acc + *x * *y * *z)
+}
+
 fn bench_mul(c: &mut Criterion) {
     let mut rng = Prg::from_seed(Block::ZERO);
 
@@ -107,11 +114,70 @@ fn bench_inner_product(c: &mut Criterion) {
     }
 }
 
+fn bench_double_inner_product(c: &mut Criterion) {
+    let mut rng = Prg::from_seed(Block::ZERO);
+
+    {
+        let mut group = c.benchmark_group("gf2_64/double_inner_product");
+        for &len in INNER_PRODUCT_LENS {
+            let a: Vec<Gf2_64> = (0..len).map(|_| rng.random()).collect();
+            let b: Vec<Gf2_64> = (0..len).map(|_| rng.random()).collect();
+            let cc: Vec<Gf2_64> = (0..len).map(|_| rng.random()).collect();
+
+            group.throughput(Throughput::Elements(len as u64));
+
+            group.bench_with_input(BenchmarkId::new("accelerated", len), &len, |bench, _| {
+                bench.iter(|| {
+                    Gf2_64::double_inner_product(black_box(&a), black_box(&b), black_box(&cc))
+                });
+            });
+            group.bench_with_input(BenchmarkId::new("naive", len), &len, |bench, _| {
+                bench.iter(|| {
+                    naive_double_inner_product::<Gf2_64>(
+                        black_box(&a),
+                        black_box(&b),
+                        black_box(&cc),
+                    )
+                });
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("gf2_128/double_inner_product");
+        for &len in INNER_PRODUCT_LENS {
+            let a: Vec<Gf2_128> = (0..len).map(|_| rng.random()).collect();
+            let b: Vec<Gf2_128> = (0..len).map(|_| rng.random()).collect();
+            let cc: Vec<Gf2_128> = (0..len).map(|_| rng.random()).collect();
+
+            group.throughput(Throughput::Elements(len as u64));
+
+            group.bench_with_input(BenchmarkId::new("accelerated", len), &len, |bench, _| {
+                bench.iter(|| {
+                    Gf2_128::double_inner_product(black_box(&a), black_box(&b), black_box(&cc))
+                });
+            });
+            group.bench_with_input(BenchmarkId::new("naive", len), &len, |bench, _| {
+                bench.iter(|| {
+                    naive_double_inner_product::<Gf2_128>(
+                        black_box(&a),
+                        black_box(&b),
+                        black_box(&cc),
+                    )
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
 criterion_group!(
     benches,
     bench_mul,
     bench_square,
     bench_inverse,
-    bench_inner_product
+    bench_inner_product,
+    bench_double_inner_product
 );
 criterion_main!(benches);

--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, Mul, Neg, Sub};
 
 use mpz_core::Block;
 
-use crate::{Field, FieldError};
+use crate::{ExtensionField, Field, FieldError, gf2::Gf2};
 
 /// A type for holding field elements of Gf(2^128).
 #[derive(
@@ -51,13 +51,13 @@ impl Gf2_128 {
 
 impl From<Gf2_128> for Block {
     fn from(value: Gf2_128) -> Self {
-        Block::new(value.0.to_be_bytes())
+        Block::new(value.0.to_le_bytes())
     }
 }
 
 impl From<Block> for Gf2_128 {
     fn from(block: Block) -> Self {
-        Gf2_128(u128::from_be_bytes(block.to_bytes()))
+        Gf2_128(u128::from_le_bytes(block.to_bytes()))
     }
 }
 
@@ -67,7 +67,7 @@ impl TryFrom<Array<u8, U16>> for Gf2_128 {
     fn try_from(value: Array<u8, U16>) -> Result<Self, Self::Error> {
         let inner: [u8; 16] = value.into();
 
-        Ok(Gf2_128(u128::from_be_bytes(inner)))
+        Ok(Gf2_128(u128::from_le_bytes(inner)))
     }
 }
 
@@ -162,8 +162,55 @@ impl Field for Gf2_128 {
     }
 
     #[inline]
+    fn double_inner_product_chunk(a: &[Self], b: &[Self], c: &[Self]) -> Self {
+        Gf2_128(gf128_double_inner_product(a, b, c))
+    }
+
+    #[inline]
     fn square(self) -> Self {
         Gf2_128(gf128_square(self.0))
+    }
+}
+
+/// Monomial basis `[α^0, α^1, …, α^127]` of `GF(2^128)` over `GF(2)`.
+static MONOMIAL_BASIS_GF2_128: [Gf2_128; 128] = {
+    let mut out = [Gf2_128::new(0); 128];
+    let mut i = 0;
+    while i < 128 {
+        out[i] = Gf2_128::new(1u128 << i);
+        i += 1;
+    }
+    out
+};
+
+impl ExtensionField<Gf2> for Gf2_128 {
+    const MONOMIAL_BASIS: &'static [Self] = &MONOMIAL_BASIS_GF2_128;
+
+    #[inline]
+    fn embed(base: Gf2) -> Self {
+        // `Gf2(false) -> 0`, `Gf2(true) -> 1`.
+        Gf2_128::new(u128::from(base.0))
+    }
+
+    /// Constant-time masked XOR: each term reduces to
+    /// `acc ^= c & mask_from_bit(v)` — no field multiplications and
+    /// no data-dependent branches.
+    #[inline]
+    fn inner_product_subfield(values: &[Gf2], challenges: &[Self]) -> Self {
+        assert_eq!(
+            values.len(),
+            challenges.len(),
+            "inner_product_subfield: slice length mismatch",
+        );
+        let mut acc = 0u128;
+        for (v, c) in values.iter().zip(challenges.iter()) {
+            // `v.0 as u128` is 0 or 1; `wrapping_neg()` gives 0 or
+            // `u128::MAX`. ANDing with `c.to_inner()` zeroes out the
+            // term when `v == Gf2(0)` without branching.
+            let mask = (v.0 as u128).wrapping_neg();
+            acc ^= c.to_inner() & mask;
+        }
+        Gf2_128::new(acc)
     }
 }
 
@@ -190,6 +237,11 @@ fn gf128_mul(a: u128, b: u128) -> u128 {
 #[inline(always)]
 fn gf128_inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
     backend::inner_product(a, b)
+}
+
+#[inline(always)]
+fn gf128_double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u128 {
+    backend::double_inner_product(a, b, c)
 }
 
 #[inline(always)]
@@ -233,10 +285,12 @@ mod tests {
     use super::Gf2_128;
     use crate::{
         Field,
+        gf2::Gf2,
         tests::{
-            test_field_axioms_random, test_field_basic, test_field_bit_ops_lsb0,
-            test_field_bit_ops_msb0, test_field_compute_product_repeated, test_field_inner_product,
-            test_field_square,
+            test_extension_field_subfield_inner_product, test_field_axioms_random,
+            test_field_basic, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
+            test_field_compute_product_repeated, test_field_double_inner_product,
+            test_field_inner_product, test_field_square,
         },
     };
     #[test]
@@ -257,6 +311,11 @@ mod tests {
     }
 
     #[test]
+    fn test_gf2_128_double_inner_product() {
+        test_field_double_inner_product::<Gf2_128>();
+    }
+
+    #[test]
     fn test_gf2_128_axioms_random() {
         test_field_axioms_random::<Gf2_128>();
     }
@@ -270,6 +329,11 @@ mod tests {
     fn test_gf2_128_bit_ops() {
         test_field_bit_ops_lsb0::<Gf2_128>();
         test_field_bit_ops_msb0::<Gf2_128>();
+    }
+
+    #[test]
+    fn test_gf2_128_subfield_inner_product() {
+        test_extension_field_subfield_inner_product::<Gf2_128, Gf2>();
     }
 
     #[test]

--- a/crates/fields/src/gf2_128/soft.rs
+++ b/crates/fields/src/gf2_128/soft.rs
@@ -54,6 +54,23 @@ pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
     reduce128(acc_lo, acc_hi)
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. One reduction per iteration for the `aᵢ·bᵢ`
+/// intermediate, one post-loop reduction on the accumulated
+/// `(aᵢbᵢ)·cᵢ` carry-less products.
+#[inline]
+pub(super) fn double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u128 {
+    let mut acc_lo = 0u128;
+    let mut acc_hi = 0u128;
+    for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+        let (xy_lo, xy_hi) = bmul128_full(x.0, y.0);
+        let xy = reduce128(xy_lo, xy_hi);
+        let (p_lo, p_hi) = bmul128_full(xy, z.0);
+        acc_lo ^= p_lo;
+        acc_hi ^= p_hi;
+    }
+    reduce128(acc_lo, acc_hi)
+}
+
 /// Reduce a 256-bit polynomial `hi·2¹²⁸ + lo` modulo
 /// p(x) = x¹²⁸ + x⁷ + x² + x + 1 (so `x¹²⁸ ≡ R = x⁷ + x² + x + 1`).
 ///

--- a/crates/fields/src/gf2_128/wasm.rs
+++ b/crates/fields/src/gf2_128/wasm.rs
@@ -79,6 +79,48 @@ pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
     reduce128(lo, hi)
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. Per iteration: one full `mul(aᵢ, bᵢ)` (bmul128_full +
+/// reduce) to get the 128-bit `xy` intermediate, then accumulate the three
+/// `(xy · cᵢ)` Karatsuba partials in raw v128 form — deferring the
+/// rev64+shift recovery and the final reduction to one post-loop pass.
+#[inline]
+pub(super) fn double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u128 {
+    let mut acc00 = u64x2_splat(0);
+    let mut acc11 = u64x2_splat(0);
+    let mut acc_mid = u64x2_splat(0);
+
+    for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+        let (xy_lo, xy_hi) = bmul128_full(x.0, y.0);
+        let xy = reduce128(xy_lo, xy_hi);
+
+        let a_lo = xy as u64;
+        let a_hi = (xy >> 64) as u64;
+        let b_lo = z.0 as u64;
+        let b_hi = (z.0 >> 64) as u64;
+
+        let p00 = bmul64_raw(a_lo, b_lo);
+        let p11 = bmul64_raw(a_hi, b_hi);
+        let p01 = bmul64_raw(a_lo, b_hi);
+        let p10 = bmul64_raw(a_hi, b_lo);
+
+        acc00 = v128_xor(acc00, p00);
+        acc11 = v128_xor(acc11, p11);
+        acc_mid = v128_xor(acc_mid, v128_xor(p01, p10));
+    }
+
+    let (p00_lo, p00_hi) = recover_raw(acc00);
+    let (p11_lo, p11_hi) = recover_raw(acc11);
+    let (mid_lo, mid_hi) = recover_raw(acc_mid);
+
+    let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
+    let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);
+
+    let lo = p00 ^ ((mid_lo as u128) << 64);
+    let hi = p11 ^ (mid_hi as u128);
+
+    reduce128(lo, hi)
+}
+
 #[inline]
 pub(super) fn inverse(a: u128) -> u128 {
     let mut y = square(a);

--- a/crates/fields/src/gf2_128/x86.rs
+++ b/crates/fields/src/gf2_128/x86.rs
@@ -110,6 +110,29 @@ pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
     }
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. One reduction per iteration for the `aᵢ·bᵢ`
+/// intermediate (needed as a 128-bit operand for the second CLMUL), then
+/// a single post-loop reduction on the accumulated `(aᵢbᵢ)·cᵢ` carry-less
+/// products — vs. the naive fold which pays two reductions per iteration.
+#[inline(always)]
+pub(super) fn double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u128 {
+    // SAFETY: see `mul`.
+    unsafe {
+        let mut acc_lo = _mm_setzero_si128();
+        let mut acc_hi = _mm_setzero_si128();
+
+        for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+            let (xy_lo, xy_hi) = clmul128(load(x.0), load(y.0));
+            let xy = reduce128(xy_lo, xy_hi);
+            let (p_lo, p_hi) = clmul128(xy, load(z.0));
+            acc_lo = _mm_xor_si128(acc_lo, p_lo);
+            acc_hi = _mm_xor_si128(acc_hi, p_hi);
+        }
+
+        extract(reduce128(acc_lo, acc_hi))
+    }
+}
+
 /// 256-bit carry-less square of a 128-bit input (two 64×64 CLMULs). In
 /// characteristic 2, all cross terms vanish — we only need `a_lo²`
 /// (for bits [0..128]) and `a_hi²` (for bits [128..256]).

--- a/crates/fields/src/gf2_64.rs
+++ b/crates/fields/src/gf2_64.rs
@@ -12,7 +12,7 @@ use itybity::{BitLength, FromBitIterator, GetBit, Lsb0, Msb0};
 use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
-use crate::{Field, FieldError};
+use crate::{ExtensionField, Field, FieldError, gf2::Gf2};
 
 /// An element of GF(2^64), represented as a `u64`.
 ///
@@ -143,8 +143,50 @@ impl Field for Gf2_64 {
     }
 
     #[inline]
+    fn double_inner_product_chunk(a: &[Self], b: &[Self], c: &[Self]) -> Self {
+        Gf2_64(gf64_double_inner_product(a, b, c))
+    }
+
+    #[inline]
     fn square(self) -> Self {
         Gf2_64(gf64_square(self.0))
+    }
+}
+
+/// Monomial basis `[α^0, α^1, …, α^63]` of `GF(2^64)` over `GF(2)`.
+static MONOMIAL_BASIS_GF2_64: [Gf2_64; 64] = {
+    let mut out = [Gf2_64(0); 64];
+    let mut i = 0;
+    while i < 64 {
+        out[i] = Gf2_64(1u64 << i);
+        i += 1;
+    }
+    out
+};
+
+impl ExtensionField<Gf2> for Gf2_64 {
+    const MONOMIAL_BASIS: &'static [Self] = &MONOMIAL_BASIS_GF2_64;
+
+    #[inline]
+    fn embed(base: Gf2) -> Self {
+        Gf2_64(u64::from(base.0))
+    }
+
+    /// Constant-time masked XOR — no field multiplications and no
+    /// data-dependent branches.
+    #[inline]
+    fn inner_product_subfield(values: &[Gf2], challenges: &[Self]) -> Self {
+        assert_eq!(
+            values.len(),
+            challenges.len(),
+            "inner_product_subfield: slice length mismatch",
+        );
+        let mut acc = 0u64;
+        for (v, c) in values.iter().zip(challenges.iter()) {
+            let mask = (v.0 as u64).wrapping_neg();
+            acc ^= c.0 & mask;
+        }
+        Gf2_64(acc)
     }
 }
 
@@ -174,6 +216,11 @@ fn gf64_inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
 }
 
 #[inline(always)]
+fn gf64_double_inner_product(a: &[Gf2_64], b: &[Gf2_64], c: &[Gf2_64]) -> u64 {
+    backend::double_inner_product(a, b, c)
+}
+
+#[inline(always)]
 fn gf64_inverse(a: u64) -> u64 {
     backend::inverse(a)
 }
@@ -186,11 +233,24 @@ fn gf64_square(a: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{test_field_axioms_random, test_field_inner_product, test_field_square};
+    use crate::tests::{
+        test_extension_field_subfield_inner_product, test_field_axioms_random,
+        test_field_double_inner_product, test_field_inner_product, test_field_square,
+    };
 
     #[test]
     fn test_inner_product() {
         test_field_inner_product::<Gf2_64>();
+    }
+
+    #[test]
+    fn test_double_inner_product() {
+        test_field_double_inner_product::<Gf2_64>();
+    }
+
+    #[test]
+    fn test_subfield_inner_product() {
+        test_extension_field_subfield_inner_product::<Gf2_64, Gf2>();
     }
 
     #[test]

--- a/crates/fields/src/gf2_64/soft.rs
+++ b/crates/fields/src/gf2_64/soft.rs
@@ -48,6 +48,23 @@ pub(super) fn inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
     reduce64(acc_lo, acc_hi)
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. One reduction per iteration for the `aᵢ·bᵢ`
+/// intermediate, one post-loop reduction on the accumulated
+/// `(aᵢbᵢ)·cᵢ` carry-less products.
+#[inline]
+pub(super) fn double_inner_product(a: &[Gf2_64], b: &[Gf2_64], c: &[Gf2_64]) -> u64 {
+    let mut acc_lo = 0u64;
+    let mut acc_hi = 0u64;
+    for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+        let (xy_lo, xy_hi) = bmul64_full(x.0, y.0);
+        let xy = reduce64(xy_lo, xy_hi);
+        let (p_lo, p_hi) = bmul64_full(xy, z.0);
+        acc_lo ^= p_lo;
+        acc_hi ^= p_hi;
+    }
+    reduce64(acc_lo, acc_hi)
+}
+
 /// Reduce a 128-bit polynomial `hi·2⁶⁴ + lo` modulo
 /// p(x) = x⁶⁴ + x⁴ + x³ + x + 1 (so `x⁶⁴ ≡ R = x⁴ + x³ + x + 1`).
 ///

--- a/crates/fields/src/gf2_64/wasm.rs
+++ b/crates/fields/src/gf2_64/wasm.rs
@@ -48,6 +48,27 @@ pub(super) fn inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
     reduce64(lo, hi)
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. Per iteration: one full `mul(aᵢ, bᵢ)` to get the
+/// 64-bit `xy` intermediate, then accumulate the raw v128 partial for
+/// `(xy · cᵢ)` — deferring the rev64+shift recovery and the final
+/// reduction to one post-loop pass.
+#[inline]
+pub(super) fn double_inner_product(a: &[Gf2_64], b: &[Gf2_64], c: &[Gf2_64]) -> u64 {
+    let mut acc = u64x2_splat(0);
+    for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+        let (xy_lo, xy_hi) = bmul64_full(x.0, y.0);
+        let xy = reduce64(xy_lo, xy_hi);
+        let v = bmul64_lo_v128(
+            u64x2(xy, rev64(xy)),
+            u64x2(z.0, rev64(z.0)),
+        );
+        acc = v128_xor(acc, v);
+    }
+    let lo = u64x2_extract_lane::<0>(acc);
+    let hi = rev64(u64x2_extract_lane::<1>(acc)) >> 1;
+    reduce64(lo, hi)
+}
+
 #[inline]
 pub(super) fn inverse(a: u64) -> u64 {
     let mut y = square(a);

--- a/crates/fields/src/gf2_64/x86.rs
+++ b/crates/fields/src/gf2_64/x86.rs
@@ -81,6 +81,29 @@ pub(super) fn inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
     }
 }
 
+/// `Σ aᵢ · bᵢ · cᵢ`. One reduction per iteration for the `aᵢ·bᵢ`
+/// intermediate, one post-loop reduction on the accumulated
+/// `(aᵢbᵢ)·cᵢ` carry-less products.
+#[inline(always)]
+pub(super) fn double_inner_product(a: &[Gf2_64], b: &[Gf2_64], c: &[Gf2_64]) -> u64 {
+    // SAFETY: see `mul`.
+    unsafe {
+        let mut acc = _mm_setzero_si128();
+
+        for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
+            let a_vec = _mm_set_epi64x(0, x.0 as i64);
+            let b_vec = _mm_set_epi64x(0, y.0 as i64);
+            let xy_raw = _mm_clmulepi64_si128(a_vec, b_vec, 0x00);
+            let xy = reduce64(xy_raw);
+            let c_vec = _mm_set_epi64x(0, z.0 as i64);
+            let prod = _mm_clmulepi64_si128(xy, c_vec, 0x00);
+            acc = _mm_xor_si128(acc, prod);
+        }
+
+        _mm_cvtsi128_si64(reduce64(acc)) as u64
+    }
+}
+
 /// Reduce a 128-bit polynomial (in the low/high halves of `prod`) modulo
 /// p(x) = x⁶⁴ + x⁴ + x³ + x + 1.
 #[inline(always)]

--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -156,6 +156,110 @@ pub trait Field:
             .zip(b.iter())
             .fold(Self::zero(), |acc, (x, y)| acc + *x * *y)
     }
+
+    /// Compute the triple inner product `Σ aᵢ · bᵢ · cᵢ` of three slices
+    /// of field elements.
+    ///
+    /// Same chunking/parallel dispatch as [`Self::inner_product`] — the
+    /// kernel does a single reduction per chunk (vs. one per iteration
+    /// for a naive fold through `Mul`), amortising reduction cost across
+    /// the whole chunk.
+    ///
+    /// Concrete types override [`Self::double_inner_product_chunk`] (not
+    /// this method) to provide an accelerated single-chunk
+    /// implementation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the three slices do not all have the same length.
+    #[inline]
+    fn double_inner_product(a: &[Self], b: &[Self], c: &[Self]) -> Self {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "double_inner_product: slice length mismatch"
+        );
+        assert_eq!(
+            a.len(),
+            c.len(),
+            "double_inner_product: slice length mismatch"
+        );
+
+        cfg_select! {
+            feature = "rayon" => {
+                const TARGET_CHUNK_BYTES: usize = 64 * 1024;
+                let chunk = (TARGET_CHUNK_BYTES / Self::BYTE_SIZE).max(1);
+                if a.len() >= chunk * 2 {
+                    use rayon::prelude::*;
+                    a.par_chunks(chunk)
+                        .zip(b.par_chunks(chunk))
+                        .zip(c.par_chunks(chunk))
+                        .map(|((ac, bc), cc)| Self::double_inner_product_chunk(ac, bc, cc))
+                        .reduce(Self::zero, |x, y| x + y)
+                } else {
+                    Self::double_inner_product_chunk(a, b, c)
+                }
+            }
+            _ => Self::double_inner_product_chunk(a, b, c),
+        }
+    }
+
+    /// Sequential triple-inner-product kernel. Concrete types override
+    /// this with their optimised single-threaded implementation;
+    /// [`Self::double_inner_product`] calls it once (sequential) or once
+    /// per chunk (parallel).
+    #[doc(hidden)]
+    #[inline]
+    fn double_inner_product_chunk(a: &[Self], b: &[Self], c: &[Self]) -> Self {
+        a.iter()
+            .zip(b.iter())
+            .zip(c.iter())
+            .fold(Self::zero(), |acc, ((x, y), z)| acc + *x * *y * *z)
+    }
+}
+
+/// A field `Self` that is an extension of the base field `B`.
+///
+/// Implementors view `Self` as a `Self::BIT_SIZE / B::BIT_SIZE`-dimensional
+/// vector space over `B`, with a fixed monomial basis available for
+/// "pack `n` subfield values into one extension element" operations
+/// (VOPE masks, random linear compressions of subfield tuples, …).
+pub trait ExtensionField<B: Field>: Field {
+    /// The monomial basis `[α^0, α^1, …, α^(d-1)]`, where `d` is the
+    /// extension degree `Self::BIT_SIZE / B::BIT_SIZE`.
+    ///
+    /// The canonical subfield injection `B^d → Self` is
+    /// [`Self::inner_product_subfield`] with `challenges = MONOMIAL_BASIS`.
+    const MONOMIAL_BASIS: &'static [Self];
+
+    /// Embed a base-field element into the extension field.
+    fn embed(base: B) -> Self;
+
+    /// `Σ values[i] · challenges[i]` with base-field values lifted
+    /// into `Self` before multiplication. Use
+    /// [`Self::MONOMIAL_BASIS`] as `challenges` for the canonical
+    /// subfield injection, or a verifier-sampled slice for a random
+    /// linear compression of a subfield tuple.
+    ///
+    /// The default uses `embed` + field multiplication. Concrete
+    /// types can override for speed (e.g. `ExtensionField<Gf2>` can
+    /// reduce each term to a conditional XOR).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the two slices have different lengths.
+    #[inline]
+    fn inner_product_subfield(values: &[B], challenges: &[Self]) -> Self {
+        assert_eq!(
+            values.len(),
+            challenges.len(),
+            "inner_product_subfield: slice length mismatch",
+        );
+        values
+            .iter()
+            .zip(challenges.iter())
+            .fold(Self::zero(), |acc, (v, c)| acc + Self::embed(*v) * *c)
+    }
 }
 
 /// Error type for finite fields.
@@ -302,6 +406,68 @@ mod tests {
 
             assert_eq!(T::inner_product(&a, &b), expected, "len={len}");
         }
+    }
+
+    pub(crate) fn test_field_double_inner_product<T: Field>() {
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        // Empty → zero.
+        assert_eq!(T::double_inner_product(&[], &[], &[]), T::zero());
+
+        // Length 1 → a · b · c.
+        let a0 = T::rand(&mut rng);
+        let b0 = T::rand(&mut rng);
+        let c0 = T::rand(&mut rng);
+        assert_eq!(T::double_inner_product(&[a0], &[b0], &[c0]), a0 * b0 * c0);
+
+        for &len in &[17usize, 1024, 20_000] {
+            let a: Vec<T> = (0..len).map(|_| T::rand(&mut rng)).collect();
+            let b: Vec<T> = (0..len).map(|_| T::rand(&mut rng)).collect();
+            let c: Vec<T> = (0..len).map(|_| T::rand(&mut rng)).collect();
+
+            let expected = a
+                .iter()
+                .zip(b.iter())
+                .zip(c.iter())
+                .fold(T::zero(), |acc, ((x, y), z)| acc + *x * *y * *z);
+
+            assert_eq!(T::double_inner_product(&a, &b, &c), expected, "len={len}");
+        }
+    }
+
+    pub(crate) fn test_extension_field_subfield_inner_product<F, B>()
+    where
+        F: super::ExtensionField<B>,
+        B: Field,
+    {
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        // Empty → zero.
+        assert_eq!(F::inner_product_subfield(&[], &[]), F::zero());
+
+        // Across a range of lengths, the optimized impl must match the
+        // semantics: embed each subfield value into `F`, then do a
+        // regular extension-field inner product.
+        for &len in &[1usize, 3, F::BIT_SIZE, 17, 1024] {
+            let values: Vec<B> = (0..len).map(|_| B::rand(&mut rng)).collect();
+            let challenges: Vec<F> = (0..len).map(|_| F::rand(&mut rng)).collect();
+
+            let embedded: Vec<F> = values.iter().map(|v| F::embed(*v)).collect();
+            let expected = F::inner_product(&embedded, &challenges);
+            let got = F::inner_product_subfield(&values, &challenges);
+            assert_eq!(got, expected, "len={len}");
+        }
+
+        // Sanity: injection via the monomial basis recovers the
+        // subfield bits as the low-order coefficients of the result.
+        // Well-defined whenever `B::BIT_SIZE * d == F::BIT_SIZE`.
+        let one = B::one();
+        let zero = B::zero();
+        let d = F::MONOMIAL_BASIS.len();
+        let mut values = vec![zero; d];
+        values[0] = one;
+        let r = F::inner_product_subfield(&values, F::MONOMIAL_BASIS);
+        assert_eq!(r, F::embed(one), "monomial basis at index 0 == embed(one)");
     }
 
     pub(crate) fn test_field_bit_ops_lsb0<T: Field>() {


### PR DESCRIPTION
Field primitives needed by upcoming gate-by-gate ZK protocols.

  - `Field::square`, `inner_product`, `double_inner_product` (chunked, rayon-aware).
  - New `ExtensionField<B>` trait: `MONOMIAL_BASIS`, `embed`, `inner_product_subfield`.
