### PR TITLE
fix(ci): install aarch64 cross compiler for Miri job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The `alloca` crate (a dev-dependency pulled in via criterion) has a
+      # build script that cross-compiles C, which needs an aarch64 C compiler
+      # for the aarch64 Miri target.
+      - name: Install aarch64 cross compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri


### PR DESCRIPTION
## Problem

The "Test with Miri" CI job fails on the aarch64 step:

```
error occurred in cc-rs: failed to find tool "aarch64-linux-gnu-gcc": No such file or directory
error: failed to run custom build command for `alloca v0.4.0`
```

This is a pre-existing failure on `dev` (independent of any feature branch). `criterion` (declared `0.8`) resolves to `0.8.2`, which now pulls in `alloca v0.4.0` as a dev-dependency of `clmul`. `alloca`'s build script cross-compiles C, and the aarch64 Miri step (`cargo miri test ... --target aarch64-unknown-linux-gnu`) has no aarch64 C compiler, so the build fails before Miri runs. Since `Cargo.lock` isn't committed, this surfaced once the newer criterion release got picked up.

## Fix

Install `gcc-aarch64-linux-gnu` before the Miri steps. cc-rs auto-detects `aarch64-linux-gnu-gcc` by target triple, so no extra env vars are needed. This mirrors the existing `CARGO_FEATURE_NO_NEON` workaround already in the job for blake3's NEON asm.

## Note

The same run also fails the "Build and Test WASM bench" job for an unrelated reason (Chrome sandbox flag), fixed separately in #407.