### PR TITLE
feat: two-shuffles protocols (RAM/set/RO-KVS protocols)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/poly-proof-lifter",
     "crates/poly-proof-macros",
     "crates/perm-proof-core",
+    "crates/two-shuffles",
 ]
 exclude = ["crates/lpn-estimator"]
 resolver = "2"

--- a/crates/two-shuffles/Cargo.toml
+++ b/crates/two-shuffles/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "mpz-two-shuffles"
+version = "0.1.0"
+edition = "2024"
+# Examples are local-only profiling scaffolding, not part of the crate.
+autoexamples = false
+
+[lib]
+name = "mpz_two_shuffles"
+
+[lints]
+workspace = true
+
+[features]
+test-utils = ["mpz-perm-proof-core/test-utils"]
+
+[dependencies]
+mpz-circuits-new = { workspace = true }
+mpz-common = { workspace = true, features = ["future"] }
+mpz-fields = { workspace = true }
+mpz-perm-proof-core = { workspace = true }
+mpz-poly-proof-core = { workspace = true }
+mpz-poly-proof-macros = { workspace = true }
+mpz-vole-core = { workspace = true }
+
+bcs = { workspace = true }
+blake3 = { workspace = true }
+hybrid-array = { workspace = true }
+itybity = { workspace = true }
+rand = { workspace = true }
+rangeset = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+zerocopy = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["cargo_bench_support"] }
+rand_chacha = { workspace = true }
+
+[[test]]
+name = "ro_kvs_api"
+path = "tests/ro_kvs_api.rs"
+required-features = ["test-utils"]
+
+[[test]]
+name = "set_api"
+path = "tests/set_api.rs"
+required-features = ["test-utils"]
+
+[[test]]
+name = "ram_api"
+path = "tests/ram_api.rs"
+required-features = ["test-utils"]
+
+[[bench]]
+name = "set"
+path = "benches/set.rs"
+harness = false
+required-features = ["test-utils"]
+
+[[bench]]
+name = "ro_kvs"
+path = "benches/ro_kvs.rs"
+harness = false
+required-features = ["test-utils"]
+
+[[bench]]
+name = "ram"
+path = "benches/ram.rs"
+harness = false
+required-features = ["test-utils"]

--- a/crates/two-shuffles/benches/ram.rs
+++ b/crates/two-shuffles/benches/ram.rs
@@ -1,0 +1,323 @@
+//! End-to-end benchmark for the RAM protocol using ideal VOLE.
+//!
+//! Run with:
+//!
+//!     cargo bench --bench ram
+
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_perm_proof_core::{
+    backend::vole_zk::{Preparation, Proof, VoleZkProverBackend, VoleZkVerifierBackend},
+    test_utils::build_ideal_perm_proof_pair,
+};
+use mpz_two_shuffles::{
+    ProverWire, VerifierWire,
+    ram::{
+        Clock, Flush, MultiplicativeClock, Prover, TeardownMsg as RamTeardownMsg,
+        TeardownPrepare as RamTeardownPrepare, Verifier,
+    },
+    set,
+    strategy::{
+        Char2Strategy,
+        version::{MultiplicativeStep, VersionStep},
+    },
+    test_utils::{generate_ram_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLESender,
+    ideal::{
+        rvole::{IdealRVOLEReceiver, IdealRVOLESender},
+        rvope::IdealRVOPESender,
+    },
+};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rangeset::set::RangeSet;
+
+// ---------------------------------------------------------------------------
+// Bench config
+// ---------------------------------------------------------------------------
+
+/// Memory size (number of byte-addressable cells).
+const MEMORY_SIZE: usize = 4 * 1024;
+/// Value bit-width.
+const VALUE_BITS: usize = 32;
+/// Number of accesses.
+const N_ACCESSES: usize = 100_000;
+const FAN_IN: usize = 8;
+
+// Concrete prover/verifier types, named so `BenchState` can hold them.
+type ProverBackend = VoleZkProverBackend<
+    Gf2_64,
+    Gf2_64,
+    IdealRVOLEReceiver<Gf2_64, Gf2_64>,
+    mpz_vole_core::ideal::rvope::IdealRVOPEReceiver<Gf2_64>,
+>;
+type VerifierBackend =
+    VoleZkVerifierBackend<Gf2_64, Gf2_64, IdealRVOLESender<Gf2_64>, IdealRVOPESender<Gf2_64>>;
+
+type RamProver =
+    Prover<IdealRVOLEReceiver<Gf2, Gf2_64>, Gf2_64, ProverBackend, Char2Strategy<Gf2_64>>;
+type RamVerifier =
+    Verifier<IdealRVOLESender<Gf2_64>, Gf2_64, VerifierBackend, Char2Strategy<Gf2_64>>;
+
+type RamTeardown = RamTeardownMsg<Gf2_64, Proof<Gf2_64>>;
+
+/// Everything the timed region needs.
+struct BenchState {
+    prover: RamProver,
+    verifier: RamVerifier,
+    delta: Gf2_64,
+    /// Initial RAM content: one value per cell, in address order.
+    content: Vec<Vec<Gf2>>,
+    /// Access trace as `[op, addr, value]` cleartext bundles.
+    accesses: Vec<[Vec<Gf2>; 3]>,
+    /// Caller-supplied Fiat-Shamir transcripts.
+    p_transcript: blake3::Hasher,
+    v_transcript: blake3::Hasher,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Offline phase: generate the witness, all VOLE correlations (RAM,
+/// mul-gate, mul-VOPE, set), build perm-proof backends for RAM and set,
+/// construct the embedded `set::Prover` / `set::Verifier`, then the RAM
+/// prover and verifier. Allocate everything.
+fn offline_setup(memory_size: usize, n_accesses: usize) -> BenchState {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let t = n_accesses;
+
+    // ---- Witness: initial content + access trace.
+    let witness = generate_ram_witness(&RangeSet::from(0..memory_size), VALUE_BITS, t, &mut rng);
+
+    // ---- Clocks (auto-sized n).
+    let prover_clock = MultiplicativeClock::new(t).expect("supported clock size");
+    let verifier_clock = MultiplicativeClock::new(t).expect("supported clock size");
+    let l_clock = prover_clock.l_clock();
+
+    // ---- RAM RVOLE (prover receives, verifier sends).
+    let (ram_vole_s, ram_vole_r) =
+        ideal_rvole_pair(&mut rng, delta, (t + memory_size) * (VALUE_BITS + l_clock));
+
+    // ---- MulProver VOPE-side RVOLE (raw on both sides; consumed at
+    // finalize for `EXTENSION_DEGREE` lifted-VOPE samples).
+    let vope_count = <Gf2_64 as mpz_poly_proof_core::ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+    let (mul_vope_s, mul_vope_r) = ideal_rvole_pair(&mut rng, delta, vope_count);
+
+    // ---- MulProver mul-gate RVOLE (`t * l_val` prod-wire commits).
+    let (mul_gate_s, mul_gate_r) = ideal_rvole_pair(&mut rng, delta, t * VALUE_BITS);
+
+    // ---- Set version steps + set RVOLE.
+    let prover_set_version = MultiplicativeStep::new(t).expect("supported version size");
+    let verifier_set_version = MultiplicativeStep::new(t).expect("supported version size");
+    let l_ver = VersionStep::<Gf2>::len(&prover_set_version);
+    let (set_vole_s, set_vole_r) = ideal_rvole_pair(&mut rng, delta, (t + t) * l_ver);
+
+    // ---- perm-proof pairs for RAM and set.
+    let (ram_perm_prover, ram_perm_verifier) =
+        build_ideal_perm_proof_pair(&mut rng, delta, memory_size + t, FAN_IN);
+    let (set_perm_prover, set_perm_verifier) =
+        build_ideal_perm_proof_pair(&mut rng, delta, t + t, FAN_IN);
+
+    // ---- Build set Prover/Verifier.
+    let prover_set = set::Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        t,
+        prover_set_version,
+        DerandVOLEReceiver::new(set_vole_r),
+        set_perm_prover,
+    )
+    .expect("set prover new");
+    let verifier_set = set::Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        t,
+        verifier_set_version,
+        set_vole_s,
+        set_perm_verifier,
+    )
+    .expect("set verifier new");
+
+    // ---- Build RAM Prover/Verifier.
+    let config = mpz_two_shuffles::ram::Config::<Gf2_64, Char2Strategy<Gf2_64>>::builder(
+        RangeSet::from(0..memory_size),
+        VALUE_BITS,
+        t,
+    )
+    .build()
+    .expect("ram config build");
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        config.clone(),
+        prover_clock,
+        DerandVOLEReceiver::new(ram_vole_r),
+        DerandVOLEReceiver::new(mul_gate_r),
+        mul_vope_r,
+        ram_perm_prover,
+        prover_set,
+    )
+    .expect("ram prover new");
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        config,
+        verifier_clock,
+        ram_vole_s,
+        DerandVOLESender::new(mul_gate_s),
+        mul_vope_s,
+        ram_perm_verifier,
+        verifier_set,
+    )
+    .expect("ram verifier new");
+
+    prover.alloc().expect("ram prover alloc");
+    verifier.alloc().expect("ram verifier alloc");
+
+    BenchState {
+        prover,
+        verifier,
+        delta,
+        content: witness.initial_memory,
+        accesses: witness.accesses,
+        p_transcript: blake3::Hasher::new(),
+        v_transcript: blake3::Hasher::new(),
+    }
+}
+
+type RamTeardownPrep = RamTeardownPrepare<Gf2_64, Preparation<Gf2_64>>;
+
+/// Prover-only online phase (timed for the prover bench): setup +
+/// per-access calls + teardown on the prover side. Returns the
+/// messages the verifier would consume.
+fn run_prover_phase(
+    mut prover: RamProver,
+    content: Vec<Vec<Gf2>>,
+    accesses: &[[Vec<Gf2>; 3]],
+    transcript: &mut blake3::Hasher,
+) -> (Flush<Gf2_64>, RamTeardownPrep, RamTeardown) {
+    prover.setup(content).expect("ram prover setup");
+    for [op, addr, w] in accesses {
+        let prover_op = ProverWire::<Gf2, Gf2_64>::constant(op.clone());
+        let prover_addr = ProverWire::<Gf2, Gf2_64>::constant(addr.clone());
+        let prover_w = ProverWire::<Gf2, Gf2_64>::constant(w.clone());
+        prover
+            .access(prover_op, prover_addr, prover_w)
+            .expect("prover access");
+    }
+    let flush = prover.flush().expect("prover flush");
+    let prepare = prover
+        .teardown_prepare(transcript)
+        .expect("prover teardown_prepare");
+    let (msg, _state) = prover.teardown(transcript).expect("prover teardown");
+    (flush, prepare, msg)
+}
+
+/// Verifier-only online phase (timed for the verifier bench): setup +
+/// per-access calls + flush + teardown_prepare + teardown on the
+/// verifier side. Consumes the prover's flush + prepare + teardown
+/// messages.
+fn run_verifier_phase(
+    mut verifier: RamVerifier,
+    content: Vec<Vec<Gf2>>,
+    accesses: &[[Vec<Gf2>; 3]],
+    delta: Gf2_64,
+    flush: Flush<Gf2_64>,
+    prepare: RamTeardownPrep,
+    msg: RamTeardown,
+    transcript: &mut blake3::Hasher,
+) {
+    verifier.setup(content).expect("ram verifier setup");
+    for [op, addr, w] in accesses {
+        let verifier_op = VerifierWire::<Gf2_64>::constant(op, delta);
+        let verifier_addr = VerifierWire::<Gf2_64>::constant(addr, delta);
+        let verifier_w = VerifierWire::<Gf2_64>::constant(w, delta);
+        verifier
+            .access(verifier_op, verifier_addr, verifier_w)
+            .expect("verifier access");
+    }
+    verifier.flush(flush).expect("verifier flush");
+    verifier
+        .teardown_prepare(transcript, prepare)
+        .expect("verifier teardown_prepare");
+    verifier.teardown(transcript, msg).expect("verifier accept");
+}
+
+// ---------------------------------------------------------------------------
+// Criterion entry points
+// ---------------------------------------------------------------------------
+
+fn bench_ram(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ram");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(30));
+
+    let suffix = format!("char2_{MEMORY_SIZE}_cells_{N_ACCESSES}_accesses");
+
+    // ---- Prover bench ----
+    group.bench_function(format!("prover_{suffix}"), |b| {
+        b.iter_batched(
+            || offline_setup(MEMORY_SIZE, N_ACCESSES),
+            |state| {
+                let BenchState {
+                    prover,
+                    content,
+                    accesses,
+                    mut p_transcript,
+                    ..
+                } = state;
+                let _out = run_prover_phase(prover, content, &accesses, &mut p_transcript);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // ---- Verifier bench ----
+    // Setup pre-runs the prover (untimed) and yields the verifier-side
+    // state plus the prover's flush + teardown messages.
+    group.bench_function(format!("verifier_{suffix}"), |b| {
+        b.iter_batched(
+            || {
+                let state = offline_setup(MEMORY_SIZE, N_ACCESSES);
+                let BenchState {
+                    prover,
+                    verifier,
+                    delta,
+                    content,
+                    accesses,
+                    mut p_transcript,
+                    v_transcript,
+                } = state;
+                let (flush, prepare, msg) =
+                    run_prover_phase(prover, content.clone(), &accesses, &mut p_transcript);
+                (
+                    verifier,
+                    content,
+                    accesses,
+                    delta,
+                    flush,
+                    prepare,
+                    msg,
+                    v_transcript,
+                )
+            },
+            |(verifier, content, accesses, delta, flush, prepare, msg, mut v_transcript)| {
+                run_verifier_phase(
+                    verifier,
+                    content,
+                    &accesses,
+                    delta,
+                    flush,
+                    prepare,
+                    msg,
+                    &mut v_transcript,
+                );
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ram);
+criterion_main!(benches);

--- a/crates/two-shuffles/benches/ro_kvs.rs
+++ b/crates/two-shuffles/benches/ro_kvs.rs
@@ -1,0 +1,265 @@
+//! End-to-end benchmark for the RO-KVS protocol using ideal VOLE.
+//!
+//! Run with:
+//!
+//!     cargo bench --bench ro_kvs
+
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_perm_proof_core::{
+    backend::vole_zk::{Preparation, Proof, VoleZkProverBackend, VoleZkVerifierBackend},
+    test_utils::build_ideal_perm_proof_pair,
+};
+use mpz_two_shuffles::{
+    ProverWire, VerifierWire,
+    ro_kvs::{self, Prover, Verifier},
+    strategy::{
+        Char2Strategy,
+        version::{MultiplicativeStep, VersionStep},
+    },
+    test_utils::{generate_ro_kvs_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::{
+    DerandVOLEReceiver,
+    ideal::{
+        rvole::{IdealRVOLEReceiver, IdealRVOLESender},
+        rvope::IdealRVOPESender,
+    },
+};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+// ---------------------------------------------------------------------------
+// Bench config
+// ---------------------------------------------------------------------------
+
+/// Number of key-value pairs in the store.
+const N_STORE: usize = 40_000;
+/// Number of lookups.
+const N_LOOKUPS: usize = 100_000;
+/// Value bit-width.
+const VALUE_BITS: usize = 7;
+/// Perm-proof fan-in.
+const FAN_IN: usize = 8;
+
+// Concrete prover/verifier types, named so `BenchState` can hold them.
+type ProverBackend = VoleZkProverBackend<
+    Gf2_64,
+    Gf2_64,
+    IdealRVOLEReceiver<Gf2_64, Gf2_64>,
+    mpz_vole_core::ideal::rvope::IdealRVOPEReceiver<Gf2_64>,
+>;
+type VerifierBackend =
+    VoleZkVerifierBackend<Gf2_64, Gf2_64, IdealRVOLESender<Gf2_64>, IdealRVOPESender<Gf2_64>>;
+
+type RoKvsProver =
+    Prover<IdealRVOLEReceiver<Gf2, Gf2_64>, Gf2_64, ProverBackend, Char2Strategy<Gf2_64>>;
+type RoKvsVerifier =
+    Verifier<IdealRVOLESender<Gf2_64>, Gf2_64, VerifierBackend, Char2Strategy<Gf2_64>>;
+
+/// Everything the timed region needs. Built once per sample.
+struct BenchState {
+    prover: RoKvsProver,
+    verifier: RoKvsVerifier,
+    delta: Gf2_64,
+    /// Value cleartexts for setup. Keys are implicit: position `i`
+    /// is key `i`.
+    content: Vec<Vec<Gf2>>,
+    /// Lookup keys (each present in `content`).
+    lookup_keys: Vec<Vec<Gf2>>,
+    /// Caller-supplied Fiat-Shamir transcripts.
+    p_transcript: blake3::Hasher,
+    v_transcript: blake3::Hasher,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Offline phase: generate the witness, correlations, and backend,
+/// construct prover and verifier, allocate VOLE / perm-proof state.
+/// Excluded from the measured time.
+fn offline_setup(n_store: usize, n_lookups: usize) -> BenchState {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+
+    // ---- Witness: key→value content + lookup trace.
+    let witness = generate_ro_kvs_witness(n_store, VALUE_BITS, n_lookups, &mut rng);
+    let content = witness.content;
+    let lookup_keys: Vec<Vec<Gf2>> = witness.lookups.into_iter().map(|[k]| k).collect();
+
+    // ---- Version steps (sized to the worst-case per-key lookup count).
+    let prover_step = MultiplicativeStep::new(n_lookups).expect("supported size");
+    let verifier_step = MultiplicativeStep::new(n_lookups).expect("supported size");
+    let l_ver = VersionStep::<Gf2>::len(&prover_step);
+
+    // ---- User-facing input-gate VOLE.
+    // Each lookup consumes (l_val + l_ver) slots; each setup entry's
+    // teardown read consumes l_ver slots.
+    let (user_rvole_s, user_rvole_r) = ideal_rvole_pair(
+        &mut rng,
+        delta,
+        n_lookups * (VALUE_BITS + l_ver) + n_store * l_ver,
+    );
+    let prover_vole = DerandVOLEReceiver::new(user_rvole_r);
+
+    // ---- vole_zk perm-proof pair.
+    let (perm_prover, perm_verifier) =
+        build_ideal_perm_proof_pair(&mut rng, delta, n_store + n_lookups, FAN_IN);
+
+    // ---- Build prover and verifier.
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_store,
+        VALUE_BITS,
+        prover_step,
+        prover_vole,
+        perm_prover,
+    )
+    .expect("prover new");
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_store,
+        VALUE_BITS,
+        verifier_step,
+        user_rvole_s,
+        perm_verifier,
+    )
+    .expect("verifier new");
+
+    prover.alloc(n_store, n_lookups).expect("prover alloc");
+    verifier.alloc(n_store, n_lookups).expect("verifier alloc");
+
+    BenchState {
+        prover,
+        verifier,
+        delta,
+        content,
+        lookup_keys,
+        p_transcript: blake3::Hasher::new(),
+        v_transcript: blake3::Hasher::new(),
+    }
+}
+
+type RoKvsTeardownPrep = ro_kvs::TeardownPrepare<Gf2_64, Preparation<Gf2_64>>;
+type RoKvsTeardownMsg = ro_kvs::TeardownMsg<Gf2_64, Proof<Gf2_64>>;
+
+/// Prover-only online phase (timed for the prover bench).
+fn run_prover_phase(
+    mut prover: RoKvsProver,
+    content: Vec<Vec<Gf2>>,
+    lookup_keys: &[Vec<Gf2>],
+    transcript: &mut blake3::Hasher,
+) -> (RoKvsTeardownPrep, RoKvsTeardownMsg) {
+    prover.setup(content).expect("prover setup");
+    for key_cleartext in lookup_keys {
+        let prover_key = ProverWire::<Gf2, Gf2_64>::constant(key_cleartext.clone());
+        prover.lookup(prover_key).expect("prover lookup");
+    }
+    let prepare = prover
+        .teardown_prepare(transcript)
+        .expect("prover teardown_prepare");
+    let msg = prover.teardown(transcript).expect("prover teardown");
+    (prepare, msg)
+}
+
+/// Verifier-only online phase (timed for the verifier bench).
+/// Consumes the prover's prepare + teardown messages.
+fn run_verifier_phase(
+    mut verifier: RoKvsVerifier,
+    content: Vec<Vec<Gf2>>,
+    lookup_keys: &[Vec<Gf2>],
+    delta: Gf2_64,
+    prepare: RoKvsTeardownPrep,
+    msg: RoKvsTeardownMsg,
+    transcript: &mut blake3::Hasher,
+) {
+    verifier.setup(content).expect("verifier setup");
+    for key_cleartext in lookup_keys {
+        let verifier_key = VerifierWire::<Gf2_64>::constant(key_cleartext, delta);
+        verifier.lookup(verifier_key).expect("verifier lookup");
+    }
+    verifier
+        .teardown_prepare(transcript, prepare)
+        .expect("verifier teardown_prepare");
+    verifier.teardown(msg, transcript).expect("verifier accept");
+}
+
+// ---------------------------------------------------------------------------
+// Criterion entry points
+// ---------------------------------------------------------------------------
+
+fn bench_ro_kvs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ro_kvs");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(20));
+
+    let suffix = format!("char2_{N_STORE}_pairs_{N_LOOKUPS}_lookups");
+
+    // ---- Prover bench ----
+    group.bench_function(format!("prover_{suffix}"), |b| {
+        b.iter_batched(
+            || offline_setup(N_STORE, N_LOOKUPS),
+            |state| {
+                let BenchState {
+                    prover,
+                    content,
+                    lookup_keys,
+                    mut p_transcript,
+                    ..
+                } = state;
+                let _out = run_prover_phase(prover, content, &lookup_keys, &mut p_transcript);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // ---- Verifier bench ----
+    // Setup pre-runs the prover (untimed) and hands the verifier the
+    // prover's teardown messages.
+    group.bench_function(format!("verifier_{suffix}"), |b| {
+        b.iter_batched(
+            || {
+                let state = offline_setup(N_STORE, N_LOOKUPS);
+                let BenchState {
+                    prover,
+                    verifier,
+                    delta,
+                    content,
+                    lookup_keys,
+                    mut p_transcript,
+                    v_transcript,
+                } = state;
+                let (prepare, msg) =
+                    run_prover_phase(prover, content.clone(), &lookup_keys, &mut p_transcript);
+                (
+                    verifier,
+                    content,
+                    lookup_keys,
+                    delta,
+                    prepare,
+                    msg,
+                    v_transcript,
+                )
+            },
+            |(verifier, content, lookup_keys, delta, prepare, msg, mut v_transcript)| {
+                run_verifier_phase(
+                    verifier,
+                    content,
+                    &lookup_keys,
+                    delta,
+                    prepare,
+                    msg,
+                    &mut v_transcript,
+                );
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ro_kvs);
+criterion_main!(benches);

--- a/crates/two-shuffles/benches/set.rs
+++ b/crates/two-shuffles/benches/set.rs
@@ -1,0 +1,260 @@
+//! End-to-end benchmark for the Set membership protocol using ideal VOLE.
+//!
+//! Run with:
+//!
+//!     cargo bench --bench set
+
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_perm_proof_core::{
+    backend::vole_zk::{Preparation, Proof, VoleZkProverBackend, VoleZkVerifierBackend},
+    test_utils::build_ideal_perm_proof_pair,
+};
+use mpz_two_shuffles::{
+    Bundle, ProverWire, VerifierWire,
+    set::{self, Prover, Verifier},
+    strategy::{
+        Char2Strategy,
+        version::{MultiplicativeStep, VersionStep},
+    },
+    test_utils::{generate_set_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::{
+    DerandVOLEReceiver,
+    ideal::{
+        rvole::{IdealRVOLEReceiver, IdealRVOLESender},
+        rvope::IdealRVOPESender,
+    },
+};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+// ---------------------------------------------------------------------------
+// Bench config
+// ---------------------------------------------------------------------------
+
+/// Number of distinct members in the set.
+const SET_SIZE: usize = 100_000;
+/// Element space — members are drawn from `0..ELEMENT_SPACE`.
+const ELEMENT_SPACE: usize = 1 << 17;
+/// Number of lookups.
+const N_LOOKUPS: usize = 100_000;
+/// Perm-proof fan-in.
+const FAN_IN: usize = 8;
+
+// Concrete prover/verifier types — spelled out so `BenchState` can
+// name them.
+type ProverBackend = VoleZkProverBackend<
+    Gf2_64,
+    Gf2_64,
+    IdealRVOLEReceiver<Gf2_64, Gf2_64>,
+    mpz_vole_core::ideal::rvope::IdealRVOPEReceiver<Gf2_64>,
+>;
+type VerifierBackend =
+    VoleZkVerifierBackend<Gf2_64, Gf2_64, IdealRVOLESender<Gf2_64>, IdealRVOPESender<Gf2_64>>;
+
+type SetProver =
+    Prover<IdealRVOLEReceiver<Gf2, Gf2_64>, Gf2_64, ProverBackend, Char2Strategy<Gf2_64>>;
+type SetVerifier =
+    Verifier<IdealRVOLESender<Gf2_64>, Gf2_64, VerifierBackend, Char2Strategy<Gf2_64>>;
+
+/// Everything the timed region needs. Built once per sample; the
+/// measured routine consumes it.
+struct BenchState {
+    prover: SetProver,
+    verifier: SetVerifier,
+    delta: Gf2_64,
+    members: Vec<Bundle<Gf2>>,
+    lookups: Vec<Vec<Gf2>>,
+    /// Caller-supplied Fiat-Shamir transcripts.
+    p_transcript: blake3::Hasher,
+    v_transcript: blake3::Hasher,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Offline phase: generate the witness, correlations, and backends,
+/// construct prover and verifier, allocate VOLE / perm-proof state.
+/// Everything here is excluded from the measured time.
+fn offline_setup(n_setup: usize, num_lookups: usize) -> BenchState {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+
+    // ---- Witness: distinct members + in-set lookup trace.
+    let witness = generate_set_witness(ELEMENT_SPACE, n_setup, num_lookups, &mut rng);
+    let members: Vec<Bundle<Gf2>> = witness.members.into_iter().map(Bundle::new).collect();
+    let lookups: Vec<Vec<Gf2>> = witness.lookups.into_iter().map(|[e]| e).collect();
+
+    // ---- Version steps (sized to the worst-case per-element lookup count).
+    let prover_step = MultiplicativeStep::new(num_lookups).expect("supported size");
+    let verifier_step = MultiplicativeStep::new(num_lookups).expect("supported size");
+    let l_ver = VersionStep::<Gf2>::len(&prover_step);
+
+    // ---- User-facing input-gate VOLE.
+    let (user_rvole_s, user_rvole_r) =
+        ideal_rvole_pair(&mut rng, delta, (num_lookups + n_setup) * l_ver);
+    let prover_vole = DerandVOLEReceiver::new(user_rvole_r);
+
+    // ---- vole_zk perm-proof pair.
+    let (perm_prover, perm_verifier) =
+        build_ideal_perm_proof_pair(&mut rng, delta, n_setup + num_lookups, FAN_IN);
+
+    // ---- Build prover and verifier.
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_setup,
+        prover_step,
+        prover_vole,
+        perm_prover,
+    )
+    .expect("prover new");
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_setup,
+        verifier_step,
+        user_rvole_s,
+        perm_verifier,
+    )
+    .expect("verifier new");
+
+    prover.alloc(num_lookups).expect("prover alloc");
+    verifier.alloc(num_lookups).expect("verifier alloc");
+
+    BenchState {
+        prover,
+        verifier,
+        delta,
+        members,
+        lookups,
+        p_transcript: blake3::Hasher::new(),
+        v_transcript: blake3::Hasher::new(),
+    }
+}
+
+type SetTeardownPrep = set::TeardownPrepare<Gf2_64, Preparation<Gf2_64>>;
+type SetTeardownMsg = set::TeardownMsg<Gf2_64, Proof<Gf2_64>>;
+
+/// Prover-only online phase (timed for the prover bench): setup +
+/// per-lookup calls + teardown_prepare + teardown on the prover side.
+/// Returns the messages the verifier would consume.
+fn run_prover_phase(
+    mut prover: SetProver,
+    members: Vec<Bundle<Gf2>>,
+    lookups: &[Vec<Gf2>],
+    transcript: &mut blake3::Hasher,
+) -> (SetTeardownPrep, SetTeardownMsg) {
+    prover.setup(members).expect("prover setup");
+    for element in lookups {
+        let prover_elem = ProverWire::<Gf2, Gf2_64>::constant(element.clone());
+        prover.lookup(prover_elem).expect("prover lookup");
+    }
+    let prepare = prover
+        .teardown_prepare(transcript)
+        .expect("prover teardown_prepare");
+    let msg = prover.teardown(transcript).expect("prover teardown");
+    (prepare, msg)
+}
+
+/// Verifier-only online phase (timed for the verifier bench): setup +
+/// per-lookup calls + teardown_prepare + teardown on the verifier
+/// side. Consumes the prover's prepare + teardown messages.
+fn run_verifier_phase(
+    mut verifier: SetVerifier,
+    members: Vec<Bundle<Gf2>>,
+    lookups: &[Vec<Gf2>],
+    delta: Gf2_64,
+    prepare: SetTeardownPrep,
+    msg: SetTeardownMsg,
+    transcript: &mut blake3::Hasher,
+) {
+    verifier.setup(members).expect("verifier setup");
+    for element in lookups {
+        let verifier_elem = VerifierWire::<Gf2_64>::constant(element, delta);
+        verifier.lookup(verifier_elem).expect("verifier lookup");
+    }
+    verifier
+        .teardown_prepare(transcript, prepare)
+        .expect("verifier teardown_prepare");
+    verifier.teardown(msg, transcript).expect("verifier accept");
+}
+
+// ---------------------------------------------------------------------------
+// Criterion entry points
+// ---------------------------------------------------------------------------
+
+fn bench_set_membership(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_membership");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(20));
+
+    let suffix = format!("char2_{SET_SIZE}_members_{N_LOOKUPS}_lookups");
+
+    // ---- Prover bench ----
+    group.bench_function(format!("prover_{suffix}"), |b| {
+        b.iter_batched(
+            || offline_setup(SET_SIZE, N_LOOKUPS),
+            |state| {
+                let BenchState {
+                    prover,
+                    members,
+                    lookups,
+                    mut p_transcript,
+                    ..
+                } = state;
+                let _out = run_prover_phase(prover, members, &lookups, &mut p_transcript);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // ---- Verifier bench ----
+    // Setup pre-runs the prover (untimed) and hands the verifier the
+    // prover's teardown messages.
+    group.bench_function(format!("verifier_{suffix}"), |b| {
+        b.iter_batched(
+            || {
+                let state = offline_setup(SET_SIZE, N_LOOKUPS);
+                let BenchState {
+                    prover,
+                    verifier,
+                    delta,
+                    members,
+                    lookups,
+                    mut p_transcript,
+                    v_transcript,
+                } = state;
+                let (prepare, msg) =
+                    run_prover_phase(prover, members.clone(), &lookups, &mut p_transcript);
+                (
+                    verifier,
+                    members,
+                    lookups,
+                    delta,
+                    prepare,
+                    msg,
+                    v_transcript,
+                )
+            },
+            |(verifier, members, lookups, delta, prepare, msg, mut v_transcript)| {
+                run_verifier_phase(
+                    verifier,
+                    members,
+                    &lookups,
+                    delta,
+                    prepare,
+                    msg,
+                    &mut v_transcript,
+                );
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_set_membership);
+criterion_main!(benches);

--- a/crates/two-shuffles/src/gf2n.rs
+++ b/crates/two-shuffles/src/gf2n.rs
@@ -1,0 +1,390 @@
+//! Characteristic-2 field arithmetic.
+
+use itybity::{FromBitIterator, ToBits};
+use mpz_fields::{Field, gf2::Gf2};
+
+/// `GF(2^n)` field constants.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct Gf2nConstants {
+    /// Primitive degree-`N` polynomial over `GF(2)`. Full bit
+    /// pattern with the leading `x^N` bit included.
+    pub(crate) poly: u64,
+    /// Generator of `GF(2^N)`'s multiplicative group.
+    pub(crate) generator: u64,
+    /// Multiplicative-group order: `2^N − 1`.
+    pub(crate) group_order: u64,
+    /// Multiplicative inverse of `generator` mod `poly`:
+    /// `g_inv · g ≡ 1` in `GF(2^N)`.
+    pub(crate) g_inv: u64,
+}
+
+/// Lookup table: GF(2^N) constants for each supported extension degree `N`.
+pub(crate) fn field_constants(n: usize) -> Result<Gf2nConstants, UnsupportedDegree> {
+    let (poly, g_inv) = match n {
+        8 => (0x11D, 0x8E),           // x^8 + x^4 + x^3 + x^2 + 1
+        9 => (0x211, 0x108),          // x^9 + x^4 + 1
+        10 => (0x409, 0x204),         // x^10 + x^3 + 1
+        11 => (0x805, 0x402),         // x^11 + x^2 + 1
+        12 => (0x1053, 0x829),        // x^12 + x^6 + x^4 + x + 1
+        13 => (0x201B, 0x100D),       // x^13 + x^4 + x^3 + x + 1
+        14 => (0x402B, 0x2015),       // x^14 + x^5 + x^3 + x + 1
+        15 => (0x8003, 0x4001),       // x^15 + x + 1
+        16 => (0x1002D, 0x8016),      // x^16 + x^5 + x^3 + x^2 + 1
+        17 => (0x20009, 0x10004),     // x^17 + x^3 + 1
+        18 => (0x40081, 0x20040),     // x^18 + x^7 + 1
+        19 => (0x80027, 0x40013),     // x^19 + x^5 + x^2 + x + 1
+        20 => (0x100009, 0x80004),    // x^20 + x^3 + 1
+        21 => (0x200005, 0x100002),   // x^21 + x^2 + 1
+        22 => (0x400003, 0x200001),   // x^22 + x + 1
+        23 => (0x800021, 0x400010),   // x^23 + x^5 + 1
+        24 => (0x100001B, 0x80000D),  // x^24 + x^4 + x^3 + x + 1
+        25 => (0x2000009, 0x1000004), // x^25 + x^3 + 1
+        26 => (0x4000047, 0x2000023), // x^26 + x^6 + x^2 + x + 1
+        _ => return Err(UnsupportedDegree(n)),
+    };
+    Ok(Gf2nConstants {
+        poly,
+        generator: 2,
+        group_order: (1u64 << n) - 1,
+        g_inv,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GF(2^N) field arithmetic
+// ---------------------------------------------------------------------------
+
+/// One shift-and-reduce step in `GF(2^n)`: returns `c · x mod poly`.
+///
+/// # Arguments
+///
+/// * `c` — element of `GF(2^n)` to multiply by `x`. Must fit in its low `n`
+///   bits.
+/// * `high` — top bit of the mask, i.e., `1 << (n − 1)`.
+/// * `mask` — low-`n`-bits mask, i.e., `(1 << n) − 1`.
+/// * `reduction` — `poly` with its leading `x^n` bit stripped. This is the
+///   polynomial we XOR in to "subtract" an `x^n` term (since `x^n ≡ poly −
+///   x^n`).
+#[inline]
+fn mul_by_x(c: u64, high: u64, mask: u64, reduction: u64) -> u64 {
+    // Snapshot the top bit *before* the shift.
+    let overflow = c & high;
+    // Mask to keep `c` below degree `n`.
+    let shifted = (c << 1) & mask;
+    // If the shift produced an `x^n` term, fold it back in by adding
+    // `reduction` (= `poly − x^n` in `GF(2)`, since `x^n ≡ poly − x^n`).
+    if overflow != 0 {
+        shifted ^ reduction
+    } else {
+        shifted
+    }
+}
+
+/// Multiply `a · b` in `GF(2^n)` modulo `poly` (whose bit `n` is set).
+///
+/// `a` and `b` must already fit in their low `n` bits (any bit at
+/// position `≥ n` will silently produce a wrong result). The output
+/// is likewise in the low `n` bits.
+pub(crate) fn gf2n_mul_mod(a: u64, b: u64, poly: u64, n: usize) -> u64 {
+    let mut a = a;
+    let mut b = b;
+    let mask = (1u64 << n) - 1;
+    let high = 1u64 << (n - 1);
+    let reduction = poly & mask;
+
+    let mut result = 0u64;
+    while b != 0 {
+        if b & 1 == 1 {
+            result ^= a;
+        }
+        a = mul_by_x(a, high, mask, reduction);
+        // Advance to the next power.
+        b >>= 1;
+    }
+    result
+}
+
+/// Pre-computed "multiply by a fixed element of `GF(2^n)`" matrix.
+pub(crate) struct GfMulMatrix {
+    /// Row-major bitmask representation. Length `n`; only the low
+    /// `n` bits of each row are meaningful.
+    rows: Vec<u64>,
+}
+
+impl GfMulMatrix {
+    /// Build the matrix.
+    ///
+    /// Conceptually we compute, for each `j ∈ 0..n`, the column
+    /// `c_j = multiplier · x^j` reduced mod `poly`, then transpose:
+    /// `rows[i]` has bit `j` set iff `c_j` has bit `i` set.
+    /// Successive columns are obtained by one multiply-by-`x` step
+    /// (shift-and-reduce).
+    ///
+    /// # Arguments
+    ///
+    /// * `poly` — irreducible polynomial of degree `n` over `GF(2)`, with the
+    ///   leading `x^n` bit included.
+    /// * `multiplier` — the fixed element of `GF(2^n)` that the resulting
+    ///   matrix multiplies by. Must fit in its low `n` bits.
+    /// * `n` — extension degree of `GF(2^n)`.
+    pub(crate) fn new(poly: u64, multiplier: u64, n: usize) -> Self {
+        let mask = (1u64 << n) - 1;
+        let high = 1u64 << (n - 1);
+        let reduction = poly & mask;
+
+        // Compute columns: c_0 = multiplier, c_{j+1} = c_j · x mod poly.
+        let mut columns = vec![0u64; n];
+        let mut c = multiplier & mask;
+        for col in columns.iter_mut() {
+            *col = c;
+            c = mul_by_x(c, high, mask, reduction);
+        }
+
+        // Transpose into row-major bitmasks.
+        let mut rows = vec![0u64; n];
+        for (j, &col) in columns.iter().enumerate() {
+            let mut col_bits = col;
+            while col_bits != 0 {
+                let i = col_bits.trailing_zeros() as usize;
+                rows[i] |= 1u64 << j;
+                col_bits &= col_bits - 1;
+            }
+        }
+        Self { rows }
+    }
+
+    /// Extension degree `n` of the underlying `GF(2^n)`.
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Apply the matrix to a slice of `Gf2` subfield-coefficients
+    /// representing one element of `GF(2^n)` (LSB-first). Returns
+    /// the subfield-coefficients of `multiplier · input`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice length doesn't match the
+    /// extension degree used to build this matrix.
+    pub(crate) fn apply(&self, input: &[Gf2]) -> Vec<Gf2> {
+        debug_assert_eq!(
+            input.len(),
+            self.len(),
+            "input length must match matrix extension degree",
+        );
+        let v = u64::from_lsb0_iter(input.iter_lsb0());
+        Vec::<Gf2>::from_lsb0_iter(self.apply_bits_u64(v).iter_lsb0().take(self.len()))
+    }
+
+    /// Apply the matrix to a `u64` value (treated as a bit vector of
+    /// length [`self.len()`](Self::len)).
+    pub(crate) fn apply_bits_u64(&self, v: u64) -> u64 {
+        let mut out = 0u64;
+        for (i, &row) in self.rows.iter().enumerate() {
+            if (row & v).count_ones() & 1 == 1 {
+                out |= 1u64 << i;
+            }
+        }
+        out
+    }
+
+    /// The canonical [`apply`](Self::apply) operation lifted to act
+    /// on `F`-element bundles via `GF(2)`-linearity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input bundle's length doesn't match the matrix's
+    /// extension degree.
+    pub(crate) fn apply_lifted<F: Field>(&self, input: &[F]) -> Vec<F> {
+        debug_assert_eq!(
+            input.len(),
+            self.len(),
+            "input length must match matrix extension degree"
+        );
+        let mut out = vec![F::zero(); self.len()];
+        for i in 0..self.len() {
+            let mut acc = F::zero();
+            let mut row = self.rows[i];
+            while row != 0 {
+                let j = row.trailing_zeros() as usize;
+                acc = acc + input[j];
+                row &= row - 1;
+            }
+            out[i] = acc;
+        }
+        out
+    }
+}
+
+/// Construction error for unsupported extension degrees (`n` not in
+/// the primitive-polynomial table's range `8..=26`).
+#[derive(Debug, thiserror::Error)]
+#[error("unsupported extension degree {0}; supported: 8..=26")]
+pub struct UnsupportedDegree(pub usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_utils::pow_mod;
+
+    fn distinct_prime_factors(mut m: u64) -> Vec<u64> {
+        let mut factors = Vec::new();
+        let mut p = 2u64;
+        while p.saturating_mul(p) <= m {
+            if m % p == 0 {
+                factors.push(p);
+                while m % p == 0 {
+                    m /= p;
+                }
+            }
+            p += 1;
+        }
+        if m > 1 {
+            factors.push(m);
+        }
+        factors
+    }
+
+    /// Verify that `generator` has multiplicative order `2^n − 1` in
+    /// `GF(2)[x] / poly`.
+    fn is_primitive(generator: u64, poly: u64, n: usize) -> bool {
+        let order = (1u64 << n) - 1;
+        for q in distinct_prime_factors(order) {
+            if pow_mod(generator, order / q, poly, n) == 1 {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[test]
+    fn field_constants_are_primitive() {
+        for n in 8..=26 {
+            let c = field_constants(n).unwrap();
+            assert!(
+                is_primitive(c.generator, c.poly, n),
+                "field_constants({n}) is not primitive: poly=0x{:X} g={}",
+                c.poly,
+                c.generator,
+            );
+            assert_eq!(
+                c.group_order,
+                (1u64 << n) - 1,
+                "field_constants({n}) group_order mismatch",
+            );
+            // The hard-coded `g_inv` actually inverts `generator` in
+            // GF(2^n) — guards against a copy-paste error from the
+            // example output.
+            assert_eq!(
+                gf2n_mul_mod(c.generator, c.g_inv, c.poly, n),
+                1,
+                "field_constants({n}): g · g_inv ≠ 1 in GF(2^{n})",
+            );
+        }
+    }
+
+    #[test]
+    fn matrix_application_matches_direct_multiply() {
+        for n in 8..=26 {
+            let c = field_constants(n).unwrap();
+            let (poly, generator) = (c.poly, c.generator);
+            let matrix = GfMulMatrix::new(poly, generator, n);
+            let mask = (1u64 << n) - 1;
+            for v in 0..=mask {
+                let expected = gf2n_mul_mod(v, generator, poly, n);
+                let got = matrix.apply_bits_u64(v);
+                assert_eq!(
+                    got, expected,
+                    "mismatch at n={n}, v=0x{v:X}: matrix=0x{got:X} direct=0x{expected:X}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn apply_matrix_over_extension_field() {
+        use mpz_fields::gf2_64::Gf2_64;
+
+        // Hand-crafted 3-row matrix on a 3-element input. Each row is
+        // a bitmask: bit `j` set means "row's output XORs `input[j]`".
+        //   rows[0] = 0b011 → out[0] = in[0] + in[1]
+        //   rows[1] = 0b101 → out[1] = in[0] + in[2]
+        //   rows[2] = 0b110 → out[2] = in[1] + in[2]
+        let matrix = GfMulMatrix {
+            rows: vec![0b011u64, 0b101, 0b110],
+        };
+        let input: Vec<Gf2_64> = vec![
+            Gf2_64(0x1234_0000_0000_0000),
+            Gf2_64(0x0000_5678_0000_0000),
+            Gf2_64(0x0000_0000_9abc_0000),
+        ];
+        let out = matrix.apply_lifted(&input);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], input[0] + input[1]);
+        assert_eq!(out[1], input[0] + input[2]);
+        assert_eq!(out[2], input[1] + input[2]);
+
+        // Cross-check the F-element `apply_lifted` path against the
+        // bit-packed `apply_bits_u64` path: applying the matrix
+        // bit-by-bit must produce the same bit pattern as packing the
+        // input as a u64, applying the bit-vector matrix, and unpacking.
+        for n in 8..=12 {
+            let c = field_constants(n).unwrap();
+            let g = GfMulMatrix::new(c.poly, c.generator, n);
+            let mask = (1u64 << n) - 1;
+            for v in [0u64, 1, mask, mask / 3, mask / 2 + 1] {
+                let bits = Vec::<Gf2>::from_lsb0_iter(v.iter_lsb0().take(n));
+                let bits_out: Vec<Gf2> = g.apply(&bits);
+                let got = u64::from_lsb0_iter(bits_out.iter_lsb0());
+                let expected = g.apply_bits_u64(v);
+                assert_eq!(
+                    got, expected,
+                    "apply<Gf2> ≠ apply_bits_u64 at n={n}, v=0x{v:X}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn gf2n_mul_mod_matches_aes_known_vectors() {
+        // AES specifies GF(2^8) under the polynomial
+        //   p(x) = x^8 + x^4 + x^3 + x + 1   (= 0x11B)
+        // and FIPS 197 §4.2 gives canonical worked examples. Used here
+        // as an external cross-check against a widely-cited reference.
+        // (Independent of our own poly table — our `n = 8` entry uses
+        // a different irreducible polynomial.)
+        let poly = 0x11B;
+        let n = 8;
+
+        // §4.2 main example: {57} · {83} = {c1}.
+        assert_eq!(gf2n_mul_mod(0x57, 0x83, poly, n), 0xC1);
+
+        // §4.2.2 alternative computation: {57} · {13} = {fe}.
+        assert_eq!(gf2n_mul_mod(0x57, 0x13, poly, n), 0xFE);
+
+        // §4.2.1 xtime() chain — repeated multiplication by `x` (0x02):
+        //   xtime({57}) = {ae},  xtime({ae}) = {47},
+        //   xtime({47}) = {8e},  xtime({8e}) = {07}.
+        assert_eq!(gf2n_mul_mod(0x02, 0x57, poly, n), 0xAE);
+        assert_eq!(gf2n_mul_mod(0x02, 0xAE, poly, n), 0x47);
+        assert_eq!(gf2n_mul_mod(0x02, 0x47, poly, n), 0x8E);
+        assert_eq!(gf2n_mul_mod(0x02, 0x8E, poly, n), 0x07);
+    }
+
+    #[test]
+    fn field_constants_rejects_unsupported_sizes() {
+        // `field_constants` only ships entries for `n ∈ 8..=26`. Any
+        // value outside that range must surface `UnsupportedDegree`
+        // carrying the requested `n` so callers can report it.
+        for &n in &[0usize, 1, 2, 7, 27, 28, 64, 1000] {
+            let err = field_constants(n)
+                .err()
+                .unwrap_or_else(|| panic!("n={n} must be unsupported"));
+            assert_eq!(err.0, n, "error should carry the requested n");
+        }
+        // Sanity: the boundary entries inside the range succeed.
+        assert!(field_constants(8).is_ok());
+        assert!(field_constants(20).is_ok());
+    }
+}

--- a/crates/two-shuffles/src/lib.rs
+++ b/crates/two-shuffles/src/lib.rs
@@ -1,0 +1,24 @@
+//! ZK data structures from "Two Shuffles Make a RAM" (Yang/Heath, 2023).
+//!
+//! Three protocols, layered:
+//!
+//! - [`ro_kvs`] — read-only key-value store (Section 4.1).
+//! - [`set`] — set membership queries (Section 4.2; the same shape as RO-KVS
+//!   minus the value column).
+//! - [`ram`] — read/write RAM (Section 4.3).
+
+#![deny(missing_docs)]
+
+pub(crate) mod gf2n;
+
+pub mod ram;
+pub mod ro_kvs;
+pub mod set;
+pub mod strategy;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
+pub mod wire;
+
+pub use wire::{Bundle, ProverWire, VerifierWire};

--- a/crates/two-shuffles/src/ram.rs
+++ b/crates/two-shuffles/src/ram.rs
@@ -1,0 +1,81 @@
+//! RAM protocol — Section 4.3 of the paper.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::Proof as PermProofMsg;
+use mpz_vole_core::VoleAdjustment;
+
+use crate::set;
+
+pub use crate::strategy::IntegerLike;
+pub use clock::{
+    AdditiveClock, AdditiveClockError, Clock, MulClockError, MultiplicativeClock, ProverClock,
+    VerifierClock,
+};
+pub use config::{Config, ConfigBuilder};
+pub use mux_mul::{MuxMulFlush, MuxMulProof};
+pub use prover::{Error as ProverError, Prover};
+pub use strategy::{CommonStrategy, ProverStrategy, VerifierStrategy};
+pub use verifier::{Error as VerifierError, Verifier};
+
+pub(crate) mod clock;
+pub(crate) mod config;
+pub(crate) mod mux_mul;
+pub(crate) mod prover;
+pub(crate) mod strategy;
+pub(crate) mod verifier;
+
+/// One authenticated `(addr, val, clock)` row.
+#[derive(Copy, Clone)]
+pub(crate) struct Record<W> {
+    pub(crate) addr: W,
+    pub(crate) val: W,
+    pub(crate) clock: W,
+}
+
+/// Flush message from the prover.
+///
+/// May be emitted any number of times during the access phase,
+/// letting the verifier process them in parallel with the prover's
+/// subsequent work.
+pub struct Flush<F>
+where
+    F: Field,
+{
+    /// One [`VoleAdjustment`] per [`prover::Prover::access`] call, in call
+    /// order.
+    ///
+    /// Each adjustment derandomizes the `(value, last_access_time)` pair.
+    pub access_adj: Vec<VoleAdjustment<F>>,
+    /// Mux-mul flush message.
+    pub mul_flush: MuxMulFlush<F>,
+}
+
+/// Pre-`teardown` message from the prover.
+///
+/// Front-loads the work that the verifier can begin before the
+/// prover starts the tear down.
+pub struct TeardownPrepare<F, P>
+where
+    F: Field,
+{
+    /// Single adjustment covering the final (value, last_access_time)
+    /// state of every memory cell.
+    pub teardown_adj: VoleAdjustment<F>,
+    /// RAM perm-proof phase-1 preparation message.
+    pub preparation: P,
+    /// Set pre-teardown message.
+    pub set: set::TeardownPrepare<F, P>,
+}
+
+/// Teardown message from the prover.
+pub struct TeardownMsg<F, BP>
+where
+    F: Field,
+{
+    /// RAM perm-proof closing message.
+    pub ram_proof: PermProofMsg<F, BP>,
+    /// Set perm-proof closing message.
+    pub set: set::TeardownMsg<F, BP>,
+    /// Mux-mul QS closing proof.
+    pub mul_proof: MuxMulProof<F>,
+}

--- a/crates/two-shuffles/src/ram/clock.rs
+++ b/crates/two-shuffles/src/ram/clock.rs
@@ -1,0 +1,545 @@
+//! Clock component layer for the RAM protocol.
+//!
+//! Per access, the RAM protocol must produce an authenticated wire
+//! for `delta = "current_clock − t_old"` and prove `delta ∈ {1..T}`
+//! via a set membership lookup. The specific encoding of clock
+//! values and the meaning of "subtraction" depend on the field
+//! arithmetic: prime fields use additive subtraction, char-2 fields
+//! use multiplicative encoding.
+
+use itybity::{FromBitIterator, ToBits};
+use mpz_fields::{Field, gf2::Gf2};
+use mpz_poly_proof_core::ExtensionField;
+
+use crate::{
+    gf2n::{GfMulMatrix, UnsupportedDegree, field_constants, gf2n_mul_mod},
+    strategy::{Char2, IntegerLike},
+    wire::{Bundle, ProverWire, VerifierWire},
+};
+
+/// Clock's running state and metadata.
+pub trait Clock<S> {
+    /// Wire length of the clock encoding.
+    fn l_clock(&self) -> usize;
+
+    /// Current clock cleartext.
+    fn current_clock(&self) -> &Bundle<S>;
+
+    /// Advance the internal clock state by one step. Subsequent
+    /// calls to `current_clock` reflect the new step.
+    fn next_clock(&mut self);
+
+    /// The valid set of delta values for the protocol.
+    fn valid_deltas(&self) -> Vec<Bundle<S>>;
+}
+
+/// Prover-side clock.
+pub trait ProverClock<S, F>: Clock<S>
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Compute the authenticated `delta` wire.
+    fn compute_delta(&self, t_old: &ProverWire<S, F>) -> ProverWire<S, F>;
+}
+
+/// Verifier-side clock.
+pub trait VerifierClock<S, F>: Clock<S>
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Compute the authenticated `delta` wire.
+    ///
+    /// # Arguments
+    ///
+    /// * `t_old` — wire for `t_old`.
+    /// * `correlation` — global correlation key.
+    fn compute_delta(&self, t_old: &VerifierWire<F>, correlation: F) -> VerifierWire<F>;
+}
+
+// ---------------------------------------------------------------------------
+// AdditiveClock
+// ---------------------------------------------------------------------------
+
+/// Additive `delta = current_clock − t_old` strategy for prime fields.
+///
+/// Clock value `i` is encoded as the field element `i` directly
+/// (`S::zero() + S::one() · i`). The valid delta set is `{1, 2, …, T}` —
+/// positive integers, since prime-field subtraction matches integer
+/// subtraction for values in this range.
+pub struct AdditiveClock<S> {
+    total_accesses: usize,
+    /// Running clock value.
+    clock: S,
+    /// Length-1 bundle wrapper around `clock`
+    //
+    // Kept in sync so we can return a borrowed `&Bundle<S>` without per-call allocation.
+    current_clock: Bundle<S>,
+}
+
+impl<S> AdditiveClock<S>
+where
+    S: Field,
+{
+    /// Construct a strategy for `total_accesses` total accesses.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `total_accesses == 0`.
+    pub fn new(total_accesses: usize) -> Result<Self, AdditiveClockError> {
+        // TODO: compare to (Field::ORDER - 1) / 2 (ORDER not exposed in mpz atm).
+        if (total_accesses.ilog2() as usize) >= S::BIT_SIZE - 2 {
+            return Err(AdditiveClockError::TooManyAccesses { total_accesses });
+        }
+        Ok(Self {
+            total_accesses,
+            clock: S::zero(),
+            current_clock: S::zero().into(),
+        })
+    }
+}
+
+impl<S> Clock<S> for AdditiveClock<S>
+where
+    S: Field + IntegerLike,
+{
+    fn l_clock(&self) -> usize {
+        1
+    }
+
+    fn current_clock(&self) -> &Bundle<S> {
+        &self.current_clock
+    }
+
+    fn next_clock(&mut self) {
+        self.clock = self.clock + S::one();
+        self.current_clock = self.clock.into();
+    }
+
+    fn valid_deltas(&self) -> Vec<Bundle<S>> {
+        // {1, 2, …, T} as length-1 bundles.
+        let mut out = Vec::with_capacity(self.total_accesses);
+        let mut y = S::zero();
+        for _ in 0..self.total_accesses {
+            y = y + S::one();
+            out.push(y.into());
+        }
+        out
+    }
+}
+
+impl<S, F> ProverClock<S, F> for AdditiveClock<S>
+where
+    S: Field + IntegerLike,
+    F: ExtensionField<S>,
+{
+    fn compute_delta(&self, t_old: &ProverWire<S, F>) -> ProverWire<S, F> {
+        assert_eq!(t_old.len(), 1);
+
+        // delta = current_clock − t_old.
+        // Subtracting a public constant from an authenticated wire:
+        //   v_delta = c − v        (cleartext op)
+        //   M_delta = −M_v         (MAC sign-flip; satisfies
+        //                            M_delta = K_delta + Δ·v_delta.embed
+        //                            with K_delta = −K_v − Δ·c.embed)
+        ProverWire::new(
+            (self.clock - t_old.value()[0]).into(),
+            (-t_old.mac()[0]).into(),
+        )
+    }
+}
+
+impl<S, F> VerifierClock<S, F> for AdditiveClock<S>
+where
+    S: Field + IntegerLike,
+    F: ExtensionField<S>,
+{
+    fn compute_delta(&self, t_old: &VerifierWire<F>, correlation: F) -> VerifierWire<F> {
+        assert_eq!(t_old.len(), 1);
+        // K_delta = −K_t_old − Δ · current_clock.embed().
+        VerifierWire::new((-t_old.key[0] - correlation * F::embed(self.clock)).into())
+    }
+}
+
+/// Construction error for [`AdditiveClock`].
+#[derive(Debug, thiserror::Error)]
+pub enum AdditiveClockError {
+    /// Too many accesses.
+    #[error("total_accesses {total_accesses} exceeds field bound")]
+    TooManyAccesses {
+        /// Requested total access count.
+        total_accesses: usize,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// MultiplicativeClock
+// ---------------------------------------------------------------------------
+
+/// Clock whose state advances by **multiplication** in `GF(2^N)`:
+/// at tick `i` the state holds `g^i` for a fixed primitive `g`, and
+/// `next_clock` is the single field op `state ← g · state`.
+///
+/// To check that the prover's claimed `t_old = g^j` corresponds to a
+/// past clock, the strategy computes
+/// `delta = g^{-current_clock} · t_old = g^{j-current_clock}`. The
+/// valid set is `{g^{-1}, g^{-2}, …, g^{-T}}` — i.e. the inverse
+/// powers of `g`, one per past tick.
+///
+/// We maintain `g^{-current_clock}` as a running scalar rather than computing
+/// `t_old^{-1}` per access, which would require a more expensive full field
+/// inversion (e.g. extended Euclidean).
+pub struct MultiplicativeClock {
+    total_accesses: usize,
+    /// Extension degree of the clock's working field `GF(2^n)`.
+    n: usize,
+    /// Irreducible polynomial defining `GF(2^n)`, with bit `n` set.
+    poly: u64,
+    /// Primitive element, i.e. the generator.
+    g: u64,
+    /// Multiplicative inverse of `g`.
+    g_inv: u64,
+
+    /// Running positive clock = `g^current_clock`, in bit-pattern
+    /// `Bundle<Gf2>` form.
+    pos_clock_bits: Bundle<Gf2>,
+
+    /// Running positive clock as a `u64` bit pattern. Same value as
+    /// `pos_clock_bits`.
+    pos_clock_u64: u64,
+
+    /// Running negative clock = `g^{-current_clock}`, as a `u64`.
+    /// Each `next_clock` advances by `· g_inv`.
+    neg_clock_u64: u64,
+}
+
+impl MultiplicativeClock {
+    /// Construct a strategy for `total_accesses` total accesses.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `total_accesses` exceeds the maximum supported.
+    pub fn new(total_accesses: usize) -> Result<Self, MulClockError> {
+        let n = smallest_valid_n(total_accesses)?;
+        let c = field_constants(n).expect("smallest_valid_n returns a supported n");
+
+        // Running counters initialized at the anchor (g^0 = 1).
+        let mut pos_clock_bits = vec![Gf2::ZERO; n];
+        pos_clock_bits[0] = Gf2::ONE;
+
+        Ok(Self {
+            total_accesses,
+            n,
+            poly: c.poly,
+            g: c.generator,
+            g_inv: c.g_inv,
+            pos_clock_bits: pos_clock_bits.into(),
+            pos_clock_u64: 1,
+            neg_clock_u64: 1,
+        })
+    }
+}
+
+impl Clock<Gf2> for MultiplicativeClock {
+    fn l_clock(&self) -> usize {
+        self.n
+    }
+
+    fn current_clock(&self) -> &Bundle<Gf2> {
+        &self.pos_clock_bits
+    }
+
+    fn next_clock(&mut self) {
+        // Advance pos by *g and neg by *g_inv.
+        self.pos_clock_u64 = gf2n_mul_mod(self.pos_clock_u64, self.g, self.poly, self.n);
+        self.neg_clock_u64 = gf2n_mul_mod(self.neg_clock_u64, self.g_inv, self.poly, self.n);
+        // Keep the bundle form in sync for `clock_encoded` borrowers.
+        self.pos_clock_bits =
+            Vec::<Gf2>::from_lsb0_iter(self.pos_clock_u64.iter_lsb0().take(self.n)).into();
+    }
+
+    fn valid_deltas(&self) -> Vec<Bundle<Gf2>> {
+        // g^{-1}, g^{-2}, …, g^{-T}} via running multiplication by g_inv.
+        let mut y = 1u64;
+        let mut out = Vec::with_capacity(self.total_accesses);
+        for _ in 0..self.total_accesses {
+            y = gf2n_mul_mod(y, self.g_inv, self.poly, self.n);
+            out.push(Vec::<Gf2>::from_lsb0_iter(y.iter_lsb0().take(self.n)).into());
+        }
+        out
+    }
+}
+
+impl<F> ProverClock<Gf2, F> for MultiplicativeClock
+where
+    F: Char2 + ExtensionField<Gf2>,
+{
+    fn compute_delta(&self, t_old: &ProverWire<Gf2, F>) -> ProverWire<Gf2, F> {
+        assert_eq!(t_old.len(), self.n);
+
+        // Build the multiply-by-`g^{-current_clock}` matrix from the
+        // running negative counter, then apply to `t_old = g^j`.
+        // Result is `g^{j-current_clock}` — a negative power of `g`.
+        let matrix = GfMulMatrix::new(self.poly, self.neg_clock_u64, self.n);
+        let next_value = matrix.apply(t_old.value());
+        let next_mac = matrix.apply_lifted(t_old.mac());
+        ProverWire::new(next_value.into(), next_mac.into())
+    }
+}
+
+impl<F> VerifierClock<Gf2, F> for MultiplicativeClock
+where
+    F: Char2 + ExtensionField<Gf2>,
+{
+    fn compute_delta(&self, t_old: &VerifierWire<F>, _correlation: F) -> VerifierWire<F> {
+        assert_eq!(t_old.len(), self.n);
+
+        // Build the multiply-by-`g^{-current_clock}` matrix from the
+        // running negative counter, then apply to `t_old = g^j`.
+        // Result is `g^{j-current_clock}` — a negative power of `g`.
+        let matrix = GfMulMatrix::new(self.poly, self.neg_clock_u64, self.n);
+        VerifierWire::new(matrix.apply_lifted(&t_old.key).into())
+    }
+}
+
+/// Construction error for [`MultiplicativeClock`].
+#[derive(Debug, thiserror::Error)]
+pub enum MulClockError {
+    /// Wire length `n` is not supported.
+    #[error("unsupported bundle size: {0}")]
+    UnsupportedDegree(#[from] UnsupportedDegree),
+
+    /// `total_accesses` size is not supported.
+    #[error("total_accesses {0} too large")]
+    TooManyAccesses(usize),
+}
+
+/// Smallest supported wire length `n` whose multiplicative group
+/// of order `2^n − 1` satisfies `≥ 2·total_accesses + 1`.
+fn smallest_valid_n(total_accesses: usize) -> Result<usize, MulClockError> {
+    let needed = 2u64
+        .checked_mul(total_accesses as u64)
+        .and_then(|x| x.checked_add(1))
+        .ok_or(MulClockError::TooManyAccesses(total_accesses))?;
+    for n in 8..=26 {
+        if field_constants(n).expect("n in 8..=26").group_order >= needed {
+            return Ok(n);
+        }
+    }
+    Err(MulClockError::TooManyAccesses(total_accesses))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{bits, pow_mod, prover_wire};
+    use mpz_fields::{gf2_64::Gf2_64, p256::P256};
+    use mpz_vole_core::test::assert_vole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    // Until mpz-fields offers a prime subfield carrying an extension
+    // field (rather than only the gf2 family), we work around it by
+    // marking Gf2_64 IntegerLike — just enough to instantiate
+    // AdditiveClock::compute_delta and test that the clock increments
+    // correctly (0 → 1).
+    impl IntegerLike for Gf2_64 {}
+
+    /// The field element equal to integer `k` (i.e. `1` summed `k`
+    /// times) — independent of the field's internal representation.
+    fn ones<S: Field>(k: u64) -> S {
+        (0..k).fold(S::zero(), |acc, _| acc + S::one())
+    }
+
+    // -----------------------------------------------------------------------
+    // MultiplicativeClock
+    // -----------------------------------------------------------------------
+
+    /// A fresh clock anchors both running counters at `g^0 = 1`.
+    #[test]
+    fn mul_clock_starts_at_anchor() {
+        let c = MultiplicativeClock::new(100).expect("new");
+        assert_eq!(c.pos_clock_u64, 1);
+        assert_eq!(c.neg_clock_u64, 1);
+        assert_eq!(c.current_clock().as_slice(), bits(1, c.n).as_slice());
+    }
+
+    /// The positive and negative counters stay multiplicative
+    /// inverses at every tick: `g^i · g^{-i} = 1`.
+    #[test]
+    fn mul_clock_counters_are_inverses() {
+        let mut c = MultiplicativeClock::new(100).expect("new");
+        for _ in 0..50 {
+            c.next_clock();
+            assert_eq!(
+                gf2n_mul_mod(c.pos_clock_u64, c.neg_clock_u64, c.poly, c.n),
+                1,
+                "pos · neg must be 1",
+            );
+        }
+    }
+
+    /// After `k` ticks the counters hold `g^k` / `g^{-k}`, and the
+    /// bundle bit-form stays in sync with the u64.
+    #[test]
+    fn mul_clock_tracks_g_powers() {
+        let mut c = MultiplicativeClock::new(100).expect("new");
+        for k in 1..=50u64 {
+            c.next_clock();
+            let pos = pow_mod(c.g, k, c.poly, c.n);
+            let neg = pow_mod(c.g_inv, k, c.poly, c.n);
+            assert_eq!(c.pos_clock_u64, pos, "g^{k}");
+            assert_eq!(c.neg_clock_u64, neg, "g^-{k}");
+            assert_eq!(c.current_clock().as_slice(), bits(pos, c.n).as_slice());
+        }
+    }
+
+    /// `valid_deltas` is exactly `[g^{-1}, …, g^{-T}]`.
+    #[test]
+    fn mul_clock_valid_deltas() {
+        let c = MultiplicativeClock::new(20).expect("new");
+        let deltas = c.valid_deltas();
+        assert_eq!(deltas.len(), 20);
+        for (k, d) in deltas.iter().enumerate() {
+            let expected = pow_mod(c.g_inv, k as u64 + 1, c.poly, c.n);
+            assert_eq!(d.as_slice(), bits(expected, c.n).as_slice(), "g^-{}", k + 1);
+        }
+    }
+
+    /// `compute_delta` yields `g^{j-current} · t_old`.
+    /// - `t_old = current_clock` (j = current) → `g^0 = 1`.
+    /// - `t_old = g^j` for a past `j` → the matching `valid_deltas` entry.
+    #[test]
+    fn mul_clock_compute_delta_cleartext() {
+        let mut clock = MultiplicativeClock::new(50).expect("new");
+        for _ in 0..10 {
+            clock.next_clock(); // current = 10
+        }
+
+        // t_old at the current tick → delta = 1.
+        let t_now = prover_wire::<Gf2, Gf2_64>(clock.current_clock().to_vec());
+        let d_now =
+            <MultiplicativeClock as ProverClock<Gf2, Gf2_64>>::compute_delta(&clock, &t_now);
+        assert_eq!(d_now.value().as_slice(), bits(1, clock.n).as_slice());
+
+        // t_old = g^3, current = 10 → delta = g^{-7} = valid_deltas[6].
+        let g3 = pow_mod(clock.g, 3, clock.poly, clock.n);
+        let t_past = prover_wire::<Gf2, Gf2_64>(bits(g3, clock.n));
+        let d_past =
+            <MultiplicativeClock as ProverClock<Gf2, Gf2_64>>::compute_delta(&clock, &t_past);
+        let expected = pow_mod(clock.g_inv, 7, clock.poly, clock.n);
+        assert_eq!(
+            d_past.value().as_slice(),
+            bits(expected, clock.n).as_slice()
+        );
+        assert_eq!(
+            d_past.value().as_slice(),
+            clock.valid_deltas()[6].as_slice(),
+            "past delta must be a valid-set member",
+        );
+    }
+
+    /// Given an authenticated `t_old` (`M = K + Δ·embed(v)` per bit),
+    /// the prover's and verifier's delta wires satisfy the same IT-MAC
+    /// invariant — i.e. `apply` (value) and `apply_lifted` (MAC/key)
+    /// stay consistent through the matrix.
+    #[test]
+    fn mul_clock_compute_delta_preserves_itmac() {
+        let mut rng = StdRng::seed_from_u64(0xc10c);
+        let mut clock = MultiplicativeClock::new(50).expect("new");
+        for _ in 0..8 {
+            clock.next_clock();
+        }
+
+        let corr: Gf2_64 = rng.random();
+        let v = bits(pow_mod(clock.g, 5, clock.poly, clock.n), clock.n);
+        let keys: Vec<Gf2_64> = (0..clock.n).map(|_| rng.random()).collect();
+        let macs: Vec<Gf2_64> = v
+            .iter()
+            .zip(&keys)
+            .map(|(vi, ki)| *ki + corr * <Gf2_64 as ExtensionField<Gf2>>::embed(*vi))
+            .collect();
+
+        let p_t = ProverWire::new(Bundle::new(v), Bundle::new(macs));
+        let v_t = VerifierWire::new(Bundle::new(keys));
+
+        let p_d = <MultiplicativeClock as ProverClock<Gf2, Gf2_64>>::compute_delta(&clock, &p_t);
+        let v_d =
+            <MultiplicativeClock as VerifierClock<Gf2, Gf2_64>>::compute_delta(&clock, &v_t, corr);
+
+        assert_vole(
+            corr,
+            v_d.key.as_slice(),
+            p_d.value().as_slice(),
+            p_d.mac().as_slice(),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AdditiveClock
+    // -----------------------------------------------------------------------
+
+    /// The `Clock` surface over a prime field — single-slot encoding,
+    /// clock starts at 0 and increments by 1, valid set is `[1..=T]`.
+    #[test]
+    fn additive_clock_surface() {
+        let mut clock = AdditiveClock::<P256>::new(5).expect("new");
+        assert_eq!(clock.l_clock(), 1);
+        assert_eq!(clock.current_clock().as_slice(), [P256::zero()].as_slice());
+
+        for k in 1..=5u64 {
+            clock.next_clock();
+            assert_eq!(
+                clock.current_clock().as_slice(),
+                [ones::<P256>(k)].as_slice()
+            );
+        }
+
+        let deltas = clock.valid_deltas();
+        assert_eq!(deltas.len(), 5);
+        for (k, d) in deltas.iter().enumerate() {
+            assert_eq!(d.as_slice(), [ones::<P256>(k as u64 + 1)].as_slice());
+        }
+    }
+
+    /// `new(0)` panics (documented; `0usize.ilog2()` is undefined).
+    #[test]
+    #[should_panic]
+    fn additive_clock_new_zero_panics() {
+        let _ = AdditiveClock::<P256>::new(0);
+    }
+
+    /// With the clock parked at 1, the additive `compute_delta` MAC
+    /// algebra — `v_delta = c − v`, `M_delta = −M_v`,
+    /// `K_delta = −K_v − Δ·embed(c)` — yields a delta wire that
+    /// satisfies the IT-MAC invariant. Field-generic algebra, so the
+    /// `Gf2_64` stand-in is sound (see the module note). The multi-step
+    /// increment semantics are covered by `additive_clock_surface` over
+    /// the real `P256`.
+    #[test]
+    fn additive_clock_compute_delta_preserves_itmac() {
+        let mut rng = StdRng::seed_from_u64(0xadd1);
+        let mut clock = AdditiveClock::<Gf2_64>::new(3).expect("new");
+        clock.next_clock(); // 0 → 1: the one step that agrees in any field
+
+        let corr: Gf2_64 = rng.random();
+        let v: Gf2_64 = rng.random();
+        let key: Gf2_64 = rng.random();
+        let mac = key + corr * <Gf2_64 as ExtensionField<Gf2_64>>::embed(v);
+
+        let p_t = ProverWire::new(Bundle::new(vec![v]), Bundle::new(vec![mac]));
+        let v_t = VerifierWire::new(Bundle::new(vec![key]));
+
+        let p_d =
+            <AdditiveClock<Gf2_64> as ProverClock<Gf2_64, Gf2_64>>::compute_delta(&clock, &p_t);
+        let v_d = <AdditiveClock<Gf2_64> as VerifierClock<Gf2_64, Gf2_64>>::compute_delta(
+            &clock, &v_t, corr,
+        );
+
+        // Cleartext: delta = current_clock − v.
+        let c = clock.current_clock()[0];
+        assert_eq!(p_d.value()[0], c - v);
+        // IT-MAC invariant carries to the delta wire.
+        assert_vole(corr, &[v_d.key[0]], &[p_d.value()[0]], &[p_d.mac()[0]]);
+    }
+}

--- a/crates/two-shuffles/src/ram/config.rs
+++ b/crates/two-shuffles/src/ram/config.rs
@@ -1,0 +1,139 @@
+//! Protocol config.
+
+use std::marker::PhantomData;
+
+use mpz_fields::Field;
+use rangeset::set::RangeSet;
+
+use crate::strategy::FieldStrategy;
+
+/// Protocol config.
+pub struct Config<F, Strat>
+where
+    F: Field,
+    Strat: FieldStrategy<F>,
+{
+    /// Addresses populated at setup.
+    pub live_addrs: RangeSet<usize>,
+    /// Bit-width of the value domain: each address stores one of
+    /// `2^value_bits` distinct values.
+    pub value_bits: usize,
+    /// Total access budget.
+    pub total_accesses: usize,
+    /// Addresses whose post-teardown state is returned.
+    pub export_addrs: RangeSet<usize>,
+    _strat: PhantomData<(F, fn() -> Strat)>,
+}
+
+impl<F, Strat> Clone for Config<F, Strat>
+where
+    F: Field,
+    Strat: FieldStrategy<F>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            live_addrs: self.live_addrs.clone(),
+            value_bits: self.value_bits,
+            total_accesses: self.total_accesses,
+            export_addrs: self.export_addrs.clone(),
+            _strat: PhantomData,
+        }
+    }
+}
+
+impl<F, Strat> Config<F, Strat>
+where
+    F: Field,
+    Strat: FieldStrategy<F>,
+{
+    /// Start building a [`Config`].
+    pub fn builder(
+        live_addrs: RangeSet<usize>,
+        value_bits: usize,
+        total_accesses: usize,
+    ) -> ConfigBuilder<F, Strat> {
+        ConfigBuilder::new(live_addrs, value_bits, total_accesses)
+    }
+}
+
+/// Builder for [`Config`].
+pub struct ConfigBuilder<F, Strat>
+where
+    F: Field,
+    Strat: FieldStrategy<F>,
+{
+    live_addrs: RangeSet<usize>,
+    value_bits: usize,
+    total_accesses: usize,
+    export_addrs: Option<RangeSet<usize>>,
+    _strat: PhantomData<(F, fn() -> Strat)>,
+}
+
+impl<F, Strat> ConfigBuilder<F, Strat>
+where
+    F: Field,
+    Strat: FieldStrategy<F>,
+{
+    /// New config builder.
+    pub fn new(live_addrs: RangeSet<usize>, value_bits: usize, total_accesses: usize) -> Self {
+        Self {
+            live_addrs,
+            value_bits,
+            total_accesses,
+            export_addrs: None,
+            _strat: PhantomData,
+        }
+    }
+
+    /// Override the default export set (which is all of `live_addrs`).
+    /// The set must be a subset of `live_addrs`.
+    pub fn export_addrs(mut self, set: RangeSet<usize>) -> Self {
+        self.export_addrs = Some(set);
+        self
+    }
+
+    /// Finalize the config.
+    pub fn build(self) -> Result<Config<F, Strat>, Error> {
+        if self.live_addrs.is_empty() {
+            return Err(Error::EmptyLiveSet);
+        }
+
+        let export_addrs = self.export_addrs.unwrap_or_else(|| self.live_addrs.clone());
+        if export_addrs.is_empty() {
+            return Err(Error::EmptyExportSet);
+        }
+        // Can only export instantiated cells.
+        if export_addrs
+            .iter_values()
+            .any(|a| !self.live_addrs.contains(&a))
+        {
+            return Err(Error::ExportNotSubset);
+        }
+
+        Ok(Config {
+            live_addrs: self.live_addrs,
+            value_bits: self.value_bits,
+            total_accesses: self.total_accesses,
+            export_addrs,
+            _strat: PhantomData,
+        })
+    }
+}
+
+/// Errors raised by [`ConfigBuilder::build`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Caller passed an empty `live_addrs` set to
+    /// [`Config::builder`].
+    #[error("live_addrs must be non-empty")]
+    EmptyLiveSet,
+
+    /// Caller passed an empty `RangeSet` to
+    /// [`ConfigBuilder::export_addrs`].
+    #[error("export_addrs must be non-empty")]
+    EmptyExportSet,
+
+    /// `export_addrs` contains an address that is not in `live_addrs`.
+    #[error("export_addrs must be a subset of live_addrs")]
+    ExportNotSubset,
+}

--- a/crates/two-shuffles/src/ram/mux_mul.rs
+++ b/crates/two-shuffles/src/ram/mux_mul.rs
@@ -1,0 +1,290 @@
+//! Mux-multiplication proof for the RAM private-op access.
+//!
+//! The RAM access multiplexer is `new = old + op·(w − old)`. This
+//! module proves the `op · diff = prod` step (where `diff = w − old`)
+//! across all accesses in a session, batched into a single QuickSilver
+//! polynomial proof.
+
+pub mod prover;
+pub mod verifier;
+pub mod vope_from_vole;
+
+use mpz_circuits_new::Context;
+use mpz_fields::{ExtensionField, Field};
+use mpz_poly_proof_core::{
+    ConstraintId, ConstraintsBuilder, ProofMessage, ProverConstraints, VerifierConstraints,
+};
+use mpz_poly_proof_macros::poly_kernel;
+use mpz_vole_core::VoleAdjustment;
+
+pub use prover::MuxMulProver;
+pub use verifier::MuxMulVerifier;
+
+/// A flush message.
+///
+/// The prover can emit this message at any time, letting the
+/// verifier pipeline its computation rather than waiting until
+/// teardown to process everything at once.
+pub struct MuxMulFlush<F: Field> {
+    /// One adjustment per [`MuxMulProver::accumulate`] call.
+    pub adjustments: Vec<VoleAdjustment<F>>,
+}
+
+/// Closing message of the proof.
+pub struct MuxMulProof<F: Field> {
+    /// QS polynomial-proof message.
+    pub qs_proof: ProofMessage<F>,
+}
+
+/// Draw a PRG seed from the transcript under a domain separation label.
+pub(crate) fn draw_seed(transcript: &mut blake3::Hasher, label: &[u8]) -> [u8; 32] {
+    transcript.update(label);
+    let mut buf = [0u8; 32];
+    transcript.finalize_xof().fill(&mut buf);
+    buf
+}
+
+/// Mux mul-gate constraint: `a · x − c = 0` over `vars = [a, x, c]`.
+/// `#[poly_kernel]` expands this into a `MulGate` `ConstraintDef`; the
+/// re-emitted fn itself is scaffolding for the macro and isn't called
+/// directly (only the generated `MulGate` type is used).
+#[allow(dead_code)]
+#[poly_kernel]
+pub fn mul_gate<C, E>(ctx: &mut C, vars: [C::Wire; 3]) -> Result<(), C::Error>
+where
+    C: Context<Field = E>,
+    E: Field,
+{
+    let prod = ctx.mul(vars[0], vars[1]);
+    let diff = ctx.sub(prod, vars[2]);
+    ctx.assert_const(diff, E::zero())
+}
+
+/// Booleanness constraint: `op · op − op = 0` over `vars = [op]`.
+/// `#[poly_kernel]` expands this into a `BoolCheck` `ConstraintDef`; the
+/// re-emitted fn itself is scaffolding for the macro and isn't called
+/// directly (only the generated `BoolCheck` type is used).
+#[allow(dead_code)]
+#[poly_kernel]
+pub fn bool_check<C, E>(ctx: &mut C, vars: [C::Wire; 1]) -> Result<(), C::Error>
+where
+    C: Context<Field = E>,
+    E: Field,
+{
+    let sq = ctx.mul(vars[0], vars[0]);
+    let diff = ctx.sub(sq, vars[0]);
+    ctx.assert_const(diff, E::zero())
+}
+
+/// IDs of the constraints.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct MuxConstraintIds {
+    /// Multiplication constraint: `a · b − c = 0`.
+    pub mul: ConstraintId,
+    /// Booleanness constraint: `op · op − op = 0`.
+    ///
+    /// Registered only when the caller requests it
+    /// (typically skipped when the cleartext is already binary by
+    /// type).
+    pub bool_check: Option<ConstraintId>,
+}
+
+/// Build the QuickSilver constraint set used by the mux-mul protocol.
+///
+/// Returns both the prover- and verifier-side constraint tables (the
+/// caller keeps the half it needs and drops the other) plus the
+/// registered [`ConstraintId`]s.
+pub(crate) fn build_mux_constraints<F, S>(
+    boolean_check_enabled: bool,
+) -> (
+    ProverConstraints<F, S>,
+    VerifierConstraints<F>,
+    MuxConstraintIds,
+)
+where
+    F: Field + ExtensionField<S>,
+    S: Field,
+{
+    let mut b = ConstraintsBuilder::<F, S>::new();
+
+    let mul = b
+        .add::<MulGate>()
+        .expect("mux mul-gate constraint registers");
+
+    let bool_check = if boolean_check_enabled {
+        let id = b
+            .add::<BoolCheck>()
+            .expect("mux boolean-check constraint registers");
+        Some(id)
+    } else {
+        None
+    };
+
+    let (pc, vc) = b.build();
+    (pc, vc, MuxConstraintIds { mul, bool_check })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{verifier::Error as VerifierError, *};
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_poly_proof_core::ExtensionField;
+    use mpz_vole_core::ideal::rvole::ideal_rvole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use crate::test_utils::commit_accesses;
+
+    /// Per-access pattern element: `(op_value, diff_value)`.
+    type Access = (Gf2, Vec<Gf2>);
+
+    fn pattern() -> Vec<Access> {
+        vec![
+            (Gf2(true), bits4(0b1010)),
+            (Gf2(false), bits4(0b0101)),
+            (Gf2(true), bits4(0b1111)),
+        ]
+    }
+
+    fn bits4(nibble: u8) -> Vec<Gf2> {
+        use itybity::{FromBitIterator, ToBits};
+        Vec::<Gf2>::from_lsb0_iter(nibble.iter_lsb0().take(4))
+    }
+
+    /// Drive the full mux-mul prover↔verifier flow.
+    fn run(tamper: TamperKind) -> Result<(), VerifierError> {
+        let mut rng = StdRng::seed_from_u64(0x42);
+        let delta: Gf2_64 = rng.random();
+        let vope_rvole_seed: u64 = rng.random();
+        let mul_rvole_seed: u64 = rng.random();
+
+        let pattern = pattern();
+        let n_accesses = pattern.len();
+        let l_val = pattern[0].1.len();
+        let num_mul_gates = n_accesses * l_val;
+        // VOPE-side pool: `EXTENSION_DEGREE` base VOLEs for the
+        // lifted-VOPE at finalize.
+        let vope_count = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+        let (mut vope_rvole_s, mut vope_rvole_r) =
+            ideal_rvole::<Gf2, Gf2_64>(vope_rvole_seed, delta);
+        vope_rvole_s.pregenerate(vope_count);
+        vope_rvole_r
+            .pregenerate(vope_count, delta)
+            .expect("vope rvole pregenerate");
+
+        // Mul-gate-side pool: one RVOLE per prod-wire commit.
+        let (mut mul_rvole_s, mut mul_rvole_r) = ideal_rvole::<Gf2, Gf2_64>(mul_rvole_seed, delta);
+        mul_rvole_s.pregenerate(num_mul_gates);
+        mul_rvole_r
+            .pregenerate(num_mul_gates, delta)
+            .expect("mul rvole pregenerate");
+        let prover_mul_vole = mpz_vole_core::DerandVOLEReceiver::new(mul_rvole_r);
+
+        // Pack each access as an (op, diff) 2-tuple and commit them.
+        let access_tuples: Vec<[Vec<Gf2>; 2]> = pattern
+            .into_iter()
+            .map(|(op_val, diff_val)| [vec![op_val], diff_val])
+            .collect();
+        let (access_commits, transcript) =
+            commit_accesses::<Gf2, Gf2_64, 2>(access_tuples, delta, &mut rng);
+
+        // Each side gets its own transcript — they start identical.
+        let mut p_transcript = transcript.clone();
+        let mut v_transcript = transcript;
+
+        // All input-side tampering happens here.
+        if let TamperKind::WrongTranscript = tamper {
+            v_transcript.update(b"diverge");
+        }
+        let v_ops: Vec<crate::wire::VerifierWire<Gf2_64>> = access_commits
+            .iter()
+            .map(|[(_, v_op), _]| {
+                let k = match tamper {
+                    TamperKind::WrongOpKey => v_op.key[0] + Gf2_64::ONE,
+                    _ => v_op.key[0],
+                };
+                crate::wire::VerifierWire::new(crate::wire::Bundle::new(vec![k]))
+            })
+            .collect();
+        let v_diffs: Vec<crate::wire::VerifierWire<Gf2_64>> = access_commits
+            .iter()
+            .map(|[_, (_, v_diff)]| v_diff.clone())
+            .collect();
+
+        // Gf2 has BIT_SIZE = 1 → no boolean check.
+        let verifier_mul_vole = mpz_vole_core::DerandVOLESender::new(mul_rvole_s);
+        let mut prover =
+            MuxMulProver::<_, _, Gf2, Gf2_64>::new(vope_rvole_r, prover_mul_vole, false);
+        let mut verifier =
+            MuxMulVerifier::<_, _, Gf2, Gf2_64>::new(vope_rvole_s, verifier_mul_vole, false);
+
+        prover.alloc(num_mul_gates).expect("prover alloc");
+        verifier.alloc(num_mul_gates).expect("verifier alloc");
+
+        // Prover phase.
+        for [(p_op, _), (p_diff, _)] in &access_commits {
+            prover.accumulate(p_op, p_diff).expect("accumulate");
+        }
+        let flush = prover.flush().expect("flush");
+        let MuxMulProof { mut qs_proof } =
+            prover.finalize(&mut p_transcript).expect("prover finalize");
+
+        // Transport tamper: corrupt the proof in flight.
+        if let TamperKind::FlipProofCoeff = tamper {
+            let c = qs_proof.coefficients[0];
+            qs_proof.coefficients[0] = c + Gf2_64::ONE;
+        }
+
+        // Verifier phase.
+        assert_eq!(flush.adjustments.len(), n_accesses);
+        verifier
+            .accumulate(&v_ops, &v_diffs, &flush)
+            .expect("accumulate");
+        verifier.finalize(&mut v_transcript, &qs_proof)
+    }
+
+    #[derive(Copy, Clone)]
+    enum TamperKind {
+        /// No tampering — the protocol should accept.
+        None,
+        /// Verifier's transcript diverges from the prover's; the QS
+        /// seed drawn at finalize will differ.
+        WrongTranscript,
+        /// Verifier sees the wrong key for `op` on every batched
+        /// access.
+        WrongOpKey,
+        /// One coefficient of the proof message gets one bit flipped.
+        FlipProofCoeff,
+    }
+
+    #[test]
+    fn accepts_honest() {
+        run(TamperKind::None).expect("honest must accept");
+    }
+
+    #[test]
+    fn rejects_mismatched_transcript() {
+        let err = run(TamperKind::WrongTranscript).expect_err("mismatched transcript must reject");
+        assert!(
+            matches!(err, VerifierError::Qs(_)),
+            "expected Qs error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_op_key() {
+        let err = run(TamperKind::WrongOpKey).expect_err("wrong op_key must reject");
+        assert!(
+            matches!(err, VerifierError::Qs(_)),
+            "expected Qs error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_flipped_proof_coeff() {
+        let err = run(TamperKind::FlipProofCoeff).expect_err("flipped proof coeff must reject");
+        assert!(
+            matches!(err, VerifierError::Qs(_)),
+            "expected Qs error, got {err:?}"
+        );
+    }
+}

--- a/crates/two-shuffles/src/ram/mux_mul/prover.rs
+++ b/crates/two-shuffles/src/ram/mux_mul/prover.rs
@@ -1,0 +1,345 @@
+//! Prover side of the mux-multiplication protocol.
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use mpz_poly_proof_core::{ExtensionField, prover::Prover as QsProver};
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, VOLEReceiver, VoleAdjustment,
+};
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::wire::ProverWire as Wire;
+
+use super::{
+    MuxConstraintIds, MuxMulFlush, MuxMulProof, build_mux_constraints,
+    vope_from_vole::prover_vope_from_vole,
+};
+
+/// Mux-multiplication prover.
+pub struct MuxMulProver<RV, RD, S, F>
+where
+    RV: RVOLEReceiver<S, F>,
+    RD: RVOLEReceiver<S, F>,
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// QuickSilver polynomial protocol prover. MACs live in `F`,
+    /// values in the subfield `S`.
+    qs: QsProver<F, S>,
+
+    /// `ConstraintId`s of the constraints registered in `qs`.
+    ids: MuxConstraintIds,
+
+    /// RVOLE pool for the lifted-VOPE.
+    rvole: RV,
+
+    /// Derandomized VOLE pool for multiplication.
+    mul_vole: DerandVOLEReceiver<RD, S, F>,
+
+    /// Queue of pending multiplication to be proven with `qs`.
+    pending_mults: Vec<PendingMult<S, F>>,
+
+    /// Queue of pending boolean-check constraints to be proven with `qs`.
+    pending_bool_checks: Vec<PendingBoolCheck<S, F>>,
+
+    /// Outbound queue of VOLE adjustments.
+    pending_adjustments: Vec<VoleAdjustment<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// True iff the boolean-check circuit was registered at
+    /// construction.
+    boolean_check_enabled: bool,
+
+    /// Lifecycle state.
+    state: State,
+}
+
+impl<RV, RD, S, F> MuxMulProver<RV, RD, S, F>
+where
+    RV: RVOLEReceiver<S, F>,
+    RD: RVOLEReceiver<S, F>,
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Construct a new mux-mul prover.
+    ///
+    /// # Arguments
+    ///
+    /// * `rvole` — random VOLE receiver.
+    /// * `mul_vole` — derandomized VOLE receiver.
+    /// * `boolean_check_enabled` — whether to enforce the `op · op = op`
+    ///   booleanness constraint per access.
+    pub fn new(
+        rvole: RV,
+        mul_vole: DerandVOLEReceiver<RD, S, F>,
+        boolean_check_enabled: bool,
+    ) -> Self {
+        let (pc, _vc, ids) = build_mux_constraints::<F, S>(boolean_check_enabled);
+        Self {
+            qs: QsProver::new(&pc),
+            ids,
+            rvole,
+            mul_vole,
+            pending_mults: Vec::new(),
+            pending_bool_checks: Vec::new(),
+            pending_adjustments: Vec::new(),
+            transcript: blake3::Hasher::new(),
+            boolean_check_enabled,
+            state: State::Initialized,
+        }
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_muls` — number of multiplications.
+    pub fn alloc(&mut self, num_muls: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+
+        self.mul_vole.alloc(num_muls).map_err(Error::DerandVole)?;
+        self.rvole
+            .alloc(self.vope_vole_count())
+            .map_err(|e| Error::Vole(Box::new(e)))?;
+
+        self.pending_mults.reserve_exact(num_muls);
+        self.pending_adjustments.reserve(num_muls);
+        if self.boolean_check_enabled {
+            self.pending_bool_checks.reserve(num_muls);
+        }
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Accumulate one multiplication, returning the product wire.
+    ///
+    /// # Arguments
+    ///
+    /// * `op` — left operand. Must be `{0, 1}`; the protocol enforces this.
+    /// * `diff` — right operand.
+    pub fn accumulate(&mut self, op: &Wire<S, F>, diff: &Wire<S, F>) -> Result<Wire<S, F>, Error>
+    where
+        S: Field,
+        F: Copy,
+        F: serde::Serialize,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if op.len() != 1 {
+            return Err(Error::LengthMismatch);
+        }
+        let n = diff.len();
+
+        // Cleartext per-slot product.
+        let prod_value: Vec<S> = (0..n).map(|i| op.value()[0] * diff.value()[i]).collect();
+
+        // Derandomize the product.
+        let mut prod_fut = self
+            .mul_vole
+            .queue_recv_vole(&prod_value)
+            .map_err(Error::DerandVole)?;
+        let adjustment = self.mul_vole.adjust().map_err(Error::DerandVole)?;
+        let prod_macs: Vec<F> = prod_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+
+        // Queue for proving.
+        for i in 0..n {
+            self.pending_mults.push(PendingMult {
+                values: [op.value()[0], diff.value()[i], prod_value[i]],
+                macs: [op.mac()[0], diff.mac()[i], prod_macs[i]],
+            });
+        }
+        if self.boolean_check_enabled {
+            self.pending_bool_checks.push(PendingBoolCheck {
+                value: [op.value()[0]],
+                mac: [op.mac()[0]],
+            });
+        }
+
+        // Absorb into transcript.
+        self.transcript
+            .update(&bcs::to_bytes(&adjustment).expect("serialize"));
+        self.pending_adjustments.push(adjustment);
+
+        Ok(Wire::new(prod_value.into(), prod_macs.into()))
+    }
+
+    /// Emits a flush message.
+    pub fn flush(&mut self) -> Result<MuxMulFlush<F>, Error> {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        Ok(MuxMulFlush {
+            adjustments: std::mem::take(&mut self.pending_adjustments),
+        })
+    }
+
+    /// Finalize the protocol, returning the proof.
+    ///
+    /// The caller is responsible for calling [`flush`](Self::flush)
+    /// before invoking this method.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`accumulate`](Self::accumulate) before this call —
+    /// otherwise the protocol's soundness guarantee no longer holds.
+    pub fn finalize(mut self, transcript: &mut blake3::Hasher) -> Result<MuxMulProof<F>, Error>
+    where
+        F: IntoBytes + FromBytes,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if !self.pending_adjustments.is_empty() {
+            return Err(Error::UnflushedAdjustments {
+                pending: self.pending_adjustments.len(),
+            });
+        }
+
+        // Lifted-VOPE: pull base VOLEs and rename them as a length-2 VOPE.
+        let k = self.vope_vole_count();
+        let vole = self
+            .rvole
+            .try_recv_vole(k)
+            .map_err(|e| Error::Vole(Box::new(e)))?;
+        let vope = prover_vope_from_vole::<S, F>(&vole);
+
+        // Absorb all emitted messages into the transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        // Draw the qs seed.
+        let seed = super::draw_seed(transcript, b"mux-mul::finalize::qs-seed");
+
+        // Prepare qs evaluations and finalize qs proof.
+        let bool_id = self.ids.bool_check;
+        let mut evaluations: Vec<(mpz_poly_proof_core::ConstraintId, &[F], &[S])> =
+            Vec::with_capacity(self.pending_mults.len() + self.pending_bool_checks.len());
+        for m in &self.pending_mults {
+            evaluations.push((self.ids.mul, m.macs.as_slice(), m.values.as_slice()));
+        }
+        if let Some(id) = bool_id {
+            for b in &self.pending_bool_checks {
+                evaluations.push((id, b.mac.as_slice(), b.value.as_slice()));
+            }
+        }
+
+        self.qs
+            .accumulate(&evaluations, seed)
+            .map_err(|e| Error::Qs(Box::new(e)))?;
+
+        let qs_proof = self
+            .qs
+            .finalize(&vope)
+            .map_err(|e| Error::Qs(Box::new(e)))?;
+
+        Ok(MuxMulProof { qs_proof })
+    }
+
+    /// Returns VOLEs count needed to build the length-2 lifted-VOPE.
+    fn vope_vole_count(&self) -> usize {
+        <F as ExtensionField<S>>::MONOMIAL_BASIS.len()
+    }
+}
+
+/// Lifecycle state for the [`MuxMulProver`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized.
+    Initialized,
+    /// Allocated.
+    Allocated,
+}
+
+/// One pending multiplication for Quicksilver evaluation.
+#[derive(Copy, Clone)]
+struct PendingMult<S, F> {
+    values: [S; 3],
+    macs: [F; 3],
+}
+
+/// One pending boolean-check for Quicksilver evaluation.
+#[derive(Copy, Clone)]
+struct PendingBoolCheck<S, F> {
+    value: [S; 1],
+    mac: [F; 1],
+}
+
+/// Errors produced by [`MuxMulProver`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A method was called while the prover was in the wrong state.
+    #[error("mux-mul prover method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// A wire's length disagreed with what was expected.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// Underlying RVOLE error.
+    #[error("VOLE error: {0}")]
+    Vole(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Derandomized VOLE error.
+    #[error("derand VOLE error: {0}")]
+    DerandVole(#[source] DerandVOLEReceiverError),
+
+    /// VOLE future failed to resolve.
+    #[error("VOLE future failed to resolve after adjust")]
+    VoleFutureUnresolved,
+
+    /// finalize was called while adjustments were still pending.
+    #[error("finalize called with {pending} unflushed adjustments")]
+    UnflushedAdjustments {
+        /// Number of adjustments still queued.
+        pending: usize,
+    },
+
+    /// QuickSilver polynomial-proof error.
+    #[error("QS polynomial-proof error: {0}")]
+    Qs(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{mux_mul_pair, prover_wire};
+    use mpz_fields::gf2::Gf2;
+
+    /// `accumulate` returns the elementwise product `op · diff` in the
+    /// product wire's cleartext: `prod[i] = op[0] · diff[i]`.
+    #[test]
+    fn accumulate_product_is_op_times_diff_elementwise() {
+        let diff = vec![Gf2(true), Gf2(false), Gf2(true), Gf2(true)];
+
+        // op = 1 → product equals diff.
+        {
+            let (mut prover, _, _) = mux_mul_pair(diff.len(), false);
+            let prod = prover
+                .accumulate(&prover_wire(vec![Gf2(true)]), &prover_wire(diff.clone()))
+                .expect("accumulate");
+            assert_eq!(prod.value().as_slice(), diff.as_slice());
+        }
+
+        // op = 0 → product is all-zero, regardless of diff.
+        {
+            let (mut prover, _, _) = mux_mul_pair(diff.len(), false);
+            let prod = prover
+                .accumulate(&prover_wire(vec![Gf2(false)]), &prover_wire(diff.clone()))
+                .expect("accumulate");
+            assert!(
+                prod.value().iter().all(|&v| v == Gf2::zero()),
+                "op = 0 must zero every product slot",
+            );
+        }
+    }
+}

--- a/crates/two-shuffles/src/ram/mux_mul/verifier.rs
+++ b/crates/two-shuffles/src/ram/mux_mul/verifier.rs
@@ -1,0 +1,447 @@
+//! Verifier side of the mux-multiplication protocol.
+use mpz_fields::Field;
+use mpz_poly_proof_core::{ExtensionField, ProofMessage, verifier::Verifier as QsVerifier};
+use mpz_vole_core::{DerandVOLESender, DerandVOLESenderError, RVOLESender};
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::wire::VerifierWire as Wire;
+
+use super::{
+    MuxConstraintIds, MuxMulFlush, build_mux_constraints, vope_from_vole::verifier_vope_from_vole,
+};
+
+/// Mux-multiplication verifier.
+pub struct MuxMulVerifier<RV, RM, S, F>
+where
+    RV: RVOLESender<F>,
+    RM: RVOLESender<F>,
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// QuickSilver polynomial protocol verifier.
+    qs: QsVerifier<F>,
+
+    /// `ConstraintId`s of the constraints registered in `qs`.
+    ids: MuxConstraintIds,
+
+    /// RVOLE pool for the lifted-VOPE.
+    rvole: RV,
+
+    /// Derandomized VOLE pool for multiplication.
+    mul_vole: DerandVOLESender<RM, F>,
+
+    /// Queue of pending boolean-check constraints to be verified with `qs`.
+    pending_bool_checks: Vec<PendingBoolCheck<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// True iff the boolean-check circuit was registered at
+    /// construction.
+    boolean_check_enabled: bool,
+
+    /// Lifecycle state.
+    state: State,
+
+    _phantom: std::marker::PhantomData<S>,
+}
+
+impl<RV, RM, S, F> MuxMulVerifier<RV, RM, S, F>
+where
+    RV: RVOLESender<F>,
+    RM: RVOLESender<F>,
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Construct a new mux-mul verifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `rvole` — random VOLE sender.
+    /// * `mul_vole` — derandomized VOLE sender. Must share Δ with `rvole`.
+    /// * `boolean_check_enabled` — whether to enforce the `op · op = op`
+    ///   booleanness constraint per access.
+    pub fn new(rvole: RV, mul_vole: DerandVOLESender<RM, F>, boolean_check_enabled: bool) -> Self {
+        let delta = rvole.delta();
+        let (_pc, vc, ids) = build_mux_constraints::<F, S>(boolean_check_enabled);
+        Self {
+            qs: QsVerifier::new(delta, &vc),
+            ids,
+            rvole,
+            mul_vole,
+            pending_bool_checks: Vec::new(),
+            transcript: blake3::Hasher::new(),
+            boolean_check_enabled,
+            state: State::Initialized,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_muls` — number of multiplications.
+    pub fn alloc(&mut self, num_muls: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+
+        self.mul_vole.alloc(num_muls).map_err(Error::DerandVole)?;
+        self.rvole
+            .alloc(self.vope_vole_count())
+            .map_err(|e| Error::Vole(Box::new(e)))?;
+
+        if self.boolean_check_enabled {
+            self.pending_bool_checks.reserve(num_muls);
+        }
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Accumulate a batch of multiplications, returning one product
+    /// per multiplication.
+    ///
+    /// # Arguments
+    ///
+    /// * `ops` — left operands, one per multiplication. Each `ops[i]` must be a
+    ///   length-1 wire; the protocol enforces that its cleartext is in `{0,
+    ///   1}`.
+    /// * `diffs` — right operands, one per multiplication.
+    /// * `flush` — a flush message from the prover.
+    pub fn accumulate(
+        &mut self,
+        ops: &[Wire<F>],
+        diffs: &[Wire<F>],
+        flush: &MuxMulFlush<F>,
+    ) -> Result<Vec<Wire<F>>, Error>
+    where
+        F: Copy + serde::Serialize,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        let m = ops.len();
+        if diffs.len() != m || flush.adjustments.len() != m {
+            return Err(Error::LengthMismatch);
+        }
+
+        let mut prods: Vec<Wire<F>> = Vec::with_capacity(m);
+
+        // Triples to be evaluated with QS.
+        let mut triples: Vec<[F; 3]> =
+            Vec::with_capacity(diffs.iter().map(|d: &Wire<F>| d.len()).sum());
+
+        for i in 0..m {
+            if ops[i].len() != 1 {
+                return Err(Error::LengthMismatch);
+            }
+            let diff = &diffs[i];
+            let adj = &flush.adjustments[i];
+            let n = diff.len();
+            if adj.diffs.len() != n {
+                return Err(Error::LengthMismatch);
+            }
+
+            // Absorb this adjustment message into the transcript.
+            self.transcript
+                .update(&bcs::to_bytes(adj).expect("serialize"));
+
+            let prod_keys = self.mul_vole.adjust(adj).map_err(Error::DerandVole)?;
+
+            let op_key = ops[i].key[0];
+            for j in 0..n {
+                triples.push([op_key, diff.key[j], prod_keys[j]]);
+            }
+
+            // Queue the boolean-check.
+            if self.boolean_check_enabled {
+                self.pending_bool_checks
+                    .push(PendingBoolCheck { key: [op_key] });
+            }
+
+            prods.push(Wire::new(prod_keys.into()));
+        }
+
+        // Bulk QS accumulate for every triple just generated.
+        let evaluations: Vec<(mpz_poly_proof_core::ConstraintId, &[F])> = triples
+            .iter()
+            .map(|t| (self.ids.mul, t.as_slice()))
+            .collect();
+        self.qs
+            .accumulate(&evaluations)
+            .map_err(|e| Error::Qs(Box::new(e)))?;
+
+        Ok(prods)
+    }
+
+    /// Finalize the protocol.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`accumulate`](Self::accumulate) before this call —
+    /// otherwise the protocol's soundness guarantee no longer holds.
+    pub fn finalize(
+        mut self,
+        transcript: &mut blake3::Hasher,
+        proof: &ProofMessage<F>,
+    ) -> Result<(), Error>
+    where
+        F: IntoBytes + FromBytes,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+
+        // Lifted-VOPE: pull base VOLEs and rename them as a length-2 VOPE.
+        let k = self.vope_vole_count();
+        let vole = self
+            .rvole
+            .try_send_vole(k)
+            .map_err(|e| Error::Vole(Box::new(e)))?;
+        let vope = verifier_vope_from_vole::<S, F>(&vole);
+
+        // Drain the boolean-check evaluations.
+        if let Some(id) = self.ids.bool_check {
+            let evaluations: Vec<(mpz_poly_proof_core::ConstraintId, &[F])> = self
+                .pending_bool_checks
+                .iter()
+                .map(|b| (id, b.key.as_slice()))
+                .collect();
+            self.qs
+                .accumulate(&evaluations)
+                .map_err(|e| Error::Qs(Box::new(e)))?;
+        }
+
+        // Absorb all received messages into the transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        // Draw the qs seed.
+        let seed = super::draw_seed(transcript, b"mux-mul::finalize::qs-seed");
+
+        self.qs
+            .finalize(proof, &vope, seed)
+            .map_err(|e| Error::Qs(Box::new(e)))
+    }
+
+    /// Returns VOLEs count needed to build the length-2 lifted-VOPE.
+    pub fn vope_vole_count(&self) -> usize {
+        <F as ExtensionField<S>>::MONOMIAL_BASIS.len()
+    }
+}
+
+/// Lifecycle state for the [`MuxMulVerifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized.
+    Initialized,
+    /// Allocated.
+    Allocated,
+}
+
+/// Errors produced by [`MuxMulVerifier`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A method was called while the verifier was in the wrong
+    /// lifecycle state.
+    #[error("mux-mul verifier method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// A wire's length disagreed with what the verifier expects.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// Underlying RVOLE error.
+    #[error("VOLE error: {0}")]
+    Vole(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Derandomized VOLE error.
+    #[error("derand VOLE error: {0}")]
+    DerandVole(#[source] DerandVOLESenderError),
+
+    /// QuickSilver polynomial-proof error.
+    #[error("QS polynomial-proof error: {0}")]
+    Qs(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+/// One pending boolean-check for Quicksilver evaluation.
+#[derive(Copy, Clone)]
+struct PendingBoolCheck<F> {
+    key: [F; 1],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{mux_mul_pair, prover_wire, verifier_wire, vole_adjustment};
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_vole_core::test::assert_vole;
+
+    /// Assert an `accumulate` call failed with `LengthMismatch`.
+    /// `Wire` has no `Debug`, so we can't use `expect_err` here.
+    fn assert_mismatch(res: Result<Vec<Wire<Gf2_64>>, Error>, ctx: &str) {
+        match res {
+            Err(Error::LengthMismatch) => {}
+            Err(e) => panic!("{ctx}: expected LengthMismatch, got {e:?}"),
+            Ok(_) => panic!("{ctx}: expected LengthMismatch, got Ok"),
+        }
+    }
+
+    /// `accumulate` rejects every shape disagreement among `ops`,
+    /// `diffs`, and the flush's adjustments before touching the VOLE.
+    #[test]
+    fn accumulate_rejects_length_mismatches() {
+        let op = || verifier_wire(vec![Gf2_64::zero()]); // valid length-1 op
+        let diff1 = || verifier_wire(vec![Gf2_64::zero()]); // width-1 diff
+
+        // ops vs diffs count mismatch.
+        {
+            let (_, mut v, _) = mux_mul_pair(1, false);
+            let flush = MuxMulFlush {
+                adjustments: vec![vole_adjustment(1)],
+            };
+            assert_mismatch(
+                v.accumulate(&[op(), op()], &[diff1()], &flush),
+                "ops/diffs count mismatch",
+            );
+        }
+
+        // adjustment count mismatch (none supplied for one mul).
+        {
+            let (_, mut v, _) = mux_mul_pair(1, false);
+            let flush = MuxMulFlush {
+                adjustments: vec![],
+            };
+            assert_mismatch(
+                v.accumulate(&[op()], &[diff1()], &flush),
+                "adjustment count mismatch",
+            );
+        }
+
+        // op wire wider than one slot.
+        {
+            let (_, mut v, _) = mux_mul_pair(1, false);
+            let flush = MuxMulFlush {
+                adjustments: vec![vole_adjustment(1)],
+            };
+            let wide_op = verifier_wire(vec![Gf2_64::zero(), Gf2_64::zero()]);
+            assert_mismatch(
+                v.accumulate(&[wide_op], &[diff1()], &flush),
+                "op must be length-1",
+            );
+        }
+
+        // adjustment width disagrees with its diff's width.
+        {
+            let (_, mut v, _) = mux_mul_pair(2, false);
+            let diff2 = verifier_wire(vec![Gf2_64::zero(), Gf2_64::zero()]); // width-2 diff
+            let flush = MuxMulFlush {
+                adjustments: vec![vole_adjustment(1)],
+            }; // width-1 adj
+            assert_mismatch(
+                v.accumulate(&[op()], &[diff2], &flush),
+                "adj width must match diff width",
+            );
+        }
+    }
+
+    /// V6: after a single paired `accumulate`, the product wire the
+    /// verifier returns (keys) and the one the prover returns
+    /// (value + MAC) satisfy the VOLE IT-MAC invariant
+    /// `mac = key + Δ · embed(value)` slot-for-slot. This validates the
+    /// derandomized multiply end-to-end *without* running the QS proof.
+    #[test]
+    fn product_wire_satisfies_itmac_invariant() {
+        let diff = vec![Gf2(true), Gf2(false), Gf2(true), Gf2(true)];
+        let (mut prover, mut verifier, delta) = mux_mul_pair(diff.len(), false);
+
+        // Prover multiplies op = 1 by diff → product = diff.
+        let prod_p = prover
+            .accumulate(&prover_wire(vec![Gf2(true)]), &prover_wire(diff.clone()))
+            .expect("prover accumulate");
+        let flush = prover.flush().expect("flush");
+
+        // Verifier op/diff keys are irrelevant to the product wire's own
+        // invariant (they only feed the QS mul-gate triples), so any
+        // keys of the right widths suffice.
+        let v_op = verifier_wire(vec![Gf2_64::zero()]);
+        let v_diff = verifier_wire(vec![Gf2_64::zero(); diff.len()]);
+        let prods_v = verifier
+            .accumulate(&[v_op], &[v_diff], &flush)
+            .expect("verifier accumulate");
+
+        assert_eq!(prods_v.len(), 1, "one product wire per multiplication");
+        assert_vole(
+            delta,
+            prods_v[0].key.as_slice(),
+            prod_p.value().as_slice(),
+            prod_p.mac().as_slice(),
+        );
+    }
+
+    /// V7: with the booleanness check enabled, `accumulate` queues
+    /// exactly one bool-check per multiplication, each bound to that
+    /// op's key; with it disabled, none are queued. Asserted by reading
+    /// the verifier's private `pending_bool_checks` — no QS finalize.
+    #[test]
+    fn boolean_check_queues_one_per_op_bound_to_op_key() {
+        // Two single-slot multiplications with distinct op keys.
+        let k0 = Gf2_64::ONE;
+        let k1 = Gf2_64::ONE + Gf2_64::ONE;
+
+        // Enabled: one bool-check per op, bound to the op key.
+        {
+            let (mut prover, mut verifier, _) = mux_mul_pair(2, true);
+            for _ in 0..2 {
+                prover
+                    .accumulate(&prover_wire(vec![Gf2(true)]), &prover_wire(vec![Gf2(true)]))
+                    .expect("prover accumulate");
+            }
+            let flush = prover.flush().expect("flush");
+
+            let ops = [verifier_wire(vec![k0]), verifier_wire(vec![k1])];
+            let diffs = [
+                verifier_wire(vec![Gf2_64::zero()]),
+                verifier_wire(vec![Gf2_64::zero()]),
+            ];
+            verifier
+                .accumulate(&ops, &diffs, &flush)
+                .expect("verifier accumulate");
+
+            assert_eq!(
+                verifier.pending_bool_checks.len(),
+                2,
+                "one bool-check queued per op",
+            );
+            assert_eq!(verifier.pending_bool_checks[0].key[0], k0);
+            assert_eq!(verifier.pending_bool_checks[1].key[0], k1);
+        }
+
+        // Disabled: nothing queued.
+        {
+            let (mut prover, mut verifier, _) = mux_mul_pair(2, false);
+            for _ in 0..2 {
+                prover
+                    .accumulate(&prover_wire(vec![Gf2(true)]), &prover_wire(vec![Gf2(true)]))
+                    .expect("prover accumulate");
+            }
+            let flush = prover.flush().expect("flush");
+
+            let ops = [verifier_wire(vec![k0]), verifier_wire(vec![k1])];
+            let diffs = [
+                verifier_wire(vec![Gf2_64::zero()]),
+                verifier_wire(vec![Gf2_64::zero()]),
+            ];
+            verifier
+                .accumulate(&ops, &diffs, &flush)
+                .expect("verifier accumulate");
+
+            assert!(
+                verifier.pending_bool_checks.is_empty(),
+                "no bool-checks when the flag is off",
+            );
+        }
+    }
+}

--- a/crates/two-shuffles/src/ram/mux_mul/vope_from_vole.rs
+++ b/crates/two-shuffles/src/ram/mux_mul/vope_from_vole.rs
@@ -1,0 +1,130 @@
+//! Lifted-VOLE-as-VOPE construction (degree-2 special case).
+//!
+//! A length-2 random VOPE is mathematically a single full-field IT-MAC viewed
+//! as a polynomial in `Δ`:
+//!
+//! ```text
+//! VOLE invariant:  m = k + v · Δ
+//! VOPE relation:   sum = coeffs[0] + coeffs[1] · Δ
+//!
+//! Match:           coeffs = [m, -v],  sum = k.
+//! ```
+
+use mpz_fields::Field;
+use mpz_poly_proof_core::{ExtensionField, ProverVope, VerifierVope};
+use mpz_vole_core::{RVOLEReceiverOutput, RVOLESenderOutput};
+
+/// Lift base VOLEs on the prover side into a length-2 [`ProverVope`].
+///
+/// # Panics
+///
+/// Panics if the number of VOLEs does not equal the extension degree.
+pub fn prover_vope_from_vole<W, F>(vole: &RVOLEReceiverOutput<W, F>) -> ProverVope<F>
+where
+    W: Field,
+    F: ExtensionField<W>,
+{
+    let basis = <F as ExtensionField<W>>::MONOMIAL_BASIS;
+    let v_lifted: F = <F as ExtensionField<W>>::inner_product_subfield(&vole.values, basis);
+    let m_lifted: F = F::inner_product(&vole.macs, basis);
+
+    ProverVope {
+        coeffs: vec![m_lifted, -v_lifted],
+    }
+}
+
+/// Lift base VOLEs on the verifier side into a length-2 [`VerifierVope`].
+///
+/// # Panics
+///
+/// Panics if the number of VOLEs does not equal the extension degree.
+pub fn verifier_vope_from_vole<W, F>(vole: &RVOLESenderOutput<F>) -> VerifierVope<F>
+where
+    W: Field,
+    F: ExtensionField<W>,
+{
+    let basis = <F as ExtensionField<W>>::MONOMIAL_BASIS;
+    let sum: F = F::inner_product(&vole.keys, basis);
+    VerifierVope { sum }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_vole_core::{
+        RVOLEReceiver, RVOLESender,
+        ideal::rvole::ideal_rvole,
+        test::{assert_vole, assert_vope},
+    };
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// Pull paired RVOLE samples from the ideal functionality so the
+    /// IT-MAC invariant holds by construction. Returns
+    /// `(receiver_output, sender_output, delta)`.
+    fn paired_samples(
+        rng_seed: u64,
+        n: usize,
+    ) -> (
+        RVOLEReceiverOutput<Gf2, Gf2_64>,
+        RVOLESenderOutput<Gf2_64>,
+        Gf2_64,
+    ) {
+        let mut rng = StdRng::seed_from_u64(rng_seed);
+        let delta: Gf2_64 = rng.random();
+        let rvole_seed: u64 = rng.random();
+        let (mut rvole_s, mut rvole_r) = ideal_rvole::<Gf2, Gf2_64>(rvole_seed, delta);
+        rvole_s.pregenerate(n);
+        rvole_r.pregenerate(n, delta).expect("rvole pregenerate");
+        let recv = rvole_r.try_recv_vole(n).expect("try_recv_vole");
+        let sender = rvole_s.try_send_vole(n).expect("try_send_vole");
+        (recv, sender, delta)
+    }
+
+    /// Honest paired samples → resulting Vopes satisfy the
+    /// length-2 VOPE relation: `sum = coeffs[0] + coeffs[1] · Δ`.
+    /// Verified via `vole_core::test::assert_vope`.
+    #[test]
+    fn vope_invariant_holds_for_paired_samples() {
+        let n = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+        let (recv, sender, delta) = paired_samples(0xC0FFEE, n);
+
+        // Sanity: ideal_rvole's output satisfies the IT-MAC invariant.
+        assert_vole(delta, &sender.keys, &recv.values, &recv.macs);
+
+        let p_vope = prover_vope_from_vole::<Gf2, _>(&recv);
+        let v_vope = verifier_vope_from_vole::<Gf2, _>(&sender);
+
+        // VOPE relation via the shared helper: sum equals the prover's
+        // polynomial coeffs evaluated at Δ.
+        assert_vope(delta, &[p_vope.coeffs], &[v_vope.sum]);
+    }
+
+    /// The prover-side Vope length is exactly `d_max = 2`.
+    #[test]
+    fn prover_vope_has_length_two() {
+        let n = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+        let (recv, _, _) = paired_samples(0xBEEF, n);
+        let p_vope = prover_vope_from_vole::<Gf2, _>(&recv);
+        assert_eq!(p_vope.coeffs.len(), 2);
+    }
+
+    /// Tampered key on the verifier side breaks the VOPE invariant.
+    #[test]
+    fn vope_invariant_fails_on_tampered_key() {
+        let n = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+        let (recv, mut sender, delta) = paired_samples(0xDEAD, n);
+        // Tamper one key on the verifier side.
+        sender.keys[7] = sender.keys[7] + Gf2_64::ONE;
+
+        let p_vope = prover_vope_from_vole::<Gf2, _>(&recv);
+        let v_vope = verifier_vope_from_vole::<Gf2, _>(&sender);
+
+        // The shared `assert_vope` would panic; check directly.
+        let reconstructed = p_vope.coeffs[0] + p_vope.coeffs[1] * delta;
+        assert_ne!(
+            v_vope.sum, reconstructed,
+            "tampered key should break the VOPE invariant",
+        );
+    }
+}

--- a/crates/two-shuffles/src/ram/prover.rs
+++ b/crates/two-shuffles/src/ram/prover.rs
@@ -1,0 +1,797 @@
+//! Prover side of the RAM protocol.
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use mpz_perm_proof_core::{Prover as PermProver, backend::ProverBackend as PermProverBackend};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, VOLEReceiver, VoleAdjustment,
+};
+
+use super::{Flush, Record, TeardownMsg, TeardownPrepare, mux_mul::MuxMulProver};
+use serde::Serialize;
+
+use super::{
+    clock::{Clock, ProverClock},
+    config::Config,
+    strategy::ProverStrategy,
+};
+use crate::{
+    set,
+    wire::{Bundle, PackedProverWire, ProverWire as Wire},
+};
+use rangeset::set::RangeSet;
+
+/// RAM prover.
+pub struct Prover<RV, F, B, Strat>
+where
+    Strat: ProverStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Wire length of the address.
+    l_addr: usize,
+    /// Wire length of the value.
+    l_val: usize,
+    /// Addresses instantiated at setup.
+    live_addrs: RangeSet<usize>,
+    /// Total access budget.
+    total_accesses: usize,
+    /// Running access counter, bounded by `total_accesses`.
+    accesses_performed: usize,
+    /// Lifecycle state.
+    state: State,
+
+    /// Clock strategy.
+    clock: Strat::Clock,
+
+    /// Derandomized VOLE receiver.
+    vole: DerandVOLEReceiver<RV, Strat::S, F>,
+
+    /// Permutation protocol prover.
+    perm_prover: PermProver<F, F, B>,
+
+    /// Set-membership prover.
+    set_prover: set::Prover<RV, F, B, Strat>,
+
+    /// Mux-multiplication prover.
+    mux_mul_prover: MuxMulProver<RV, RV, Strat::S, F>,
+
+    /// Cleartext shadow indexed by the address's integer form.
+    shadow: Vec<Option<ShadowEntry<Strat::S>>>,
+
+    /// Reads log.
+    reads: Vec<Record<PackedProverWire<F>>>,
+
+    /// Writes log.
+    writes: Vec<Record<PackedProverWire<F>>>,
+
+    /// Outbound queue of `VoleAdjustment` messages.
+    pending_adjustments: Vec<VoleAdjustment<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// Addresses whose post-teardown state is returned.
+    export_addrs: RangeSet<usize>,
+
+    /// Wires at `export_addrs` addresses.
+    state_dump: Option<Vec<Wire<Strat::S, F>>>,
+}
+
+impl<RV, F, B, Strat> Prover<RV, F, B, Strat>
+where
+    Strat: ProverStrategy<F, Wire = Wire<<Strat as crate::strategy::FieldStrategy<F>>::S, F>>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Construct an empty RAM prover.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` — protocol config.
+    /// * `clock` — clock strategy.
+    /// * `vole` — derandomized VOLE receiver.
+    /// * `mul_vole` — derandomized VOLE receiver (for multiplication protocol).
+    /// * `mul_rvole` — random VOLE receiver (for multiplication protocol).
+    /// * `perm_prover` — permutation protocol prover.
+    /// * `set_prover` — set-membership prover.
+    pub fn new(
+        config: Config<F, Strat>,
+        clock: Strat::Clock,
+        vole: DerandVOLEReceiver<RV, Strat::S, F>,
+        mul_vole: DerandVOLEReceiver<RV, Strat::S, F>,
+        mul_rvole: RV,
+        perm_prover: PermProver<F, F, B>,
+        set_prover: set::Prover<RV, F, B, Strat>,
+    ) -> Result<Self, Error> {
+        let Config {
+            live_addrs,
+            value_bits,
+            total_accesses,
+            export_addrs,
+            ..
+        } = config;
+
+        let address_bound = live_addrs
+            .end()
+            .expect("Config::build rejects an empty live_addrs");
+        let l_addr = Strat::wire_length_for(address_bound);
+        let l_val = Strat::wire_length_for_log2(value_bits);
+        let mut shadow = Vec::with_capacity(address_bound);
+        shadow.resize_with(address_bound, || None);
+
+        Ok(Self {
+            l_addr,
+            l_val,
+            live_addrs,
+            total_accesses,
+            accesses_performed: 0,
+            state: State::Initialized,
+            clock,
+            vole,
+            perm_prover,
+            set_prover,
+            mux_mul_prover: MuxMulProver::new(mul_rvole, mul_vole, Strat::BOOLEAN_CHECK_ENABLED),
+            shadow,
+            reads: Vec::new(),
+            writes: Vec::new(),
+            pending_adjustments: Vec::new(),
+            transcript: blake3::Hasher::new(),
+            export_addrs,
+            state_dump: None,
+        })
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    pub fn alloc(&mut self) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        // Per access we input-gate `(val_old, t_old)` — `l_val +
+        // l_clock` VOLEs each. Plus one such input-gating pass per
+        // live cell at teardown for the per-cell final read.
+        // Total VOLEs: `(T + live_count) · (l_val + l_clock)`.
+        let live_count = self.live_addrs.len();
+        let l_clock = self.clock.l_clock();
+        let ram_vole_count = (self.total_accesses + live_count) * (self.l_val + l_clock);
+        self.vole.alloc(ram_vole_count).map_err(Error::Vole)?;
+        self.perm_prover
+            .alloc(live_count + self.total_accesses)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        // Set: T lookups (one per access). The set_size = T was
+        // baked into set_prover at its own construction.
+        self.set_prover
+            .alloc(self.total_accesses)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        // MuxMul: one product per access.
+        self.mux_mul_prover
+            .alloc(self.total_accesses * self.l_val)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Initialize RAM with cleartext initial content.
+    ///
+    /// `values` must have length `live_addrs.len()`: one value per
+    /// address in [`Config::live_addrs`].
+    pub fn setup(&mut self, values: Vec<Vec<Strat::S>>) -> Result<(), Error> {
+        if values.len() != self.live_addrs.len() {
+            return Err(Error::LengthMismatch);
+        }
+        let wired: Vec<Wire<Strat::S, F>> = values.into_iter().map(Wire::constant).collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Initialize RAM with pre-authenticated initial content.
+    ///
+    /// `values` must have length `live_addrs.len()`: one value per
+    /// address in [`Config::live_addrs`].
+    pub fn setup_with_wires(&mut self, values: Vec<Wire<Strat::S, F>>) -> Result<(), Error> {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if values.len() != self.live_addrs.len() {
+            return Err(Error::LengthMismatch);
+        }
+        self.writes.reserve(values.len());
+
+        let clock_cleartext: Bundle<Strat::S> = self.clock.current_clock().clone();
+        let clock0_wire: Wire<Strat::S, F> = Wire::constant(clock_cleartext.clone());
+        let clock0_wire = (&clock0_wire).into();
+
+        for (addr, val_input) in self.live_addrs.iter_values().zip(values) {
+            if val_input.len() != self.l_val {
+                return Err(Error::LengthMismatch);
+            }
+            let idx = addr as u32;
+            let addr_wire = addr_wire_for_index::<Strat, F>(idx, self.l_addr);
+            let val_cleartext = val_input.value().clone();
+            let val_wire = (&val_input).into();
+
+            self.shadow[addr] = Some(ShadowEntry {
+                value: val_cleartext,
+                last_clock: clock_cleartext.clone(),
+            });
+
+            self.writes.push(Record {
+                addr: addr_wire,
+                val: val_wire,
+                clock: clock0_wire,
+            });
+        }
+
+        // Initialize the set with the valid {1..T} set.
+        let set_members = self.clock.valid_deltas();
+        self.set_prover
+            .setup(set_members)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Perform a memory access, returning the new value (= `old` on load, `w`
+    /// on store, by construction).
+    ///
+    /// Computes the multiplexer `new = old + op · (w − old)` and
+    /// emits the corresponding records, so:
+    ///   - op = 0 ⇒ new = old (value preserved)
+    ///   - op = 1 ⇒ new = w   (value overwritten)
+    ///
+    /// # Arguments
+    ///
+    /// * `op` — operation: `0` for load or `1` for store.
+    /// * `addr` — target cell's address.
+    /// * `w` — would-be-stored value on the `op = 1` branch (ignored at `op =
+    ///   0`, but still committed).
+    pub fn access(
+        &mut self,
+        op: Wire<Strat::S, F>,
+        addr: Wire<Strat::S, F>,
+        w: Wire<Strat::S, F>,
+    ) -> Result<Wire<Strat::S, F>, Error>
+    where
+        F: Copy + serde::Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        // Length validation. op is a single authenticated value;
+        // addr matches l_addr; w matches l_val.
+        if op.len() != 1 {
+            return Err(Error::LengthMismatch);
+        }
+        if addr.len() != self.l_addr {
+            return Err(Error::LengthMismatch);
+        }
+        if w.len() != self.l_val {
+            return Err(Error::LengthMismatch);
+        }
+        if self.accesses_performed >= self.total_accesses {
+            return Err(Error::TooManyAccesses);
+        }
+
+        // Shadow lookup.
+        let idx = Strat::bundle_to_index(addr.value());
+        let entry = self
+            .shadow
+            .get(idx as usize)
+            .and_then(|slot| slot.as_ref())
+            .ok_or(Error::AddressNotFound)?;
+        let val_old_cleartext = entry.value.clone();
+        let t_old_cleartext = entry.last_clock.clone();
+        let addr = (&addr).into();
+
+        // Input-gate (val_old, t_old). Queue both, run adjust to
+        // resolve the futures, then receive macs.
+        let mut val_fut = self
+            .vole
+            .queue_recv_vole(&val_old_cleartext)
+            .map_err(Error::Vole)?;
+        let mut t_fut = self
+            .vole
+            .queue_recv_vole(&t_old_cleartext)
+            .map_err(Error::Vole)?;
+        let adjustment = self.vole.adjust().map_err(Error::Vole)?;
+        let val_macs: Vec<F> = val_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+        let t_macs: Vec<F> = t_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+
+        let val_old = Wire::new(val_old_cleartext.clone(), val_macs.into());
+        let t_old = Wire::new(t_old_cleartext, t_macs.into());
+
+        // Absorb the adjustment into the prover-internal transcript.
+        self.transcript
+            .update(&bcs::to_bytes(&adjustment).expect("serialize"));
+        self.pending_adjustments.push(adjustment);
+
+        // Append read record.
+        self.reads.push(Record {
+            addr,
+            val: (&val_old).into(),
+            clock: (&t_old).into(),
+        });
+
+        // 4. Advance clock.
+        self.accesses_performed += 1;
+        self.clock.next_clock();
+        let new_clock_cleartext: Bundle<Strat::S> = self.clock.current_clock().clone();
+        // Clock value is public.
+        let new_clock: Wire<Strat::S, F> = Wire::constant(new_clock_cleartext.clone());
+
+        // Mux: new = val_old + op · (w − val_old).
+        //    diff = w − val_old
+        //    prod = op · diff
+        //    new  = val_old + prod
+        let diff = Strat::sub_wires(&w, &val_old);
+        let prod = self
+            .mux_mul_prover
+            .accumulate(&op, &diff)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+        let new_val = Strat::add_wires(&val_old, &prod);
+
+        self.writes.push(Record {
+            addr,
+            val: (&new_val).into(),
+            clock: (&new_clock).into(),
+        });
+
+        // Set membership: delta = current_clock − t_old.
+        let delta = self.clock.compute_delta(&t_old);
+        self.set_prover
+            .lookup(delta)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        // Update shadow.
+        let entry = self.shadow[idx as usize]
+            .as_mut()
+            .expect("shadow entry must still exist after access");
+        entry.value = new_val.value().clone();
+        entry.last_clock = new_clock_cleartext;
+
+        Ok(new_val)
+    }
+
+    /// Emit a flush message.
+    ///
+    /// May be called any number of times during the access phase.
+    pub fn flush(&mut self) -> Result<Flush<F>, Error>
+    where
+        F: Copy,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        let mul_flush = self
+            .mux_mul_prover
+            .flush()
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+        Ok(Flush {
+            access_adj: std::mem::take(&mut self.pending_adjustments),
+            mul_flush,
+        })
+    }
+
+    /// Emit a pre-`teardown` message.
+    ///
+    /// If any unflushed accesses exist, the caller is responsible for
+    /// calling [`flush`](Self::flush) before this method.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`access`](Self::access) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<TeardownPrepare<F, B::Preparation>, Error>
+    where
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if !self.pending_adjustments.is_empty() {
+            return Err(Error::UnflushedAdjustments {
+                pending: self.pending_adjustments.len(),
+            });
+        }
+        // Per-address teardown reads with fresh input-gated
+        // (val_final, t_final), over the live cells.
+        let teardown_data: Vec<(u32, PackedProverWire<F>, Bundle<Strat::S>, Bundle<Strat::S>)> =
+            self.live_addrs
+                .iter_values()
+                .map(|addr| {
+                    let idx = addr as u32;
+                    let entry = self.shadow[addr]
+                        .as_ref()
+                        .expect("every live cell is populated at setup");
+                    (
+                        idx,
+                        addr_wire_for_index::<Strat, F>(idx, self.l_addr),
+                        entry.value.clone(),
+                        entry.last_clock.clone(),
+                    )
+                })
+                .collect();
+
+        let mut futs = Vec::with_capacity(teardown_data.len());
+        for (_, _, val_cleartext, t_cleartext) in &teardown_data {
+            let val_fut = self
+                .vole
+                .queue_recv_vole(val_cleartext)
+                .map_err(Error::Vole)?;
+            let t_fut = self
+                .vole
+                .queue_recv_vole(t_cleartext)
+                .map_err(Error::Vole)?;
+            futs.push((val_fut, t_fut));
+        }
+
+        let teardown_adj = self.vole.adjust().map_err(Error::Vole)?;
+        self.transcript
+            .update(&bcs::to_bytes(&teardown_adj).expect("serialize"));
+
+        let mut state_dump: Vec<Wire<Strat::S, F>> = Vec::with_capacity(self.export_addrs.len());
+        for ((idx, addr_wire, val_cleartext, t_cleartext), (mut val_fut, mut t_fut)) in
+            teardown_data.into_iter().zip(futs)
+        {
+            let val_macs: Vec<F> = val_fut
+                .try_recv()
+                .map_err(|_| Error::VoleFutureUnresolved)?
+                .ok_or(Error::VoleFutureUnresolved)?
+                .macs;
+            let t_macs: Vec<F> = t_fut
+                .try_recv()
+                .map_err(|_| Error::VoleFutureUnresolved)?
+                .ok_or(Error::VoleFutureUnresolved)?
+                .macs;
+
+            let val_wire = Wire::new(val_cleartext, val_macs.into());
+            let t_wire = Wire::new(t_cleartext, t_macs.into());
+
+            self.reads.push(Record {
+                addr: addr_wire,
+                val: (&val_wire).into(),
+                clock: (&t_wire).into(),
+            });
+
+            if self.export_addrs.contains(&(idx as usize)) {
+                state_dump.push(val_wire);
+            }
+        }
+        self.state_dump = Some(state_dump);
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        // perm-proof phase 1: prepare.
+        let (read_values, read_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.reads.iter().map(|r| r.to_parts()).unzip();
+        let (write_values, write_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.writes.iter().map(|r| r.to_parts()).unzip();
+
+        let preparation = self
+            .perm_prover
+            .prepare(
+                transcript,
+                (&read_values, &read_macs),
+                (&write_values, &write_macs),
+            )
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        let set_prepare = self
+            .set_prover
+            .teardown_prepare(transcript)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(TeardownPrepare {
+            teardown_adj,
+            preparation,
+            set: set_prepare,
+        })
+    }
+
+    /// Tear down the instance, returning the message to be sent to
+    /// the verifier and the cell values at [`Config::export_addrs`].
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown(
+        mut self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<(TeardownMsg<F, B::BackendProof>, Vec<Wire<Strat::S, F>>), Error>
+    where
+        F: Copy + Serialize + zerocopy::IntoBytes + zerocopy::FromBytes,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        let state_dump = self
+            .state_dump
+            .take()
+            .expect("teardown_prepare populates state_dump");
+        let Self {
+            perm_prover,
+            set_prover,
+            mux_mul_prover,
+            ..
+        } = self;
+
+        // Finalize all sub proofs.
+        let proof = perm_prover
+            .prove(transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        let set_msg = set_prover
+            .teardown(transcript)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        let mul_proof = mux_mul_prover
+            .finalize(transcript)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+
+        Ok((
+            TeardownMsg {
+                ram_proof: proof,
+                set: set_msg,
+                mul_proof,
+            },
+            state_dump,
+        ))
+    }
+}
+
+/// Per-address shadow entry.
+struct ShadowEntry<S> {
+    /// Value at the address slot.
+    value: Bundle<S>,
+    /// Clock value at the time of the most recent access.
+    last_clock: Bundle<S>,
+}
+
+/// Build the packed prover wire for cell `idx`'s address (a public
+/// constant derived from the cell's index).
+fn addr_wire_for_index<Strat, F>(idx: u32, l_addr: usize) -> PackedProverWire<F>
+where
+    Strat: ProverStrategy<F>,
+    F: Field + ExtensionField<Strat::S> + ExtensionField<F>,
+{
+    let addr_bundle = Strat::index_to_bundle(idx, l_addr);
+    let addr_input: Wire<Strat::S, F> = Wire::constant(addr_bundle);
+    (&addr_input).into()
+}
+
+impl<F: Copy> Record<PackedProverWire<F>> {
+    /// Decompose into `(values, macs)` slot vectors in `addr, val,
+    /// clock` order.
+    fn to_parts(&self) -> (Vec<F>, Vec<F>) {
+        (
+            vec![self.addr.value, self.val.value, self.clock.value],
+            vec![self.addr.mac, self.val.mac, self.clock.mac],
+        )
+    }
+}
+
+/// Lifecycle state for the [`Prover`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized.
+    Initialized,
+    /// Allocated.
+    Allocated,
+    /// Setup.
+    Setup,
+    /// Teardown-prepared.
+    TeardownPrepared,
+}
+
+/// RAM prover error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Address not registered in the shadow.
+    #[error("address not found in RAM shadow")]
+    AddressNotFound,
+
+    /// More accesses requested than the prover was sized for.
+    #[error("access count exceeded total_accesses")]
+    TooManyAccesses,
+
+    /// A method was called while the prover was in the wrong
+    /// lifecycle state .
+    #[error("ram prover method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// [`teardown_prepare`](Prover::teardown_prepare) called while
+    /// per-access adjustments were still pending.
+    #[error("teardown_prepare called with {pending} unflushed adjustments")]
+    UnflushedAdjustments {
+        /// Number of adjustments still queued.
+        pending: usize,
+    },
+
+    /// Bundle length mismatch between configured and actual.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// Underlying VOLE receiver error.
+    #[error("VOLE error: {0}")]
+    Vole(#[source] DerandVOLEReceiverError),
+
+    /// VOLE future failed to resolve after `adjust`.
+    #[error("VOLE future failed to resolve after adjust")]
+    VoleFutureUnresolved,
+
+    /// Permutation-proof error during teardown.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Embedded set-membership error.
+    #[error("set-membership error: {0}")]
+    Set(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Mux-multiplication sub-proof error.
+    #[error("mux-mul error: {0}")]
+    MuxMul(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use crate::{
+        ram::MultiplicativeClock,
+        strategy::{Char2Strategy, FieldStrategy, version::MultiplicativeStep},
+        test_utils::{bits, prover_wire},
+    };
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair;
+    use mpz_vole_core::ideal::rvole::ideal_rvole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// The cleartext RAM model: `access` returns the right value (store
+    /// → `w`, load → the cell's current value), and the prover's shadow
+    /// ends in the correct state — read-after-write holds, loads do not
+    /// mutate, and cells stay independent.
+    #[test]
+    fn access_cleartext_ram_semantics() {
+        const MEMORY_SIZE: usize = 3;
+        const VALUE_BITS: usize = 4;
+        const FAN_IN: usize = 8;
+
+        // Access script: (addr index, op bit, would-be-stored value).
+        let script = [
+            (2usize, true, 0b1010u64), // store 0b1010 → addr 2
+            (2, false, 0b0000),        // load addr 2  → read-after-write
+            (1, false, 0b0000),        // load addr 1  → untouched setup value
+            (0, true, 0b0101),         // store 0b0101 → addr 0
+            (2, false, 0b0000),        // load addr 2  → unaffected by store to 0
+        ];
+        let t = script.len();
+
+        let mut rng = StdRng::seed_from_u64(0x4a17);
+        let delta: Gf2_64 = rng.random();
+
+        // Sizing — mirrors `alloc`.
+        let clock = MultiplicativeClock::new(t).expect("clock");
+        let l_clock = clock.l_clock();
+        let l_val =
+            <Char2Strategy<Gf2_64> as FieldStrategy<Gf2_64>>::wire_length_for_log2(VALUE_BITS);
+        let l_addr = <Char2Strategy<Gf2_64> as FieldStrategy<Gf2_64>>::wire_length_for(MEMORY_SIZE);
+        let n_ver = l_clock;
+
+        // Derandomized VOLE pools.
+        let mk_derand = |seed: u64, count: usize| {
+            let (_, mut r) = ideal_rvole::<Gf2, Gf2_64>(seed, delta);
+            r.pregenerate(count, delta).expect("pregen");
+            DerandVOLEReceiver::new(r)
+        };
+        let ram_vole = mk_derand(rng.random(), (t + MEMORY_SIZE) * (l_val + l_clock));
+        let mul_gate_vole = mk_derand(rng.random(), t * l_val);
+        let set_vole = mk_derand(rng.random(), (t + t) * n_ver);
+
+        // Raw RVOLE for the mux VOPE — reserved by `alloc`, consumed
+        // only at finalize (never reached here).
+        let vope_count = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+        let (_, mut mul_vope_r) = ideal_rvole::<Gf2, Gf2_64>(rng.random(), delta);
+        mul_vope_r
+            .pregenerate(vope_count, delta)
+            .expect("vope pregen");
+
+        // Perm-proof provers.
+        let (ram_perm, _) = build_ideal_perm_proof_pair(&mut rng, delta, MEMORY_SIZE + t, FAN_IN);
+        let (set_perm, _) = build_ideal_perm_proof_pair(&mut rng, delta, t + t, FAN_IN);
+
+        let set_prover = crate::set::Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+            t,
+            MultiplicativeStep::new(n_ver).expect("version step"),
+            set_vole,
+            set_perm,
+        )
+        .expect("set prover");
+
+        let config = Config::<Gf2_64, Char2Strategy<Gf2_64>>::builder(
+            RangeSet::from(0..MEMORY_SIZE),
+            VALUE_BITS,
+            t,
+        )
+        .build()
+        .expect("config");
+
+        let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+            config,
+            clock,
+            ram_vole,
+            mul_gate_vole,
+            mul_vope_r,
+            ram_perm,
+            set_prover,
+        )
+        .expect("prover");
+        prover.alloc().expect("alloc");
+
+        // Setup: one value per cell, in address order.
+        let setup = vec![
+            bits(0b0011, l_val),
+            bits(0b1100, l_val),
+            bits(0b0110, l_val),
+        ];
+        let mut model = setup.clone(); // cleartext memory model
+        prover.setup(setup).expect("setup");
+
+        // Drive the script, asserting each access's returned value.
+        for (addr_idx, op_bit, w_val) in script {
+            let op = prover_wire(vec![Gf2(op_bit)]);
+            let addr = prover_wire(bits(addr_idx as u64, l_addr));
+            let w = prover_wire(bits(w_val, l_val));
+
+            let returned = prover.access(op, addr, w).expect("access");
+
+            // Store → w; load → the cell's current value.
+            let expected = if op_bit {
+                bits(w_val, l_val)
+            } else {
+                model[addr_idx].clone()
+            };
+            assert_eq!(
+                returned.value().as_slice(),
+                expected.as_slice(),
+                "access(addr={addr_idx}, op={op_bit}) returned the wrong value",
+            );
+            model[addr_idx] = expected; // store updates the model; load is a no-op
+        }
+
+        // Final shadow must match the model.
+        for (idx, want) in model.iter().enumerate() {
+            let got = prover.shadow[idx].as_ref().expect("cell populated");
+            assert_eq!(
+                got.value.as_slice(),
+                want.as_slice(),
+                "shadow cell {idx} mismatch",
+            );
+        }
+    }
+}

--- a/crates/two-shuffles/src/ram/strategy.rs
+++ b/crates/two-shuffles/src/ram/strategy.rs
@@ -1,0 +1,298 @@
+//! RAM protocol strategy traits.
+
+use mpz_fields::{Field, gf2::Gf2};
+use mpz_poly_proof_core::ExtensionField;
+
+use super::clock::{AdditiveClock, MultiplicativeClock, ProverClock, VerifierClock};
+use crate::{
+    strategy::{Char2, Char2Strategy, IntegerLike, PrimeFieldStrategy, VersionStrategy},
+    wire::{ProverWire, VerifierWire},
+};
+
+/// Strategy shared by both parties.
+pub trait CommonStrategy<F: Field>: VersionStrategy<F>
+where
+    F: ExtensionField<Self::S>,
+{
+    /// Whether mux-multiplication protocol should register the
+    /// boolean-check circuit.
+    const BOOLEAN_CHECK_ENABLED: bool;
+}
+
+/// Prover-side extension of [`CommonStrategy`].
+pub trait ProverStrategy<F: Field>: CommonStrategy<F>
+where
+    F: ExtensionField<Self::S>,
+{
+    /// Prover-side wire form.
+    type Wire;
+    /// Clock strategy.
+    type Clock: ProverClock<Self::S, F>;
+
+    /// Returns the wire encoding `a − b` under the strategy's
+    /// encoding. Result width matches the inputs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a.len() != b.len()`.
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire;
+
+    /// Returns the wire encoding `a + b` under the strategy's
+    /// encoding. Result width matches the inputs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a.len() != b.len()`.
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire;
+}
+
+/// Verifier-side extension of [`CommonStrategy`].
+pub trait VerifierStrategy<F: Field>: CommonStrategy<F>
+where
+    F: ExtensionField<Self::S>,
+{
+    /// Verifier-side wire form.
+    type Wire;
+    /// Clock strategy.
+    type Clock: VerifierClock<Self::S, F>;
+
+    /// Returns the key wire encoding `a − b` (per-slot field
+    /// subtraction). Result width matches the inputs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a.len() != b.len()`.
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire;
+
+    /// Returns the key wire encoding `a + b` (per-slot field
+    /// addition). Result width matches the inputs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a.len() != b.len()`.
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire;
+}
+
+impl<F> CommonStrategy<F> for Char2Strategy<F>
+where
+    F: Field + Char2 + ExtensionField<Gf2>,
+{
+    const BOOLEAN_CHECK_ENABLED: bool = false;
+}
+
+impl<F> ProverStrategy<F> for Char2Strategy<F>
+where
+    F: Field + Char2 + ExtensionField<Gf2>,
+{
+    type Wire = ProverWire<Gf2, F>;
+    type Clock = MultiplicativeClock;
+
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires/add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len()
+        );
+        ProverWire::new(
+            a.value()
+                .iter()
+                .zip(b.value().iter())
+                .map(|(x, y)| *x - *y)
+                .collect(),
+            a.mac()
+                .iter()
+                .zip(b.mac().iter())
+                .map(|(x, y)| *x - *y)
+                .collect(),
+        )
+    }
+
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires/add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len()
+        );
+        ProverWire::new(
+            a.value()
+                .iter()
+                .zip(b.value().iter())
+                .map(|(x, y)| *x + *y)
+                .collect(),
+            a.mac()
+                .iter()
+                .zip(b.mac().iter())
+                .map(|(x, y)| *x + *y)
+                .collect(),
+        )
+    }
+}
+
+impl<F> VerifierStrategy<F> for Char2Strategy<F>
+where
+    F: Field + Char2 + ExtensionField<Gf2>,
+{
+    type Wire = VerifierWire<F>;
+    type Clock = MultiplicativeClock;
+
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires/add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len()
+        );
+        VerifierWire::new(
+            a.key
+                .iter()
+                .zip(b.key.iter())
+                .map(|(x, y)| *x - *y)
+                .collect(),
+        )
+    }
+
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires/add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len()
+        );
+        VerifierWire::new(
+            a.key
+                .iter()
+                .zip(b.key.iter())
+                .map(|(x, y)| *x + *y)
+                .collect(),
+        )
+    }
+}
+
+impl<F> CommonStrategy<F> for PrimeFieldStrategy<F>
+where
+    F: ExtensionField<F> + IntegerLike,
+{
+    const BOOLEAN_CHECK_ENABLED: bool = true;
+}
+
+impl<F> ProverStrategy<F> for PrimeFieldStrategy<F>
+where
+    F: ExtensionField<F> + IntegerLike,
+{
+    type Wire = ProverWire<F, F>;
+    type Clock = AdditiveClock<F>;
+
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len(),
+        );
+        ProverWire::new(
+            (a.value()[0] - b.value()[0]).into(),
+            (a.mac()[0] - b.mac()[0]).into(),
+        )
+    }
+
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len(),
+        );
+        ProverWire::new(
+            (a.value()[0] + b.value()[0]).into(),
+            (a.mac()[0] + b.mac()[0]).into(),
+        )
+    }
+}
+
+impl<F> VerifierStrategy<F> for PrimeFieldStrategy<F>
+where
+    F: ExtensionField<F> + IntegerLike,
+{
+    type Wire = VerifierWire<F>;
+    type Clock = AdditiveClock<F>;
+
+    fn sub_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "sub_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len(),
+        );
+        VerifierWire::new((a.key[0] - b.key[0]).into())
+    }
+
+    fn add_wires(a: &Self::Wire, b: &Self::Wire) -> Self::Wire {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "add_wires: a.len()={} != b.len()={}",
+            a.len(),
+            b.len(),
+        );
+        VerifierWire::new((a.key[0] + b.key[0]).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpz_fields::gf2_64::Gf2_64;
+
+    use crate::wire::Bundle;
+
+    #[test]
+    fn char2_sub_wires_is_elementwise_xor() {
+        // Element-wise. Gf2 sub == XOR; Gf2_64 sub == XOR (char-2).
+        let a = ProverWire::<Gf2, Gf2_64>::new(
+            Bundle::new(vec![Gf2(true), Gf2(false), Gf2(true)]),
+            Bundle::new(vec![Gf2_64(0xa), Gf2_64(0xb), Gf2_64(0xc)]),
+        );
+        let b = ProverWire::<Gf2, Gf2_64>::new(
+            Bundle::new(vec![Gf2(true), Gf2(true), Gf2(false)]),
+            Bundle::new(vec![Gf2_64(0x1), Gf2_64(0x2), Gf2_64(0x3)]),
+        );
+        let out = <Char2Strategy<Gf2_64> as ProverStrategy<Gf2_64>>::sub_wires(&a, &b);
+        assert_eq!(
+            **out.value(),
+            [Gf2(false), Gf2(true), Gf2(true)],
+            "value side ≠ a XOR b"
+        );
+        assert_eq!(
+            **out.mac(),
+            [Gf2_64(0xb), Gf2_64(0x9), Gf2_64(0xf)],
+            "mac side ≠ a XOR b",
+        );
+    }
+
+    #[test]
+    fn char2_add_equals_sub_in_char2() {
+        // In any char-2 field, `+` and `−` collapse — sub_wires and
+        // add_wires must produce identical results.
+        let a = ProverWire::<Gf2, Gf2_64>::new(
+            Bundle::new(vec![Gf2(true), Gf2(false)]),
+            Bundle::new(vec![Gf2_64(0x1234), Gf2_64(0x5678)]),
+        );
+        let b = ProverWire::<Gf2, Gf2_64>::new(
+            Bundle::new(vec![Gf2(false), Gf2(true)]),
+            Bundle::new(vec![Gf2_64(0x9abc), Gf2_64(0xdef0)]),
+        );
+        let sub = <Char2Strategy<Gf2_64> as ProverStrategy<Gf2_64>>::sub_wires(&a, &b);
+        let add = <Char2Strategy<Gf2_64> as ProverStrategy<Gf2_64>>::add_wires(&a, &b);
+        assert_eq!(**sub.value(), **add.value());
+        assert_eq!(**sub.mac(), **add.mac());
+    }
+}

--- a/crates/two-shuffles/src/ram/verifier.rs
+++ b/crates/two-shuffles/src/ram/verifier.rs
@@ -1,0 +1,590 @@
+//! Verifier side of the RAM protocol.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::{
+    Verifier as PermVerifier, backend::VerifierBackend as PermVerifierBackend,
+};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{DerandVOLESender, DerandVOLESenderError, RVOLESender, VoleAdjustment};
+use serde::Serialize;
+
+use super::{
+    Flush, Record, TeardownMsg, TeardownPrepare,
+    clock::{Clock, VerifierClock},
+    config::Config,
+    mux_mul::MuxMulVerifier,
+    strategy::VerifierStrategy,
+};
+use crate::{
+    set,
+    wire::{PackedVerifierWire as PackedWire, VerifierWire as Wire},
+};
+use rangeset::set::RangeSet;
+
+/// RAM verifier.
+pub struct Verifier<RV, F, B, Strat>
+where
+    Strat: VerifierStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Wire length of the address.
+    l_addr: usize,
+    /// Wire length of the value.
+    l_val: usize,
+    /// Addresses instantiated at setup.
+    live_addrs: RangeSet<usize>,
+    /// Total access budget.
+    total_accesses: usize,
+    /// Running access counter, bounded by `total_accesses`.
+    accesses_performed: usize,
+    /// Lifecycle state. Enforces the call-order contract at runtime.
+    state: State,
+
+    /// Global correlation key.
+    delta: F,
+
+    /// Clock strategy.
+    clock: Strat::Clock,
+
+    /// Derandomized VOLE sender.
+    vole: DerandVOLESender<RV, F>,
+
+    /// Permutation protocol verifier.
+    perm_verifier: PermVerifier<F, F, B>,
+
+    /// Set-membership verifier.
+    set_verifier: set::Verifier<RV, F, B, Strat>,
+
+    /// Mux-multiplication verifier.
+    mux_mul_verifier: MuxMulVerifier<RV, RV, Strat::S, F>,
+
+    /// Pending accesses.
+    pending_accesses: Vec<PendingAccess<F>>,
+
+    /// Reads log.
+    reads: Vec<Record<PackedWire<F>>>,
+
+    /// Writes log.
+    writes: Vec<Record<PackedWire<F>>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// Addresses whose post-teardown state is returned.
+    export_addrs: RangeSet<usize>,
+
+    /// Wires at `export_addrs` addresses.
+    state_dump: Option<Vec<Wire<F>>>,
+}
+
+impl<RV, F, B, Strat> Verifier<RV, F, B, Strat>
+where
+    Strat: VerifierStrategy<F, Wire = Wire<F>>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Construct an empty RAM verifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` — protocol config.
+    /// * `clock` — clock strategy .
+    /// * `rvole` — random VOLE sender.
+    /// * `mul_vole` — derandomized VOLE sender (for multiplication protocol).
+    /// * `mul_rvole` — random VOLE sender (for multiplication protocol).
+    /// * `perm_verifier` — permutation-proof verifier.
+    /// * `set_verifier` — set-membership verifier.
+    pub fn new(
+        config: Config<F, Strat>,
+        clock: Strat::Clock,
+        rvole: RV,
+        mul_vole: DerandVOLESender<RV, F>,
+        mul_rvole: RV,
+        perm_verifier: PermVerifier<F, F, B>,
+        set_verifier: set::Verifier<RV, F, B, Strat>,
+    ) -> Result<Self, Error> {
+        let Config {
+            live_addrs,
+            value_bits,
+            total_accesses,
+            export_addrs,
+            ..
+        } = config;
+        let address_bound = live_addrs
+            .end()
+            .expect("Config::build rejects an empty live_addrs");
+        let l_addr = Strat::wire_length_for(address_bound);
+        let l_val = Strat::wire_length_for_log2(value_bits);
+        let delta = rvole.delta();
+
+        Ok(Self {
+            l_addr,
+            l_val,
+            live_addrs,
+            total_accesses,
+            accesses_performed: 0,
+            state: State::Initialized,
+            delta,
+            clock,
+            vole: DerandVOLESender::new(rvole),
+            perm_verifier,
+            set_verifier,
+            mux_mul_verifier: MuxMulVerifier::new(
+                mul_rvole,
+                mul_vole,
+                Strat::BOOLEAN_CHECK_ENABLED,
+            ),
+            pending_accesses: Vec::new(),
+            reads: Vec::new(),
+            writes: Vec::new(),
+            transcript: blake3::Hasher::new(),
+            export_addrs,
+            state_dump: None,
+        })
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    pub fn alloc(&mut self) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        // Per access we input-gate `(val_old, t_old)` — `l_val +
+        // l_clock` VOLEs each. Plus one such input-gating pass per
+        // live cell at teardown for the per-cell final read.
+        // Total VOLEs: `(T + live_count) · (l_val + l_clock)`.
+        let live_count = self.live_addrs.len();
+        let l_clock = self.clock.l_clock();
+        let ram_vole_count = (self.total_accesses + live_count) * (self.l_val + l_clock);
+        self.vole.alloc(ram_vole_count).map_err(Error::DerandVole)?;
+        self.perm_verifier
+            .alloc(live_count + self.total_accesses)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        // Set: T lookups (one per access). The set_size = T was
+        // baked into set_prover at its own construction.
+        self.set_verifier
+            .alloc(self.total_accesses)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        // MuxMul: one product per access.
+        self.mux_mul_verifier
+            .alloc(self.total_accesses * self.l_val)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Initialize RAM with cleartext initial content.
+    ///
+    /// `values` must have length `live_addrs.len()`: one value per
+    /// address in [`Config::live_addrs`].
+    pub fn setup(&mut self, values: Vec<Vec<Strat::S>>) -> Result<(), Error> {
+        if values.len() != self.live_addrs.len() {
+            return Err(Error::LengthMismatch);
+        }
+        let wired: Vec<Wire<F>> = values
+            .into_iter()
+            .map(|val| Wire::constant(&val, self.delta))
+            .collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Initialize RAM with pre-authenticated initial content.
+    ///
+    /// `values` must have length `live_addrs.len()`: one value per
+    /// address in [`Config::live_addrs`].
+    pub fn setup_with_wires(&mut self, values: Vec<Wire<F>>) -> Result<(), Error> {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if values.len() != self.live_addrs.len() {
+            return Err(Error::LengthMismatch);
+        }
+        self.writes.reserve(values.len());
+
+        let clock0 = self.clock_packed();
+
+        for (addr, val) in self.live_addrs.iter_values().zip(values) {
+            if val.len() != self.l_val {
+                return Err(Error::LengthMismatch);
+            }
+            let idx = addr as u32;
+            let addr_cleartext = Strat::index_to_bundle(idx, self.l_addr);
+            let addr: Wire<F> = Wire::constant(&addr_cleartext, self.delta);
+
+            self.writes.push(Record {
+                addr: addr.pack::<Strat::S>(),
+                val: val.pack::<Strat::S>(),
+                clock: clock0,
+            });
+        }
+
+        // Initialize the set with the valid {1..T} set.
+        let set_members = self.clock.valid_deltas();
+        self.set_verifier
+            .setup(set_members)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Record a memory access.
+    ///
+    /// Computes the multiplexer `new = old + op · (w − old)` and
+    /// emits the corresponding records, so:
+    ///   - op = 0 ⇒ new = old (value preserved)
+    ///   - op = 1 ⇒ new = w   (value overwritten)
+    ///
+    /// # Arguments
+    ///
+    /// * `op` — operation: `0` for load or `1` for store.
+    /// * `addr` — target cell's address.
+    /// * `w` — would-be-stored value on the `op = 1` branch (ignored at `op =
+    ///   0`, but still committed).
+    pub fn access(&mut self, op: Wire<F>, addr: Wire<F>, w: Wire<F>) -> Result<(), Error> {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if op.len() != 1 || addr.len() != self.l_addr || w.len() != self.l_val {
+            return Err(Error::LengthMismatch);
+        }
+        if self.accesses_performed >= self.total_accesses {
+            return Err(Error::TooManyAccesses);
+        }
+        self.accesses_performed += 1;
+        self.pending_accesses.push(PendingAccess {
+            op,
+            addr: addr.pack::<Strat::S>(),
+            w,
+        });
+        Ok(())
+    }
+
+    /// Process the prover's flush message.
+    pub fn flush(&mut self, msg: Flush<F>) -> Result<(), Error>
+    where
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        let num_accesses = self.pending_accesses.len();
+        if msg.access_adj.len() != num_accesses {
+            return Err(Error::LengthMismatch);
+        }
+        if msg.mul_flush.adjustments.len() != num_accesses {
+            return Err(Error::LengthMismatch);
+        }
+
+        let Flush {
+            access_adj: ram_access_adjustments,
+            mul_flush,
+        } = msg;
+
+        let l_clock = self.clock.l_clock();
+
+        // Prepare the values to compute the per-access multiplexer `new = old + op ·
+        // diff`, where diff = ( w - old).
+        let mut olds: Vec<Wire<F>> = Vec::with_capacity(num_accesses);
+        let mut ops: Vec<Wire<F>> = Vec::with_capacity(num_accesses);
+        let mut diffs: Vec<Wire<F>> = Vec::with_capacity(num_accesses);
+        let mut addrs: Vec<PackedWire<F>> = Vec::with_capacity(num_accesses);
+        let mut t_olds: Vec<Wire<F>> = Vec::with_capacity(num_accesses);
+
+        for (adj, access) in ram_access_adjustments
+            .iter()
+            .zip(std::mem::take(&mut self.pending_accesses).into_iter())
+        {
+            if adj.diffs.len() != self.l_val + l_clock {
+                return Err(Error::LengthMismatch);
+            }
+            self.transcript
+                .update(&bcs::to_bytes(adj).expect("serialize"));
+
+            let PendingAccess { op, addr, w } = access;
+
+            // Two derand pulls: val_old, then t_old.
+            let val_old: Wire<F> = self
+                .vole
+                .adjust(&VoleAdjustment {
+                    diffs: adj.diffs[..self.l_val].to_vec(),
+                })
+                .map_err(Error::DerandVole)?
+                .into();
+            let t_old: Wire<F> = self
+                .vole
+                .adjust(&VoleAdjustment {
+                    diffs: adj.diffs[self.l_val..].to_vec(),
+                })
+                .map_err(Error::DerandVole)?
+                .into();
+
+            diffs.push(Strat::sub_wires(&w, &val_old));
+            ops.push(op);
+            addrs.push(addr);
+            olds.push(val_old);
+            t_olds.push(t_old);
+        }
+
+        // Batch-multiply op · diff.
+        let prod_wires = self
+            .mux_mul_verifier
+            .accumulate(&ops, &diffs, &mul_flush)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+
+        // Complete the access: advance clock, push records.
+        for (((addr, old), t_old), prod) in addrs
+            .into_iter()
+            .zip(olds.into_iter())
+            .zip(t_olds.into_iter())
+            .zip(prod_wires.into_iter())
+        {
+            let new = Strat::add_wires(&old, &prod);
+
+            self.reads.push(Record {
+                addr,
+                val: old.pack::<Strat::S>(),
+                clock: t_old.pack::<Strat::S>(),
+            });
+
+            self.clock.next_clock();
+            self.writes.push(Record {
+                addr,
+                val: new.pack::<Strat::S>(),
+                clock: self.clock_packed(),
+            });
+
+            let delta = self.clock.compute_delta(&t_old, self.delta);
+            self.set_verifier
+                .lookup(delta)
+                .map_err(|e| Error::Set(Box::new(e)))?;
+        }
+
+        Ok(())
+    }
+
+    /// Process the prover's pre-teardown message.
+    ///
+    /// If any unflushed accesses exist, the caller is responsible for
+    /// calling [`flush`](Self::flush) before this method.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`access`](Self::access) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+        msg: TeardownPrepare<F, B::Preparation>,
+    ) -> Result<(), Error>
+    where
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if !self.pending_accesses.is_empty() {
+            return Err(Error::UnflushedAdjustments {
+                pending: self.pending_accesses.len(),
+            });
+        }
+
+        // Absorb into the internal transcript.
+        self.transcript
+            .update(&bcs::to_bytes(&msg.teardown_adj).expect("serialize"));
+
+        // Per-cell derand.
+        let stride = self.l_val + self.clock.l_clock();
+        let expected = self.live_addrs.len() * stride;
+        if msg.teardown_adj.diffs.len() != expected {
+            return Err(Error::LengthMismatch);
+        }
+        let mut state_dump = Vec::with_capacity(self.export_addrs.len());
+        for (pos, i) in self.live_addrs.iter_values().enumerate() {
+            let idx = i as u32;
+            let base = pos * stride;
+
+            let val_keys = self
+                .vole
+                .adjust(&VoleAdjustment {
+                    diffs: msg.teardown_adj.diffs[base..base + self.l_val].to_vec(),
+                })
+                .map_err(Error::DerandVole)?;
+
+            let t_keys = self
+                .vole
+                .adjust(&VoleAdjustment {
+                    diffs: msg.teardown_adj.diffs[base + self.l_val..base + stride].to_vec(),
+                })
+                .map_err(Error::DerandVole)?;
+
+            let addr_bundle = Strat::index_to_bundle(idx, self.l_addr);
+            let addr: Wire<F> = Wire::constant(&addr_bundle, self.delta);
+
+            if self.export_addrs.contains(&i) {
+                state_dump.push(Wire::new(val_keys.clone().into()));
+            }
+
+            self.reads.push(Record {
+                addr: addr.pack::<Strat::S>(),
+                val: PackedWire::pack::<Strat::S>(&val_keys),
+                clock: PackedWire::pack::<Strat::S>(&t_keys),
+            });
+        }
+        self.state_dump = Some(state_dump);
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        let read_keys: Vec<Vec<F>> = self.reads.iter().map(|r| r.to_keys()).collect();
+        let write_keys: Vec<Vec<F>> = self.writes.iter().map(|r| r.to_keys()).collect();
+
+        // perm-proof phase 1: prepare.
+        self.perm_verifier
+            .prepare(transcript, &read_keys, &write_keys, msg.preparation)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.set_verifier
+            .teardown_prepare(transcript, msg.set)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(())
+    }
+
+    /// Tear down the instance, verifying the prover message and returning the
+    /// cell values at [`Config::export_addrs`].
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`access`](Self::access) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown(
+        mut self,
+        transcript: &mut blake3::Hasher,
+        msg: TeardownMsg<F, B::BackendProof>,
+    ) -> Result<Vec<Wire<F>>, Error>
+    where
+        F: Copy + Serialize + zerocopy::IntoBytes + zerocopy::FromBytes,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        let state_dump = self
+            .state_dump
+            .take()
+            .expect("state_dump populated at teardown_prepare");
+        let Self {
+            perm_verifier,
+            set_verifier,
+            mux_mul_verifier,
+            ..
+        } = self;
+
+        // Verify all sub proofs.
+        perm_verifier
+            .verify(msg.ram_proof, transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        set_verifier
+            .teardown(msg.set, transcript)
+            .map_err(|e| Error::Set(Box::new(e)))?;
+
+        mux_mul_verifier
+            .finalize(transcript, &msg.mul_proof.qs_proof)
+            .map_err(|e| Error::MuxMul(Box::new(e)))?;
+
+        Ok(state_dump)
+    }
+
+    /// Pack the current clock.
+    fn clock_packed(&self) -> PackedWire<F> {
+        let bits = self.clock.current_clock();
+        let wire: Wire<F> = Wire::constant(bits, self.delta);
+        wire.pack::<Strat::S>()
+    }
+}
+
+/// Pending access.
+struct PendingAccess<F> {
+    /// Operation.
+    op: Wire<F>,
+    /// Target cell's address.
+    addr: PackedWire<F>,
+    /// New value.
+    w: Wire<F>,
+}
+
+/// Lifecycle state for the [`Verifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized.
+    Initialized,
+    /// Allocated.
+    Allocated,
+    /// Setup.
+    Setup,
+    /// Teardown-prepared.
+    TeardownPrepared,
+}
+
+impl<F: Copy> Record<PackedWire<F>> {
+    /// Decompose into per-slot keys in `addr, val, clock` order.
+    fn to_keys(&self) -> Vec<F> {
+        vec![self.addr.key, self.val.key, self.clock.key]
+    }
+}
+
+/// RAM verifier error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Bundle length mismatch or wrong adjustment count.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// More accesses requested than the verifier was sized for.
+    #[error("access count exceeded total_accesses")]
+    TooManyAccesses,
+
+    /// A method was called while the verifier was in the wrong
+    /// lifecycle state.
+    #[error("ram verifier method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// [`teardown_prepare`](Verifier::teardown_prepare) called while
+    /// per-access pending data had not been drained by
+    /// [`flush`](Verifier::flush).
+    #[error("teardown_prepare called with {pending} unflushed accesses")]
+    UnflushedAdjustments {
+        /// Number of accesses still queued.
+        pending: usize,
+    },
+
+    /// Derandomized VOLE sender error.
+    #[error("derand VOLE error: {0}")]
+    DerandVole(#[source] DerandVOLESenderError),
+
+    /// Permutation-proof error.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Set-membership error.
+    #[error("set-membership error: {0}")]
+    Set(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// Mux-multiplication error.
+    #[error("mux-mul error: {0}")]
+    MuxMul(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}

--- a/crates/two-shuffles/src/ro_kvs.rs
+++ b/crates/two-shuffles/src/ro_kvs.rs
@@ -1,0 +1,44 @@
+//! Read-only key-value store (RO-KVS) — Section 4.1 of the paper.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::Proof;
+use mpz_vole_core::VoleAdjustment;
+
+pub(crate) mod prover;
+pub(crate) mod verifier;
+
+pub use prover::{Error as ProverError, Prover};
+pub use verifier::{Error as VerifierError, Verifier};
+
+/// Pre-`teardown` message from the prover.
+///
+/// Bundles the verifier-side teardown work that can run in parallel
+/// with the prover building the closing [`TeardownMsg`].
+pub struct TeardownPrepare<F, P>
+where
+    F: Field,
+{
+    /// All VOLE adjustments accumulated during `lookup` plus the
+    /// single teardown adjustment, in order.
+    pub adjustments: Vec<VoleAdjustment<F>>,
+    /// Perm-proof phase-1 preparation DTO — see
+    /// [`Backend::Preparation`](mpz_perm_proof_core::backend::Backend::Preparation).
+    pub preparation: P,
+}
+
+/// Closing message from [`Prover::teardown`].
+pub struct TeardownMsg<F, BP>
+where
+    F: Field,
+{
+    /// Perm-proof closing message.
+    pub proof: Proof<F, BP>,
+}
+
+/// One authenticated `(key, value, version)` record.
+#[derive(Copy, Clone)]
+pub(crate) struct Record<W> {
+    pub(crate) key: W,
+    pub(crate) value: W,
+    pub(crate) version: W,
+}

--- a/crates/two-shuffles/src/ro_kvs/prover.rs
+++ b/crates/two-shuffles/src/ro_kvs/prover.rs
@@ -1,0 +1,619 @@
+//! Prover side of the RO-KVS protocol.
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use mpz_perm_proof_core::{Prover as PermProver, backend::ProverBackend as PermProverBackend};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, VOLEReceiver, VoleAdjustment,
+};
+use serde::Serialize;
+
+use super::{Record, TeardownMsg, TeardownPrepare};
+use crate::{
+    strategy::{
+        VersionStrategy,
+        version::{ProverVersionStep, VersionStep},
+    },
+    wire::{Bundle, PackedProverWire as PackedWire, ProverWire as Wire},
+};
+
+/// Prover for the RO-KVS protocol.
+pub struct Prover<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Cardinality of the key space.
+    key_space: usize,
+
+    /// Total number of lookups expected during this session.
+    num_lookups: usize,
+
+    /// Running lookup counter, bounded by `num_lookups`.
+    lookups_performed: usize,
+
+    /// Wire length for keys.
+    l_key: usize,
+
+    /// Wire length for values.
+    l_val: usize,
+
+    /// Wire length for versions.
+    l_ver: usize,
+
+    /// Version-chain step strategy.
+    version_step: Strat::VersionStep,
+
+    /// Derandomized VOLE receiver.
+    vole: DerandVOLEReceiver<RV, Strat::S, F>,
+
+    /// Permutation protocol prover.
+    perm: PermProver<F, F, B>,
+
+    /// Cleartext shadow indexed by key (= position in `0..key_space`).
+    shadow: Vec<ShadowEntry<Strat::S>>,
+
+    /// Setup-time packed wires per key, kept for replay at teardown.
+    setup_wires: Vec<(PackedWire<F>, PackedWire<F>)>,
+
+    /// Reads log.
+    reads: Vec<Record<PackedWire<F>>>,
+
+    /// Writes log.
+    writes: Vec<Record<PackedWire<F>>>,
+
+    /// Outbound queue of `VoleAdjustment` messages.
+    pending_adjustments: Vec<VoleAdjustment<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// Lifecycle state.
+    state: State,
+}
+
+impl<RV, F, B, Strat> Prover<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Construct an empty RO-KVS prover.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_space` — cardinality of the key space.
+    /// * `value_bits` — bit-width of the value domain (`2^value_bits` distinct
+    ///   values).
+    /// * `version_step` — version-chain step strategy.
+    /// * `vole` — derandomized VOLE receiver.
+    /// * `perm` — permutation protocol prover.
+    pub fn new(
+        key_space: usize,
+        value_bits: usize,
+        version_step: Strat::VersionStep,
+        vole: DerandVOLEReceiver<RV, Strat::S, F>,
+        perm: PermProver<F, F, B>,
+    ) -> Result<Self, Error> {
+        let l_key = Strat::wire_length_for(key_space);
+        let l_val = Strat::wire_length_for_log2(value_bits);
+        let l_ver = version_step.len();
+        let k = <F as ExtensionField<Strat::S>>::MONOMIAL_BASIS.len();
+        if l_ver == 0 || l_ver > k {
+            return Err(Error::LengthMismatch);
+        }
+        Ok(Self {
+            key_space,
+            num_lookups: 0,
+            lookups_performed: 0,
+            l_key,
+            l_val,
+            l_ver,
+            version_step,
+            vole,
+            perm,
+            shadow: Vec::with_capacity(key_space),
+            setup_wires: Vec::with_capacity(key_space),
+            reads: Vec::new(),
+            writes: Vec::new(),
+            pending_adjustments: Vec::new(),
+            transcript: blake3::Hasher::new(),
+            state: State::Initialized,
+        })
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    ///
+    /// # Arguments
+    ///
+    /// * `n_setup` — number of setup entries.
+    /// * `num_lookups` — number of lookups expected during the session.
+    pub fn alloc(&mut self, n_setup: usize, num_lookups: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        // Per-key version-chain cycle must accommodate the worst case:
+        // a single key absorbing every lookup.
+        if (num_lookups as u64) > self.version_step.max_advances() {
+            return Err(Error::TooManyLookupsForVersionChain);
+        }
+        // VOLE correlations:
+        //   per lookup:        l_val + l_ver
+        //   per teardown read: l_ver (the per-key final version)
+        let vole_count = num_lookups * (self.l_val + self.l_ver) + n_setup * self.l_ver;
+        self.vole.alloc(vole_count).map_err(Error::Vole)?;
+
+        // Permutation vectors:
+        //   writes = setup + lookups
+        //   reads  = teardown (same size as setup) + lookups
+        self.perm
+            .alloc(n_setup + num_lookups)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        // Pre-size the reads/writes logs to their final capacities so
+        // the hot path is push-only.
+        self.reads.reserve_exact(n_setup + num_lookups);
+        self.writes.reserve_exact(n_setup + num_lookups);
+
+        self.num_lookups = num_lookups;
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Populate the RO-KVS with cleartext initial content.
+    ///
+    /// Keys are implicit: position `i` of `values` is key `i`. `values.len()`
+    /// must equal the configured `key_space`.
+    pub fn setup(&mut self, values: Vec<Vec<Strat::S>>) -> Result<(), Error>
+    where
+        Strat::S: Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if values.len() != self.key_space {
+            return Err(Error::LengthMismatch);
+        }
+        let wired = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let key_bundle = Strat::index_to_bundle(i as u32, self.l_key);
+                (Wire::constant(key_bundle), Wire::constant(v))
+            })
+            .collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Populate the RO-KVS with pre-authenticated wires.
+    ///
+    /// `content.len()` must equal `key_space`, and the i-th `key_wire`'s
+    /// cleartext must encode index `i` — i.e., keys are still the implicit
+    /// sequence `0..key_space`.
+    pub fn setup_with_wires(
+        &mut self,
+        content: Vec<(Wire<Strat::S, F>, Wire<Strat::S, F>)>,
+    ) -> Result<(), Error>
+    where
+        Strat::S: Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if content.len() != self.key_space {
+            return Err(Error::LengthMismatch);
+        }
+
+        let anchor_input = self.version_step.anchor();
+        let anchor_wire: PackedWire<F> = (&anchor_input).into();
+
+        for (i, (key_input, value_input)) in content.into_iter().enumerate() {
+            if key_input.len() != self.l_key || value_input.len() != self.l_val {
+                return Err(Error::LengthMismatch);
+            }
+            if Strat::bundle_to_index(key_input.value()) as usize != i {
+                return Err(Error::LengthMismatch);
+            }
+
+            let value_cleartext = value_input.value().clone();
+
+            let key_wire = (&key_input).into();
+            let value_wire = (&value_input).into();
+
+            self.shadow.push(ShadowEntry {
+                value_cleartext,
+                version_cleartext: anchor_input.value().clone(),
+            });
+            self.setup_wires.push((key_wire, value_wire));
+
+            self.writes.push(Record {
+                key: key_wire,
+                value: value_wire,
+                version: anchor_wire,
+            });
+        }
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Look up the value at `key` and return its authenticated wire.
+    pub fn lookup(&mut self, key: Wire<Strat::S, F>) -> Result<Wire<Strat::S, F>, Error>
+    where
+        Strat::S: Clone,
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if self.lookups_performed >= self.num_lookups {
+            return Err(Error::LookupCountExceeded);
+        }
+        if key.len() != self.l_key {
+            return Err(Error::LengthMismatch);
+        }
+        self.lookups_performed += 1;
+
+        // 1. Shadow lookup by key index.
+        let idx = Strat::bundle_to_index(key.value()) as usize;
+        if idx >= self.shadow.len() {
+            return Err(Error::KeyNotFound);
+        }
+        let entry = &self.shadow[idx];
+        let value_cleartext = entry.value_cleartext.clone();
+        let version_cleartext = entry.version_cleartext.clone();
+
+        // 2. Queue for derandomization.
+        let mut val_fut = self
+            .vole
+            .queue_recv_vole(&value_cleartext)
+            .map_err(Error::Vole)?;
+        let mut ver_fut = self
+            .vole
+            .queue_recv_vole(&version_cleartext)
+            .map_err(Error::Vole)?;
+
+        // 3. Adjust.
+        let adjustment = self.vole.adjust().map_err(Error::Vole)?;
+        self.transcript
+            .update(&bcs::to_bytes(&adjustment).expect("serialize"));
+        self.pending_adjustments.push(adjustment);
+
+        // 4. Extract resolved MACs.
+        let val_macs: Vec<F> = val_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+        let ver_macs: Vec<F> = ver_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+
+        let value_input = Wire::new(value_cleartext, val_macs.into());
+        let version_input = Wire::new(version_cleartext, ver_macs.into());
+
+        // 5. Compute the next-version input wire.
+        let next_version_input = self.version_step.next(&version_input);
+
+        // 6. Update the shadow's version cleartext.
+        self.shadow[idx].version_cleartext = next_version_input.value().clone();
+
+        // 7. Pack the input wires and append records.
+        let key_wire = (&key).into();
+        let value_wire = (&value_input).into();
+        let version_wire = (&version_input).into();
+        let next_version_wire = (&next_version_input).into();
+
+        self.reads.push(Record {
+            key: key_wire,
+            value: value_wire,
+            version: version_wire,
+        });
+        self.writes.push(Record {
+            key: key_wire,
+            value: value_wire,
+            version: next_version_wire,
+        });
+
+        Ok(value_input)
+    }
+
+    /// Pre-`teardown` setup.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<TeardownPrepare<F, B::Preparation>, Error>
+    where
+        Strat::S: Clone,
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        // Append teardown reads.
+        let teardown_data: Vec<(PackedWire<F>, PackedWire<F>, Bundle<Strat::S>)> = self
+            .shadow
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                let (key_wire, value_wire) = self.setup_wires[i];
+                (key_wire, value_wire, entry.version_cleartext.clone())
+            })
+            .collect();
+
+        let mut version_futs = Vec::with_capacity(teardown_data.len());
+        for (_, _, ver_cleartext) in &teardown_data {
+            let fut = self
+                .vole
+                .queue_recv_vole(ver_cleartext)
+                .map_err(Error::Vole)?;
+            version_futs.push(fut);
+        }
+        let teardown_adjustment = self.vole.adjust().map_err(Error::Vole)?;
+        self.transcript
+            .update(&bcs::to_bytes(&teardown_adjustment).expect("serialize"));
+        self.pending_adjustments.push(teardown_adjustment);
+
+        for ((key_wire, value_wire, ver_cleartext), mut fut) in
+            teardown_data.into_iter().zip(version_futs)
+        {
+            let ver_macs: Vec<F> = fut
+                .try_recv()
+                .map_err(|_| Error::VoleFutureUnresolved)?
+                .ok_or(Error::VoleFutureUnresolved)?
+                .macs;
+            let version_input = Wire::new(ver_cleartext, ver_macs.into());
+
+            self.reads.push(Record {
+                key: key_wire,
+                value: value_wire,
+                version: (&version_input).into(),
+            });
+        }
+
+        // Convert records to the (Vec<Vec<F>>, Vec<Vec<F>>) shape
+        // expected by perm-proof's prepare.
+        let (read_values, read_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.reads.iter().map(|r| r.to_parts()).unzip();
+        let (write_values, write_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.writes.iter().map(|r| r.to_parts()).unzip();
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        let preparation = self
+            .perm
+            .prepare(
+                transcript,
+                (&read_values, &read_macs),
+                (&write_values, &write_macs),
+            )
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(TeardownPrepare {
+            adjustments: std::mem::take(&mut self.pending_adjustments),
+            preparation,
+        })
+    }
+
+    /// Tear down the instance, returning the message to be sent to the
+    /// verifier.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown(
+        self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<TeardownMsg<F, B::BackendProof>, Error>
+    where
+        F: Copy + Serialize,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        let proof = self
+            .perm
+            .prove(transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+        Ok(TeardownMsg { proof })
+    }
+}
+
+impl<F: Copy> Record<PackedWire<F>> {
+    /// Decompose into `(values, macs)` slot vectors in `key, value,
+    /// version` order.
+    fn to_parts(&self) -> (Vec<F>, Vec<F>) {
+        (
+            vec![self.key.value, self.value.value, self.version.value],
+            vec![self.key.mac, self.value.mac, self.version.mac],
+        )
+    }
+}
+
+/// Lifecycle state for the [`Prover`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized state.
+    Initialized,
+    /// Allocated state.
+    Allocated,
+    /// Setup state.
+    Setup,
+    /// Teardown-prepared state.
+    TeardownPrepared,
+}
+
+/// Per-key shadow entry — cleartext mirror of one setup key's value
+/// and current version.
+struct ShadowEntry<S> {
+    /// Value cleartext.
+    value_cleartext: Bundle<S>,
+    /// Version cleartext.
+    version_cleartext: Bundle<S>,
+}
+
+/// RO-KVS prover error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A method was called while the prover was in the wrong state.
+    #[error("prover method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// The looked-up key is not in the prover's shadow.
+    #[error("key not found in RO-KVS shadow")]
+    KeyNotFound,
+
+    /// More lookups than declared at `alloc` were attempted.
+    #[error("lookup count exceeded num_lookups")]
+    LookupCountExceeded,
+
+    /// `num_lookups` exceeds the version chain's cycle length.
+    /// Worst case is all lookups hitting the same key — versions
+    /// would wrap and lose distinctness, breaking soundness.
+    #[error("num_lookups exceeds version-chain cycle length")]
+    TooManyLookupsForVersionChain,
+
+    /// A wire's length does not match the configured one.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// Underlying VOLE receiver error.
+    #[error("VOLE error: {0}")]
+    Vole(#[source] DerandVOLEReceiverError),
+
+    /// Internal invariant: a queued VOLE future failed to resolve.
+    #[error("VOLE future failed to resolve after adjust")]
+    VoleFutureUnresolved,
+
+    /// Permutation-proof error during teardown.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use crate::{
+        strategy::{Char2Strategy, FieldStrategy, version::MultiplicativeStep},
+        test_utils::{bits, prover_wire},
+    };
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair;
+    use mpz_vole_core::ideal::rvole::ideal_rvole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// The cleartext RO-KVS model: every `lookup(key)` returns that
+    /// key's setup value (read-only, repeatable, correctly addressed),
+    /// and each lookup advances exactly that key's version chain by one
+    /// step while leaving other keys untouched.
+    #[test]
+    fn lookup_cleartext_rokvs_semantics() {
+        const KEY_SPACE: usize = 4;
+        const VALUE_BITS: usize = 4;
+        const N_VER: usize = 8;
+        const FAN_IN: usize = 8;
+
+        // Per-key setup values (key i lives at position i).
+        let content = vec![
+            bits(0b1100, 4), // key 0
+            bits(0b0110, 4), // key 1
+            bits(0b0011, 4), // key 2
+            bits(0b1010, 4), // key 3
+        ];
+        // Lookup script: key 1 twice, keys 2 and 3 once, key 0 never.
+        let lookups = [1usize, 2, 1, 3];
+        let n_setup = KEY_SPACE;
+        let num_lookups = lookups.len();
+
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+        let delta: Gf2_64 = rng.random();
+
+        let l_key = <Char2Strategy<Gf2_64> as FieldStrategy<Gf2_64>>::wire_length_for(KEY_SPACE);
+        let l_val =
+            <Char2Strategy<Gf2_64> as FieldStrategy<Gf2_64>>::wire_length_for_log2(VALUE_BITS);
+
+        // Single derand VOLE pool — mirrors `alloc`'s sizing.
+        let vole_count = num_lookups * (l_val + N_VER) + n_setup * N_VER;
+        let (_, mut r) = ideal_rvole::<Gf2, Gf2_64>(rng.random(), delta);
+        r.pregenerate(vole_count, delta).expect("pregen");
+        let vole = DerandVOLEReceiver::new(r);
+
+        // Perm-proof prover; verifier half dropped (prover-only test).
+        let (perm, _) = build_ideal_perm_proof_pair(&mut rng, delta, n_setup + num_lookups, FAN_IN);
+
+        let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+            KEY_SPACE,
+            VALUE_BITS,
+            MultiplicativeStep::new(N_VER).expect("step"),
+            vole,
+            perm,
+        )
+        .expect("prover");
+        prover.alloc(n_setup, num_lookups).expect("alloc");
+        prover.setup(content.clone()).expect("setup");
+
+        // Each lookup must return that key's setup value, every time.
+        for &key_idx in &lookups {
+            let key = prover_wire(bits(key_idx as u64, l_key));
+            let got = prover.lookup(key).expect("lookup");
+            assert_eq!(
+                got.value().as_slice(),
+                content[key_idx].as_slice(),
+                "lookup(key {key_idx}) returned the wrong value",
+            );
+        }
+
+        // Expected version chain: `versions[k]` is the anchor advanced
+        // `k` steps, computed with a parallel step instance.
+        let mut step = MultiplicativeStep::new(N_VER).expect("step");
+        let anchor: crate::wire::ProverWire<Gf2, Gf2_64> = step.anchor();
+        let mut versions = vec![anchor.value().clone()];
+        let mut cur = anchor;
+        for _ in 0..num_lookups {
+            let next = step.next(&cur);
+            versions.push(next.value().clone());
+            cur = next;
+        }
+
+        // Each key's version advanced exactly once per lookup of it;
+        // its value never changed (read-only).
+        let mut counts = [0usize; KEY_SPACE];
+        for &k in &lookups {
+            counts[k] += 1;
+        }
+        for i in 0..KEY_SPACE {
+            assert_eq!(
+                prover.shadow[i].value_cleartext.as_slice(),
+                content[i].as_slice(),
+                "key {i} value must be unchanged (read-only)",
+            );
+            assert_eq!(
+                prover.shadow[i].version_cleartext.as_slice(),
+                versions[counts[i]].as_slice(),
+                "key {i} version chain mismatch after {} lookup(s)",
+                counts[i],
+            );
+        }
+    }
+}

--- a/crates/two-shuffles/src/ro_kvs/verifier.rs
+++ b/crates/two-shuffles/src/ro_kvs/verifier.rs
@@ -1,0 +1,433 @@
+//! Verifier side of the RO-KVS protocol.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::{
+    Verifier as PermVerifier, backend::VerifierBackend as PermVerifierBackend,
+};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{DerandVOLESender, DerandVOLESenderError, RVOLESender, VoleAdjustment};
+use serde::Serialize;
+
+use super::{Record, TeardownMsg, TeardownPrepare};
+use crate::{
+    strategy::{
+        VersionStrategy,
+        version::{VerifierVersionStep, VersionStep},
+    },
+    wire::{PackedVerifierWire as PackedWire, VerifierWire as Wire},
+};
+
+/// Verifier for the RO-KVS protocol.
+pub struct Verifier<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Cardinality of the key space.
+    key_space: usize,
+
+    /// Total number of lookups expected during this session.
+    num_lookups: usize,
+
+    /// Running lookup counter, bounded by `num_lookups`.
+    lookups_performed: usize,
+
+    /// Wire length for keys.
+    l_key: usize,
+
+    /// Wire length for values.
+    l_val: usize,
+
+    /// Wire length for versions.
+    l_ver: usize,
+
+    /// Global correlation key.
+    delta: F,
+
+    /// Version-chain step strategy.
+    version_step: Strat::VersionStep,
+
+    /// Derandomized VOLE sender.
+    vole: DerandVOLESender<RV, F>,
+
+    /// Permutation protocol verifier.
+    perm: PermVerifier<F, F, B>,
+
+    /// Per-lookup key wires.
+    pending_lookups: Vec<PackedWire<F>>,
+
+    /// Setup-time (key, value) wires, indexed by key (=
+    /// position in `0..key_space`).
+    setup_wires: Vec<(PackedWire<F>, PackedWire<F>)>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+
+    /// Lifecycle state.
+    state: State,
+}
+
+impl<RV, F, B, Strat> Verifier<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Construct an empty RO-KVS verifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_space` — cardinality of the key space.
+    /// * `value_bits` — bit-width of the value domain (`2^value_bits` distinct
+    ///   values).
+    /// * `version_step` — version-chain step strategy.
+    /// * `rvole` — random VOLE sender.
+    /// * `perm` — permutation protocol verifier.
+    pub fn new(
+        key_space: usize,
+        value_bits: usize,
+        version_step: Strat::VersionStep,
+        rvole: RV,
+        perm: PermVerifier<F, F, B>,
+    ) -> Result<Self, Error> {
+        let l_key = Strat::wire_length_for(key_space);
+        let l_val = Strat::wire_length_for_log2(value_bits);
+        let l_ver = version_step.len();
+        let k = <F as ExtensionField<Strat::S>>::MONOMIAL_BASIS.len();
+        if l_ver == 0 || l_ver > k {
+            return Err(Error::LengthMismatch);
+        }
+        let delta = rvole.delta();
+        Ok(Self {
+            key_space,
+            num_lookups: 0,
+            lookups_performed: 0,
+            l_key,
+            l_val,
+            l_ver,
+            delta,
+            version_step,
+            vole: DerandVOLESender::new(rvole),
+            perm,
+            pending_lookups: Vec::new(),
+            setup_wires: Vec::with_capacity(key_space),
+            transcript: blake3::Hasher::new(),
+            state: State::Initialized,
+        })
+    }
+
+    /// Allocate VOLE correlations and perm-proof state.
+    pub fn alloc(&mut self, n_setup: usize, num_lookups: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        // Per-key version-chain cycle must accommodate the worst case:
+        // a single key absorbing every lookup.
+        if (num_lookups as u64) > self.version_step.max_advances() {
+            return Err(Error::TooManyLookupsForVersionChain);
+        }
+        self.num_lookups = num_lookups;
+
+        // VOLE correlations:
+        //   per lookup:        l_val + l_ver
+        //   per teardown read: l_ver (the per-key final version)
+        let vole_count = num_lookups * (self.l_val + self.l_ver) + n_setup * self.l_ver;
+        self.vole.alloc(vole_count).map_err(Error::DerandVole)?;
+
+        // Permutation vectors:
+        //   writes = setup + lookups
+        //   reads  = teardown (same size as setup) + lookups
+        self.perm
+            .alloc(n_setup + num_lookups)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Populate the RO-KVS with cleartext initial content.
+    ///
+    /// Keys are implicit: position `i` of `values` is key `i`. `values.len()`
+    /// must equal the configured `key_space`.
+    pub fn setup(&mut self, values: Vec<Vec<Strat::S>>) -> Result<(), Error>
+    where
+        Strat::S: Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if values.len() != self.key_space {
+            return Err(Error::LengthMismatch);
+        }
+        let wired: Vec<_> = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let key_bundle = Strat::index_to_bundle(i as u32, self.l_key);
+                let key_wire = Wire::constant(&key_bundle, self.delta);
+                let val_wire = Wire::constant(&v, self.delta);
+                (key_wire, val_wire)
+            })
+            .collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Populate the RO-KVS with pre-authenticated wires.
+    ///
+    /// `content.len()` must equal `key_space`, and the i-th `key_wire`'s
+    /// cleartext must encode index `i` — i.e., keys are still the implicit
+    /// sequence `0..key_space`.
+    pub fn setup_with_wires(&mut self, content: Vec<(Wire<F>, Wire<F>)>) -> Result<(), Error> {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if content.len() != self.key_space {
+            return Err(Error::LengthMismatch);
+        }
+
+        for (key_wire, value_wire) in content {
+            if key_wire.len() != self.l_key || value_wire.len() != self.l_val {
+                return Err(Error::LengthMismatch);
+            }
+
+            let key_packed = key_wire.pack::<Strat::S>();
+            let value_packed = value_wire.pack::<Strat::S>();
+            self.setup_wires.push((key_packed, value_packed));
+        }
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Record a lookup of the `key` wire.
+    pub fn lookup(&mut self, key: Wire<F>) -> Result<(), Error> {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if self.lookups_performed >= self.num_lookups {
+            return Err(Error::LookupCountExceeded);
+        }
+        if key.len() != self.l_key {
+            return Err(Error::LengthMismatch);
+        }
+        self.lookups_performed += 1;
+        self.pending_lookups.push(key.pack::<Strat::S>());
+        Ok(())
+    }
+
+    /// Pre-`teardown` processing. Consumes the prover's
+    /// [`TeardownPrepare`] message.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+        msg: TeardownPrepare<F, B::Preparation>,
+    ) -> Result<(), Error>
+    where
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        let num_lookups = self.pending_lookups.len();
+        let expected_adjs = num_lookups + 1; // one per lookup + one teardown
+        if msg.adjustments.len() != expected_adjs {
+            return Err(Error::LengthMismatch);
+        }
+
+        // Reads and writes only exist within this method; materialize
+        // locally, drain into the perm-proof, discard.
+        let mut reads: Vec<Record<PackedWire<F>>> =
+            Vec::with_capacity(num_lookups + self.key_space);
+        let mut writes: Vec<Record<PackedWire<F>>> =
+            Vec::with_capacity(num_lookups + self.key_space);
+
+        // Seed `writes` with the setup-time records (one per key,
+        // version = anchor).
+        let anchor_packed = self.version_step.anchor(self.delta).pack::<Strat::S>();
+        for &(key, value) in &self.setup_wires {
+            writes.push(Record {
+                key,
+                value,
+                version: anchor_packed,
+            });
+        }
+
+        // Process per-lookup adjustments.
+        for i in 0..num_lookups {
+            let adj = &msg.adjustments[i];
+            self.transcript
+                .update(&bcs::to_bytes(adj).expect("serialize"));
+            let key = self.pending_lookups[i];
+            self.process_lookup_adjustment(&mut reads, &mut writes, adj, key)?;
+        }
+
+        // Process the teardown adjustment.
+        let teardown_adj = &msg.adjustments[num_lookups];
+        self.transcript
+            .update(&bcs::to_bytes(teardown_adj).expect("serialize"));
+        if teardown_adj.diffs.len() != self.key_space * self.l_ver {
+            return Err(Error::LengthMismatch);
+        }
+        // Per-key derand pulls — one per `queue_recv_vole` chunk the
+        // prover queued in its own teardown loop — so the RVOLE
+        // sample pairing stays aligned with the prover.
+        for i in 0..self.key_space {
+            let (key, value) = self.setup_wires[i];
+            let sub = VoleAdjustment {
+                diffs: teardown_adj.diffs[i * self.l_ver..(i + 1) * self.l_ver].to_vec(),
+            };
+            let version_keys = self.vole.adjust(&sub).map_err(Error::DerandVole)?;
+            let version_packed = PackedWire::pack::<Strat::S>(&version_keys);
+
+            reads.push(Record {
+                key,
+                value,
+                version: version_packed,
+            });
+        }
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        // Convert records to the (Vec<Vec<F>>) shape perm-proof expects.
+        let read_keys: Vec<Vec<F>> = reads.iter().map(|r| r.to_keys()).collect();
+        let write_keys: Vec<Vec<F>> = writes.iter().map(|r| r.to_keys()).collect();
+
+        self.perm
+            .prepare(transcript, &read_keys, &write_keys, msg.preparation)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(())
+    }
+
+    /// Tear down the instance, consuming the tear down message from the prover.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee no longer holds.
+    pub fn teardown(
+        self,
+        msg: TeardownMsg<F, B::BackendProof>,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<(), Error>
+    where
+        F: Copy + Serialize,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        self.perm
+            .verify(msg.proof, transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))
+    }
+
+    /// Consume one lookup adjustment: derive value and version wires,
+    /// advance to next version, and append the corresponding read/write
+    /// records.
+    fn process_lookup_adjustment(
+        &mut self,
+        reads: &mut Vec<Record<PackedWire<F>>>,
+        writes: &mut Vec<Record<PackedWire<F>>>,
+        adj: &VoleAdjustment<F>,
+        key: PackedWire<F>,
+    ) -> Result<(), Error> {
+        let n_total = self.l_val + self.l_ver;
+        if adj.diffs.len() != n_total {
+            return Err(Error::LengthMismatch);
+        }
+
+        // Two derand pulls — one per `queue_recv_vole` chunk the
+        // prover queued (value, then version) — so the RVOLE sample
+        // pairing stays aligned with the prover.
+        let val_adj = VoleAdjustment {
+            diffs: adj.diffs[..self.l_val].to_vec(),
+        };
+        let value_keys = self.vole.adjust(&val_adj).map_err(Error::DerandVole)?;
+        let ver_adj = VoleAdjustment {
+            diffs: adj.diffs[self.l_val..].to_vec(),
+        };
+        let version_keys = self.vole.adjust(&ver_adj).map_err(Error::DerandVole)?;
+
+        let version_wire: Wire<F> = version_keys.into();
+        let next_version_wire = self.version_step.next(&version_wire, self.delta);
+
+        let value_packed = PackedWire::pack::<Strat::S>(&value_keys);
+
+        reads.push(Record {
+            key,
+            value: value_packed,
+            version: version_wire.pack::<Strat::S>(),
+        });
+        writes.push(Record {
+            key,
+            value: value_packed,
+            version: next_version_wire.pack::<Strat::S>(),
+        });
+
+        Ok(())
+    }
+}
+
+impl<F: Copy> Record<PackedWire<F>> {
+    /// Extract the keys in `key, value, version` order.
+    fn to_keys(&self) -> Vec<F> {
+        vec![self.key.key, self.value.key, self.version.key]
+    }
+}
+
+/// Lifecycle state for the [`Verifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized state.
+    Initialized,
+    /// Allocated state.
+    Allocated,
+    /// Setup state.
+    Setup,
+    /// Teardown-prepared state.
+    TeardownPrepared,
+}
+
+/// RO-KVS verifier error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A method was called while the verifier was in the wrong state.
+    #[error("wrong verifier state: {0:?}")]
+    WrongState(State),
+
+    /// More lookups than declared at `alloc` were attempted.
+    #[error("lookup count exceeded num_lookups")]
+    LookupCountExceeded,
+
+    /// `num_lookups` exceeds the version chain's cycle length.
+    #[error("num_lookups exceeds version-chain cycle length")]
+    TooManyLookupsForVersionChain,
+
+    /// A wire's length does not match the configured one.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// Derandomized VOLE sender error.
+    #[error("derand VOLE error: {0}")]
+    DerandVole(#[source] DerandVOLESenderError),
+
+    /// Permutation-proof error.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}

--- a/crates/two-shuffles/src/set.rs
+++ b/crates/two-shuffles/src/set.rs
@@ -1,0 +1,43 @@
+//! Set with membership queries — Section 4.2 of the paper.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::Proof;
+use mpz_vole_core::VoleAdjustment;
+
+pub(crate) mod prover;
+pub(crate) mod verifier;
+
+pub use prover::{Error as ProverError, Prover};
+pub use verifier::{Error as VerifierError, Verifier};
+
+/// Pre-`teardown` message from the prover.
+///
+/// Bundles the verifier-side teardown work that can run in parallel
+/// with the prover building the closing [`TeardownMsg`].
+pub struct TeardownPrepare<F, P>
+where
+    F: Field,
+{
+    /// All VOLE adjustments accumulated during `lookup` plus the
+    /// single teardown adjustment, in order.
+    pub adjustments: Vec<VoleAdjustment<F>>,
+    /// Perm-proof phase-1 preparation DTO — see
+    /// [`Backend::Preparation`](mpz_perm_proof_core::backend::Backend::Preparation).
+    pub preparation: P,
+}
+
+/// Closing message from [`Prover::teardown`].
+pub struct TeardownMsg<F, BP>
+where
+    F: Field,
+{
+    /// Perm-proof closing message.
+    pub proof: Proof<F, BP>,
+}
+
+/// One authenticated `(key, version)` record.
+#[derive(Copy, Clone)]
+pub(crate) struct Record<W> {
+    pub(crate) key: W,
+    pub(crate) version: W,
+}

--- a/crates/two-shuffles/src/set/prover.rs
+++ b/crates/two-shuffles/src/set/prover.rs
@@ -1,0 +1,556 @@
+//! Prover side of the set membership protocol.
+
+use mpz_common::future::Output;
+use mpz_fields::Field;
+use mpz_perm_proof_core::{Prover as PermProver, backend::ProverBackend as PermProverBackend};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLEReceiverError, RVOLEReceiver, VOLEReceiver, VoleAdjustment,
+};
+use serde::Serialize;
+
+use std::collections::BTreeMap;
+
+use super::{Record, TeardownMsg, TeardownPrepare};
+use crate::{
+    strategy::{
+        VersionStrategy,
+        version::{ProverVersionStep, VersionStep},
+    },
+    wire::{Bundle, PackedProverWire, ProverWire as Wire},
+};
+
+/// Prover for the set membership protocol.
+pub struct Prover<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Wire length for the version.
+    l_ver: usize,
+    /// Number of distinct elements in the set.
+    set_size: usize,
+    /// Total number of lookups expected during this session.
+    num_lookups: usize,
+    /// Running lookup counter, bounded by `num_lookups`.
+    lookups_performed: usize,
+    /// Lifecycle state.
+    state: State,
+
+    /// Per-element version-chain step rule.
+    version_step: Strat::VersionStep,
+
+    /// Derandomized VOLE receiver.
+    vole: DerandVOLEReceiver<RV, Strat::S, F>,
+
+    /// Permutation protocol prover.
+    perm: PermProver<F, F, B>,
+
+    /// Element → slot index. Built at setup, read at lookup.
+    index_of: BTreeMap<Bundle<Strat::S>, u32>,
+
+    /// Setup-time key wires, indexed by slot index. Read at teardown.
+    setup_wires: Vec<PackedProverWire<F>>,
+
+    /// Cleartext shadow indexed by slot index.
+    shadow: Vec<ShadowEntry<Strat::S>>,
+
+    /// Reads log.
+    reads: Vec<Record<PackedProverWire<F>>>,
+
+    /// Writes log.
+    writes: Vec<Record<PackedProverWire<F>>>,
+
+    /// Outbound queue of `VoleAdjustment` messages.
+    pending_adjustments: Vec<VoleAdjustment<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+}
+
+impl<RV, F, B, Strat> Prover<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLEReceiver<Strat::S, F>,
+    F: Field,
+    B: PermProverBackend<F, F>,
+{
+    /// Construct an empty set prover.
+    ///
+    /// # Arguments
+    ///
+    /// * `set_size` — number of distinct members the set will hold.
+    /// * `version_step` — version-chain step strategy.
+    /// * `vole` — derandomized VOLE receiver.
+    /// * `perm` — permutation protocol prover.
+    pub fn new(
+        set_size: usize,
+        version_step: Strat::VersionStep,
+        vole: DerandVOLEReceiver<RV, Strat::S, F>,
+        perm: PermProver<F, F, B>,
+    ) -> Result<Self, Error> {
+        if set_size > u32::MAX as usize {
+            return Err(Error::SetSizeTooLarge);
+        }
+        let l_ver = version_step.len();
+        let k = <F as ExtensionField<Strat::S>>::MONOMIAL_BASIS.len();
+        if l_ver == 0 || l_ver > k {
+            return Err(Error::LengthMismatch);
+        }
+        Ok(Self {
+            l_ver,
+            set_size,
+            num_lookups: 0,
+            lookups_performed: 0,
+            state: State::Initialized,
+            version_step,
+            vole,
+            perm,
+            index_of: BTreeMap::new(),
+            setup_wires: Vec::with_capacity(set_size),
+            shadow: Vec::with_capacity(set_size),
+            reads: Vec::new(),
+            writes: Vec::new(),
+            pending_adjustments: Vec::new(),
+            transcript: blake3::Hasher::new(),
+        })
+    }
+
+    /// Allocates resources. Must be called exactly once.
+    ///
+    /// # Arguments
+    ///
+    /// * `num_lookups` — number of lookups expected during the session.
+    pub fn alloc(&mut self, num_lookups: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        if (num_lookups as u64) > self.version_step.max_advances() {
+            return Err(Error::TooManyLookupsForVersionChain);
+        }
+        self.num_lookups = num_lookups;
+        // VOLE correlations:
+        //   per lookup:        l_ver
+        //   per teardown read: l_ver
+        let vole_count = (num_lookups + self.set_size) * self.l_ver;
+        self.vole.alloc(vole_count).map_err(Error::Vole)?;
+
+        // Permutation vectors:
+        //   writes = setup + lookups
+        //   reads  = teardown (set_size) + lookups
+        self.perm
+            .alloc(self.set_size + num_lookups)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        // Pre-size the reads/writes logs to their final capacities
+        // so the hot path is push-only.
+        self.reads.reserve_exact(self.set_size + num_lookups);
+        self.writes.reserve_exact(self.set_size + num_lookups);
+
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Initialize the set with public cleartext elements.
+    pub fn setup(&mut self, members: Vec<Bundle<Strat::S>>) -> Result<(), Error>
+    where
+        Strat::S: Ord + Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        let wired = members.into_iter().map(Wire::constant).collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Initialize the set with pre-authenticated element wires.
+    pub fn setup_with_wires(&mut self, members: Vec<Wire<Strat::S, F>>) -> Result<(), Error>
+    where
+        Strat::S: Ord + Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if members.len() != self.set_size {
+            return Err(Error::SetSizeMismatch {
+                expected: self.set_size,
+                got: members.len(),
+            });
+        }
+
+        let anchor_input = self.version_step.anchor();
+
+        for (idx, member) in members.into_iter().enumerate() {
+            let key_cleartext = member.value().clone();
+            let key = (&member).into();
+
+            self.index_of.insert(key_cleartext, idx as u32);
+            self.setup_wires.push(key);
+            self.shadow.push(ShadowEntry {
+                version: anchor_input.value().clone(),
+            });
+
+            self.writes.push(Record {
+                key,
+                version: (&anchor_input).into(),
+            });
+        }
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Prove that `element` is a member of the set.
+    pub fn lookup(&mut self, element: Wire<Strat::S, F>) -> Result<(), Error>
+    where
+        Strat::S: Ord + Clone,
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if self.lookups_performed >= self.num_lookups {
+            return Err(Error::LookupCountExceeded);
+        }
+        self.lookups_performed += 1;
+
+        let idx = *self.index_of.get(element.value()).ok_or(Error::NotInSet)? as usize;
+        let version_cleartext = self.shadow[idx].version.clone();
+
+        let mut ver_fut = self
+            .vole
+            .queue_recv_vole(&version_cleartext)
+            .map_err(Error::Vole)?;
+        let adjustment = self.vole.adjust().map_err(Error::Vole)?;
+        self.transcript
+            .update(&bcs::to_bytes(&adjustment).expect("serialize"));
+        self.pending_adjustments.push(adjustment);
+
+        let ver_macs: Vec<F> = ver_fut
+            .try_recv()
+            .map_err(|_| Error::VoleFutureUnresolved)?
+            .ok_or(Error::VoleFutureUnresolved)?
+            .macs;
+
+        let version_input = Wire::new(version_cleartext, ver_macs.into());
+
+        let next_version_input = self.version_step.next(&version_input);
+
+        self.shadow[idx].version = next_version_input.value().clone();
+
+        let key = (&element).into();
+
+        self.reads.push(Record {
+            key,
+            version: (&version_input).into(),
+        });
+        self.writes.push(Record {
+            key,
+            version: (&next_version_input).into(),
+        });
+
+        Ok(())
+    }
+
+    /// Pre-`teardown` setup.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee against a malicious prover no
+    /// longer holds.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<TeardownPrepare<F, B::Preparation>, Error>
+    where
+        Strat::S: Ord + Clone,
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+
+        let teardown_data: Vec<(PackedProverWire<F>, Bundle<Strat::S>)> = self
+            .setup_wires
+            .iter()
+            .zip(self.shadow.iter())
+            .map(|(key, entry)| (*key, entry.version.clone()))
+            .collect();
+
+        // Queue for derandomization.
+        let mut version_futs = Vec::with_capacity(teardown_data.len());
+        for (_, ver_cleartext) in &teardown_data {
+            let fut = self
+                .vole
+                .queue_recv_vole(ver_cleartext)
+                .map_err(Error::Vole)?;
+            version_futs.push(fut);
+        }
+        let teardown_adjustment = self.vole.adjust().map_err(Error::Vole)?;
+        self.transcript
+            .update(&bcs::to_bytes(&teardown_adjustment).expect("serialize"));
+        self.pending_adjustments.push(teardown_adjustment);
+
+        for ((key_wire, ver_cleartext), mut fut) in teardown_data.into_iter().zip(version_futs) {
+            // Compute the next-version input wire.
+            let ver_macs: Vec<F> = fut
+                .try_recv()
+                .map_err(|_| Error::VoleFutureUnresolved)?
+                .ok_or(Error::VoleFutureUnresolved)?
+                .macs;
+            if ver_macs.len() != self.l_ver {
+                return Err(Error::LengthMismatch);
+            }
+            let version_input = Wire::new(ver_cleartext, ver_macs.into());
+
+            self.reads.push(Record {
+                key: key_wire,
+                version: (&version_input).into(),
+            });
+        }
+
+        // Convert records to (Vec<Vec<F>>, Vec<Vec<F>>) shape
+        // expected by perm-proof's prepare.
+        let (read_values, read_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.reads.iter().map(|r| r.to_parts()).unzip();
+        let (write_values, write_macs): (Vec<Vec<F>>, Vec<Vec<F>>) =
+            self.writes.iter().map(|r| r.to_parts()).unzip();
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        let preparation = self
+            .perm
+            .prepare(
+                transcript,
+                (&read_values, &read_macs),
+                (&write_values, &write_macs),
+            )
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(TeardownPrepare {
+            adjustments: std::mem::take(&mut self.pending_adjustments),
+            preparation,
+        })
+    }
+
+    /// Tear down the instance, returning the message to be sent to the
+    /// verifier.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee against a malicious prover no
+    /// longer holds.
+    pub fn teardown(
+        self,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<TeardownMsg<F, B::BackendProof>, Error>
+    where
+        F: Copy + Serialize,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        let proof = self
+            .perm
+            .prove(transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+        Ok(TeardownMsg { proof })
+    }
+}
+
+impl<F: Copy> Record<PackedProverWire<F>> {
+    /// Decompose into `(values, macs)` slot vectors in `key, version`
+    /// order.
+    fn to_parts(&self) -> (Vec<F>, Vec<F>) {
+        (
+            vec![self.key.value, self.version.value],
+            vec![self.key.mac, self.version.mac],
+        )
+    }
+}
+
+/// Per-element shadow entry — cleartext mirror of current version.
+struct ShadowEntry<S> {
+    /// Cleartext version, advanced on each successful lookup.
+    version: Bundle<S>,
+}
+
+/// Lifecycle state for the [`Prover`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized state.
+    Initialized,
+    /// Allocated state.
+    Allocated,
+    /// Setup state.
+    Setup,
+    /// Teardown-prepared state.
+    TeardownPrepared,
+}
+
+/// Set prover error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The looked-up element is not a registered set member.
+    #[error("element not in set")]
+    NotInSet,
+
+    /// More lookups than declared at `alloc` were attempted.
+    #[error("lookup count exceeded num_lookups")]
+    LookupCountExceeded,
+
+    /// `num_lookups` exceeds the version chain's cycle length.
+    #[error("num_lookups exceeds version-chain cycle length")]
+    TooManyLookupsForVersionChain,
+
+    /// `set_size` does not fit in `u32`.
+    #[error("set_size exceeds u32::MAX")]
+    SetSizeTooLarge,
+
+    /// A wire's length does not match the configured one.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// `members.len()` did not match the `set_size` declared at
+    /// construction.
+    #[error("set size mismatch: expected {expected}, got {got}")]
+    SetSizeMismatch {
+        /// `set_size` from the constructor.
+        expected: usize,
+        /// `members.len()` actually passed to setup.
+        got: usize,
+    },
+
+    /// A method was called while the prover was in the wrong
+    /// lifecycle state.
+    #[error("prover method called from wrong state: {0:?}")]
+    WrongState(State),
+
+    /// Underlying VOLE receiver error.
+    #[error("VOLE error: {0}")]
+    Vole(#[source] DerandVOLEReceiverError),
+
+    /// A queued VOLE future failed to resolve.
+    #[error("VOLE future failed to resolve after adjust")]
+    VoleFutureUnresolved,
+
+    /// Permutation-proof error during teardown.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use crate::{
+        strategy::{Char2Strategy, version::MultiplicativeStep},
+        test_utils::{bits, prover_wire},
+    };
+    use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+    use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair;
+    use mpz_vole_core::ideal::rvole::ideal_rvole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// The cleartext set model: `lookup` admits members and rejects
+    /// non-members (`NotInSet`), and each admitted lookup advances
+    /// exactly that element's version chain by one step while leaving
+    /// other elements untouched.
+    #[test]
+    fn lookup_membership_and_version_chain() {
+        const N_VER: usize = 8;
+        const FAN_IN: usize = 8;
+
+        // Members live at slots 0..4, keyed by value.
+        let members = [0b0000_0001u64, 0b0000_0010, 0b0000_0011, 0b0000_0100];
+        // Lookup script (by value): slot 1 twice, slots 2 and 3 once,
+        // slot 0 never.
+        let lookups = [members[1], members[2], members[1], members[3]];
+        let non_member = 0b1111_1111u64;
+
+        let set_size = members.len();
+        // One extra slot for the trailing non-member probe.
+        let num_lookups = lookups.len() + 1;
+
+        let mut rng = StdRng::seed_from_u64(0x5e7);
+        let delta: Gf2_64 = rng.random();
+
+        // Single derand VOLE pool — mirrors `alloc`'s sizing.
+        let vole_count = (num_lookups + set_size) * N_VER;
+        let (_, mut r) = ideal_rvole::<Gf2, Gf2_64>(rng.random(), delta);
+        r.pregenerate(vole_count, delta).expect("pregen");
+        let vole = DerandVOLEReceiver::new(r);
+
+        // Perm-proof prover; verifier half dropped (prover-only test).
+        let (perm, _) =
+            build_ideal_perm_proof_pair(&mut rng, delta, set_size + num_lookups, FAN_IN);
+
+        let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+            set_size,
+            MultiplicativeStep::new(N_VER).expect("step"),
+            vole,
+            perm,
+        )
+        .expect("prover");
+        prover.alloc(num_lookups).expect("alloc");
+        prover
+            .setup(
+                members
+                    .iter()
+                    .map(|&v| Bundle::from(bits(v, N_VER)))
+                    .collect(),
+            )
+            .expect("setup");
+
+        // Members are admitted.
+        for &v in &lookups {
+            prover
+                .lookup(prover_wire(bits(v, N_VER)))
+                .expect("member lookup");
+        }
+        // A non-member is rejected (consumes a slot, touches no shadow).
+        match prover.lookup(prover_wire(bits(non_member, N_VER))) {
+            Err(Error::NotInSet) => {}
+            other => panic!("non-member must be rejected with NotInSet, got {other:?}"),
+        }
+
+        // Expected version chain: `versions[k]` is the anchor advanced
+        // `k` steps, computed with a parallel step instance.
+        let mut step = MultiplicativeStep::new(N_VER).expect("step");
+        let anchor: crate::wire::ProverWire<Gf2, Gf2_64> = step.anchor();
+        let mut versions = vec![anchor.value().clone()];
+        let mut cur = anchor;
+        for _ in 0..lookups.len() {
+            let next = step.next(&cur);
+            versions.push(next.value().clone());
+            cur = next;
+        }
+
+        // Each element's version advanced once per lookup of it.
+        let mut counts = vec![0usize; set_size];
+        for &v in &lookups {
+            let slot = members.iter().position(|&m| m == v).expect("member");
+            counts[slot] += 1;
+        }
+        for slot in 0..set_size {
+            assert_eq!(
+                prover.shadow[slot].version.as_slice(),
+                versions[counts[slot]].as_slice(),
+                "slot {slot} version chain mismatch after {} lookup(s)",
+                counts[slot],
+            );
+        }
+    }
+}

--- a/crates/two-shuffles/src/set/verifier.rs
+++ b/crates/two-shuffles/src/set/verifier.rs
@@ -1,0 +1,387 @@
+//! Verifier side of the Set membership protocol.
+
+use mpz_fields::Field;
+use mpz_perm_proof_core::{
+    Verifier as PermVerifier, backend::VerifierBackend as PermVerifierBackend,
+};
+use mpz_poly_proof_core::ExtensionField;
+use mpz_vole_core::{DerandVOLESender, DerandVOLESenderError, RVOLESender, VoleAdjustment};
+use serde::Serialize;
+
+use super::{Record, TeardownMsg, TeardownPrepare};
+use crate::{
+    strategy::{
+        VersionStrategy,
+        version::{VerifierVersionStep, VersionStep},
+    },
+    wire::{Bundle, PackedVerifierWire as PackedWire, VerifierWire as Wire},
+};
+
+/// Verifier for the set membership protocol.
+pub struct Verifier<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Wire length for the version chain.
+    l_ver: usize,
+    /// Number of distinct elements in the set.
+    set_size: usize,
+    /// Total number of lookups expected during this session.
+    num_lookups: usize,
+    /// Running lookup counter, bounded by `num_lookups`.
+    lookups_performed: usize,
+    /// Lifecycle state.
+    state: State,
+
+    /// Global correlation key.
+    delta: F,
+
+    /// Per-element version-chain step rule.
+    version_step: Strat::VersionStep,
+
+    /// Derandomized VOLE sender.
+    vole: DerandVOLESender<RV, F>,
+
+    /// Permutation protocol verifier.
+    perm: PermVerifier<F, F, B>,
+
+    /// Setup-time key wires, indexed by slot index. Read at teardown.
+    setup_wires: Vec<PackedWire<F>>,
+
+    /// Per-lookup key wires.
+    pending_lookups: Vec<PackedWire<F>>,
+
+    /// Fiat-Shamir transcript private to this protocol. Absorbs wire
+    /// commitments emitted directly here; embedded sub-protocols own
+    /// their own internal transcripts and fold independently.
+    transcript: blake3::Hasher,
+}
+
+impl<RV, F, B, Strat> Verifier<RV, F, B, Strat>
+where
+    Strat: VersionStrategy<F>,
+    F: ExtensionField<Strat::S> + ExtensionField<F>,
+    RV: RVOLESender<F>,
+    F: Field,
+    B: PermVerifierBackend<F, F>,
+{
+    /// Construct an empty Set verifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `set_size` — number of distinct members the set will hold.
+    /// * `version_step` — version-chain step strategy.
+    /// * `rvole` — random VOLE sender.
+    /// * `perm` — permutation protocol verifier.
+    pub fn new(
+        set_size: usize,
+        version_step: Strat::VersionStep,
+        rvole: RV,
+        perm: PermVerifier<F, F, B>,
+    ) -> Result<Self, Error> {
+        if set_size > u32::MAX as usize {
+            return Err(Error::SetSizeTooLarge);
+        }
+        let l_ver = version_step.len();
+        let k = <F as ExtensionField<Strat::S>>::MONOMIAL_BASIS.len();
+        if l_ver == 0 || l_ver > k {
+            return Err(Error::LengthMismatch);
+        }
+        let delta = rvole.delta();
+        Ok(Self {
+            l_ver,
+            set_size,
+            num_lookups: 0,
+            lookups_performed: 0,
+            state: State::Initialized,
+            delta,
+            version_step,
+            vole: DerandVOLESender::new(rvole),
+            perm,
+            setup_wires: Vec::with_capacity(set_size),
+            pending_lookups: Vec::new(),
+            transcript: blake3::Hasher::new(),
+        })
+    }
+
+    /// Allocate VOLE correlations and perm-proof state for
+    /// `num_lookups` lookups; setup-side allocation is sized from
+    /// `set_size` stored at construction.
+    pub fn alloc(&mut self, num_lookups: usize) -> Result<(), Error> {
+        if self.state != State::Initialized {
+            return Err(Error::WrongState(self.state));
+        }
+        if (num_lookups as u64) > self.version_step.max_advances() {
+            return Err(Error::TooManyLookupsForVersionChain);
+        }
+        self.num_lookups = num_lookups;
+        let vole_count = (num_lookups + self.set_size) * self.l_ver;
+        self.vole.alloc(vole_count).map_err(Error::DerandVole)?;
+        self.perm
+            .alloc(self.set_size + num_lookups)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.state = State::Allocated;
+        Ok(())
+    }
+
+    /// Initialize the set with public cleartext members.
+    pub fn setup(&mut self, members: Vec<Bundle<Strat::S>>) -> Result<(), Error>
+    where
+        Strat::S: Ord + Clone,
+    {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        let wired: Vec<_> = members
+            .into_iter()
+            .map(|k| Wire::constant(&k, self.delta))
+            .collect();
+        self.setup_with_wires(wired)
+    }
+
+    /// Initialize the set with pre-authenticated K wires. Position
+    /// `i` of `content` is the K-wire for slot `i`.
+    pub fn setup_with_wires(&mut self, content: Vec<Wire<F>>) -> Result<(), Error> {
+        if self.state != State::Allocated {
+            return Err(Error::WrongState(self.state));
+        }
+        if content.len() != self.set_size {
+            return Err(Error::SetSizeMismatch {
+                expected: self.set_size,
+                got: content.len(),
+            });
+        }
+
+        for key_wire in content {
+            self.setup_wires.push(key_wire.pack::<Strat::S>());
+        }
+
+        self.state = State::Setup;
+        Ok(())
+    }
+
+    /// Record a membership claim for `element`.
+    pub fn lookup(&mut self, element: Wire<F>) -> Result<(), Error> {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        if self.lookups_performed >= self.num_lookups {
+            return Err(Error::LookupCountExceeded);
+        }
+        self.lookups_performed += 1;
+        let key_packed = element.pack::<Strat::S>();
+        self.pending_lookups.push(key_packed);
+        Ok(())
+    }
+
+    /// Pre-`teardown` processing. Consumes the prover's
+    /// [`TeardownPrepare`] message.
+    ///
+    /// `transcript` is the caller's transcript. This method mixes
+    /// the same adjustment bytes into it that
+    /// [`Prover::teardown_prepare`](super::prover::Prover::teardown_prepare)
+    /// mixed into its own, so a session that threads one transcript
+    /// through every external step stays in sync across the prover /
+    /// verifier divide.
+    pub fn teardown_prepare(
+        &mut self,
+        transcript: &mut blake3::Hasher,
+        msg: TeardownPrepare<F, B::Preparation>,
+    ) -> Result<(), Error>
+    where
+        Strat::S: Ord + Clone,
+        F: Copy + Serialize,
+    {
+        if self.state != State::Setup {
+            return Err(Error::WrongState(self.state));
+        }
+        let num_lookups = self.pending_lookups.len();
+        let expected_adjs = num_lookups + 1;
+        if msg.adjustments.len() != expected_adjs {
+            return Err(Error::LengthMismatch);
+        }
+
+        let mut reads: Vec<Record<PackedWire<F>>> = Vec::with_capacity(num_lookups + self.set_size);
+        let mut writes: Vec<Record<PackedWire<F>>> =
+            Vec::with_capacity(num_lookups + self.set_size);
+
+        // Seed `writes` with the setup-time records (one per slot,
+        // version = anchor).
+        let anchor = self.version_step.anchor(self.delta).pack::<Strat::S>();
+        for &key in &self.setup_wires {
+            writes.push(Record {
+                key,
+                version: anchor,
+            });
+        }
+
+        for i in 0..num_lookups {
+            let adj = &msg.adjustments[i];
+            self.transcript
+                .update(&bcs::to_bytes(adj).expect("serialize"));
+            let key_packed = self.pending_lookups[i];
+            self.process_lookup_adjustment(&mut reads, &mut writes, adj, key_packed)?;
+        }
+
+        // Process the teardown adjustment.
+        let teardown_adj = &msg.adjustments[num_lookups];
+        self.transcript
+            .update(&bcs::to_bytes(teardown_adj).expect("serialize"));
+        if teardown_adj.diffs.len() != self.set_size * self.l_ver {
+            return Err(Error::LengthMismatch);
+        }
+        // Per-element derand pulls — one per `queue_recv_vole` chunk
+        // the prover queued in its own teardown loop — so the RVOLE
+        // sample pairing stays aligned with the prover.
+        for i in 0..self.set_size {
+            let key = self.setup_wires[i];
+            let sub = VoleAdjustment {
+                diffs: teardown_adj.diffs[i * self.l_ver..(i + 1) * self.l_ver].to_vec(),
+            };
+            let version_keys = self.vole.adjust(&sub).map_err(Error::DerandVole)?;
+            reads.push(Record {
+                key,
+                version: PackedWire::pack::<Strat::S>(&version_keys),
+            });
+        }
+
+        // Fold the protocol-internal transcript.
+        transcript.update(self.transcript.finalize().as_bytes());
+
+        let read_keys: Vec<Vec<F>> = reads.iter().map(|r| r.to_keys()).collect();
+        let write_keys: Vec<Vec<F>> = writes.iter().map(|r| r.to_keys()).collect();
+
+        self.perm
+            .prepare(transcript, &read_keys, &write_keys, msg.preparation)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+
+        self.state = State::TeardownPrepared;
+        Ok(())
+    }
+
+    /// Tear down the instance, consuming the tear down message from the prover.
+    ///
+    /// `transcript` is the caller's transcript. The caller is
+    /// responsible for having already absorbed every wire that was
+    /// fed as an input to [`setup_with_wires`](Self::setup_with_wires) or to
+    /// [`lookup`](Self::lookup) before this call — otherwise the
+    /// protocol's soundness guarantee against a malicious prover no
+    /// longer holds.
+    pub fn teardown(
+        self,
+        msg: TeardownMsg<F, B::BackendProof>,
+        transcript: &mut blake3::Hasher,
+    ) -> Result<(), Error>
+    where
+        F: Copy + Serialize,
+        B::BackendProof: Serialize,
+    {
+        if self.state != State::TeardownPrepared {
+            return Err(Error::WrongState(self.state));
+        }
+        self.perm
+            .verify(msg.proof, transcript)
+            .map_err(|e| Error::PermProof(Box::new(e)))?;
+        Ok(())
+    }
+
+    /// Consume one lookup adjustment: derive version wires,
+    /// advance to next version, and append the corresponding read/write
+    /// records.
+    fn process_lookup_adjustment(
+        &mut self,
+        reads: &mut Vec<Record<PackedWire<F>>>,
+        writes: &mut Vec<Record<PackedWire<F>>>,
+        adj: &VoleAdjustment<F>,
+        key_packed: PackedWire<F>,
+    ) -> Result<(), Error> {
+        if adj.diffs.len() != self.l_ver {
+            return Err(Error::LengthMismatch);
+        }
+
+        let version_keys = self.vole.adjust(adj).map_err(Error::DerandVole)?;
+        let version: Wire<F> = version_keys.into();
+        let next_version = self.version_step.next(&version, self.delta);
+
+        let version = PackedWire::pack::<Strat::S>(&version.key);
+        let next_version = PackedWire::pack::<Strat::S>(&next_version.key);
+
+        reads.push(Record {
+            key: key_packed,
+            version,
+        });
+        writes.push(Record {
+            key: key_packed,
+            version: next_version,
+        });
+
+        Ok(())
+    }
+}
+
+impl<F: Copy> Record<PackedWire<F>> {
+    /// Extract the per-slot keys in `key, version` order.
+    fn to_keys(&self) -> Vec<F> {
+        vec![self.key.key, self.version.key]
+    }
+}
+
+/// Lifecycle state for the [`Verifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Initialized state.
+    Initialized,
+    /// Allocated state.
+    Allocated,
+    /// Setup state.
+    Setup,
+    /// Teardown-prepared state.
+    TeardownPrepared,
+}
+
+/// Set verifier error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A wire's length does not match the configured one.
+    #[error("bundle length mismatch")]
+    LengthMismatch,
+
+    /// More lookups than declared at `alloc` were attempted.
+    #[error("lookup count exceeded num_lookups")]
+    LookupCountExceeded,
+
+    /// `num_lookups` exceeds the version chain's cycle length.
+    #[error("num_lookups exceeds version-chain cycle length")]
+    TooManyLookupsForVersionChain,
+
+    /// `set_size` does not fit in `u32`.
+    #[error("set_size exceeds u32::MAX")]
+    SetSizeTooLarge,
+
+    /// `members.len()` did not match the `set_size` declared at
+    /// construction.
+    #[error("set size mismatch: expected {expected}, got {got}")]
+    SetSizeMismatch {
+        /// `set_size` from the constructor.
+        expected: usize,
+        /// `members.len()` actually passed to setup.
+        got: usize,
+    },
+
+    /// A method was called in the wrong lifecycle state.
+    #[error("wrong verifier state: {0:?}")]
+    WrongState(State),
+
+    /// Derandomized VOLE sender error.
+    #[error("derand VOLE error: {0}")]
+    DerandVole(#[source] DerandVOLESenderError),
+
+    /// Permutation-proof error.
+    #[error("permutation-proof error: {0}")]
+    PermProof(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+}

--- a/crates/two-shuffles/src/strategy.rs
+++ b/crates/two-shuffles/src/strategy.rs
@@ -1,0 +1,318 @@
+//! Field-strategy traits.
+
+use std::marker::PhantomData;
+
+use itybity::{FromBitIterator, ToBits};
+use mpz_fields::{Field, gf2::Gf2};
+use mpz_poly_proof_core::ExtensionField;
+
+pub mod version;
+
+use version::{AdditiveStep, MultiplicativeStep, ProverVersionStep, VerifierVersionStep};
+
+// ---------------------------------------------------------------------------
+// Field-property markers
+// ---------------------------------------------------------------------------
+/// Marker: this field has characteristic 2 (`1 + 1 = 0`).
+pub trait Char2 {}
+
+impl Char2 for mpz_fields::gf2_64::Gf2_64 {}
+impl Char2 for mpz_fields::gf2_128::Gf2_128 {}
+
+/// Marker: in this field, the `+1` chain produces distinct values
+/// and field `+`/`−` coincide with integer arithmetic over the
+/// protocol's range `0..=T`.
+pub trait IntegerLike {}
+
+// ---------------------------------------------------------------------------
+// Trait hierarchy
+// ---------------------------------------------------------------------------
+
+/// Base layer: subfield element type + wire-length sizing.
+///
+/// Every wire in any protocol is a [`Bundle<S>`](crate::Bundle); this
+/// trait pins the `S` and provides the conversion from a user-facing
+/// "number of distinct values" to the corresponding wire length.
+pub trait FieldStrategy<F: Field> {
+    /// Subfield element type used for cleartext slots.
+    type S: Field;
+
+    /// Compute the wire length needed to encode `n` distinct values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n < 2` (encoding requires at least two distinct
+    /// values), or if `n`'s required wire length exceeds `F`'s
+    /// extension degree over [`Self::S`] (the bundle would not fit
+    /// in a single `F` element).
+    fn wire_length_for(n: usize) -> usize;
+
+    /// Compute the wire length needed to encode a value domain of
+    /// `value_bits` bits (i.e. `2^value_bits` distinct values).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value_bits == 0` (encoding requires at least two
+    /// distinct values), or if the required wire length exceeds `F`'s
+    /// capacity.
+    fn wire_length_for_log2(value_bits: usize) -> usize;
+
+    /// Convert a bundle to its integer index.
+    ///
+    /// The caller is responsible for passing a bundle that the
+    /// encoding can map to a valid index. Inputs outside the
+    /// encoding's representable range produce an unspecified `u32`;
+    /// no representability check is performed.
+    fn bundle_to_index(bundle: &[Self::S]) -> u32;
+
+    /// Produce the cleartext bundle that encodes `idx`. `length` is
+    /// the wire length (slot count) of the encoding.
+    fn index_to_bundle(idx: u32, length: usize) -> Vec<Self::S>;
+}
+
+/// Per-key version-chain step strategy.
+///
+/// The protocols built on this trait attach a *version counter* to
+/// every key and advance it by one step on every access. This trait
+/// pins the rule for what "one step" means.
+pub trait VersionStrategy<F: Field>: FieldStrategy<F>
+where
+    F: ExtensionField<Self::S>,
+{
+    /// The rule used to advance the per-key version counter on
+    /// every access.
+    type VersionStep: ProverVersionStep<Self::S, F> + VerifierVersionStep<Self::S, F>;
+}
+
+/// Strategy for char-2 extension fields with `Gf2` as the subfield
+/// element.
+pub struct Char2Strategy<F>(PhantomData<F>);
+
+impl<F> FieldStrategy<F> for Char2Strategy<F>
+where
+    F: Field + Char2,
+{
+    type S = Gf2;
+
+    fn wire_length_for(n: usize) -> usize {
+        // Gf2-bundle encoding: ceil(log2(n)) Gf2 slots represent `n`
+        // distinct values.
+        assert!(
+            n >= 2,
+            "Char2Strategy: n={n} too small (need at least 2 distinct values)"
+        );
+        let bits = n.next_power_of_two().trailing_zeros() as usize;
+        assert!(
+            bits <= F::BIT_SIZE,
+            "Char2Strategy: n={n} exceeds field capacity 2^{}",
+            F::BIT_SIZE,
+        );
+        bits
+    }
+
+    fn wire_length_for_log2(value_bits: usize) -> usize {
+        // Gf2-bundle encoding: one Gf2 slot per bit.
+        assert!(
+            value_bits >= 1,
+            "Char2Strategy: value_bits must be ≥ 1 (need at least 2 distinct values)"
+        );
+        assert!(
+            value_bits <= F::BIT_SIZE,
+            "Char2Strategy: value_bits={value_bits} exceeds field capacity 2^{}",
+            F::BIT_SIZE,
+        );
+        value_bits
+    }
+
+    // LSB-first bit pack: bit `i` of the bundle becomes bit `i` of
+    // the returned `u32`.
+    #[inline]
+    fn bundle_to_index(bundle: &[Gf2]) -> u32 {
+        debug_assert!(bundle.len() <= 32, "wire length exceeds u32");
+        u32::from_lsb0_iter(bundle.iter_lsb0())
+    }
+
+    /// LSB-first bit decomposition: bit `i` of `idx` becomes slot `i`
+    /// of the returned bundle.
+    #[inline]
+    fn index_to_bundle(idx: u32, length: usize) -> Vec<Gf2> {
+        debug_assert!(length <= 32, "wire length exceeds u32");
+        Vec::<Gf2>::from_lsb0_iter(idx.iter_lsb0().take(length))
+    }
+}
+
+impl<F> VersionStrategy<F> for Char2Strategy<F>
+where
+    F: Field + Char2 + ExtensionField<Gf2>,
+{
+    type VersionStep = MultiplicativeStep;
+}
+
+/// Strategy for prime fields with single-wire value encoding.
+pub struct PrimeFieldStrategy<F>(PhantomData<F>);
+
+impl<F> FieldStrategy<F> for PrimeFieldStrategy<F>
+where
+    F: Field + IntegerLike,
+{
+    type S = F;
+
+    fn wire_length_for(n: usize) -> usize {
+        // Single-wire encoding: one field element holds any value
+        // up to `|F|`. Wire length is always 1 if `n` fits.
+        assert!(
+            n >= 2,
+            "PrimeFieldStrategy: n={n} too small (need at least 2 distinct values)"
+        );
+        // `n > 2^BIT_SIZE` exceeds the field. Skip the shift if the
+        // bound is unreachable on `usize` (e.g. P256: BIT_SIZE = 256).
+        if F::BIT_SIZE < usize::BITS as usize {
+            assert!(
+                n <= (1usize << F::BIT_SIZE),
+                "PrimeFieldStrategy: n={n} exceeds field capacity 2^{}",
+                F::BIT_SIZE,
+            );
+        }
+        1
+    }
+
+    fn wire_length_for_log2(value_bits: usize) -> usize {
+        // Single-wire encoding: one field element holds the value.
+        assert!(
+            value_bits >= 1,
+            "PrimeFieldStrategy: value_bits must be ≥ 1 (need at least 2 distinct values)"
+        );
+        assert!(
+            value_bits <= F::BIT_SIZE,
+            "PrimeFieldStrategy: value_bits={value_bits} exceeds field capacity 2^{}",
+            F::BIT_SIZE,
+        );
+        1
+    }
+
+    // Take the low 32 bits of the single field element's
+    // little-endian byte representation.
+    #[inline]
+    fn bundle_to_index(bits: &[F]) -> u32 {
+        debug_assert_eq!(bits.len(), 1, "PrimeFieldStrategy wire length is 1");
+        let bytes = bits[0].to_le_bytes();
+        let (head, _) = bytes.split_at(std::mem::size_of::<u32>());
+        u32::from_le_bytes(head.try_into().expect("4 bytes or less"))
+    }
+
+    #[inline]
+    fn index_to_bundle(idx: u32, length: usize) -> Vec<F> {
+        debug_assert_eq!(length, 1, "PrimeFieldStrategy wire length is 1");
+        let mut buf = hybrid_array::Array::<u8, F::ByteSize>::default();
+        buf.as_mut_slice()[..4].copy_from_slice(&idx.to_le_bytes());
+        let f = F::try_from(buf).expect("zero-padded u32 fits any prime field");
+        vec![f]
+    }
+}
+
+impl<F> VersionStrategy<F> for PrimeFieldStrategy<F>
+where
+    F: ExtensionField<F> + IntegerLike,
+{
+    type VersionStep = AdditiveStep;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpz_fields::{gf2_64::Gf2_64, p256::P256};
+
+    #[test]
+    fn char2_wire_length_for_table() {
+        // ceil(log2(n)) for n in {2..=16, plus a few boundaries above}.
+        let cases = [
+            (2usize, 1usize),
+            (3, 2),
+            (4, 2),
+            (5, 3),
+            (7, 3),
+            (8, 3),
+            (9, 4),
+            (16, 4),
+            (17, 5),
+            (255, 8),
+            (256, 8),
+            (257, 9),
+            (1024, 10),
+            (1025, 11),
+        ];
+        for (n, expected) in cases {
+            let got = Char2Strategy::<Gf2_64>::wire_length_for(n);
+            assert_eq!(got, expected, "Char2 wire_length_for({n}) mismatch");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "too small")]
+    fn char2_wire_length_for_panics_on_n_zero() {
+        let _ = Char2Strategy::<Gf2_64>::wire_length_for(0);
+    }
+
+    #[test]
+    fn char2_wire_length_for_log2_is_identity() {
+        for value_bits in 1..=Gf2_64::BIT_SIZE {
+            assert_eq!(
+                Char2Strategy::<Gf2_64>::wire_length_for_log2(value_bits),
+                value_bits,
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "value_bits must be ≥ 1")]
+    fn char2_wire_length_for_log2_panics_on_zero() {
+        let _ = Char2Strategy::<Gf2_64>::wire_length_for_log2(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds field capacity")]
+    fn char2_wire_length_for_log2_panics_over_capacity() {
+        let _ = Char2Strategy::<Gf2_64>::wire_length_for_log2(Gf2_64::BIT_SIZE + 1);
+    }
+
+    #[test]
+    fn prime_wire_length_for_log2_is_always_one() {
+        // P256 holds any value up to 256 bits in a single wire — a
+        // domain the cardinality-based API cannot even express.
+        for value_bits in [1usize, 8, 32, 64, 128, 256] {
+            assert_eq!(
+                PrimeFieldStrategy::<P256>::wire_length_for_log2(value_bits),
+                1
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "too small")]
+    fn char2_wire_length_for_panics_on_n_one() {
+        let _ = Char2Strategy::<Gf2_64>::wire_length_for(1);
+    }
+
+    #[test]
+    fn prime_wire_length_for_is_always_one() {
+        // Single-wire encoding: any `n >= 2` that fits in the field
+        // produces wire length 1. P256 has BIT_SIZE = 256, so the
+        // capacity assertion is unreachable on `usize`.
+        for &n in &[2usize, 3, 100, 1024, usize::MAX] {
+            let got = PrimeFieldStrategy::<P256>::wire_length_for(n);
+            assert_eq!(got, 1, "PrimeField wire_length_for({n}) ≠ 1");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "too small")]
+    fn prime_wire_length_for_panics_on_n_zero() {
+        let _ = PrimeFieldStrategy::<P256>::wire_length_for(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "too small")]
+    fn prime_wire_length_for_panics_on_n_one() {
+        let _ = PrimeFieldStrategy::<P256>::wire_length_for(1);
+    }
+}

--- a/crates/two-shuffles/src/strategy/version.rs
+++ b/crates/two-shuffles/src/strategy/version.rs
@@ -1,0 +1,325 @@
+//! Version-chain step rules.
+//!
+//! Protocols that maintain a per-key version counter advance it by one
+//! step on every access. This
+//! module defines what "one step" means.
+
+use mpz_fields::{Field, gf2::Gf2};
+
+use super::{Char2, IntegerLike};
+use mpz_poly_proof_core::ExtensionField;
+
+use crate::{
+    gf2n::{GfMulMatrix, field_constants},
+    wire::{ProverWire, VerifierWire},
+};
+
+pub use crate::gf2n::UnsupportedDegree;
+
+// ---------------------------------------------------------------------------
+// Trait hierarchy
+// ---------------------------------------------------------------------------
+
+/// Common base: wire length of every version-chain wire under this
+/// strategy.
+pub trait VersionStep<S> {
+    /// Wire length of every version wire under this strategy.
+    fn len(&self) -> usize;
+
+    /// Maximum number of `next()` advances before the version chain
+    /// cycles back to the anchor. Callers must ensure that the
+    /// per-key access count never exceeds this — otherwise two
+    /// distinct lookups would commit to the same version slot,
+    /// breaking the protocol's soundness.
+    ///
+    /// Returned as `u64` so the bound stays representable on 32-bit
+    /// targets (where `usize::MAX < u64::MAX`).
+    fn max_advances(&self) -> u64;
+}
+
+/// Prover-side: advance the authenticated wire to the next version.
+pub trait ProverVersionStep<S, F>: VersionStep<S>
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Anchor wire — the public-constant initial version.
+    fn anchor(&self) -> ProverWire<S, F>;
+
+    /// Compute the next version wire from the current one.
+    fn next(&mut self, current: &ProverWire<S, F>) -> ProverWire<S, F>;
+}
+
+/// Verifier-side advance the authenticated wire to the next version.
+pub trait VerifierVersionStep<S, F>: VersionStep<S>
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    /// Anchor wire — the public-constant initial version.
+    fn anchor(&self, delta: F) -> VerifierWire<F>;
+
+    /// Compute the next version wire from the current one.
+    fn next(&mut self, current: &VerifierWire<F>, delta: F) -> VerifierWire<F>;
+}
+
+// ---------------------------------------------------------------------------
+// AdditiveStep
+// ---------------------------------------------------------------------------
+
+/// Additive version-chain step rule for length-1 wires.
+///
+/// The next version is `current + 1`. The MAC is unchanged because
+/// adding a public constant has zero MAC contribution.
+pub struct AdditiveStep;
+
+impl<S> VersionStep<S> for AdditiveStep
+where
+    S: Field + IntegerLike,
+{
+    fn len(&self) -> usize {
+        1
+    }
+
+    fn max_advances(&self) -> u64 {
+        // TODO: add `const ORDER` to the `Field` trait and use
+        // that here.
+        u32::MAX as u64
+    }
+}
+
+impl<S, F> ProverVersionStep<S, F> for AdditiveStep
+where
+    S: Field + IntegerLike,
+    F: ExtensionField<S>,
+{
+    fn anchor(&self) -> ProverWire<S, F> {
+        // Anchor at zero — the additive identity.
+        ProverWire::constant(S::zero())
+    }
+
+    fn next(&mut self, current: &ProverWire<S, F>) -> ProverWire<S, F> {
+        assert_eq!(current.len(), 1, "AdditiveStep operates on length-1 wires",);
+        ProverWire::new(
+            (current.value()[0] + S::one()).into(),
+            current.mac().clone(), // MAC unchanged for "+ public constant".
+        )
+    }
+}
+
+impl<S, F> VerifierVersionStep<S, F> for AdditiveStep
+where
+    S: Field + IntegerLike,
+    F: ExtensionField<S>,
+{
+    fn anchor(&self, delta: F) -> VerifierWire<F> {
+        // Anchor at zero — the additive identity.
+        VerifierWire::constant(&[S::zero()], delta)
+    }
+
+    fn next(&mut self, current: &VerifierWire<F>, delta: F) -> VerifierWire<F> {
+        assert_eq!(current.len(), 1, "AdditiveStep operates on length-1 wires",);
+        // Adding `+1` keeps the prover's MAC unchanged but shifts
+        // K by −Δ · 1.embed() = −Δ on the verifier side.
+        (current.key[0] - delta).into()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MultiplicativeStep
+// ---------------------------------------------------------------------------
+
+/// Multiplicative version-chain step rule for GF2 wires.
+///
+/// Treats `[Gf2; N]` as an element of `GF(2^N)` under a fixed primitive
+/// polynomial; the next version is `current · g` where `g` is the
+/// multiplicative generator.
+pub struct MultiplicativeStep {
+    /// Pre-computed `· g` matrix.
+    matrix: GfMulMatrix,
+    /// Order of `g` in `GF(2^N)`'s multiplicative group (`2^N − 1`).
+    group_order: u64,
+}
+
+impl MultiplicativeStep {
+    /// Construct a step rule sized to support at least `num_steps`
+    /// advances.
+    pub fn new(num_steps: usize) -> Result<Self, MulStepError> {
+        let n = smallest_degree_for(num_steps).ok_or(MulStepError::TooManySteps(num_steps))?;
+        let c = field_constants(n).expect("smallest_degree_for returns a supported degree");
+        Ok(Self {
+            matrix: GfMulMatrix::new(c.poly, c.generator, n),
+            group_order: c.group_order,
+        })
+    }
+
+    /// Bit pattern of `1 ∈ GF(2^N)` — the multiplicative identity.
+    fn anchor(&self) -> Vec<Gf2> {
+        let mut a = vec![Gf2::ZERO; self.matrix.len()];
+        a[0] = Gf2::ONE;
+        a
+    }
+}
+
+/// Smallest supported degree whose multiplicative group admits `num_steps`
+/// advances without cycling.
+fn smallest_degree_for(num_steps: usize) -> Option<usize> {
+    (8..=26).find(|&n| (1u64 << n) >= num_steps as u64 + 2)
+}
+
+/// Construction error for [`MultiplicativeStep`].
+#[derive(Debug, thiserror::Error)]
+pub enum MulStepError {
+    /// `num_steps` exceeds the largest supported version chain
+    /// (`2^26 − 2`).
+    #[error("num_steps {0} exceeds the largest supported version chain (2^26 - 2)")]
+    TooManySteps(usize),
+}
+
+impl VersionStep<Gf2> for MultiplicativeStep {
+    fn len(&self) -> usize {
+        self.matrix.len()
+    }
+
+    fn max_advances(&self) -> u64 {
+        self.group_order - 1
+    }
+}
+
+impl<F> ProverVersionStep<Gf2, F> for MultiplicativeStep
+where
+    F: Char2 + ExtensionField<Gf2>,
+{
+    fn anchor(&self) -> ProverWire<Gf2, F> {
+        ProverWire::constant(self.anchor())
+    }
+
+    fn next(&mut self, current: &ProverWire<Gf2, F>) -> ProverWire<Gf2, F> {
+        // Cleartext bits and MAC bundle both advance via the same
+        // `· g` linear map.
+        let next_value = self.matrix.apply(current.value());
+        let next_mac = self.matrix.apply_lifted(current.mac());
+        ProverWire::new(next_value.into(), next_mac.into())
+    }
+}
+
+impl<F> VerifierVersionStep<Gf2, F> for MultiplicativeStep
+where
+    F: Char2 + ExtensionField<Gf2>,
+{
+    fn anchor(&self, delta: F) -> VerifierWire<F> {
+        VerifierWire::constant(&self.anchor(), delta)
+    }
+
+    fn next(&mut self, current: &VerifierWire<F>, _delta: F) -> VerifierWire<F> {
+        // No Δ-adjustment needed (pure linear `· g`): key updates with
+        // the same matrix as MAC.
+        self.matrix.apply_lifted(&current.key).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        test_utils::{bits, pow_mod},
+        wire::Bundle,
+    };
+    use mpz_fields::gf2_64::Gf2_64;
+    use mpz_vole_core::test::assert_vole;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// The anchor is `1 ∈ GF(2^n)` (the multiplicative identity).
+    #[test]
+    fn mul_step_anchor_is_one() {
+        let step = MultiplicativeStep::new(50).expect("step");
+        let n = VersionStep::<Gf2>::len(&step);
+        let anchor = <MultiplicativeStep as ProverVersionStep<Gf2, Gf2_64>>::anchor(&step);
+        assert_eq!(anchor.value().as_slice(), bits(1, n).as_slice());
+    }
+
+    /// `new(num_steps)` picks the smallest field whose group admits
+    /// `num_steps` advances (`max_advances = 2^len − 2 >= num_steps`),
+    /// and rejects counts beyond the largest supported field.
+    #[test]
+    fn mul_step_sizes_to_num_steps() {
+        // Degree floor is 8 (group order 255 ⇒ max_advances 254).
+        let s = MultiplicativeStep::new(0).expect("step");
+        assert_eq!(VersionStep::<Gf2>::len(&s), 8);
+        assert_eq!(VersionStep::<Gf2>::max_advances(&s), (1u64 << 8) - 2);
+
+        // 254 still fits degree 8; 255 needs degree 9.
+        assert_eq!(
+            VersionStep::<Gf2>::len(&MultiplicativeStep::new(254).unwrap()),
+            8
+        );
+        assert_eq!(
+            VersionStep::<Gf2>::len(&MultiplicativeStep::new(255).unwrap()),
+            9
+        );
+
+        // Every result satisfies the cycle bound it was sized for.
+        for num_steps in [300usize, 5_000, 100_000] {
+            let s = MultiplicativeStep::new(num_steps).expect("step");
+            assert!(VersionStep::<Gf2>::max_advances(&s) >= num_steps as u64);
+        }
+
+        // Beyond the largest supported field (2^26 − 2) → error.
+        assert!(MultiplicativeStep::new((1 << 26) - 1).is_err());
+    }
+
+    /// Advancing the anchor `k` times yields `g^k` — the version chain
+    /// walks the multiplicative group.
+    #[test]
+    fn mul_step_next_tracks_g_powers() {
+        let mut step = MultiplicativeStep::new(50).expect("step");
+        let n = VersionStep::<Gf2>::len(&step);
+        let c = field_constants(n).expect("constants");
+
+        let mut cur = <MultiplicativeStep as ProverVersionStep<Gf2, Gf2_64>>::anchor(&step);
+        for k in 1..=50u64 {
+            cur = <MultiplicativeStep as ProverVersionStep<Gf2, Gf2_64>>::next(&mut step, &cur);
+            let expected = pow_mod(c.generator, k, c.poly, n);
+            assert_eq!(
+                cur.value().as_slice(),
+                bits(expected, n).as_slice(),
+                "g^{k}"
+            );
+        }
+    }
+
+    /// `next` preserves the IT-MAC relation.
+    #[test]
+    fn mul_step_next_preserves_itmac() {
+        let mut step = MultiplicativeStep::new(50).expect("step");
+        let n = VersionStep::<Gf2>::len(&step);
+        let c = field_constants(n).expect("constants");
+        let mut rng = StdRng::seed_from_u64(0x5715);
+        let delta: Gf2_64 = rng.random();
+
+        // An authenticated current version (a valid power, g^5).
+        let value = bits(pow_mod(c.generator, 5, c.poly, n), n);
+        let keys: Vec<Gf2_64> = (0..n).map(|_| rng.random()).collect();
+        let macs: Vec<Gf2_64> = value
+            .iter()
+            .zip(&keys)
+            .map(|(v, k)| *k + delta * <Gf2_64 as ExtensionField<Gf2>>::embed(*v))
+            .collect();
+
+        let p_cur = ProverWire::new(Bundle::new(value), Bundle::new(macs));
+        let v_cur = VerifierWire::new(Bundle::new(keys));
+
+        let p_next =
+            <MultiplicativeStep as ProverVersionStep<Gf2, Gf2_64>>::next(&mut step, &p_cur);
+        let v_next = <MultiplicativeStep as VerifierVersionStep<Gf2, Gf2_64>>::next(
+            &mut step, &v_cur, delta,
+        );
+
+        assert_vole(
+            delta,
+            v_next.key.as_slice(),
+            p_next.value().as_slice(),
+            p_next.mac().as_slice(),
+        );
+    }
+}

--- a/crates/two-shuffles/src/test_utils.rs
+++ b/crates/two-shuffles/src/test_utils.rs
@@ -1,0 +1,399 @@
+//! Test utilities shared across the end-to-end protocol tests in
+//! this crate.
+
+use itybity::{FromBitIterator, ToBits};
+use mpz_common::future::Output;
+use mpz_fields::{ExtensionField, Field, gf2::Gf2, gf2_64::Gf2_64};
+use mpz_vole_core::{
+    DerandVOLEReceiver, DerandVOLESender, RVOLEReceiver, RVOLESender, VOLEReceiver, VoleAdjustment,
+    ideal::{
+        rvole::{IdealRVOLEReceiver, IdealRVOLESender, ideal_rvole},
+        vole::{FlushMsg, ideal_vole},
+    },
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use rangeset::set::RangeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    gf2n::gf2n_mul_mod,
+    ram::mux_mul::{MuxMulProver, MuxMulVerifier},
+    strategy::{Char2Strategy, FieldStrategy, IntegerLike},
+    wire::{Bundle, ProverWire, VerifierWire},
+};
+
+// Test-only opt-in: `P256` is integer-like for protocol purposes, but
+// the production crate ships no prime-field strategy wired up, so this
+// marker lives here for the test harness. Drop once a production impl
+// exists.
+impl IntegerLike for mpz_fields::p256::P256 {}
+
+/// Commit one cleartext bundle via an ideal chosen-VOLE session and
+/// return the matching prover/verifier wires.
+pub fn commit_value<W, E>(
+    value: Vec<W>,
+    delta: E,
+    rng: &mut impl Rng,
+    transcript: &mut blake3::Hasher,
+) -> (ProverWire<W, E>, VerifierWire<E>)
+where
+    W: Field,
+    E: ExtensionField<W> + serde::Serialize,
+{
+    let width = value.len();
+    let seed: u64 = rng.random();
+
+    let (mut sender, mut receiver) = ideal_vole::<W, E>(seed, delta);
+    <_ as RVOLESender<E>>::alloc(&mut sender, width).expect("sender alloc");
+    <_ as VOLEReceiver<W, E>>::alloc(&mut receiver, width).expect("receiver alloc");
+
+    let mut fut = receiver.queue_recv_vole(&value).expect("queue");
+
+    let flush = sender.flush().expect("flush must produce a message");
+    absorb_vole_flush(transcript, &flush);
+    receiver.flush(flush).expect("receiver flush");
+
+    let macs = fut
+        .try_recv()
+        .expect("future must not cancel")
+        .expect("future must resolve after flush")
+        .macs;
+    let keys = sender.try_send_vole(width).expect("sender keys").keys;
+
+    (
+        ProverWire::new(Bundle::new(value), Bundle::new(macs)),
+        VerifierWire::new(Bundle::new(keys)),
+    )
+}
+
+/// Commit an `N`-slot tuple of cleartext bundles.
+pub fn commit_tuple<W, E, const N: usize>(
+    values: [Vec<W>; N],
+    delta: E,
+    rng: &mut impl Rng,
+    transcript: &mut blake3::Hasher,
+) -> [(ProverWire<W, E>, VerifierWire<E>); N]
+where
+    W: Field,
+    E: ExtensionField<W> + serde::Serialize,
+{
+    values.map(|v| commit_value(v, delta, rng, transcript))
+}
+
+/// Commit a sequence of `N`-tuples against a *fresh* shared
+/// transcript and return the per-tuple wire arrays alongside the
+/// post-commit transcript both sides start from.
+pub fn commit_accesses<W, E, const N: usize>(
+    accesses: Vec<[Vec<W>; N]>,
+    delta: E,
+    rng: &mut impl Rng,
+) -> (
+    Vec<[(ProverWire<W, E>, VerifierWire<E>); N]>,
+    blake3::Hasher,
+)
+where
+    W: Field,
+    E: ExtensionField<W> + serde::Serialize,
+{
+    let mut transcript = blake3::Hasher::new();
+    let commits = accesses
+        .into_iter()
+        .map(|tuple| commit_tuple::<W, E, N>(tuple, delta, rng, &mut transcript))
+        .collect();
+    (commits, transcript)
+}
+
+/// Absorb the bytes of an ideal-VOLE [`FlushMsg`] into a transcript.
+fn absorb_vole_flush<E: Field + serde::Serialize>(
+    transcript: &mut blake3::Hasher,
+    msg: &FlushMsg<E>,
+) {
+    transcript.update(b"two-shuffles::test::ideal-vole-flush");
+    transcript.update(&bcs::to_bytes(msg).expect("serialize"));
+}
+
+/// An unauthenticated prover wire.
+pub fn prover_wire<W, E: Field>(values: Vec<W>) -> ProverWire<W, E> {
+    let macs = vec![E::zero(); values.len()];
+    ProverWire::new(Bundle::new(values), Bundle::new(macs))
+}
+
+/// A verifier wire built directly from its key slots.
+pub fn verifier_wire<E: Field>(keys: Vec<E>) -> VerifierWire<E> {
+    VerifierWire::new(Bundle::new(keys))
+}
+
+/// A zeroed VOLE adjustment of the given slot width.
+pub fn vole_adjustment<E: Field>(width: usize) -> VoleAdjustment<E> {
+    VoleAdjustment {
+        diffs: vec![E::zero(); width],
+    }
+}
+
+/// Build a paired, `Allocated` mux-mul prover/verifier over
+/// `Gf2`/`Gf2_64`, sharing one Δ and one mul-VOLE pool sized for
+/// `num_slots` product slots. `verifier_bool` selects the verifier's
+/// booleanness-check flag. Returns `(prover, verifier, delta)`.
+pub fn mux_mul_pair(
+    num_slots: usize,
+    verifier_bool: bool,
+) -> (
+    MuxMulProver<impl RVOLEReceiver<Gf2, Gf2_64>, impl RVOLEReceiver<Gf2, Gf2_64>, Gf2, Gf2_64>,
+    MuxMulVerifier<impl RVOLESender<Gf2_64>, impl RVOLESender<Gf2_64>, Gf2, Gf2_64>,
+    Gf2_64,
+) {
+    let mut rng = StdRng::seed_from_u64(0x2b2b);
+    let delta: Gf2_64 = rng.random();
+
+    let vope_count = <Gf2_64 as ExtensionField<Gf2>>::MONOMIAL_BASIS.len();
+    let (mut vope_s, mut vope_r) = ideal_rvole::<Gf2, Gf2_64>(rng.random(), delta);
+    vope_s.pregenerate(vope_count);
+    vope_r
+        .pregenerate(vope_count, delta)
+        .expect("vope r pregenerate");
+
+    // One shared mul pool: same seed + Δ on both sides so the prover's
+    // product MACs and the verifier's product keys pair up.
+    let mul_seed: u64 = rng.random();
+    let (mut mul_s, mut mul_r) = ideal_rvole::<Gf2, Gf2_64>(mul_seed, delta);
+    mul_s.pregenerate(num_slots);
+    mul_r
+        .pregenerate(num_slots, delta)
+        .expect("mul r pregenerate");
+
+    let mut prover = MuxMulProver::new(vope_r, DerandVOLEReceiver::new(mul_r), false);
+    let mut verifier = MuxMulVerifier::new(vope_s, DerandVOLESender::new(mul_s), verifier_bool);
+    prover.alloc(num_slots).expect("prover alloc");
+    verifier.alloc(num_slots).expect("verifier alloc");
+    (prover, verifier, delta)
+}
+
+/// A VOLE pool size provisioned far above any API test's actual demand.
+pub const IDEAL_VOLE_POOL: usize = 1 << 22;
+
+/// Build a pregenerated ideal RVOLE pair over `Gf2`/`Gf2_64` of pool
+/// size `count`. The pair's seed is drawn from `rng`; both halves share
+/// `delta` and are pre-filled so the wrapping `DerandVOLE*` pools
+/// resolve without an online setup.
+///
+/// Ideal-functionality scaffolding shared by the API tests and benches.
+/// The caller wraps the returned `(sender, receiver)` as it needs —
+/// e.g. `DerandVOLEReceiver::new(receiver)` on the prover side, the raw
+/// `sender` (or `DerandVOLESender::new(sender)`) on the verifier side.
+pub fn ideal_rvole_pair(
+    rng: &mut impl Rng,
+    delta: Gf2_64,
+    count: usize,
+) -> (IdealRVOLESender<Gf2_64>, IdealRVOLEReceiver<Gf2, Gf2_64>) {
+    let seed: u64 = rng.random();
+    let (mut sender, mut receiver) = ideal_rvole::<Gf2, Gf2_64>(seed, delta);
+    sender.pregenerate(count);
+    receiver
+        .pregenerate(count, delta)
+        .expect("ideal rvole pregenerate");
+    (sender, receiver)
+}
+
+/// Low-`n` bits of `val`, least-significant-bit first — the protocols'
+/// canonical bundle encoding of a small integer.
+pub fn bits(val: u64, n: usize) -> Vec<Gf2> {
+    Vec::<Gf2>::from_lsb0_iter(val.iter_lsb0().take(n))
+}
+
+/// `base^exp` in `GF(2^n)` modulo `poly`, via square-and-multiply over
+/// [`gf2n_mul_mod`].
+pub fn pow_mod(base: u64, mut exp: u64, poly: u64, n: usize) -> u64 {
+    let mut result = 1u64;
+    let mut b = base;
+    while exp > 0 {
+        if exp & 1 == 1 {
+            result = gf2n_mul_mod(result, b, poly, n);
+        }
+        b = gf2n_mul_mod(b, b, poly, n);
+        exp >>= 1;
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// RAM witness generation
+// ---------------------------------------------------------------------------
+
+/// A randomly generated RAM session for the API tests and benches, in
+/// the `Char2Strategy<Gf2_64>` encoding (`Gf2` bundles).
+pub struct RamWitness {
+    /// Public starting state — one value per live address, in
+    /// ascending-address order, as `l_val`-bit bundles. Matches the
+    /// order `Prover::setup` / `Verifier::setup` consume.
+    pub initial_memory: Vec<Vec<Gf2>>,
+    /// The prover's witness: the access trace as `[op, addr, value]`
+    /// bundles, ready for `commit_accesses` and both sides' `access`.
+    /// `op = 1` is a store, `op = 0` a load.
+    pub accesses: Vec<[Vec<Gf2>; 3]>,
+    /// Cleartext memory after applying the trace, in the same
+    /// ascending-address order as [`initial_memory`](Self::initial_memory).
+    pub final_memory: Vec<Vec<Gf2>>,
+}
+
+/// Generate a random RAM session over an arbitrary live-address set:
+/// one initial cell per address in `live_addrs` and `total_accesses`
+/// random read/write accesses, each addressing a *live* cell with a
+/// value in `0..2^value_bits`. `live_addrs` need not be zero-based or
+/// contiguous — addresses are encoded against the bound
+/// `live_addrs.end()` (matching the prover), and holes are never
+/// accessed. A cleartext shadow keeps the trace self-consistent and
+/// reports the resulting state.
+///
+/// The verifier needs only [`RamWitness::initial_memory`]; the prover
+/// additionally drives the [`RamWitness::accesses`] witness. (In this
+/// committed-access harness both sides consume the committed trace.)
+pub fn generate_ram_witness(
+    live_addrs: &RangeSet<usize>,
+    value_bits: usize,
+    total_accesses: usize,
+    rng: &mut impl Rng,
+) -> RamWitness {
+    let address_bound = live_addrs.end().expect("live_addrs must be non-empty");
+    let l_addr = Char2Strategy::<Gf2_64>::wire_length_for(address_bound);
+    let l_val = Char2Strategy::<Gf2_64>::wire_length_for_log2(value_bits);
+
+    // Live addresses in ascending order, each seeded with a random
+    // value. The shadow is keyed by address so holes carry no state.
+    let live: Vec<usize> = live_addrs.iter_values().collect();
+    let mut shadow: BTreeMap<usize, u64> = live
+        .iter()
+        .map(|&a| (a, sample_value(value_bits, rng)))
+        .collect();
+    let initial_memory: Vec<Vec<Gf2>> = live.iter().map(|a| bits(shadow[a], l_val)).collect();
+
+    let mut accesses = Vec::with_capacity(total_accesses);
+    for _ in 0..total_accesses {
+        let addr = live[rng.random_range(0..live.len())];
+        let is_write: bool = rng.random();
+        // For a load the value is ignored by the mux but still
+        // committed, so a random in-range value is fine.
+        let value = sample_value(value_bits, rng);
+        if is_write {
+            shadow.insert(addr, value);
+        }
+        let op = Gf2(is_write);
+        accesses.push([vec![op], bits(addr as u64, l_addr), bits(value, l_val)]);
+    }
+
+    let final_memory: Vec<Vec<Gf2>> = live.iter().map(|a| bits(shadow[a], l_val)).collect();
+    RamWitness {
+        initial_memory,
+        accesses,
+        final_memory,
+    }
+}
+
+/// Sample a uniform value from the `value_bits`-wide domain
+/// `0..2^value_bits` (`value_bits ≤ 64`).
+fn sample_value(value_bits: usize, rng: &mut impl Rng) -> u64 {
+    assert!(
+        value_bits <= 64,
+        "sample_value: value_bits={value_bits} > 64"
+    );
+    if value_bits == 64 {
+        rng.random()
+    } else {
+        rng.random_range(0..1u64 << value_bits)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RO-KVS witness generation
+// ---------------------------------------------------------------------------
+
+/// A randomly generated RO-KVS session for the API tests and benches, in
+/// the `Char2Strategy<Gf2_64>` encoding (`Gf2` bundles).
+pub struct RoKvsWitness {
+    /// Public key→value content — one value per implicit key
+    /// `0..key_space`, as `l_val`-bit bundles. Both prover and verifier
+    /// set up from this.
+    pub content: Vec<Vec<Gf2>>,
+    /// The lookup trace: `num_lookups` random keys, each a single
+    /// `[key]` bundle ready for `commit_accesses::<_, _, 1>`.
+    pub lookups: Vec<[Vec<Gf2>; 1]>,
+}
+
+/// Generate a random RO-KVS session: `key_space` key→value entries
+/// (values in `0..2^value_bits`) and `num_lookups` lookups of random
+/// keys in `0..key_space`. RO-KVS is read-only — every key is populated
+/// and the content is fixed, so there is no shadow to track.
+pub fn generate_ro_kvs_witness(
+    key_space: usize,
+    value_bits: usize,
+    num_lookups: usize,
+    rng: &mut impl Rng,
+) -> RoKvsWitness {
+    let l_key = Char2Strategy::<Gf2_64>::wire_length_for(key_space);
+    let l_val = Char2Strategy::<Gf2_64>::wire_length_for_log2(value_bits);
+
+    let content: Vec<Vec<Gf2>> = (0..key_space)
+        .map(|_| bits(sample_value(value_bits, rng), l_val))
+        .collect();
+    let lookups: Vec<[Vec<Gf2>; 1]> = (0..num_lookups)
+        .map(|_| [bits(rng.random_range(0..key_space) as u64, l_key)])
+        .collect();
+
+    RoKvsWitness { content, lookups }
+}
+
+// ---------------------------------------------------------------------------
+// Set-membership witness generation
+// ---------------------------------------------------------------------------
+
+/// A randomly generated set-membership session for the API tests, in
+/// the `Char2Strategy<Gf2_64>` encoding (`Gf2` bundles).
+pub struct SetWitness {
+    /// The set members — `set_size` distinct elements drawn from
+    /// `0..element_space`, ascending, as `l_elem`-bit bundles. Both
+    /// prover and verifier set up from this.
+    pub members: Vec<Vec<Gf2>>,
+    /// The lookup trace: `num_lookups` elements, each a single
+    /// `[element]` bundle ready for `commit_accesses::<_, _, 1>`. Every
+    /// lookup is a member (repeats allowed), so the prover's shadow
+    /// lookup always resolves in-set.
+    pub lookups: Vec<[Vec<Gf2>; 1]>,
+}
+
+/// Generate a random set-membership session: `set_size` distinct
+/// members drawn from `0..element_space` and `num_lookups` lookups, each
+/// a randomly chosen member (with repeats). `set_size` must not exceed
+/// `element_space`.
+pub fn generate_set_witness(
+    element_space: usize,
+    set_size: usize,
+    num_lookups: usize,
+    rng: &mut impl Rng,
+) -> SetWitness {
+    assert!(
+        set_size <= element_space,
+        "set_size {set_size} exceeds element_space {element_space}",
+    );
+    let l_elem = Char2Strategy::<Gf2_64>::wire_length_for(element_space);
+
+    // Distinct member values, sampled by rejection; `BTreeSet` keeps
+    // them ascending.
+    let mut chosen: BTreeSet<usize> = BTreeSet::new();
+    while chosen.len() < set_size {
+        chosen.insert(rng.random_range(0..element_space));
+    }
+    let member_vals: Vec<usize> = chosen.into_iter().collect();
+    let members: Vec<Vec<Gf2>> = member_vals
+        .iter()
+        .map(|&v| bits(v as u64, l_elem))
+        .collect();
+
+    // Lookups: random members (repeats allowed), guaranteed in-set.
+    let lookups: Vec<[Vec<Gf2>; 1]> = (0..num_lookups)
+        .map(|_| {
+            let v = member_vals[rng.random_range(0..member_vals.len())];
+            [bits(v as u64, l_elem)]
+        })
+        .collect();
+
+    SetWitness { members, lookups }
+}

--- a/crates/two-shuffles/src/wire.rs
+++ b/crates/two-shuffles/src/wire.rs
@@ -1,0 +1,420 @@
+//! Authenticated wire types.
+
+use mpz_fields::Field;
+use mpz_poly_proof_core::ExtensionField;
+
+/// Fixed-length container of `T` slots holding one component of a
+/// logical wire — its cleartext, its IT-MAC, or its key.
+///
+/// A wire may span multiple slots when its encoding takes more than one field
+/// element.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bundle<T>(Vec<T>);
+
+impl<T> Bundle<T> {
+    /// Wrap an existing `Vec<T>` as a bundle.
+    pub fn new(slots: Vec<T>) -> Self {
+        Self(slots)
+    }
+
+    /// Unwrap into the underlying `Vec<T>`.
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+
+    /// Borrow as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T> From<Vec<T>> for Bundle<T> {
+    fn from(v: Vec<T>) -> Self {
+        Self(v)
+    }
+}
+
+/// Singleton bundle: a single value lifted into a length-1 bundle.
+impl<T> From<T> for Bundle<T> {
+    fn from(v: T) -> Self {
+        Self(vec![v])
+    }
+}
+
+impl<T> FromIterator<T> for Bundle<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(it: I) -> Self {
+        Self(it.into_iter().collect())
+    }
+}
+
+impl<T> std::ops::Deref for Bundle<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T> IntoIterator for Bundle<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Bundle<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+/// Prover-side authenticated wire.
+///
+/// Value and IT-MAC bundles are parallel.
+#[derive(Clone)]
+pub struct ProverWire<S, F> {
+    value: Bundle<S>,
+    mac: Bundle<F>,
+}
+
+impl<S, F> ProverWire<S, F>
+where
+    F: Field,
+{
+    /// Pair a value-side bundle with its mac-side bundle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` and `mac` have different lengths, or if
+    /// either is empty.
+    pub fn new(value: Bundle<S>, mac: Bundle<F>) -> Self {
+        assert_eq!(
+            value.len(),
+            mac.len(),
+            "ProverWire: value/mac length mismatch ({} vs {})",
+            value.len(),
+            mac.len(),
+        );
+        assert!(
+            !value.is_empty(),
+            "ProverWire: zero-slot wires are not allowed",
+        );
+        Self { value, mac }
+    }
+
+    /// Construct a public-constant wire.
+    pub fn constant(value: impl Into<Bundle<S>>) -> Self {
+        let value = value.into();
+        let mac = Bundle::from(vec![F::zero(); value.len()]);
+        Self::new(value, mac)
+    }
+
+    /// Cleartext value of the wire.
+    pub fn value(&self) -> &Bundle<S> {
+        &self.value
+    }
+
+    /// IT-MAC of the wire.
+    pub fn mac(&self) -> &Bundle<F> {
+        &self.mac
+    }
+
+    /// Number of slots in this wire.
+    pub fn len(&self) -> usize {
+        self.value.len()
+    }
+}
+
+/// Verifier-side authenticated wire.
+#[derive(Clone)]
+pub struct VerifierWire<F> {
+    /// Verifier-side keys.
+    pub key: Bundle<F>,
+}
+
+impl<F: Field> VerifierWire<F> {
+    /// Creates a new wire.
+    pub fn new(key: Bundle<F>) -> Self {
+        Self { key }
+    }
+
+    /// Construct the verifier-side wire for a public-constant value.
+    pub fn constant<S>(value: &[S], delta: F) -> Self
+    where
+        S: Field,
+        F: ExtensionField<S>,
+    {
+        // Convention: when the prover constructs a public-constant wire
+        // (MAC=0), the verifier holds `K = −Δ · v.embed()` per slot.
+        let key = value.iter().map(|v| -(F::embed(*v) * delta)).collect();
+        Self { key }
+    }
+
+    /// Number of slots in this wire.
+    pub fn len(&self) -> usize {
+        self.key.len()
+    }
+
+    /// Pack into a [`PackedVerifierWire`] over the chosen subfield `S`.
+    pub(crate) fn pack<S>(&self) -> PackedVerifierWire<F>
+    where
+        S: Field,
+        F: ExtensionField<S>,
+    {
+        PackedVerifierWire::pack::<S>(&self.key)
+    }
+}
+
+/// Build a [`VerifierWire`] directly from anything convertible to a
+/// [`Bundle<F>`].
+impl<F, T> From<T> for VerifierWire<F>
+where
+    T: Into<Bundle<F>>,
+{
+    fn from(keys: T) -> Self {
+        Self { key: keys.into() }
+    }
+}
+
+/// Prover-side packed wire.
+#[derive(Copy, Clone)]
+pub(crate) struct PackedProverWire<F> {
+    pub value: F,
+    pub mac: F,
+}
+
+/// Verifier-side packed wire.
+#[derive(Copy, Clone)]
+pub(crate) struct PackedVerifierWire<F> {
+    pub key: F,
+}
+
+/// Pack a `VerifierWire` into a `PackedVerifierWire`.
+///
+/// The caller is responsible for ensuring that the input wire's
+/// key bundle can be packed into the extension field `F` without
+/// information loss — i.e. that its slot count fits within `F`'s
+/// extension degree over `S`.
+impl<F> PackedVerifierWire<F>
+where
+    F: Field,
+{
+    /// Pack a raw key slice into a `PackedVerifierWire`.
+    pub(crate) fn pack<S>(keys: &[F]) -> Self
+    where
+        S: Field,
+        F: ExtensionField<S>,
+    {
+        Self {
+            key: pack_extension::<S, F>(keys),
+        }
+    }
+}
+
+/// Pack a `ProverWire` into a `PackedWire`.
+///
+/// The caller is responsible for ensuring that the input wire's
+/// value bundle can be packed into the extension field `F` without
+/// information loss — i.e. that its slot count fits within `F`'s
+/// extension degree over `S`.
+impl<S, F> From<&ProverWire<S, F>> for PackedProverWire<F>
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    fn from(input: &ProverWire<S, F>) -> Self {
+        let value_bundle = input.value();
+        // Σ embed(value[i]) · α^i — canonical subfield→extension lift
+        // against the leading slice of the monomial basis.
+        let value = <F as ExtensionField<S>>::inner_product_subfield(
+            value_bundle,
+            &<F as ExtensionField<S>>::MONOMIAL_BASIS[..value_bundle.len()],
+        );
+        let mac = pack_extension::<S, F>(input.mac());
+        Self { value, mac }
+    }
+}
+
+/// Pack a bundle of `F` elements into a single `F` element by taking
+/// a linear combination against the leading slice of `F`'s canonical
+/// monomial basis over `S`.
+///
+/// The caller is responsible for ensuring `values.len()` fits within
+/// the basis size.
+pub(crate) fn pack_extension<S, F>(values: &[F]) -> F
+where
+    S: Field,
+    F: ExtensionField<S>,
+{
+    let basis = &<F as ExtensionField<S>>::MONOMIAL_BASIS[..values.len()];
+    values
+        .iter()
+        .zip(basis.iter())
+        .fold(F::zero(), |acc, (&v, &b)| acc + v * b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpz_fields::{Field, gf2::Gf2, gf2_64::Gf2_64};
+
+    // -----------------------------------------------------------------------
+    // Bundle: constructors + round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bundle_new_and_into_inner_round_trip() {
+        let v = vec![1u32, 2, 3, 4];
+        let bundle = Bundle::new(v.clone());
+        assert_eq!(bundle.into_inner(), v);
+    }
+
+    #[test]
+    fn bundle_from_vec_wraps_full_vec() {
+        let bundle: Bundle<u32> = vec![10, 20, 30].into();
+        assert_eq!(bundle.len(), 3);
+        assert_eq!(*bundle, [10, 20, 30]);
+    }
+
+    #[test]
+    fn bundle_from_singleton_lifts_to_length_one() {
+        // `From<T> for Bundle<T>` — single value → length-1 bundle.
+        // Critical for prime-field call sites that use `.into()`
+        // without an explicit `vec![...]` wrap.
+        let bundle: Bundle<u32> = 42u32.into();
+        assert_eq!(bundle.len(), 1);
+        assert_eq!(bundle[0], 42);
+    }
+
+    #[test]
+    fn bundle_from_iter_collects() {
+        let bundle: Bundle<u32> = (0..5).collect();
+        assert_eq!(*bundle, [0, 1, 2, 3, 4]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bundle: Deref + IntoIterator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bundle_deref_exposes_slice_methods() {
+        let bundle: Bundle<u32> = vec![7, 8, 9].into();
+        // Methods that come from `&[T]` via Deref:
+        assert_eq!(bundle.len(), 3);
+        assert!(!bundle.is_empty());
+        assert_eq!(bundle.first(), Some(&7));
+        assert_eq!(bundle.iter().sum::<u32>(), 24);
+        // Indexing:
+        assert_eq!(bundle[1], 8);
+        // as_slice() helper:
+        assert_eq!(bundle.as_slice(), &[7, 8, 9]);
+    }
+
+    #[test]
+    fn bundle_owned_into_iter_consumes() {
+        let bundle: Bundle<u32> = vec![1, 2, 3].into();
+        let collected: Vec<u32> = bundle.into_iter().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn bundle_ref_into_iter_borrows() {
+        let bundle: Bundle<u32> = vec![1, 2, 3].into();
+        // `for x in &bundle` works.
+        let collected: Vec<u32> = (&bundle).into_iter().copied().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+        // bundle is still usable.
+        assert_eq!(bundle.len(), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bundle: Ord + Eq for BTreeMap key use
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bundle_ord_lexicographic() {
+        let a: Bundle<u32> = vec![1, 2, 3].into();
+        let b: Bundle<u32> = vec![1, 2, 4].into();
+        let c: Bundle<u32> = vec![1, 2, 3].into();
+        assert!(a < b, "shorter-first byte should sort earlier");
+        assert_eq!(a, c, "elementwise equality");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn bundle_works_as_btreemap_key() {
+        // Smoke: Ord + Eq derives are wired up so Bundle<S> can key
+        // a BTreeMap. Used by the shadow tables in every protocol.
+        use std::collections::BTreeMap;
+        let mut m: BTreeMap<Bundle<u32>, &'static str> = BTreeMap::new();
+        m.insert(vec![1, 2].into(), "ab");
+        m.insert(vec![3].into(), "c");
+        assert_eq!(m.get(&Bundle::<u32>::from(vec![1, 2])), Some(&"ab"));
+        assert_eq!(m.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // InputWire::constant
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn input_wire_constant_vec_zeroes_mac() {
+        // `Vec<S>` source → bundle of same length, mac is all zero.
+        let value = vec![Gf2(true), Gf2(false), Gf2(true)];
+        let wire: ProverWire<Gf2, Gf2_64> = ProverWire::constant(value.clone());
+        assert_eq!(wire.value.len(), 3);
+        assert_eq!(wire.mac.len(), 3);
+        assert_eq!(*wire.value, value[..]);
+        for m in wire.mac.iter() {
+            assert_eq!(*m, Gf2_64::zero(), "mac slot must be zero for constant");
+        }
+    }
+
+    #[test]
+    fn input_wire_constant_singleton() {
+        // `S` source → length-1 wire, mac = [0].
+        let wire: ProverWire<Gf2, Gf2_64> = ProverWire::constant(Gf2(true));
+        assert_eq!(wire.value.len(), 1);
+        assert_eq!(wire.mac.len(), 1);
+        assert_eq!(wire.value[0], Gf2(true));
+        assert_eq!(wire.mac[0], Gf2_64::zero());
+    }
+
+    #[test]
+    fn input_wire_constant_bundle_passes_through() {
+        // `Bundle<S>` source → identity on value side, mac = zeros.
+        let value: Bundle<Gf2> = vec![Gf2(false), Gf2(true)].into();
+        let wire: ProverWire<Gf2, Gf2_64> = ProverWire::constant(value.clone());
+        assert_eq!(*wire.value, *value);
+        assert!(wire.mac.iter().all(|&m| m == Gf2_64::zero()));
+    }
+
+    // -----------------------------------------------------------------------
+    // VerifierWire::constant
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn verifier_wire_constant_negates_scalar_mul_per_slot() {
+        // For each slot `v`, key = −v.scalar_mul(delta).
+        //   Gf2(false) → 0
+        //   Gf2(true)  → −delta  (= delta in char-2 Gf2_64)
+        let delta = Gf2_64(0xdead_beef_cafe_babe);
+        let value = [Gf2(true), Gf2(false), Gf2(true)];
+        let wire: VerifierWire<Gf2_64> = VerifierWire::constant(&value, delta);
+        assert_eq!(wire.key.len(), 3);
+        assert_eq!(wire.key[0], -delta);
+        assert_eq!(wire.key[1], Gf2_64::zero());
+        assert_eq!(wire.key[2], -delta);
+        // Char-2 cross-check: -delta == delta in Gf2_64.
+        assert_eq!(-delta, delta);
+    }
+
+    #[test]
+    fn verifier_wire_constant_empty_input_yields_empty_key() {
+        let delta = Gf2_64(0x1234);
+        let wire: VerifierWire<Gf2_64> = VerifierWire::constant::<Gf2>(&[], delta);
+        assert_eq!(wire.key.len(), 0);
+    }
+}

--- a/crates/two-shuffles/tests/ram_api.rs
+++ b/crates/two-shuffles/tests/ram_api.rs
@@ -1,0 +1,311 @@
+//! End-to-end tests for the RAM protocol public API.
+//!
+//! Drives the full `ram::Prover` → `ram::Verifier` lifecycle.
+
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_two_shuffles::{
+    ProverWire, VerifierWire,
+    ram::{Config, MultiplicativeClock, Prover, Verifier},
+    set,
+    strategy::{Char2Strategy, version::MultiplicativeStep},
+    test_utils::{IDEAL_VOLE_POOL, commit_accesses, generate_ram_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::{DerandVOLEReceiver, DerandVOLESender};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rangeset::set::RangeSet;
+
+use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair as build_perm_proof_pair;
+
+/// Number of addressable memory cells.
+const MEMORY_SIZE: usize = 1024;
+/// Value bit-width (`2^VALUE_BITS` distinct values per cell).
+const VALUE_BITS: usize = 16;
+/// Memory accesses performed per session.
+const TOTAL_ACCESSES: usize = 512;
+const FAN_IN: usize = 8;
+
+/// Build all VOLE / perm-proof / set machinery, run setup → accesses
+/// → flush → teardown_prepare → teardown for one session, and return
+/// the exported `(prover_state, verifier_state)` pair.
+fn run_one_session(
+    rng: &mut ChaCha8Rng,
+    delta: Gf2_64,
+    live_addrs: RangeSet<usize>,
+    value_bits: usize,
+    export_addrs: Option<RangeSet<usize>>,
+    setup: SetupSource,
+    access_tuples: Vec<[Vec<Gf2>; 3]>,
+) -> Result<SessionState, mpz_two_shuffles::ram::VerifierError> {
+    let t = access_tuples.len();
+    let live_count = live_addrs.len();
+
+    // ---- RAM RVOLE.
+    let (ram_vole_s, ram_vole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- MulProver RVOLE.
+    let (mul_rvole_s, mul_rvole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- MulProver VOLE.
+    let (mul_vole_s, mul_vole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- set RVOLE.
+    let (set_vole_s, set_vole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- vole_zk perm-proof for RAM.
+    let (ram_perm_prover, ram_perm_verifier) =
+        build_perm_proof_pair(rng, delta, live_count + t, FAN_IN);
+
+    // ---- vole_zk perm-proof for set.
+    let (set_perm_prover, set_perm_verifier) = build_perm_proof_pair(rng, delta, t + t, FAN_IN);
+
+    // ---- Build set Prover/Verifier ----
+    let prover_set = set::Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        t,
+        MultiplicativeStep::new(t).expect("supported version size"),
+        DerandVOLEReceiver::new(set_vole_r),
+        set_perm_prover,
+    )
+    .expect("set prover new");
+
+    let verifier_set = set::Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        t,
+        MultiplicativeStep::new(t).expect("supported version size"),
+        set_vole_s,
+        set_perm_verifier,
+    )
+    .expect("set verifier new");
+
+    // ---- Build RAM Prover/Verifier ----
+    let mut cfg_builder =
+        Config::<Gf2_64, Char2Strategy<Gf2_64>>::builder(live_addrs, value_bits, t);
+    if let Some(export) = export_addrs {
+        cfg_builder = cfg_builder.export_addrs(export);
+    }
+    let config = cfg_builder.build().expect("ram config build");
+
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        config.clone(),
+        MultiplicativeClock::new(t).expect("supported clock size"),
+        DerandVOLEReceiver::new(ram_vole_r),
+        DerandVOLEReceiver::new(mul_vole_r),
+        mul_rvole_r,
+        ram_perm_prover,
+        prover_set,
+    )
+    .expect("ram prover new");
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        config,
+        MultiplicativeClock::new(t).expect("supported clock size"),
+        ram_vole_s,
+        DerandVOLESender::new(mul_vole_s),
+        mul_rvole_s,
+        ram_perm_verifier,
+        verifier_set,
+    )
+    .expect("ram verifier new");
+
+    prover.alloc().expect("ram prover alloc");
+    verifier.alloc().expect("ram verifier alloc");
+
+    // ---- Setup ----
+    match setup {
+        SetupSource::Public(content) => {
+            prover.setup(content.clone()).expect("ram prover setup");
+            verifier.setup(content).expect("ram verifier setup");
+        }
+        SetupSource::PublicDishonest {
+            verifier_truth,
+            prover_content,
+        } => {
+            prover.setup(prover_content).expect("ram prover setup");
+            verifier.setup(verifier_truth).expect("ram verifier setup");
+        }
+        SetupSource::Chained {
+            prover_state,
+            verifier_state,
+        } => {
+            prover
+                .setup_with_wires(prover_state)
+                .expect("ram prover setup_with_wires");
+            verifier
+                .setup_with_wires(verifier_state)
+                .expect("ram verifier setup_with_wires");
+        }
+    }
+
+    // Commit accesses to a transcript.
+    let (access_commits, transcript) = commit_accesses(access_tuples, delta, rng);
+
+    // Prover and verifier transcript.
+    let mut p_transcript = transcript.clone();
+    let mut v_transcript = transcript;
+
+    for [
+        (prover_op, verifier_op),
+        (prover_addr, verifier_addr),
+        (prover_w, verifier_w),
+    ] in access_commits
+    {
+        prover
+            .access(prover_op, prover_addr, prover_w)
+            .expect("prover access (mux)");
+        verifier
+            .access(verifier_op, verifier_addr, verifier_w)
+            .expect("verifier access (mux)");
+    }
+
+    let flush = prover.flush().expect("prover flush");
+    verifier.flush(flush).expect("verifier flush");
+
+    let prepare = prover
+        .teardown_prepare(&mut p_transcript)
+        .expect("prover teardown_prepare");
+    verifier
+        .teardown_prepare(&mut v_transcript, prepare)
+        .expect("verifier teardown_prepare");
+
+    let (msg, prover_state) = prover.teardown(&mut p_transcript).expect("prover teardown");
+    let verifier_state = verifier.teardown(&mut v_transcript, msg)?;
+    Ok((prover_state, verifier_state))
+}
+
+/// How a session seeds its memory at setup.
+enum SetupSource {
+    /// Public-constant setup. Both sides commit to the same content.
+    Public(Vec<Vec<Gf2>>),
+    /// Public-constant setup, but the prover commits to a tampered
+    /// copy of the verifier's truth.
+    PublicDishonest {
+        verifier_truth: Vec<Vec<Gf2>>,
+        prover_content: Vec<Vec<Gf2>>,
+    },
+    /// Chained from a previous session's exported state.
+    Chained {
+        prover_state: Vec<ProverWire<Gf2, Gf2_64>>,
+        verifier_state: Vec<VerifierWire<Gf2_64>>,
+    },
+}
+
+/// What a session returns when it tears down. Per-cell val wires
+/// filtered to `config.export_addrs` and ordered by setup-time
+/// insertion.
+type SessionState = (Vec<ProverWire<Gf2, Gf2_64>>, Vec<VerifierWire<Gf2_64>>);
+
+/// Honest end-to-end.
+#[test]
+fn accepts_honest_ram() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_ram_witness(
+        &RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        TOTAL_ACCESSES,
+        &mut rng,
+    );
+
+    run_one_session(
+        &mut rng,
+        delta,
+        RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        None,
+        SetupSource::Public(witness.initial_memory),
+        witness.accesses,
+    )
+    .expect("honest RAM must accept");
+}
+
+/// Dishonest end-to-end.
+#[test]
+fn rejects_dishonest_ram() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_ram_witness(
+        &RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        TOTAL_ACCESSES,
+        &mut rng,
+    );
+
+    let verifier_truth = witness.initial_memory.clone();
+    let mut prover_content = witness.initial_memory;
+    // Flip a bit in cell 0's value — the lie resolves locally on the
+    // prover but the IT-MAC mismatch only surfaces at teardown.
+    prover_content[0][0] = Gf2(!prover_content[0][0].0);
+
+    let err = run_one_session(
+        &mut rng,
+        delta,
+        RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        None,
+        SetupSource::PublicDishonest {
+            verifier_truth,
+            prover_content,
+        },
+        witness.accesses,
+    )
+    .map(|_| ())
+    .expect_err("dishonest setup content must be rejected");
+    assert!(
+        matches!(err, mpz_two_shuffles::ram::VerifierError::PermProof(_)),
+        "expected PermProof rejection, got {err:?}",
+    );
+}
+
+/// Two chained sessions end-to-end. Session 1 runs over the full
+/// memory but narrows its export to an arbitrary live region: two
+/// disjoint, non-zero-based ranges, with holes below, between, and
+/// above. Session 2 instantiates *only* that region (`live_addrs =
+/// live_region`, so a smaller, sparse address space with a tighter
+/// bound, fewer records, smaller perm proof) from session 1's exported
+/// wires via `setup_with_wires`, and confines its accesses to it.
+/// Integration check — both sessions must verify; the exported state
+/// itself isn't re-checked here.
+#[test]
+fn accepts_chained_sessions() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0xC0DE_C0DE);
+    let delta: Gf2_64 = rng.random();
+
+    // Arbitrary live region carried from session 1 into session 2:
+    // 16 cells across two disjoint, non-zero-based ranges.
+    let live_region = RangeSet::from(vec![100..108usize, 500..508usize]);
+
+    // ---- Session 1: full memory, export narrowed to `live_region`. ----
+    let s1 = generate_ram_witness(
+        &RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        TOTAL_ACCESSES,
+        &mut rng,
+    );
+    let (s1_prover_state, s1_verifier_state) = run_one_session(
+        &mut rng,
+        delta,
+        RangeSet::from(0..MEMORY_SIZE),
+        VALUE_BITS,
+        Some(live_region.clone()),
+        SetupSource::Public(s1.initial_memory),
+        s1.accesses,
+    )
+    .expect("session 1 must accept");
+    assert_eq!(s1_prover_state.len(), live_region.len());
+    assert_eq!(s1_verifier_state.len(), live_region.len());
+
+    // ---- Session 2: a RAM living on exactly `live_region`, chained
+    // from session 1's exported wires; accesses confined to it. ----
+    let s2 = generate_ram_witness(&live_region, VALUE_BITS, TOTAL_ACCESSES, &mut rng);
+    run_one_session(
+        &mut rng,
+        delta,
+        live_region,
+        VALUE_BITS,
+        None,
+        SetupSource::Chained {
+            prover_state: s1_prover_state,
+            verifier_state: s1_verifier_state,
+        },
+        s2.accesses,
+    )
+    .expect("session 2 must accept");
+}

--- a/crates/two-shuffles/tests/ro_kvs_api.rs
+++ b/crates/two-shuffles/tests/ro_kvs_api.rs
@@ -1,0 +1,134 @@
+//! End-to-end tests for the RO-KVS protocol public API.
+//!
+//! Drives the full `Prover` → `Verifier` lifecycle.
+
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_two_shuffles::{
+    ro_kvs::{Prover, Verifier},
+    strategy::{Char2Strategy, version::MultiplicativeStep},
+    test_utils::{IDEAL_VOLE_POOL, commit_accesses, generate_ro_kvs_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::DerandVOLEReceiver;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair as build_perm_proof_pair;
+
+/// Key space — number of implicit keys `0..KEY_SPACE`, all populated.
+const KEY_SPACE: usize = 1024;
+/// Value bit-width.
+const VALUE_BITS: usize = 16;
+/// Lookups performed per session.
+const TOTAL_LOOKUPS: usize = 512;
+const FAN_IN: usize = 8;
+
+/// Build the VOLE / perm-proof machinery and run setup → lookups →
+/// teardown_prepare → teardown for one RO-KVS session.
+fn run_session(
+    rng: &mut ChaCha8Rng,
+    delta: Gf2_64,
+    prover_content: Vec<Vec<Gf2>>,
+    verifier_content: Vec<Vec<Gf2>>,
+    lookups: Vec<[Vec<Gf2>; 1]>,
+) -> Result<(), mpz_two_shuffles::ro_kvs::VerifierError> {
+    let n_setup = verifier_content.len();
+
+    // ---- VOLE----
+    let (user_rvole_s, user_rvole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- vole_zk perm-proof ----
+    let (perm_prover, perm_verifier) =
+        build_perm_proof_pair(rng, delta, n_setup + lookups.len(), FAN_IN);
+
+    // ---- Build prover and verifier ----
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        KEY_SPACE,
+        VALUE_BITS,
+        MultiplicativeStep::new(lookups.len()).expect("supported size"),
+        DerandVOLEReceiver::new(user_rvole_r),
+        perm_prover,
+    )
+    .expect("prover new");
+
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        KEY_SPACE,
+        VALUE_BITS,
+        MultiplicativeStep::new(lookups.len()).expect("supported size"),
+        user_rvole_s,
+        perm_verifier,
+    )
+    .expect("verifier new");
+
+    prover.alloc(n_setup, lookups.len()).expect("prover alloc");
+    verifier
+        .alloc(n_setup, lookups.len())
+        .expect("verifier alloc");
+
+    // Setup is public.
+    prover.setup(prover_content).expect("prover setup");
+    verifier.setup(verifier_content).expect("verifier setup");
+
+    // Commit accesses to a transcript.
+    let (lookup_commits, transcript) = commit_accesses::<Gf2, Gf2_64, 1>(lookups, delta, rng);
+    // Prover and verifier transcript.
+    let mut p_transcript = transcript.clone();
+    let mut v_transcript = transcript;
+
+    for [(prover_key, verifier_key)] in lookup_commits {
+        prover.lookup(prover_key).expect("prover lookup");
+        verifier.lookup(verifier_key).expect("verifier lookup");
+    }
+
+    let prepare = prover
+        .teardown_prepare(&mut p_transcript)
+        .expect("prover teardown_prepare");
+    verifier
+        .teardown_prepare(&mut v_transcript, prepare)
+        .expect("verifier teardown_prepare");
+
+    let msg = prover.teardown(&mut p_transcript).expect("prover teardown");
+    verifier.teardown(msg, &mut v_transcript)
+}
+
+/// Honest end-to-end.
+#[test]
+fn accepts_honest_protocol() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_ro_kvs_witness(KEY_SPACE, VALUE_BITS, TOTAL_LOOKUPS, &mut rng);
+
+    run_session(
+        &mut rng,
+        delta,
+        witness.content.clone(),
+        witness.content,
+        witness.lookups,
+    )
+    .expect("honest case must accept");
+}
+
+/// Dishonest end-to-end.
+#[test]
+fn rejects_dishonest_prover() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_ro_kvs_witness(KEY_SPACE, VALUE_BITS, TOTAL_LOOKUPS, &mut rng);
+
+    let verifier_content = witness.content.clone();
+    let mut prover_content = witness.content;
+    // Flip a bit in key 0's value — caught by the teardown read.
+    prover_content[0][0] = Gf2(!prover_content[0][0].0);
+
+    let err = run_session(
+        &mut rng,
+        delta,
+        prover_content,
+        verifier_content,
+        witness.lookups,
+    )
+    .expect_err("dishonest case must reject");
+    assert!(
+        matches!(err, mpz_two_shuffles::ro_kvs::VerifierError::PermProof(_)),
+        "expected PermProof error, got {err:?}",
+    );
+}

--- a/crates/two-shuffles/tests/set_api.rs
+++ b/crates/two-shuffles/tests/set_api.rs
@@ -1,0 +1,137 @@
+//! End-to-end tests for the Set membership protocol.
+
+use mpz_fields::{gf2::Gf2, gf2_64::Gf2_64};
+use mpz_two_shuffles::{
+    set::{Prover, Verifier},
+    strategy::{Char2Strategy, version::MultiplicativeStep},
+    test_utils::{IDEAL_VOLE_POOL, commit_accesses, generate_set_witness, ideal_rvole_pair},
+};
+use mpz_vole_core::DerandVOLEReceiver;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use mpz_perm_proof_core::test_utils::build_ideal_perm_proof_pair as build_perm_proof_pair;
+
+/// Element space — members are drawn from `0..ELEMENT_SPACE`.
+const ELEMENT_SPACE: usize = 1 << 16;
+/// Number of distinct members in the set.
+const SET_SIZE: usize = 1024;
+/// Lookups performed per session.
+const TOTAL_LOOKUPS: usize = 512;
+const FAN_IN: usize = 8;
+
+/// Build the VOLE / perm-proof / version machinery and run setup →
+/// lookups → teardown_prepare → teardown for one membership session.
+fn run_session(
+    rng: &mut ChaCha8Rng,
+    delta: Gf2_64,
+    prover_members: Vec<Vec<Gf2>>,
+    verifier_members: Vec<Vec<Gf2>>,
+    lookups: Vec<[Vec<Gf2>; 1]>,
+) -> Result<(), mpz_two_shuffles::set::VerifierError> {
+    let n_setup = verifier_members.len();
+
+    // ---- VOLE ----
+    let (user_rvole_s, user_rvole_r) = ideal_rvole_pair(rng, delta, IDEAL_VOLE_POOL);
+
+    // ---- vole_zk perm-proof ----
+    let (perm_prover, perm_verifier) =
+        build_perm_proof_pair(rng, delta, n_setup + lookups.len(), FAN_IN);
+
+    // ---- Build prover and verifier ----
+    let mut prover = Prover::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_setup,
+        MultiplicativeStep::new(lookups.len()).expect("supported size"),
+        DerandVOLEReceiver::new(user_rvole_r),
+        perm_prover,
+    )
+    .expect("prover new");
+
+    let mut verifier = Verifier::<_, _, _, Char2Strategy<Gf2_64>>::new(
+        n_setup,
+        MultiplicativeStep::new(lookups.len()).expect("supported size"),
+        user_rvole_s,
+        perm_verifier,
+    )
+    .expect("verifier new");
+
+    prover.alloc(lookups.len()).expect("prover alloc");
+    verifier.alloc(lookups.len()).expect("verifier alloc");
+
+    prover
+        .setup(prover_members.into_iter().map(Into::into).collect())
+        .expect("prover setup");
+    verifier
+        .setup(verifier_members.into_iter().map(Into::into).collect())
+        .expect("verifier setup");
+
+    // Commit lookups to a transcript.
+    let (lookup_commits, transcript) = commit_accesses::<Gf2, Gf2_64, 1>(lookups, delta, rng);
+
+    let mut p_transcript = transcript.clone();
+    let mut v_transcript = transcript;
+    // Prover and verifier transcript.
+    for [(prover_elem, verifier_elem)] in lookup_commits {
+        prover.lookup(prover_elem).expect("prover lookup");
+        verifier.lookup(verifier_elem).expect("verifier lookup");
+    }
+
+    let prepare = prover
+        .teardown_prepare(&mut p_transcript)
+        .expect("prover teardown_prepare");
+    verifier
+        .teardown_prepare(&mut v_transcript, prepare)
+        .expect("verifier teardown_prepare");
+
+    let msg = prover.teardown(&mut p_transcript).expect("prover teardown");
+    verifier.teardown(msg, &mut v_transcript)
+}
+
+/// Honest end-to-end.
+#[test]
+fn accepts_honest_membership() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_set_witness(ELEMENT_SPACE, SET_SIZE, TOTAL_LOOKUPS, &mut rng);
+
+    run_session(
+        &mut rng,
+        delta,
+        witness.members.clone(),
+        witness.members,
+        witness.lookups,
+    )
+    .expect("honest case must accept");
+}
+
+/// Dishonest end-to-end.
+#[test]
+fn rejects_dishonest_set() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0x42);
+    let delta: Gf2_64 = rng.random();
+    let witness = generate_set_witness(ELEMENT_SPACE, SET_SIZE, TOTAL_LOOKUPS, &mut rng);
+
+    let verifier_members = witness.members.clone();
+    let mut prover_members = witness.members;
+
+    // Pick a member that no lookup queries (fewer lookups than members,
+    // so one is guaranteed) and flip a bit in it.
+    let idx = prover_members
+        .iter()
+        .position(|m| !witness.lookups.iter().any(|[e]| e == m))
+        .expect("some member is never looked up");
+    prover_members[idx][0] = Gf2(!prover_members[idx][0].0);
+
+    let err = run_session(
+        &mut rng,
+        delta,
+        prover_members,
+        verifier_members,
+        witness.lookups,
+    )
+    .expect_err("dishonest case must reject");
+    assert!(
+        matches!(err, mpz_two_shuffles::set::VerifierError::PermProof(_)),
+        "expected PermProof error, got {err:?}",
+    );
+}


### PR DESCRIPTION
Implementation of ZK data structures from "Two Shuffles Make a RAM" (Yang/Heath, 2023)

## Benchmarks

| Protocol | Workload | Native Prover | Native Verifier | WASM Prover | WASM Verifier |
  |----------|----------|--------------:|----------------:|------------:|--------------:|
  | RAM      | 4 096 cells, 100 000 accesses    | 1.972 s  | 1.576 s  | 2.917 s  | 2.398 s  |
  | RO-KVS   | 40 000 pairs, 100 000 lookups    | 514.2 ms | 388.5 ms | 808.2 ms | 655.7 ms |
  | Set      | 100 000 members, 100 000 lookups | 739.0 ms | 425.5 ms | 1.109 s  | 715.6 ms |

  Runs are single-threaded with hardware acceleration.
