### PR TITLE
feat(fields): add ExtensionField::scale_by_subfield

### DIFF
--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -197,6 +197,14 @@ impl ExtensionField<Gf2> for Gf2_128 {
         Gf2_128::new(u128::from(base.0))
     }
 
+    /// Branchless masked AND — drops `self` to zero when `base` is
+    /// false, leaves it unchanged when true.
+    #[inline]
+    fn scale_by_subfield(self, base: Gf2) -> Self {
+        let mask = (base.0 as u128).wrapping_neg();
+        Gf2_128::new(self.0 & mask)
+    }
+
     /// Constant-time masked XOR: each term reduces to
     /// `acc ^= c & mask_from_bit(v)` — no field multiplications and
     /// no data-dependent branches.

--- a/crates/fields/src/gf2_64.rs
+++ b/crates/fields/src/gf2_64.rs
@@ -187,6 +187,14 @@ impl ExtensionField<Gf2> for Gf2_64 {
         Gf2_64(u64::from(base.0))
     }
 
+    /// Branchless masked AND — drops `self` to zero when `base` is
+    /// false, leaves it unchanged when true.
+    #[inline]
+    fn scale_by_subfield(self, base: Gf2) -> Self {
+        let mask = (base.0 as u64).wrapping_neg();
+        Gf2_64(self.0 & mask)
+    }
+
     /// Constant-time masked XOR — no field multiplications and no
     /// data-dependent branches.
     #[inline]

--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -235,6 +235,17 @@ pub trait ExtensionField<B: Field>: Field {
     /// Embed a base-field element into the extension field.
     fn embed(base: B) -> Self;
 
+    /// Multiply `self` by a base-field scalar.
+    ///
+    /// Algebraically equivalent to `self * Self::embed(base)`, but
+    /// concrete impls can override to avoid the full extension
+    /// multiplier when the operation is intrinsically cheaper at the
+    /// subfield.
+    #[inline]
+    fn scale_by_subfield(self, base: B) -> Self {
+        self * Self::embed(base)
+    }
+
     /// `Σ values[i] · challenges[i]` with base-field values lifted
     /// into `Self` before multiplication. Use
     /// [`Self::MONOMIAL_BASIS`] as `challenges` for the canonical


### PR DESCRIPTION
This PR adds  `ExtensionField::scale_by_subfield` method to speed up multiplication.