### PR TITLE
ci(wasm-bench): build + headless smoke test, export __heap_base

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,37 @@ jobs:
         working-directory: crates/wasm-bench
         run: cargo +nightly clippy --lib --target wasm32-unknown-unknown -- -D warnings
 
+  wasm:
+    name: "Build and Test WASM bench"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Nightly with rust-src
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          targets: wasm32-unknown-unknown
+          components: rust-src
+
+      - uses: Swatinem/rust-cache@v2.7.7
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: stable
+
+      - name: Build WASM bundle
+        working-directory: crates/wasm-bench
+        run: ./build-wasm.sh
+
+      - name: Build benchmark runner
+        run: cargo build --release --bin wasm-bench-runner
+
+      - name: Smoke-test in headless Chrome
+        working-directory: crates/wasm-bench
+        run: ../../target/release/wasm-bench-runner -b garbler_core/half_gates --iterations 1 --samples 1
+
   miri:
     if: ( ! github.event.pull_request.draft )
     name: "Test with Miri"

--- a/crates/common/src/context/mt/worker.rs
+++ b/crates/common/src/context/mt/worker.rs
@@ -21,7 +21,7 @@ impl Handle {
         self.sender.send(Box::new(job)).map_err(|_| {
             ContextError::new(
                 ErrorKind::Thread,
-                format!("failed to send job to worker {}", &self.id),
+                format!("failed to send job to worker {}", self.id),
             )
         })
     }

--- a/crates/wasm-bench/.cargo/config.toml
+++ b/crates/wasm-bench/.cargo/config.toml
@@ -9,6 +9,7 @@ rustflags = [
     "-Clink-arg=--export=__tls_size",
     "-Clink-arg=--export=__tls_align",
     "-Clink-arg=--export=__tls_base",
+    "-Clink-arg=--export=__heap_base",
     "--cfg",
     'getrandom_backend="wasm_js"',
 ]


### PR DESCRIPTION
## Summary
- Add a `wasm` job to `.github/workflows/rust.yml` that runs `crates/wasm-bench/build-wasm.sh` end-to-end (nightly + `-Zbuild-std` + atomics/simd128) and then runs a single benchmark iteration in headless Chrome via `wasm-bench-runner`. Today CI only runs `cargo +nightly clippy --lib --target wasm32-unknown-unknown`, which misses regressions that surface only under wasm-pack/build-std/atomics.
- Apply the `__heap_base` linker-arg fix from tlsn ([tlsnotary/tlsn@d50658a](https://github.com/tlsnotary/tlsn/commit/d50658a)) to `crates/wasm-bench/.cargo/config.toml`, exporting `__heap_base` alongside the existing TLS symbols.

## Test plan
- [x] Ran `./build-wasm.sh` locally — bundle builds successfully with the new `__heap_base` export.
- [x] Ran `wasm-bench-runner -b garbler_core/half_gates --iterations 1 --samples 1` in headless Chrome locally — completes and reports a result.
- [x] Verify the new `wasm` GitHub Actions job runs and passes on this PR.