### PR TITLE
perf(tkprp): batch AES across each expand call

### DIFF
--- a/crates/core/src/tkprp.rs
+++ b/crates/core/src/tkprp.rs
@@ -16,8 +16,8 @@ impl TwoKeyPrp {
 
     /// Expands inputs to the destination slice.
     ///
-    /// Outputs are written to the destination slice in the same order as the
-    /// inputs.
+    /// For each input `x`, writes `aes0(x) ^ x` to `dest[2i]` and
+    /// `aes1(x) ^ x` to `dest[2i+1]`.
     ///
     /// # Panics
     ///
@@ -31,20 +31,24 @@ impl TwoKeyPrp {
     pub fn expand(&self, inputs: &[Block], dest: &mut [Block]) {
         assert_eq!(
             dest.len(),
-            inputs.len() * 2,
+            2 * inputs.len(),
             "dest should have twice the length of inputs"
         );
 
-        inputs
-            .iter()
-            .zip(dest.chunks_exact_mut(2))
-            .for_each(|(input, dest)| {
-                dest[1] = *input;
-                dest[0] = *input;
-                self.0[1].encrypt_block_inplace(&mut dest[1]);
-                self.0[0].encrypt_block_inplace(&mut dest[0]);
-                dest[1] ^= *input;
-                dest[0] ^= *input;
-            });
+        const CHUNK: usize = 64;
+
+        for (in_chunk, out_chunk) in inputs.chunks(CHUNK).zip(dest.chunks_mut(2 * CHUNK)) {
+            let m = in_chunk.len();
+            let mut s0 = [Block::ZERO; CHUNK];
+            let mut s1 = [Block::ZERO; CHUNK];
+            s0[..m].copy_from_slice(in_chunk);
+            s1[..m].copy_from_slice(in_chunk);
+            self.0[0].encrypt_blocks(&mut s0[..m]);
+            self.0[1].encrypt_blocks(&mut s1[..m]);
+            for (i, &x) in in_chunk.iter().enumerate() {
+                out_chunk[2 * i] = s0[i] ^ x;
+                out_chunk[2 * i + 1] = s1[i] ^ x;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

`TwoKeyPrp::expand` previously encrypted one block at a time per input, calling `encrypt_block_inplace` twice per input. For deeper GGM-tree layers this left a large fraction of the AES backend's throughput on the table:

- **AES-NI:** the 8-deep pipeline never filled.
- **Bitsliced soft AES** (wasm, ARM without NEON crypto): each single-block call ran an 8-lane bitslice round to encrypt one block — wasting 7/8 lanes.

This change reshapes `expand` to walk inputs in fixed-size chunks of 64 blocks staged on the stack. Each chunk issues two batched `encrypt_blocks` calls (one per key) on fully-utilised lanes, then XOR-interleaves the staging buffers back into `dest`. No heap scratch, no caller-visible API change.

Output layout is unchanged: for input `x` at index `i`, `dest[2i] = aes0(x) ^ x` and `dest[2i+1] = aes1(x) ^ x` — same mapping as before. Existing `ggm` known-answer tests pass without modification.

## Changes

- `crates/core/src/tkprp.rs` — rewrite `TwoKeyPrp::expand`:
  - Process inputs in `CHUNK = 64` block tiles on the stack (`[Block; 64]` × 2).
  - Replace per-block `encrypt_block_inplace` × 2 with batched `encrypt_blocks` × 2 per chunk.
  - XOR the AES outputs against the inputs in an interleaved write to `dest`.

## Measurements

### `cargo bench -p mpz-ot-core --bench ot` — `ferret/regular`

Native (AES-NI, single-threaded), commit message numbers:

| Workload | Before | After | Change |
|---|---|---|---|
| `ferret/regular/1_000_000` | 151.7 ms | 142 ms | −6% |

V8 engine, `wasm32-wasip1-threads`, `--features rayon` (auto-thread count via `scripts/wasm-runner.sh`):

| Workload | Before | After | Change |
|---|---|---|---|
| `ferret/regular/262144` | 286.74 ms | 246.49 ms | **−14.0%** |
| `ferret/regular/1000000` | 641.58 ms | 537.99 ms | **−16.1%** |

### `cargo bench -p mpz-core --bench ggm` (V8, single-threaded)

GGM microbenches are dominated by `TwoKeyPrp::expand` on the bitsliced soft-AES path, isolating the patch:

| Bench | Before | After | Change |
|---|---|---|---|
| `ggm::gen::1K` | 502.17 µs | 131.74 µs | **−73.8%** (3.81×) |
| `ggm::reconstruction::1K` | 500.17 µs | 132.06 µs | **−73.6%** (3.79×) |

The much larger wasm gain (vs. native) reflects the soft-AES backend's bitslice saturation: there's now exactly one wasted lane per chunk's tail, where before nearly every shallow-layer call wasted 7 of 8 lanes. In the full Ferret protocol, tkprp/GGM is one of several costs so the proportional win shrinks to ~16% — still meaningful, and stacks with other AES-bound improvements.