### PR TITLE
feat(vm-core): add Vm::commit and Vm::call_local

### DIFF
--- a/crates/vm-core/src/lib.rs
+++ b/crates/vm-core/src/lib.rs
@@ -133,6 +133,46 @@ pub trait Vm {
         func_idx: u32,
         params: Vec<Param>,
     ) -> impl std::future::Future<Output = Result<Option<Value>, Self::Error>>;
+
+    /// Flushes any queued memory operations, committing them over `io` without
+    /// running a function.
+    ///
+    /// [`write`](Self::write) and [`reveal`](Self::reveal) stage their effects
+    /// for the next exchange, which normally happens at the start of the next
+    /// [`call`](Self::call). `commit` performs that exchange on demand: queued
+    /// inputs are committed and queued reveals are opened up front. With nothing
+    /// left pending, a subsequent [`call_local`](Self::call_local) can run with
+    /// no further communication.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the exchange over `io` fails.
+    fn commit(
+        &mut self,
+        io: &mut mpz_common::Context,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>>;
+
+    /// Invokes the function at `func_idx` with `params` using only local work,
+    /// without an `io` context.
+    ///
+    /// Unlike [`call`](Self::call), this performs no communication with other
+    /// parties: it runs the function only while every step can be evaluated from
+    /// values this party already holds. It is intended for functions whose
+    /// inputs are all public (or have already been committed via
+    /// [`commit`](Self::commit)).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the call would require communication — for
+    /// example when private or blind inputs remain uncommitted, when a reveal is
+    /// pending, or when execution reaches a symbolic operation that cannot be
+    /// resolved locally — in addition to the usual failures: an invalid
+    /// `func_idx`, a signature mismatch, or a trap.
+    fn call_local(
+        &mut self,
+        func_idx: u32,
+        params: Vec<Param>,
+    ) -> Result<Option<Value>, Self::Error>;
 }
 
 /// An operand of an [`Op`], either a concrete value or a symbolic register.

--- a/crates/vm-ideal/src/lib.rs
+++ b/crates/vm-ideal/src/lib.rs
@@ -15,7 +15,8 @@ use rangeset::{prelude::*, set::RangeSet};
 use serio::{SinkExt, stream::IoStreamExt};
 
 use mpz_vm_core::{
-    Call, Error as CoreError, Global, Module, Operand, Param, Trap, Visibility, Vm, Write,
+    Call, Directive, Error as CoreError, Global, Module, Operand, Param, Trap, Visibility, Vm,
+    Write,
     thread::{Pending, StepResult, Thread},
     value::Value,
 };
@@ -63,6 +64,11 @@ pub enum IdealError {
     /// An I/O operation over the coordination channel failed.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// A local-only call ([`Vm::call_local`]) reached work that requires
+    /// communication with another party.
+    #[error("operation requires communication: {0}")]
+    RequiresCommunication(String),
 
     /// An invariant of the ideal VM was violated, indicating a bug.
     #[error("internal error: {0}")]
@@ -525,6 +531,56 @@ impl Instance {
             }
         }
     }
+
+    /// Runs `thread` to completion using only local work, rejecting any step
+    /// that would require communication in a real multi-party backend.
+    ///
+    /// Host calls are still serviced (the ideal functionality holds every
+    /// value, so reveals are local), but a symbolic [`Op`], a private branch, or
+    /// a block on an unheld value reports [`IdealError::RequiresCommunication`].
+    fn run_loop_local(&mut self, thread: &mut Thread) -> Result<Option<Value>, IdealError> {
+        loop {
+            let result = match thread.step(&self.module, &mut self.global) {
+                Ok(r) => r,
+                Err(e) => {
+                    let e: IdealError = e.into();
+                    self.dump_error(thread, &e);
+                    return Err(e);
+                }
+            };
+
+            match result {
+                StepResult::Continue => {}
+                // Control-flow directives (local calls, returns, public branches)
+                // are in-thread bookkeeping; a symbolic op or private branch is
+                // not locally resolvable in a real backend.
+                StepResult::Directive(Directive::Op(_)) => {
+                    return Err(IdealError::RequiresCommunication(
+                        "symbolic operation requires communication".into(),
+                    ));
+                }
+                StepResult::Directive(Directive::Branch {
+                    cond: Some(Operand::Symbol { .. }),
+                    ..
+                }) => {
+                    return Err(IdealError::RequiresCommunication(
+                        "private branch requires communication".into(),
+                    ));
+                }
+                StepResult::Directive(_) => {}
+                StepResult::Blocked(Pending::HostCall { func_idx, args, .. }) => {
+                    self.service_host_call(thread, func_idx, &args)?;
+                }
+                StepResult::Blocked(_) => {
+                    return Err(IdealError::RequiresCommunication(
+                        "execution blocked on a value not held locally".into(),
+                    ));
+                }
+                StepResult::Trapped { trap, .. } => return Err(IdealError::Trap(trap)),
+                StepResult::Done { result, .. } => return Ok(result),
+            }
+        }
+    }
 }
 
 impl Vm for Instance {
@@ -635,6 +691,80 @@ impl Vm for Instance {
         thread.call(&self.module, &mut self.global, call)?;
         self.flush(&mut thread, io, &params).await?;
         self.run_loop(&mut thread).await
+    }
+
+    /// Flushes any pending memory regions over `io` without running a function.
+    ///
+    /// Staged private, blind, public, and reveal regions are exchanged exactly
+    /// as the next [`call`](Vm::call) would, leaving nothing pending. Returns
+    /// immediately when there is no pending memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`IdealError`] if the exchange over `io` fails or the module
+    /// has no linear memory to exchange.
+    async fn commit(&mut self, io: &mut IoContext) -> Result<(), IdealError> {
+        if !self.has_pending_memory() {
+            return Ok(());
+        }
+        // No call is in progress, so there are no private/blind parameters to
+        // exchange; `flush` runs the memory exchange against a fresh thread.
+        let mut thread = Thread::new();
+        self.flush(&mut thread, io, &[]).await
+    }
+
+    /// Calls the function at `func_idx` with `params`, running it to completion
+    /// using only local work.
+    ///
+    /// Pending public writes are settled locally; private, blind, or reveal
+    /// regions must first be flushed with [`commit`](Vm::commit), and `params`
+    /// must be public. Execution then runs with no communication.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdealError::RequiresCommunication`] if `params` carry private
+    /// or blind values, if any private/blind/reveal region is still pending, or
+    /// if execution reaches a step that is not locally resolvable. Otherwise
+    /// returns a [`IdealError`] for an invalid `func_idx`, a signature mismatch,
+    /// or a trap.
+    fn call_local(
+        &mut self,
+        func_idx: u32,
+        params: Vec<Param>,
+    ) -> Result<Option<Value>, IdealError> {
+        self.validate_call(func_idx, &params)?;
+        if params
+            .iter()
+            .any(|p| matches!(p, Param::Private(_) | Param::Blind(_)))
+        {
+            return Err(IdealError::RequiresCommunication(
+                "call_local requires public params; private or blind inputs must be exchanged via call".into(),
+            ));
+        }
+        if !self.pending_private.is_empty()
+            || !self.pending_blind.is_empty()
+            || !self.pending_reveal.is_empty()
+        {
+            return Err(IdealError::RequiresCommunication(
+                "pending private, blind, or reveal memory must be flushed with commit before call_local".into(),
+            ));
+        }
+
+        // Pending public writes need no exchange: their bytes are already in
+        // memory; settle their visibility locally and clear the queue.
+        let public_ranges: Vec<Range<u32>> = self.pending_public.iter().collect();
+        for range in public_ranges {
+            self.global.set_memory_visibility(
+                range.start,
+                (range.end - range.start) as usize,
+                Visibility::Public,
+            );
+        }
+        self.pending_public.clear();
+
+        let mut thread = Thread::new();
+        thread.call(&self.module, &mut self.global, Call { func_idx, params })?;
+        self.run_loop_local(&mut thread)
     }
 }
 

--- a/crates/vm-ideal/tests/behavior.rs
+++ b/crates/vm-ideal/tests/behavior.rs
@@ -12,7 +12,7 @@ use mpz_vm_ir::Module;
 use mpz_vm_core::{Param, Vm, Write, value::Value};
 use mpz_vm_ideal::{IdealError, Instance};
 use mpz_vm_test_harness::behavior::{
-    Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index,
+    Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index, parse_module,
 };
 
 /// A pair of ideal-VM instances exchanging over an in-process channel.
@@ -89,6 +89,18 @@ impl MemVm for IdealPair {
                     ));
                     observations.push(Observation::Agreement(agreement(a, b)));
                 }
+                MemStep::Commit => {
+                    let (mut ctx_a, mut ctx_b) = test_st_context(8);
+                    block_on(try_join(self.a.commit(&mut ctx_a), self.b.commit(&mut ctx_b)))?;
+                }
+                MemStep::CallLocal { func, args } => {
+                    let idx = func_index(self.a.module(), func)
+                        .ok_or_else(|| IdealError::Internal(format!("no export {func}")))?;
+                    let params: Vec<Param> = args.iter().copied().map(Param::Public).collect();
+                    let a = self.a.call_local(idx, params.clone())?;
+                    let b = self.b.call_local(idx, params)?;
+                    observations.push(Observation::Call { a, b });
+                }
             }
         }
         Ok(observations)
@@ -117,3 +129,43 @@ fn agreement(
 }
 
 mpz_vm_test_harness::mem_behavior_tests!(IdealPair);
+
+/// `call_local` refuses a private parameter: settling it requires an exchange.
+#[test]
+fn call_local_rejects_private_param() {
+    let module =
+        parse_module("(module (func (export \"id\") (param i32) (result i32) local.get 0))")
+            .unwrap();
+    let mut inst = Instance::new(module.clone()).unwrap();
+    let idx = func_index(inst.module(), "id").unwrap();
+    let err = inst
+        .call_local(idx, vec![Param::Private(Value::I32(1))])
+        .unwrap_err();
+    assert!(
+        matches!(err, IdealError::RequiresCommunication(_)),
+        "got {err:?}"
+    );
+}
+
+/// `call_local` refuses to run once execution turns symbolic: a committed
+/// private write feeds a load that cannot be evaluated locally.
+#[test]
+fn call_local_rejects_symbolic_execution() {
+    let module = parse_module(
+        "(module (memory 1)
+            (func (export \"loadadd\") (result i32)
+                i32.const 0 i32.load i32.const 1 i32.add))",
+    )
+    .unwrap();
+    let mut pair = IdealPair::instantiate(&module).unwrap();
+    pair.a.write(0, Write::Private(&7i32.to_le_bytes())).unwrap();
+    pair.b.write(0, Write::Blind(4)).unwrap();
+    let (mut ctx_a, mut ctx_b) = test_st_context(8);
+    block_on(try_join(pair.a.commit(&mut ctx_a), pair.b.commit(&mut ctx_b))).unwrap();
+    let idx = func_index(pair.a.module(), "loadadd").unwrap();
+    let err = pair.a.call_local(idx, vec![]).unwrap_err();
+    assert!(
+        matches!(err, IdealError::RequiresCommunication(_)),
+        "got {err:?}"
+    );
+}

--- a/crates/vm-test-harness/src/behavior.rs
+++ b/crates/vm-test-harness/src/behavior.rs
@@ -63,6 +63,17 @@ pub enum MemStep {
     /// Both parties queue a reveal of `ptr..ptr+len`. Takes effect on the next
     /// flush, after which the range is concrete.
     Reveal { ptr: u32, len: usize },
+    /// Both parties flush pending writes and reveals via [`Vm::commit`], with no
+    /// function call. Records no observation: it is a pure flush.
+    ///
+    /// [`Vm::commit`]: mpz_vm_core::Vm::commit
+    Commit,
+    /// Invoke the exported function `func` with public `args` on both parties
+    /// via [`Vm::call_local`] — local work only, with no communication. Records
+    /// a [`Observation::Call`] with each party's return value.
+    ///
+    /// [`Vm::call_local`]: mpz_vm_core::Vm::call_local
+    CallLocal { func: String, args: Vec<Value> },
     /// Invoke the exported function `func` with public `args` on both parties.
     /// Flushes any pending writes/reveals first. Records a [`Observation::Call`]
     /// with each party's return value. A no-op export flushes without computing.
@@ -156,6 +167,11 @@ pub fn scenarios() -> Vec<Scenario> {
         consistent_public_checked_call(),
         inconsistent_public_write_disagrees(),
         inconsistent_public_feeds_authenticated_op(),
+        commit_flushes_private_write(),
+        commit_reveal_separate_rounds(),
+        commit_then_call_consumes_memory(),
+        call_local_runs_public_function(),
+        call_local_with_public_args(),
     ]
 }
 
@@ -397,6 +413,137 @@ fn inconsistent_public_feeds_authenticated_op() -> Scenario {
             },
         ],
         expected: vec![Observation::Agreement(Agreement::Disagreed)],
+    }
+}
+
+/// `commit` flushes a queued private write with no function call: the bytes
+/// become committed (symbolic, unreadable on both sides) without any export
+/// being invoked. The module exports no function at all, so a flush could not
+/// have ridden on a stand-in no-op call. Before the commit, party A could still
+/// read its own un-flushed bytes; after it, the range is symbolic on both.
+fn commit_flushes_private_write() -> Scenario {
+    let bytes = vec![0xca, 0xfe, 0xba, 0xbe];
+    Scenario {
+        name: "commit_flushes_private_write",
+        wat: r#"(module (memory 1))"#.to_string(),
+        steps: vec![
+            MemStep::WritePrivateA {
+                ptr: 0,
+                bytes: bytes.clone(),
+            },
+            MemStep::Commit,
+            MemStep::Read { ptr: 0, len: 4 },
+        ],
+        expected: vec![Observation::Read {
+            a: ReadOutcome::Err,
+            b: ReadOutcome::Err,
+        }],
+    }
+}
+
+/// `commit` run twice: the first commits a private write (leaving it symbolic
+/// and unreadable), the second opens a later reveal against those
+/// already-committed wires — exercising a reveal that spans commit rounds.
+fn commit_reveal_separate_rounds() -> Scenario {
+    let bytes = vec![0x11, 0x22, 0x33, 0x44];
+    Scenario {
+        name: "commit_reveal_separate_rounds",
+        wat: r#"(module (memory 1))"#.to_string(),
+        steps: vec![
+            MemStep::WritePrivateA {
+                ptr: 0,
+                bytes: bytes.clone(),
+            },
+            MemStep::Commit,
+            MemStep::Read { ptr: 0, len: 4 },
+            MemStep::Reveal { ptr: 0, len: 4 },
+            MemStep::Commit,
+            MemStep::Read { ptr: 0, len: 4 },
+        ],
+        expected: vec![
+            Observation::Read {
+                a: ReadOutcome::Err,
+                b: ReadOutcome::Err,
+            },
+            Observation::Read {
+                a: ReadOutcome::Ok(bytes.clone()),
+                b: ReadOutcome::Ok(bytes),
+            },
+        ],
+    }
+}
+
+/// A private write committed up front via `commit` is then consumed by a full
+/// proving `call`: the committed memory wires persist across rounds and feed the
+/// later computation, which returns the right value on both parties.
+fn commit_then_call_consumes_memory() -> Scenario {
+    let wat = r#"(module
+        (memory 1)
+        (func (export "loadadd") (result i32)
+            i32.const 0 i32.load i32.const 1 i32.add))"#
+        .to_string();
+    Scenario {
+        name: "commit_then_call_consumes_memory",
+        wat,
+        steps: vec![
+            MemStep::WritePrivateA {
+                ptr: 0,
+                bytes: 7i32.to_le_bytes().to_vec(),
+            },
+            MemStep::Commit,
+            MemStep::Call {
+                func: "loadadd".to_string(),
+                args: vec![],
+            },
+        ],
+        expected: vec![Observation::Call {
+            a: Some(Value::I32(8)),
+            b: Some(Value::I32(8)),
+        }],
+    }
+}
+
+/// `call_local` runs an all-public function with no communication: a public
+/// write feeds a load that both parties evaluate identically in-thread.
+fn call_local_runs_public_function() -> Scenario {
+    Scenario {
+        name: "call_local_runs_public_function",
+        wat: load0_module(),
+        steps: vec![
+            MemStep::WritePublic {
+                ptr: 0,
+                bytes: 5i32.to_le_bytes().to_vec(),
+            },
+            MemStep::CallLocal {
+                func: "load0".to_string(),
+                args: vec![],
+            },
+        ],
+        expected: vec![Observation::Call {
+            a: Some(Value::I32(5)),
+            b: Some(Value::I32(5)),
+        }],
+    }
+}
+
+/// `call_local` runs a pure public computation over its public arguments, with
+/// no memory and no communication.
+fn call_local_with_public_args() -> Scenario {
+    let wat = r#"(module
+        (func (export "add") (param i32 i32) (result i32)
+            local.get 0 local.get 1 i32.add))"#
+        .to_string();
+    Scenario {
+        name: "call_local_with_public_args",
+        wat,
+        steps: vec![MemStep::CallLocal {
+            func: "add".to_string(),
+            args: vec![Value::I32(2), Value::I32(3)],
+        }],
+        expected: vec![Observation::Call {
+            a: Some(Value::I32(5)),
+            b: Some(Value::I32(5)),
+        }],
     }
 }
 

--- a/crates/vm-zk/src/capture.rs
+++ b/crates/vm-zk/src/capture.rs
@@ -13,7 +13,9 @@
 
 use std::collections::BTreeMap;
 
-use mpz_vm_core::{Directive, Global, Pending, Reg, StepResult, Thread, Trap, value::Value};
+use mpz_vm_core::{
+    Directive, Global, Operand, Pending, Reg, StepResult, Thread, Trap, value::Value,
+};
 use mpz_vm_ir::{Function, Module};
 
 use crate::{
@@ -230,6 +232,47 @@ pub(crate) fn capture_chunk(
                     reveals,
                 });
             }
+        }
+    }
+}
+
+/// Steps `thread` to completion using only local work, rejecting any step that
+/// would require a proving round (and thus communication with the other party).
+///
+/// Public computation is reproduced in-thread and runs to a [`StepResult::Done`]
+/// or a trap. A symbolic [`Op`](mpz_vm_core::Op), a private branch, or a host
+/// call (every zk-vm host call is a reveal) reports
+/// [`ZkVmError::RequiresCommunication`]; the remaining directives — local calls,
+/// returns, and public branches — are in-thread control flow.
+pub(crate) fn run_local(
+    module: &Module,
+    global: &mut Global,
+    thread: &mut Thread,
+) -> Result<Option<Value>> {
+    loop {
+        match thread.step(module, global)? {
+            StepResult::Continue => {}
+            StepResult::Directive(Directive::Op(_)) => {
+                return Err(ZkVmError::RequiresCommunication(
+                    "symbolic operation requires a proving round".into(),
+                ));
+            }
+            StepResult::Directive(Directive::Branch {
+                cond: Some(Operand::Symbol { .. }),
+                ..
+            }) => {
+                return Err(ZkVmError::RequiresCommunication(
+                    "private branch requires a proving round".into(),
+                ));
+            }
+            StepResult::Directive(_) => {}
+            StepResult::Blocked(_) => {
+                return Err(ZkVmError::RequiresCommunication(
+                    "execution requires communication".into(),
+                ));
+            }
+            StepResult::Trapped { trap, .. } => return Err(ZkVmError::Trap(trap)),
+            StepResult::Done { result, .. } => return Ok(result),
         }
     }
 }

--- a/crates/vm-zk/src/error.rs
+++ b/crates/vm-zk/src/error.rs
@@ -61,6 +61,8 @@ pub enum ZkVmError {
 
     #[error("unsupported: {0}")]
     Unsupported(String),
+    #[error("operation requires communication: {0}")]
+    RequiresCommunication(String),
     #[error("internal: {0}")]
     Internal(String),
 }

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -467,4 +467,142 @@ where
         tracing::info!(chunks = chunk_idx, ?final_result, "prover call complete");
         Ok(final_result)
     }
+
+    /// Commits any queued private writes and opens any queued reveals over `io`
+    /// without running a function.
+    ///
+    /// This performs a single proving round that commits the wires of every
+    /// pending [`Write::Private`] region and proves-then-opens every pending
+    /// [`reveal`](Vm::reveal) range, leaving nothing queued. The committed
+    /// memory wires persist and are consumed by a later [`call`](Vm::call).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ZkVmError`] if proving fails or communication over `io`
+    /// fails.
+    #[tracing::instrument(level = "info", skip(self, io))]
+    async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
+        let commit_bits = self.pending_io.cost_bits();
+        let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
+        let reveal_pending = !reveal_ranges.is_empty();
+        if commit_bits == 0 && !reveal_pending {
+            return Ok(());
+        }
+
+        // A commit round runs no gates, so the only authenticated bits are the
+        // committed inputs.
+        let execute_bits = commit_bits;
+        let total = execute_bits + VOPE_BITS;
+        let (mut masks, macs) = self.allocate(io, total).await?;
+        let (exec_masks, vope_masks) = masks.split_at_mut(execute_bits);
+        let vope_masks: &[bool; VOPE_BITS] = (&*vope_masks)
+            .try_into()
+            .expect("vope tail is VOPE_BITS wide");
+        let (exec_macs, vope_macs) = macs.split_at(execute_bits);
+        let vope_macs: &[Gf2_128; VOPE_BITS] =
+            vope_macs.try_into().expect("vope tail is VOPE_BITS wide");
+
+        let mut revealed: Vec<u8> = Vec::new();
+        {
+            let mut exec = self
+                .zk
+                .execute(exec_masks, exec_macs)
+                .map_err(|e| ZkVmError::Internal(e.to_string()))?;
+            if commit_bits > 0 {
+                commit::commit_memory_prover(
+                    &mut self.auth,
+                    &self.pending_io,
+                    &self.global,
+                    &mut exec,
+                )?;
+            }
+            if reveal_pending {
+                let memory = self
+                    .global
+                    .memory()
+                    .ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
+                revealed = reveal::reveal_prover(&mut exec, &self.auth, memory, &reveal_ranges)?;
+            }
+            exec.finish()
+                .map_err(|e| ZkVmError::Internal(e.to_string()))?;
+        }
+
+        let commit_payload = Commit {
+            adjust: exec_masks.iter().copied().collect(),
+        };
+        io.io_mut()
+            .send(commit_payload)
+            .await
+            .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+        let chi: [u8; 32] = io
+            .io_mut()
+            .expect_next()
+            .await
+            .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
+        let proof = self.zk.prove(chi, vope_masks, vope_macs);
+        io.io_mut()
+            .send(ProofMessage {
+                output: None,
+                revealed,
+                proof,
+            })
+            .await
+            .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+
+        // Opened ranges are now public to both parties; drop their taint so
+        // later reads succeed. The cleartext already lives in linear memory.
+        if reveal_pending {
+            for r in &reveal_ranges {
+                self.global.set_memory_visibility(
+                    r.start,
+                    (r.end - r.start) as usize,
+                    Visibility::Public,
+                );
+            }
+        }
+        self.pending_io.clear();
+        self.pending_reveal = RangeSet::default();
+        Ok(())
+    }
+
+    /// Runs `func_idx` with `params` using only local work, without an `io`
+    /// context.
+    ///
+    /// Public computation is reproduced in-thread, so a function with public
+    /// inputs runs with no communication. Any authenticated work — a symbolic
+    /// op, a private branch, or a reveal host call — reports
+    /// [`ZkVmError::RequiresCommunication`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private
+    /// or blind values, if inputs or reveals remain queued (commit them first),
+    /// or if execution reaches authenticated work. Otherwise returns
+    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or [`ZkVmError::Trap`]
+    /// on a trap.
+    fn call_local(
+        &mut self,
+        func_idx: u32,
+        params: Vec<Param>,
+    ) -> Result<Option<Value>, ZkVmError> {
+        match self.module.function(func_idx) {
+            Some(Function::Local(_)) => {}
+            _ => return Err(ZkVmError::Core(CoreError::InvalidFunction(func_idx))),
+        }
+        if prepare_params(&params)? > 0 {
+            return Err(ZkVmError::RequiresCommunication(
+                "call_local requires public params; private or blind inputs need a proving round"
+                    .into(),
+            ));
+        }
+        if self.pending_io.cost_bits() > 0 || !self.pending_reveal.is_empty() {
+            return Err(ZkVmError::RequiresCommunication(
+                "queued inputs or reveals must be flushed with commit before call_local".into(),
+            ));
+        }
+
+        let mut thread = Thread::new();
+        thread.call(&self.module, &mut self.global, Call { func_idx, params })?;
+        capture::run_local(&self.module, &mut self.global, &mut thread)
+    }
 }

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -485,4 +485,145 @@ where
         tracing::info!(chunks = chunk_idx, ?final_output, "verifier call complete");
         Ok(final_output)
     }
+
+    /// Commits any queued blind writes and checks any queued reveals over `io`
+    /// without running a function.
+    ///
+    /// This mirrors the prover's [`commit`](crate::Prover::commit): a single
+    /// proving round commits the wires of every pending [`Write::Blind`] region
+    /// and verifies the prover's opening of every pending [`reveal`](Vm::reveal)
+    /// range, leaving nothing queued. The committed memory wires persist and are
+    /// consumed by a later [`call`](Vm::call).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ZkVmError`] if verification fails or communication over `io`
+    /// fails.
+    #[tracing::instrument(level = "info", skip(self, io))]
+    async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
+        let commit_bits = self.pending_io.cost_bits();
+        let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
+        let reveal_pending = !reveal_ranges.is_empty();
+        if commit_bits == 0 && !reveal_pending {
+            return Ok(());
+        }
+
+        // A commit round runs no gates, so the only authenticated bits are the
+        // committed inputs.
+        let execute_bits = commit_bits;
+        let total = execute_bits + VOPE_BITS;
+        let keys = self.allocate(io, total).await?;
+        let (exec_keys, vope_keys) = keys.split_at(execute_bits);
+        let vope_keys: &[Gf2_128; VOPE_BITS] =
+            vope_keys.try_into().expect("vope tail is VOPE_BITS wide");
+
+        let commit_msg: mpz_zk_core::Commit = io
+            .io_mut()
+            .expect_next()
+            .await
+            .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
+        let adjust: Vec<bool> = commit_msg.adjust.iter().by_vals().collect();
+        if adjust.len() != execute_bits {
+            return Err(ZkVmError::Internal(format!(
+                "commit adjust short: got {} want {}",
+                adjust.len(),
+                execute_bits
+            )));
+        }
+        let chi: [u8; 32] = rand::rng().random();
+        io.io_mut()
+            .send(chi)
+            .await
+            .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+
+        let ProofMessage {
+            output: _,
+            revealed,
+            proof,
+        } = io
+            .io_mut()
+            .expect_next()
+            .await
+            .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
+
+        {
+            let mut exec = self
+                .zk
+                .execute(exec_keys, &adjust)
+                .map_err(|e| ZkVmError::Internal(e.to_string()))?;
+            if commit_bits > 0 {
+                commit::commit_memory_verifier(&mut self.auth, &self.pending_io, &mut exec);
+            }
+            if reveal_pending {
+                reveal::reveal_verifier(&mut exec, &self.auth, &reveal_ranges, &revealed)?;
+            }
+            exec.finish()
+                .map_err(|e| ZkVmError::Internal(e.to_string()))?;
+        }
+        self.zk
+            .verify(chi, vope_keys, proof)
+            .map_err(|_| ZkVmError::BatchCheckFailed)?;
+
+        // The opening verified: write the revealed cleartext into linear memory
+        // and drop the ranges' taint so later reads succeed.
+        if reveal_pending {
+            let mut idx = 0;
+            for r in &reveal_ranges {
+                let len = (r.end - r.start) as usize;
+                let memory = self
+                    .global
+                    .memory_mut()
+                    .ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
+                memory
+                    .write_bytes(r.start, &revealed[idx..idx + len])
+                    .map_err(ZkVmError::Trap)?;
+                idx += len;
+                self.global
+                    .set_memory_visibility(r.start, len, Visibility::Public);
+            }
+        }
+        self.pending_io.clear();
+        self.pending_reveal = RangeSet::default();
+        Ok(())
+    }
+
+    /// Runs `func_idx` with `params` using only local work, without an `io`
+    /// context.
+    ///
+    /// Public computation is reproduced in-thread, so a function with public
+    /// inputs yields the same value the prover computes, with no communication.
+    /// Any authenticated work reports [`ZkVmError::RequiresCommunication`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private or
+    /// blind values, if inputs or reveals remain queued (commit them first), or
+    /// if execution reaches authenticated work. Otherwise returns
+    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or [`ZkVmError::Trap`]
+    /// on a trap.
+    fn call_local(
+        &mut self,
+        func_idx: u32,
+        params: Vec<Param>,
+    ) -> Result<Option<Value>, ZkVmError> {
+        match self.module.function(func_idx) {
+            Some(Function::Local(_)) => {}
+            _ => return Err(ZkVmError::Core(CoreError::InvalidFunction(func_idx))),
+        }
+        if prepare_params(&params)? > 0 {
+            return Err(ZkVmError::RequiresCommunication(
+                "call_local requires public params; private or blind inputs need a proving round"
+                    .into(),
+            ));
+        }
+        if self.pending_io.cost_bits() > 0 || !self.pending_reveal.is_empty() {
+            return Err(ZkVmError::RequiresCommunication(
+                "queued inputs or reveals must be flushed with commit before call_local".into(),
+            ));
+        }
+
+        let mut thread = Thread::new();
+        thread.call(&self.module, &mut self.global, Call { func_idx, params })?;
+        capture::run_local(&self.module, &mut self.global, &mut thread)
+    }
 }

--- a/crates/vm-zk/tests/mem_behavior.rs
+++ b/crates/vm-zk/tests/mem_behavior.rs
@@ -17,7 +17,7 @@ use mpz_vm_ir::Module;
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, Write, value::Value};
 use mpz_vm_test_harness::behavior::{
-    Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index,
+    Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index, parse_module,
 };
 use mpz_vm_zk::{Prover, Verifier, ZkVmError};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -103,6 +103,21 @@ impl MemVm for ZkPair {
                     ));
                     observations.push(Observation::Agreement(agreement(a, b)));
                 }
+                MemStep::Commit => {
+                    let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
+                    block_on(try_join(
+                        self.prover.commit(&mut ctx_p),
+                        self.verifier.commit(&mut ctx_v),
+                    ))?;
+                }
+                MemStep::CallLocal { func, args } => {
+                    let idx = func_index(&self.module, func)
+                        .ok_or_else(|| ZkVmError::Internal(format!("no export {func}")))?;
+                    let params: Vec<Param> = args.iter().copied().map(Param::Public).collect();
+                    let a = self.prover.call_local(idx, params.clone())?;
+                    let b = self.verifier.call_local(idx, params)?;
+                    observations.push(Observation::Call { a, b });
+                }
             }
         }
         Ok(observations)
@@ -128,3 +143,53 @@ fn agreement(a: Result<Option<Value>, ZkVmError>, b: Result<Option<Value>, ZkVmE
 }
 
 mpz_vm_test_harness::mem_behavior_tests!(ZkPair);
+
+/// `call_local` refuses a private parameter: committing it requires a proving
+/// round.
+#[test]
+fn call_local_rejects_private_param() {
+    let module =
+        parse_module("(module (func (export \"id\") (param i32) (result i32) local.get 0))")
+            .unwrap();
+    let mut pair = ZkPair::instantiate(&module).unwrap();
+    let idx = func_index(&pair.module, "id").unwrap();
+    let err = pair
+        .prover
+        .call_local(idx, vec![Param::Private(Value::I32(1))])
+        .unwrap_err();
+    assert!(
+        matches!(err, ZkVmError::RequiresCommunication(_)),
+        "got {err:?}"
+    );
+}
+
+/// `call_local` refuses to run once execution turns symbolic: a committed
+/// private write feeds a load, which can only be evaluated under proof. The
+/// same program runs fine through a full `call` (see
+/// `commit_then_call_consumes_memory`).
+#[test]
+fn call_local_rejects_symbolic_execution() {
+    let module = parse_module(
+        "(module (memory 1)
+            (func (export \"loadadd\") (result i32)
+                i32.const 0 i32.load i32.const 1 i32.add))",
+    )
+    .unwrap();
+    let mut pair = ZkPair::instantiate(&module).unwrap();
+    pair.prover
+        .write(0, Write::Private(&7i32.to_le_bytes()))
+        .unwrap();
+    pair.verifier.write(0, Write::Blind(4)).unwrap();
+    let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
+    block_on(try_join(
+        pair.prover.commit(&mut ctx_p),
+        pair.verifier.commit(&mut ctx_v),
+    ))
+    .unwrap();
+    let idx = func_index(&pair.module, "loadadd").unwrap();
+    let err = pair.prover.call_local(idx, vec![]).unwrap_err();
+    assert!(
+        matches!(err, ZkVmError::RequiresCommunication(_)),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
Adds two methods to the `Vm` trait, implemented across `vm-ideal` and the `vm-zk` prover/verifier.

## `commit`
Flushes queued memory operations (private/blind writes and reveals) over `io` **without running a function**. Lets inputs be committed up front, decoupled from a call.

- vm-ideal: reuses the existing memory exchange with no params.
- vm-zk: a single proving round that commits pending memory wires and opens pending reveals (no gates). The existing `call` path is untouched; committed wires persist and are consumed by a later `call`.

## `call_local`
Runs a function with **no `io` context** — steps the thread directly (no chunking) and errors with a new `RequiresCommunication` variant the moment a step would need communication (private/blind params, queued private/reveal memory, a symbolic `Op`, a private branch, or a host call). Intended for local-only work such as all-public inputs.

Composes as: `write` → `commit(io)` → `call_local()`.

## Tests
Coverage lives in the shared `vm-test-harness` `behavior` module (new `Commit`/`CallLocal` steps + scenarios) so **both backends run it from one place**, including the trickiest zk paths — a reveal-only commit round (`execute_bits = 0`) and a standalone `commit` whose wires feed a later proving `call`. Plus negative tests per backend. No regressions; no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)