### PR TITLE
feat(fields): derive zerocopy traits on Gf2_64

### DIFF
--- a/crates/fields/src/gf2_64.rs
+++ b/crates/fields/src/gf2_64.rs
@@ -18,7 +18,22 @@ use crate::{Field, FieldError};
 ///
 /// Field arithmetic uses the irreducible polynomial
 /// p(x) = x^64 + x^4 + x^3 + x + 1.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    zerocopy::FromBytes,
+    zerocopy::IntoBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
+)]
+#[repr(transparent)]
 pub struct Gf2_64(pub u64);
 
 impl Gf2_64 {


### PR DESCRIPTION
## Summary

Mirrors Gf2_128, which has carried these derives since #382. Adds `#[repr(transparent)]` (required for zerocopy soundness) and the `FromBytes`, `IntoBytes`, `Immutable`, `KnownLayout` derives.