### PR TITLE
feat(fields): add deferred-reduction Accumulator trait

### DIFF
--- a/crates/fields/benches/fields.rs
+++ b/crates/fields/benches/fields.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use mpz_core::{Block, prg::Prg};
-use mpz_fields::{Field, gf2_64::Gf2_64, gf2_128::Gf2_128};
+use mpz_fields::{Accumulator, Field, gf2_64::Gf2_64, gf2_128::Gf2_128};
 use rand::{Rng, SeedableRng};
 
 const INNER_PRODUCT_LENS: &[usize] = &[1 << 8, 1 << 16, 1 << 20];
@@ -9,6 +9,16 @@ fn naive_inner_product<T: Field>(a: &[T], b: &[T]) -> T {
     a.iter()
         .zip(b.iter())
         .fold(T::zero(), |acc, (x, y)| acc + *x * *y)
+}
+
+/// Sum `Σ aᵢ·bᵢ` through the deferred-reduction [`Accumulator`]: each product
+/// is folded in unreduced and a single reduction runs at the end.
+fn accumulator_inner_product<T: Field>(a: &[T], b: &[T]) -> T {
+    let mut acc = T::Accumulator::zero();
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc.add_product(*x, *y);
+    }
+    acc.reduce()
 }
 
 fn naive_double_inner_product<T: Field>(a: &[T], b: &[T], c: &[T]) -> T {
@@ -172,12 +182,63 @@ fn bench_double_inner_product(c: &mut Criterion) {
     }
 }
 
+/// Deferred-reduction accumulator vs. an eager multiply-accumulate that reduces
+/// after every product. Both compute `Σ aᵢ·bᵢ`; the gap is the per-product
+/// reduction the accumulator defers. `inner_product` (the hand-tuned fused
+/// kernel, which also defers but stays in vector registers) is the ceiling.
+fn bench_accumulator(c: &mut Criterion) {
+    let mut rng = Prg::from_seed(Block::ZERO);
+
+    {
+        let mut group = c.benchmark_group("gf2_64/accumulator");
+        for &len in INNER_PRODUCT_LENS {
+            let a: Vec<Gf2_64> = (0..len).map(|_| rng.random()).collect();
+            let b: Vec<Gf2_64> = (0..len).map(|_| rng.random()).collect();
+
+            group.throughput(Throughput::Elements(len as u64));
+
+            group.bench_with_input(BenchmarkId::new("deferred", len), &len, |bench, _| {
+                bench.iter(|| accumulator_inner_product::<Gf2_64>(black_box(&a), black_box(&b)));
+            });
+            group.bench_with_input(BenchmarkId::new("eager", len), &len, |bench, _| {
+                bench.iter(|| naive_inner_product::<Gf2_64>(black_box(&a), black_box(&b)));
+            });
+            group.bench_with_input(BenchmarkId::new("inner_product", len), &len, |bench, _| {
+                bench.iter(|| Gf2_64::inner_product(black_box(&a), black_box(&b)));
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("gf2_128/accumulator");
+        for &len in INNER_PRODUCT_LENS {
+            let a: Vec<Gf2_128> = (0..len).map(|_| rng.random()).collect();
+            let b: Vec<Gf2_128> = (0..len).map(|_| rng.random()).collect();
+
+            group.throughput(Throughput::Elements(len as u64));
+
+            group.bench_with_input(BenchmarkId::new("deferred", len), &len, |bench, _| {
+                bench.iter(|| accumulator_inner_product::<Gf2_128>(black_box(&a), black_box(&b)));
+            });
+            group.bench_with_input(BenchmarkId::new("eager", len), &len, |bench, _| {
+                bench.iter(|| naive_inner_product::<Gf2_128>(black_box(&a), black_box(&b)));
+            });
+            group.bench_with_input(BenchmarkId::new("inner_product", len), &len, |bench, _| {
+                bench.iter(|| Gf2_128::inner_product(black_box(&a), black_box(&b)));
+            });
+        }
+        group.finish();
+    }
+}
+
 criterion_group!(
     benches,
     bench_mul,
     bench_square,
     bench_inverse,
     bench_inner_product,
-    bench_double_inner_product
+    bench_double_inner_product,
+    bench_accumulator
 );
 criterion_main!(benches);

--- a/crates/fields/src/gf2.rs
+++ b/crates/fields/src/gf2.rs
@@ -7,7 +7,7 @@ use itybity::{BitLength, FromBitIterator, GetBit, Lsb0, Msb0, SetBit};
 use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
-use crate::{Field, FieldError};
+use crate::{Field, FieldError, NaiveAccumulator};
 
 /// An element of GF(2), i.e. a single bit under XOR/AND.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -124,6 +124,10 @@ impl Field for Gf2 {
     type BitSize = U1;
     type ByteSize = U1;
 
+    // GF(2) multiplication is a single AND with no reduction, so eager
+    // reduction is already optimal.
+    type Accumulator = NaiveAccumulator<Gf2>;
+
     fn zero() -> Self {
         Gf2::ZERO
     }
@@ -151,10 +155,15 @@ mod tests {
     use crate::{
         Field,
         tests::{
-            test_field_bit_ops_lsb0, test_field_bit_ops_msb0, test_field_set_bit_lsb0,
-            test_field_set_bit_msb0,
+            test_field_accumulator, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
+            test_field_set_bit_lsb0, test_field_set_bit_msb0,
         },
     };
+
+    #[test]
+    fn gf2_accumulator() {
+        test_field_accumulator::<Gf2>();
+    }
 
     #[test]
     fn gf2_arith() {

--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -133,6 +133,8 @@ impl Field for Gf2_128 {
 
     type ByteSize = U16;
 
+    type Accumulator = Gf2_128Accumulator;
+
     fn zero() -> Self {
         Self::new(0)
     }
@@ -174,6 +176,55 @@ impl Field for Gf2_128 {
     #[inline]
     fn square(self) -> Self {
         Gf2_128(gf128_square(self.0))
+    }
+}
+
+/// Deferred-reduction [`Accumulator`](crate::Accumulator) for [`Gf2_128`].
+///
+/// Holds the XOR of unreduced 256-bit carry-less products as `(lo, hi)` and
+/// reduces once modulo `p(x) = x¹²⁸ + x⁷ + x² + x + 1`. Reduction is linear
+/// over XOR, so reducing the accumulated sum equals the field sum of the
+/// individual products.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Gf2_128Accumulator {
+    lo: u128,
+    hi: u128,
+}
+
+impl crate::Accumulator for Gf2_128Accumulator {
+    type Field = Gf2_128;
+
+    #[inline]
+    fn zero() -> Self {
+        Self { lo: 0, hi: 0 }
+    }
+
+    #[inline]
+    fn from_field(value: Gf2_128) -> Self {
+        // A reduced element is already `< x¹²⁸`, so it sits entirely in `lo`;
+        // reducing `(value, 0)` is the identity.
+        Self {
+            lo: value.0,
+            hi: 0,
+        }
+    }
+
+    #[inline]
+    fn add_product(&mut self, a: Gf2_128, b: Gf2_128) {
+        let (lo, hi) = gf128_mul_full(a.0, b.0);
+        self.lo ^= lo;
+        self.hi ^= hi;
+    }
+
+    #[inline]
+    fn merge(&mut self, other: &Self) {
+        self.lo ^= other.lo;
+        self.hi ^= other.hi;
+    }
+
+    #[inline]
+    fn reduce(self) -> Gf2_128 {
+        Gf2_128(gf128_reduce(self.lo, self.hi))
     }
 }
 
@@ -273,6 +324,16 @@ fn gf128_double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u1
 }
 
 #[inline(always)]
+fn gf128_mul_full(a: u128, b: u128) -> (u128, u128) {
+    backend::mul_full(a, b)
+}
+
+#[inline(always)]
+fn gf128_reduce(lo: u128, hi: u128) -> u128 {
+    backend::reduce(lo, hi)
+}
+
+#[inline(always)]
 fn gf128_inverse(a: u128) -> u128 {
     backend::inverse(a)
 }
@@ -327,11 +388,11 @@ mod tests {
         Field,
         gf2::Gf2,
         tests::{
-            test_extension_field_subfield_inner_product, test_field_axioms_random,
-            test_field_basic, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
-            test_field_compute_product_repeated, test_field_double_inner_product,
-            test_field_inner_product, test_field_set_bit_lsb0, test_field_set_bit_msb0,
-            test_field_square,
+            test_extension_field_subfield_inner_product, test_field_accumulator,
+            test_field_axioms_random, test_field_basic, test_field_bit_ops_lsb0,
+            test_field_bit_ops_msb0, test_field_compute_product_repeated,
+            test_field_double_inner_product, test_field_inner_product, test_field_set_bit_lsb0,
+            test_field_set_bit_msb0, test_field_square,
         },
     };
     #[test]
@@ -354,6 +415,11 @@ mod tests {
     #[test]
     fn test_gf2_128_double_inner_product() {
         test_field_double_inner_product::<Gf2_128>();
+    }
+
+    #[test]
+    fn test_gf2_128_accumulator() {
+        test_field_accumulator::<Gf2_128>();
     }
 
     #[test]

--- a/crates/fields/src/gf2_128/soft.rs
+++ b/crates/fields/src/gf2_128/soft.rs
@@ -42,6 +42,19 @@ pub(super) fn inverse(a: u128) -> u128 {
     out
 }
 
+/// Unreduced 256-bit carry-less product `a · b`, as `(lo, hi)`. The
+/// accumulator XORs these and reduces once with [`reduce`].
+#[inline]
+pub(super) fn mul_full(a: u128, b: u128) -> (u128, u128) {
+    bmul128_full(a, b)
+}
+
+/// Reduces an accumulated 256-bit polynomial `hi·x¹²⁸ + lo` to a field element.
+#[inline]
+pub(super) fn reduce(lo: u128, hi: u128) -> u128 {
+    reduce128(lo, hi)
+}
+
 #[inline]
 pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
     let mut acc_lo = 0u128;

--- a/crates/fields/src/gf2_128/wasm.rs
+++ b/crates/fields/src/gf2_128/wasm.rs
@@ -17,6 +17,19 @@ pub(super) fn mul(a: u128, b: u128) -> u128 {
     reduce128(lo, hi)
 }
 
+/// Unreduced 256-bit carry-less product `a · b`, as `(lo, hi)`. The
+/// accumulator XORs these and reduces once with [`reduce`].
+#[inline]
+pub(super) fn mul_full(a: u128, b: u128) -> (u128, u128) {
+    bmul128_full(a, b)
+}
+
+/// Reduces an accumulated 256-bit polynomial `hi·x¹²⁸ + lo` to a field element.
+#[inline]
+pub(super) fn reduce(lo: u128, hi: u128) -> u128 {
+    reduce128(lo, hi)
+}
+
 /// Squaring via parallel bit-spread. In characteristic 2,
 /// `(a_lo + a_hi · x⁶⁴)² = a_lo² + a_hi² · x¹²⁸` — the cross term
 /// vanishes. Each half-square is a pure bit-spread of a u64 into a

--- a/crates/fields/src/gf2_128/x86.rs
+++ b/crates/fields/src/gf2_128/x86.rs
@@ -20,6 +20,24 @@ pub(super) fn mul(a: u128, b: u128) -> u128 {
     }
 }
 
+/// Unreduced 256-bit carry-less product `a · b`, as `(lo, hi)`. The
+/// accumulator XORs these and reduces once with [`reduce`].
+#[inline(always)]
+pub(super) fn mul_full(a: u128, b: u128) -> (u128, u128) {
+    // SAFETY: see `mul`.
+    unsafe {
+        let (lo, hi) = clmul128(load(a), load(b));
+        (extract(lo), extract(hi))
+    }
+}
+
+/// Reduces an accumulated 256-bit polynomial `hi·x¹²⁸ + lo` to a field element.
+#[inline(always)]
+pub(super) fn reduce(lo: u128, hi: u128) -> u128 {
+    // SAFETY: see `mul`.
+    unsafe { extract(reduce128(load(lo), load(hi))) }
+}
+
 /// Squaring via scalar bit-spread — **faster than CLMUL** on x86 for
 /// isolated squarings. In char 2, squaring is just "spread each bit to
 /// twice its index", with all cross terms vanishing. Four 32→64 spreads

--- a/crates/fields/src/gf2_64.rs
+++ b/crates/fields/src/gf2_64.rs
@@ -137,6 +137,8 @@ impl Field for Gf2_64 {
     type BitSize = U64;
     type ByteSize = U8;
 
+    type Accumulator = Gf2_64Accumulator;
+
     fn zero() -> Self {
         Gf2_64::ZERO
     }
@@ -177,6 +179,47 @@ impl Field for Gf2_64 {
     #[inline]
     fn square(self) -> Self {
         Gf2_64(gf64_square(self.0))
+    }
+}
+
+/// Deferred-reduction [`Accumulator`](crate::Accumulator) for [`Gf2_64`].
+///
+/// A `GF(2⁶⁴)·GF(2⁶⁴)` carry-less product is at most 127 bits, so the XOR of
+/// many unreduced products fits in a single `u128`; reduction modulo
+/// `p(x) = x⁶⁴ + x⁴ + x³ + x + 1` runs once. Reduction is linear over XOR, so
+/// reducing the accumulated sum equals the field sum of the individual
+/// products.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Gf2_64Accumulator(u128);
+
+impl crate::Accumulator for Gf2_64Accumulator {
+    type Field = Gf2_64;
+
+    #[inline]
+    fn zero() -> Self {
+        Self(0)
+    }
+
+    #[inline]
+    fn from_field(value: Gf2_64) -> Self {
+        // A reduced element is `< x⁶⁴`, so it sits in the low 64 bits;
+        // reducing it back is the identity.
+        Self(value.0 as u128)
+    }
+
+    #[inline]
+    fn add_product(&mut self, a: Gf2_64, b: Gf2_64) {
+        self.0 ^= gf64_mul_full(a.0, b.0);
+    }
+
+    #[inline]
+    fn merge(&mut self, other: &Self) {
+        self.0 ^= other.0;
+    }
+
+    #[inline]
+    fn reduce(self) -> Gf2_64 {
+        Gf2_64(gf64_reduce(self.0))
     }
 }
 
@@ -276,6 +319,16 @@ fn gf64_inverse(a: u64) -> u64 {
 }
 
 #[inline(always)]
+fn gf64_mul_full(a: u64, b: u64) -> u128 {
+    backend::mul_full(a, b)
+}
+
+#[inline(always)]
+fn gf64_reduce(prod: u128) -> u64 {
+    backend::reduce(prod)
+}
+
+#[inline(always)]
 fn gf64_square(a: u64) -> u64 {
     backend::square(a)
 }
@@ -284,11 +337,16 @@ fn gf64_square(a: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::tests::{
-        test_extension_field_subfield_inner_product, test_field_axioms_random,
-        test_field_bit_ops_lsb0, test_field_bit_ops_msb0, test_field_double_inner_product,
-        test_field_inner_product, test_field_set_bit_lsb0, test_field_set_bit_msb0,
-        test_field_square,
+        test_extension_field_subfield_inner_product, test_field_accumulator,
+        test_field_axioms_random, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
+        test_field_double_inner_product, test_field_inner_product, test_field_set_bit_lsb0,
+        test_field_set_bit_msb0, test_field_square,
     };
+
+    #[test]
+    fn test_accumulator() {
+        test_field_accumulator::<Gf2_64>();
+    }
 
     #[test]
     fn test_bit_ops() {

--- a/crates/fields/src/gf2_64/soft.rs
+++ b/crates/fields/src/gf2_64/soft.rs
@@ -36,6 +36,20 @@ pub(super) fn inverse(a: u64) -> u64 {
     out
 }
 
+/// Unreduced carry-less product `a · b` (≤ 127 bits) packed into a `u128`.
+/// The accumulator XORs these and reduces once with [`reduce`].
+#[inline]
+pub(super) fn mul_full(a: u64, b: u64) -> u128 {
+    let (lo, hi) = bmul64_full(a, b);
+    (lo as u128) | ((hi as u128) << 64)
+}
+
+/// Reduces an accumulated 128-bit polynomial to a field element.
+#[inline]
+pub(super) fn reduce(prod: u128) -> u64 {
+    reduce64(prod as u64, (prod >> 64) as u64)
+}
+
 #[inline]
 pub(super) fn inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
     let mut acc_lo = 0u64;

--- a/crates/fields/src/gf2_64/wasm.rs
+++ b/crates/fields/src/gf2_64/wasm.rs
@@ -18,6 +18,20 @@ pub(super) fn mul(a: u64, b: u64) -> u64 {
     reduce64(lo, hi)
 }
 
+/// Unreduced carry-less product `a · b` (≤ 127 bits) packed into a `u128`.
+/// The accumulator XORs these and reduces once with [`reduce`].
+#[inline]
+pub(super) fn mul_full(a: u64, b: u64) -> u128 {
+    let (lo, hi) = bmul64_full(a, b);
+    (lo as u128) | ((hi as u128) << 64)
+}
+
+/// Reduces an accumulated 128-bit polynomial to a field element.
+#[inline]
+pub(super) fn reduce(prod: u128) -> u64 {
+    reduce64(prod as u64, (prod >> 64) as u64)
+}
+
 /// Squaring via parallel bit-spread. In char 2,
 /// `(Σ aᵢ xⁱ)² = Σ aᵢ x^(2i)`. Pack the low and high 32-bit halves of
 /// `a` into the two v128 lanes and run the 32→64 bit-spread on both

--- a/crates/fields/src/gf2_64/x86.rs
+++ b/crates/fields/src/gf2_64/x86.rs
@@ -18,6 +18,39 @@ pub(super) fn mul(a: u64, b: u64) -> u64 {
     }
 }
 
+/// Unreduced carry-less product `a · b` (≤ 127 bits) packed into a `u128`.
+/// The accumulator XORs these and reduces once with [`reduce`].
+#[inline(always)]
+pub(super) fn mul_full(a: u64, b: u64) -> u128 {
+    // SAFETY: see `mul`.
+    unsafe {
+        let a_vec = _mm_set_epi64x(0, a as i64);
+        let b_vec = _mm_set_epi64x(0, b as i64);
+        extract128(_mm_clmulepi64_si128(a_vec, b_vec, 0x00))
+    }
+}
+
+/// Reduces an accumulated 128-bit polynomial to a field element.
+#[inline(always)]
+pub(super) fn reduce(prod: u128) -> u64 {
+    // SAFETY: see `mul`.
+    unsafe { _mm_cvtsi128_si64(reduce64(load128(prod))) as u64 }
+}
+
+#[inline(always)]
+unsafe fn load128(x: u128) -> __m128i {
+    unsafe { _mm_set_epi64x((x >> 64) as i64, x as i64) }
+}
+
+#[inline(always)]
+unsafe fn extract128(x: __m128i) -> u128 {
+    unsafe {
+        let lo = _mm_cvtsi128_si64(x) as u64 as u128;
+        let hi = _mm_extract_epi64(x, 1) as u64 as u128;
+        (hi << 64) | lo
+    }
+}
+
 /// Squaring: at the CLMUL level this is identical to `mul(a, a)` (one
 /// carry-less multiply either way), but exposing a dedicated `square`
 /// lets callers express intent and keeps the backend interface uniform

--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -73,6 +73,16 @@ pub trait Field:
     /// The number of bytes of a field element as a type number.
     type ByteSize: ArraySize;
 
+    /// The deferred-reduction [`Accumulator`] for this field.
+    ///
+    /// Summing products of field elements (`Σ aᵢ·bᵢ`, a running MAC, a random
+    /// linear combination) normally reduces modulo the field's defining
+    /// polynomial after every product, and that per-product reduction
+    /// dominates. An accumulator folds in *unreduced* products and reduces once
+    /// at the end — see [`Accumulator`]. Fields with no cheaper unreduced form
+    /// (e.g. the prime field) use [`NaiveAccumulator`], which reduces eagerly.
+    type Accumulator: Accumulator<Field = Self>;
+
     /// Return the additive identity element.
     fn zero() -> Self;
 
@@ -217,6 +227,96 @@ pub trait Field:
             .zip(b.iter())
             .zip(c.iter())
             .fold(Self::zero(), |acc, ((x, y), z)| acc + *x * *y * *z)
+    }
+}
+
+/// An accumulator over a [`Field`] that supports *deferred modular reduction*.
+///
+/// Field multiplication reduces modulo the field's defining polynomial (or
+/// prime) after every product. When summing many products that per-product
+/// reduction dominates the cost. An `Accumulator` instead folds *unreduced*
+/// products into a wider internal representation and reduces exactly once, in
+/// [`reduce`](Accumulator::reduce).
+///
+/// An accumulator is an additive group homomorphic to the field under
+/// [`reduce`](Accumulator::reduce): [`zero`](Accumulator::zero) is the identity,
+/// [`merge`](Accumulator::merge) adds two accumulators (e.g. partial sums from
+/// parallel chunks), [`add_product`](Accumulator::add_product) folds in one
+/// product, and reducing yields the field sum of everything folded in. That is,
+/// for any elements,
+///
+/// ```text
+/// { let mut acc = A::zero();
+///   acc.add_product(a, b);
+///   acc.add_product(c, d);
+///   acc.reduce() }                 ==   a * b + c * d
+/// ```
+///
+/// For binary extension fields the unreduced form is the XOR of the double-width
+/// carry-less products, reduced once modulo the irreducible polynomial. For
+/// fields with no cheaper unreduced form, [`NaiveAccumulator`] reduces eagerly
+/// and the deferral is a no-op.
+pub trait Accumulator: Copy {
+    /// The field whose products this accumulates and to which it reduces.
+    type Field: Field;
+
+    /// The empty accumulator; reduces to [`Field::zero`].
+    fn zero() -> Self;
+
+    /// Lifts a reduced field element into an accumulator.
+    ///
+    /// `Self::from_field(x).reduce() == x` for every `x`.
+    fn from_field(value: Self::Field) -> Self;
+
+    /// Folds the product `a · b` into the accumulator without reducing.
+    fn add_product(&mut self, a: Self::Field, b: Self::Field);
+
+    /// Adds `other` into `self`, both still unreduced.
+    ///
+    /// `(self + other).reduce() == self.reduce() + other.reduce()`.
+    fn merge(&mut self, other: &Self);
+
+    /// Reduces the accumulator to a field element: the field sum of every
+    /// product and element folded in.
+    fn reduce(self) -> Self::Field;
+}
+
+/// An [`Accumulator`] that reduces *eagerly*: every product is reduced
+/// immediately, so there is no deferral.
+///
+/// Used by fields whose multiplication has no cheaper unreduced form (e.g. the
+/// prime field [`P256`](crate::p256::P256), and the trivial field
+/// [`Gf2`](crate::gf2::Gf2)). It satisfies the [`Accumulator`] contract by
+/// holding a single reduced field element.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct NaiveAccumulator<F>(F);
+
+impl<F: Field> Accumulator for NaiveAccumulator<F> {
+    type Field = F;
+
+    #[inline]
+    fn zero() -> Self {
+        Self(F::zero())
+    }
+
+    #[inline]
+    fn from_field(value: F) -> Self {
+        Self(value)
+    }
+
+    #[inline]
+    fn add_product(&mut self, a: F, b: F) {
+        self.0 = self.0 + a * b;
+    }
+
+    #[inline]
+    fn merge(&mut self, other: &Self) {
+        self.0 = self.0 + other.0;
+    }
+
+    #[inline]
+    fn reduce(self) -> F {
+        self.0
     }
 }
 
@@ -446,6 +546,65 @@ mod tests {
 
             assert_eq!(T::double_inner_product(&a, &b, &c), expected, "len={len}");
         }
+    }
+
+    pub(crate) fn test_field_accumulator<T: Field>() {
+        use crate::Accumulator;
+        let mut rng = Prg::from_seed(Block::ZERO);
+
+        // The empty accumulator reduces to zero.
+        assert_eq!(<T::Accumulator as Accumulator>::zero().reduce(), T::zero());
+
+        // Lifting a reduced element round-trips through reduce.
+        for _ in 0..100 {
+            let x = T::rand(&mut rng);
+            assert_eq!(T::Accumulator::from_field(x).reduce(), x);
+        }
+
+        // Accumulated products reduce to the field sum of those products, and
+        // agree with the dedicated `inner_product` over the same inputs.
+        for &len in &[1usize, 2, 17, 1024] {
+            let a: Vec<T> = (0..len).map(|_| T::rand(&mut rng)).collect();
+            let b: Vec<T> = (0..len).map(|_| T::rand(&mut rng)).collect();
+
+            let mut acc = T::Accumulator::zero();
+            for (x, y) in a.iter().zip(b.iter()) {
+                acc.add_product(*x, *y);
+            }
+            let expected = a
+                .iter()
+                .zip(b.iter())
+                .fold(T::zero(), |s, (x, y)| s + *x * *y);
+            assert_eq!(acc.reduce(), expected, "deferred sum, len={len}");
+            assert_eq!(
+                acc.reduce(),
+                T::inner_product(&a, &b),
+                "matches inner_product, len={len}"
+            );
+
+            // Merging partial accumulators (as a parallel reduction would)
+            // gives the same result as one running accumulator.
+            let mid = len / 2;
+            let mut left = T::Accumulator::zero();
+            for (x, y) in a[..mid].iter().zip(b[..mid].iter()) {
+                left.add_product(*x, *y);
+            }
+            let mut right = T::Accumulator::zero();
+            for (x, y) in a[mid..].iter().zip(b[mid..].iter()) {
+                right.add_product(*x, *y);
+            }
+            left.merge(&right);
+            assert_eq!(left.reduce(), expected, "merge of partials, len={len}");
+        }
+
+        // A lifted element composes additively with folded products:
+        // `seed + a·b`.
+        let seed = T::rand(&mut rng);
+        let a = T::rand(&mut rng);
+        let b = T::rand(&mut rng);
+        let mut acc = T::Accumulator::from_field(seed);
+        acc.add_product(a, b);
+        assert_eq!(acc.reduce(), seed + a * b, "lifted seed plus product");
     }
 
     pub(crate) fn test_extension_field_subfield_inner_product<F, B>()

--- a/crates/fields/src/p256.rs
+++ b/crates/fields/src/p256.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typenum::{U32, U256};
 
-use crate::{Field, FieldError};
+use crate::{Field, FieldError, NaiveAccumulator};
 
 /// A type for holding field elements of P256.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
@@ -112,6 +112,10 @@ impl Field for P256 {
 
     type ByteSize = U32;
 
+    // Deferred reduction is left for a future change; the prime field uses the
+    // eager accumulator for now.
+    type Accumulator = NaiveAccumulator<P256>;
+
     fn zero() -> Self {
         P256(<Fq as Zero>::zero())
     }
@@ -201,9 +205,14 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     use crate::tests::{
-        test_field_basic, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
+        test_field_accumulator, test_field_basic, test_field_bit_ops_lsb0, test_field_bit_ops_msb0,
         test_field_compute_product_repeated, test_field_set_bit_lsb0, test_field_set_bit_msb0,
     };
+
+    #[test]
+    fn test_p256_accumulator() {
+        test_field_accumulator::<P256>();
+    }
 
     #[test]
     fn test_p256_basic() {


### PR DESCRIPTION
Adds an `Accumulator` abstraction to `mpz-fields` for deferred modular reduction: fold many unreduced products into a wide representation and reduce once, instead of reducing after every product.

## API
- New `Accumulator` trait, separate from `Field`: `zero`, `from_field`, `add_product`, `merge`, `reduce`. It is an additive group homomorphic to the field under `reduce`.
- `Field::Accumulator` associated type links each field to its accumulator.

## Implementations
- **`Gf2_128`, `Gf2_64`** — deferred accumulators that XOR unreduced carry-less products and reduce once, backed by new per-backend `mul_full` / `reduce` primitives (soft, x86, wasm).
- **`Gf2`, `P256`** — `NaiveAccumulator`, which reduces eagerly, for fields with no cheaper unreduced form.

## Tests & benchmarks
- Shared `test_field_accumulator` across all four fields: the empty accumulator reduces to zero, `from_field` round-trips, accumulated products match both the field sum and `inner_product`, and `merge` of partial accumulators matches a single running accumulator.
- Benchmark comparing deferred accumulation against an eager multiply-accumulate, with `inner_product` as a reference.

Verified on the x86 and soft backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)