### PR TITLE
fix(wasm-bench): actually disable Chrome sandbox in CI

### DIFF
--- a/crates/wasm-bench/src/bin/runner.rs
+++ b/crates/wasm-bench/src/bin/runner.rs
@@ -526,14 +526,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start HTTP server
     let server_addr = start_server(crate_dir).await?;
 
-    // Configure browser (headless)
-    // Chromiumoxide's `Arg` parser treats the whole string as the flag key and
-    // prepends `--` itself, so passing `--no-sandbox` yields the invalid flag
-    // `----no-sandbox`, which Chrome silently ignores. Pass bare keys, and use
-    // the dedicated `no_sandbox` builder so the sandbox is actually disabled
-    // (required on CI runners where unprivileged user namespaces are blocked).
+    // Configure headless browser.
     let builder = BrowserConfig::builder()
-        .no_sandbox()
+        .no_sandbox() // CI runners block the unprivileged user namespaces the sandbox needs
         .arg("disable-dev-shm-usage")
         .arg("disable-gpu")
         .arg("disable-cache")

--- a/crates/wasm-bench/src/bin/runner.rs
+++ b/crates/wasm-bench/src/bin/runner.rs
@@ -527,13 +527,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server_addr = start_server(crate_dir).await?;
 
     // Configure browser (headless)
+    // Chromiumoxide's `Arg` parser treats the whole string as the flag key and
+    // prepends `--` itself, so passing `--no-sandbox` yields the invalid flag
+    // `----no-sandbox`, which Chrome silently ignores. Pass bare keys, and use
+    // the dedicated `no_sandbox` builder so the sandbox is actually disabled
+    // (required on CI runners where unprivileged user namespaces are blocked).
     let builder = BrowserConfig::builder()
-        .arg("--no-sandbox")
-        .arg("--disable-dev-shm-usage")
-        .arg("--disable-gpu")
-        .arg("--disable-cache")
-        .arg("--disable-application-cache")
-        .arg("--headless")
+        .no_sandbox()
+        .arg("disable-dev-shm-usage")
+        .arg("disable-gpu")
+        .arg("disable-cache")
+        .arg("disable-application-cache")
         .window_size(1200, 800);
 
     let config = builder.build()?;


### PR DESCRIPTION
## Problem

The "Build and Test WASM bench" CI job fails when launching headless Chrome:

```
FATAL ... zygote_host_impl_linux.cc:128] No usable sandbox! ... Ubuntu 23.10+ ...
disabled unprivileged user namespaces with AppArmor ... you can try using --no-sandbox.
```

This is a pre-existing bug on `dev`, surfaced by a GitHub runner-image change (the `ubuntu-24.04` image now blocks unprivileged user namespaces via AppArmor). It is unrelated to any feature branch.

## Root cause

The runner passed flags as `.arg("--no-sandbox")`. In chromiumoxide 0.9.1, `From<&str> for Arg` stores the **entire** string as the flag key, and `launch()` later renders every key as `format!("--{key}")`. So `.arg("--no-sandbox")` becomes `----no-sandbox` (four dashes), which Chrome silently ignores. Every `--`-prefixed `.arg()` call here was mangled the same way.

Because chromiumoxide defaults its internal `sandbox` field to `true`, and the malformed flag never disabled it, Chrome ran with the sandbox enabled and aborted on the restricted runner.

Verified by executing chromiumoxide's exact arg-rendering logic:

| `.arg(...)` | resulting argv | valid? |
|---|---|---|
| `.arg("--no-sandbox")` | `----no-sandbox` | ❌ ignored |
| `.arg("no-sandbox")` | `--no-sandbox` | ✅ |

## Fix

- Use the dedicated `.no_sandbox()` builder, which sets the internal `sandbox` field chromiumoxide actually checks.
- Pass bare keys (no `--` prefix) for the remaining flags.
- Drop `--headless`, since chromiumoxide already defaults to headless mode.