### PR TITLE
feat: improve SHA256 arithmetization

### DIFF
--- a/crates/circuits-new/fuzz/.gitignore
+++ b/crates/circuits-new/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/crates/circuits-new/fuzz/Cargo.toml
+++ b/crates/circuits-new/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mpz-circuits-new-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+itybity = "0.3"
+sha2 = { version = "0.10", features = ["compress"] }
+mpz-circuits-new = { path = ".." }
+mpz-fields = { path = "../../fields" }
+
+[[bin]]
+name = "sha256_compress"
+path = "fuzz_targets/sha256_compress.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]

--- a/crates/circuits-new/fuzz/fuzz_targets/sha256_compress.rs
+++ b/crates/circuits-new/fuzz/fuzz_targets/sha256_compress.rs
@@ -1,0 +1,37 @@
+#![no_main]
+
+use itybity::{FromBitIterator, ToBits};
+use libfuzzer_sys::fuzz_target;
+use mpz_circuits_new::{
+    WitnessCtx,
+    sha256::{AND_PER_BLOCK, compress},
+};
+use mpz_fields::gf2::Gf2;
+
+fuzz_target!(|data: &[u8]| {
+    // Need 64 bytes block + 32 bytes state = 96 bytes.
+    if data.len() < 96 {
+        return;
+    }
+    let block: [u8; 64] = data[..64].try_into().unwrap();
+    let state: [u32; 8] = core::array::from_fn(|i| {
+        u32::from_be_bytes(data[64 + i * 4..64 + (i + 1) * 4].try_into().unwrap())
+    });
+
+    let msg_words: [u32; 16] =
+        core::array::from_fn(|i| u32::from_be_bytes(block[i * 4..i * 4 + 4].try_into().unwrap()));
+    let msg: [Gf2; 512] = <[Gf2; 512]>::from_lsb0_iter(msg_words.iter_lsb0());
+    let state_in: [Gf2; 256] = <[Gf2; 256]>::from_lsb0_iter(state.iter_lsb0());
+
+    let mut witness = Vec::with_capacity(AND_PER_BLOCK);
+    let mut ctx = WitnessCtx {
+        witness: &mut witness,
+    };
+    let out = compress(&mut ctx, msg, state_in);
+    let got: [u32; 8] = <[u32; 8]>::from_lsb0_iter(out.iter().map(|g| g.0));
+
+    let mut expected = state;
+    sha2::compress256(&mut expected, &[block.into()]);
+
+    assert_eq!(got, expected);
+});

--- a/crates/circuits-new/src/sha256.rs
+++ b/crates/circuits-new/src/sha256.rs
@@ -25,7 +25,7 @@ pub const H0: [u32; 8] = [
 ];
 
 /// AND-gate count of a single SHA-256 compression block.
-pub const AND_PER_BLOCK: usize = 23_296;
+pub const AND_PER_BLOCK: usize = 22_696;
 
 fn xor_word<C: Context<Field = Gf2>>(
     ctx: &mut C,
@@ -62,7 +62,8 @@ fn shr<C: Context<Field = Gf2>>(ctx: &mut C, a: Word<C::Wire>, n: usize) -> Word
     out
 }
 
-/// Ripple-carry 32-bit add modulo 2^32. One AND gate per bit.
+/// Ripple-carry 32-bit add modulo 2^32. 31 AND gates (the carry-out at bit 31
+/// is unused).
 fn add_word<C: Context<Field = Gf2>>(
     ctx: &mut C,
     a: Word<C::Wire>,
@@ -72,13 +73,17 @@ fn add_word<C: Context<Field = Gf2>>(
     let mut out = [zero; 32];
     let mut carry = zero;
     for i in 0..32 {
-        let ab = ctx.add(a[i], b[i]);
-        out[i] = ctx.add(ab, carry);
+        let axb = ctx.add(a[i], b[i]);
+        out[i] = ctx.add(axb, carry);
 
-        let x = ctx.add(a[i], carry);
-        let y = ctx.add(b[i], carry);
-        let z = ctx.mul(x, y);
-        carry = ctx.add(z, carry);
+        if i == 31 {
+            continue;
+        }
+
+        // carry_out = MAJ(a, b, carry) = ((a ^ b) AND (b ^ carry)) ^ b
+        let bxc = ctx.add(b[i], carry);
+        let m = ctx.mul(axb, bxc);
+        carry = ctx.add(m, b[i]);
     }
     out
 }


### PR DESCRIPTION
This PR reduces the sha2 arithmetization to 22,696 AND which is within 1% of the bristol circuit. It also uses shared subexpressions to reduce XOR count (matters for CPU cost) down to 100,176 which is 10% less than the bristol circuit.

Lastly, I added fuzzing.