### PR TITLE
refactor: use wasm-harness

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,12 @@
+[target.wasm32-wasip1]
+rustflags = [
+    "-C",
+    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
+    "-C",
+    "link-arg=--max-memory=4294967296",
+]
+runner = "scripts/wasm-runner.sh"
+
 [target.wasm32-wasip1-threads]
 rustflags = [
     "-C",
@@ -5,4 +14,4 @@ rustflags = [
     "-C",
     "link-arg=--max-memory=4294967296",
 ]
-runner = "wasmtime --wasi threads"
+runner = "scripts/wasm-runner.sh"

--- a/scripts/wasm-runner.sh
+++ b/scripts/wasm-runner.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${WASM_HARNESS_ENV_RAYON_NUM_THREADS:-}" ]; then
+    if command -v nproc >/dev/null 2>&1; then
+        cores=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        cores=$(sysctl -n hw.ncpu)
+    else
+        cores=1
+    fi
+    export WASM_HARNESS_ENV_RAYON_NUM_THREADS=$cores
+fi
+
+exec wasm-harness "$@"


### PR DESCRIPTION
# Switch wasm test/bench runner to wasm-harness

## Summary

Replaces the `wasmtime --wasi threads` runner with [`wasm-harness`](https://github.com/sinui0/wasm-harness), which executes `wasm32-wasip1[-threads]` binaries under a chosen engine (`wasmtime`, V8/`d8`, SpiderMonkey/`sm`) via a bundled WASI polyfill. Enables running `cargo test` / `cargo bench` against the same JS engines used in browser-targeted benches, without source changes.

## Changes

- **`.cargo/config.toml`**
  - Added a `[target.wasm32-wasip1]` entry mirroring the threaded target's `rustflags` (atomics, bulk-memory, mutable-globals, simd128, 4 GiB max memory).
  - Both `wasm32-wasip1` and `wasm32-wasip1-threads` now use `runner = "scripts/wasm-runner.sh"`.
- **`scripts/wasm-runner.sh`** (new, executable)
  - Auto-detects host core count (`nproc` on Linux, `sysctl hw.ncpu` on macOS, fallback `1`) and exports `WASM_HARNESS_ENV_RAYON_NUM_THREADS=<cores>`.
  - `wasm-harness` forwards env vars prefixed with `WASM_HARNESS_ENV_` into the guest with the prefix stripped, so rayon sees `RAYON_NUM_THREADS` without polluting the host shell.
  - Pre-existing `WASM_HARNESS_ENV_RAYON_NUM_THREADS` is respected (user override).
  - `exec`s `wasm-harness` with cargo-supplied args.

## Usage

Prerequisites: `cargo install wasm-harness`. For JS engines, `npm i -g jsvu && jsvu` to install `v8` / `sm` shells. With no engine selected, `wasm-harness` picks the first available from `$PATH` / `~/.jsvu/bin`.

```bash
cargo test  --target wasm32-wasip1
cargo bench --target wasm32-wasip1-threads
WASM_HARNESS_ENGINE=sm cargo bench --target wasm32-wasip1   # pick SpiderMonkey
```

Engine can also be selected per-invocation by editing the script to pass `--engine <name>`, or by setting `WASM_HARNESS_ENGINE` in the environment.

## Notes

- `wasm-harness` propagates a default whitelist of host env vars into the guest; the `WASM_HARNESS_ENV_` prefix is the explicit escape hatch used here to set `RAYON_NUM_THREADS` without depending on whitelist contents.
- `--inherit-env` is available on `wasm-harness` if you'd rather forward every host env var instead of using the prefix.
- Bench code that builds its own rayon pool with an explicit `num_threads()` will ignore `RAYON_NUM_THREADS` — that's a per-bench concern, not a runner one.