### PR TITLE
refactor(core): make aes/prp/tkprp byte-native and in-place

### DIFF
--- a/crates/core/benches/aes.rs
+++ b/crates/core/benches/aes.rs
@@ -1,24 +1,24 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
-use mpz_core::{aes::AesEncryptor, block::Block};
+use mpz_core::aes::AesEncryptor;
 
 #[allow(clippy::all)]
 fn criterion_benchmark(c: &mut Criterion) {
-    let x = rand::random::<Block>();
+    let x = rand::random::<[u8; 16]>();
     let aes = AesEncryptor::new(x);
-    let blk = rand::random::<Block>();
+    let mut blk = rand::random::<[u8; 16]>();
 
     c.bench_function("aes::encrypt_block", move |bench| {
         bench.iter(|| {
-            let z = aes.encrypt_block(black_box(blk));
-            black_box(z);
+            aes.encrypt_block(black_box(&mut blk));
+            black_box(&blk);
         });
     });
 
     c.bench_function("aes::encrypt_many_blocks::<8>", move |bench| {
-        let key = rand::random::<Block>();
+        let key = rand::random::<[u8; 16]>();
         let aes = AesEncryptor::new(key);
-        let mut blks = rand::random::<[Block; 8]>();
+        let mut blks = std::array::from_fn::<_, 8, _>(|_| rand::random::<[u8; 16]>());
 
         bench.iter(|| {
             let z = aes.encrypt_many_blocks(black_box(&mut blks));
@@ -27,10 +27,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("aes::para_encrypt::<1,8>", move |bench| {
-        let key = rand::random::<Block>();
+        let key = rand::random::<[u8; 16]>();
         let aes = AesEncryptor::new(key);
         let aes = [aes];
-        let mut blks = rand::random::<[Block; 8]>();
+        let mut blks = std::array::from_fn::<_, 8, _>(|_| rand::random::<[u8; 16]>());
 
         bench.iter(|| {
             let z = AesEncryptor::para_encrypt::<1, 8>(black_box(&aes), black_box(&mut blks));

--- a/crates/core/src/aes.rs
+++ b/crates/core/src/aes.rs
@@ -2,9 +2,8 @@
 
 use aes::Aes128Enc;
 use cipher::{BlockCipherEncrypt, KeyInit};
+use hybrid_array::{Array, typenum::consts::U16};
 use once_cell::sync::Lazy;
-
-use crate::Block;
 
 /// A fixed AES key (arbitrarily chosen).
 pub const FIXED_KEY: [u8; 16] = [
@@ -13,8 +12,26 @@ pub const FIXED_KEY: [u8; 16] = [
 
 /// Fixed-key AES cipher
 pub static FIXED_KEY_AES: Lazy<FixedKeyAes> = Lazy::new(|| FixedKeyAes {
-    aes: Aes128Enc::new_from_slice(&FIXED_KEY).unwrap(),
+    aes: Aes128Enc::new(&FIXED_KEY.into()),
 });
+
+/// XOR of two 16-byte blocks.
+#[inline(always)]
+fn xor(a: [u8; 16], b: [u8; 16]) -> [u8; 16] {
+    (u128::from_ne_bytes(a) ^ u128::from_ne_bytes(b)).to_ne_bytes()
+}
+
+/// Reinterprets a mutable block as the AES cipher's array type.
+#[inline(always)]
+fn as_array(block: &mut [u8; 16]) -> &mut Array<u8, U16> {
+    block.into()
+}
+
+/// Reinterprets a mutable slice of blocks as the AES cipher's array type.
+#[inline(always)]
+fn as_array_slice(blocks: &mut [[u8; 16]]) -> &mut [Array<u8, U16>] {
+    Array::cast_slice_from_core_mut(blocks)
+}
 
 /// Fixed-key AES cipher
 pub struct FixedKeyAes {
@@ -35,15 +52,20 @@ impl FixedKeyAes {
     /// See <https://eprint.iacr.org/2019/074> (Section 7.4)
     ///
     /// `π(π(x) ⊕ i) ⊕ π(x)`, where `π` is instantiated using fixed-key AES.
+    ///
+    /// The result is written back into `block`.
     #[inline]
-    pub fn tccr(&self, tweak: Block, block: Block) -> Block {
-        let mut h1 = block;
-        self.aes.encrypt_block(h1.as_array_mut());
+    pub fn tccr(&self, tweak: [u8; 16], block: &mut [u8; 16]) {
+        // h1 = π(x)
+        self.aes.encrypt_block(as_array(block));
+        let h1 = *block;
 
-        let mut h2 = h1 ^ tweak;
-        self.aes.encrypt_block(h2.as_array_mut());
+        // h2 = π(π(x) ⊕ i)
+        let mut h2 = xor(h1, tweak);
+        self.aes.encrypt_block(as_array(&mut h2));
 
-        h1 ^ h2
+        // π(π(x) ⊕ i) ⊕ π(x)
+        *block = xor(h1, h2);
     }
 
     /// Tweakable circular correlation-robust hash function instantiated
@@ -58,79 +80,21 @@ impl FixedKeyAes {
     /// * `tweaks` - The tweaks to use for each block in `blocks`.
     /// * `blocks` - The blocks to hash in-place.
     #[inline]
-    pub fn tccr_many<const N: usize>(&self, tweaks: &[Block; N], blocks: &mut [Block; N]) {
+    pub fn tccr_many<const N: usize>(&self, tweaks: &[[u8; 16]; N], blocks: &mut [[u8; 16]; N]) {
         // Store π(x) in `blocks`
-        self.aes.encrypt_blocks(Block::as_array_mut_slice(blocks));
+        self.aes.encrypt_blocks(as_array_slice(blocks));
 
         // Write π(x) ⊕ i into `buf`
-        let mut buf: [Block; N] = std::array::from_fn(|i| blocks[i] ^ tweaks[i]);
+        let mut buf: [[u8; 16]; N] = std::array::from_fn(|i| xor(blocks[i], tweaks[i]));
 
         // Write π(π(x) ⊕ i) in `buf`
-        self.aes.encrypt_blocks(Block::as_array_mut_slice(&mut buf));
+        self.aes.encrypt_blocks(as_array_slice(&mut buf));
 
         // Write π(π(x) ⊕ i) ⊕ π(x) into `blocks`
         blocks
             .iter_mut()
             .zip(buf.iter())
-            .for_each(|(a, b)| *a ^= *b);
-    }
-
-    /// Correlation-robust hash function instantiated using fixed-key AES
-    /// (cf. <https://eprint.iacr.org/2019/074>, §7.2).
-    ///
-    /// `π(x) ⊕ x`, where `π` is instantiated using fixed-key AES.
-    #[inline]
-    pub fn cr(&self, block: Block) -> Block {
-        let mut h = block;
-        self.aes.encrypt_block(h.as_array_mut());
-        h ^ block
-    }
-
-    /// Correlation-robust hash function instantiated using fixed-key AES
-    /// (cf. <https://eprint.iacr.org/2019/074>, §7.2).
-    ///
-    /// `π(x) ⊕ x`, where `π` is instantiated using fixed-key AES.
-    ///
-    /// # Arguments
-    ///
-    /// * `blocks` - The blocks to hash in-place.
-    #[inline]
-    pub fn cr_many<const N: usize>(&self, blocks: &mut [Block; N]) {
-        let mut buf = *blocks;
-
-        self.aes.encrypt_blocks(Block::as_array_mut_slice(&mut buf));
-
-        blocks
-            .iter_mut()
-            .zip(buf.iter())
-            .for_each(|(a, b)| *a ^= *b);
-    }
-
-    /// Circular correlation-robust hash function instantiated using fixed-key
-    /// AES (cf.<https://eprint.iacr.org/2019/074>, §7.3).
-    ///
-    /// `π(σ(x)) ⊕ σ(x)`, where `π` is instantiated using fixed-key AES
-    ///
-    /// See [`Block::sigma`](Block::sigma) for more details on `σ`.
-    #[inline]
-    pub fn ccr(&self, block: Block) -> Block {
-        self.cr(Block::sigma(block))
-    }
-
-    /// Circular correlation-robust hash function instantiated using fixed-key
-    /// AES (cf.<https://eprint.iacr.org/2019/074>, §7.3).
-    ///
-    /// `π(σ(x)) ⊕ σ(x)`, where `π` is instantiated using fixed-key AES
-    ///
-    /// See [`Block::sigma`](Block::sigma) for more details on `σ`.
-    ///
-    /// # Arguments
-    ///
-    /// * `blocks` - The blocks to hash in-place.
-    #[inline]
-    pub fn ccr_many<const N: usize>(&self, blocks: &mut [Block; N]) {
-        blocks.iter_mut().for_each(|b| *b = Block::sigma(*b));
-        self.cr_many(blocks);
+            .for_each(|(a, b)| *a = xor(*a, *b));
     }
 }
 
@@ -144,34 +108,26 @@ impl AesEncryptor {
 
     /// Initiate an AesEncryptor instance with key.
     #[inline(always)]
-    pub fn new(key: Block) -> Self {
-        let _key: [u8; 16] = key.into();
-        AesEncryptor(Aes128Enc::new_from_slice(&_key).unwrap())
-    }
-
-    /// Encrypt a block.
-    #[inline(always)]
-    pub fn encrypt_block(&self, mut blk: Block) -> Block {
-        self.0.encrypt_block(blk.as_array_mut());
-        blk
+    pub fn new(key: [u8; 16]) -> Self {
+        AesEncryptor(Aes128Enc::new(&key.into()))
     }
 
     /// Encrypt a block in-place.
-    pub fn encrypt_block_inplace(&self, blk: &mut Block) {
-        self.0.encrypt_block(blk.as_array_mut());
+    #[inline(always)]
+    pub fn encrypt_block(&self, blk: &mut [u8; 16]) {
+        self.0.encrypt_block(as_array(blk));
     }
 
     /// Encrypt many blocks in-place.
     #[inline(always)]
-    pub fn encrypt_many_blocks<const N: usize>(&self, blks: &mut [Block; N]) {
-        self.0
-            .encrypt_blocks(Block::as_array_mut_slice(blks.as_mut_slice()));
+    pub fn encrypt_many_blocks<const N: usize>(&self, blks: &mut [[u8; 16]; N]) {
+        self.0.encrypt_blocks(as_array_slice(blks));
     }
 
     /// Encrypt slice of blocks in-place.
     #[inline]
-    pub fn encrypt_blocks(&self, blks: &mut [Block]) {
-        self.0.encrypt_blocks(Block::as_array_mut_slice(blks));
+    pub fn encrypt_blocks(&self, blks: &mut [[u8; 16]]) {
+        self.0.encrypt_blocks(as_array_slice(blks));
     }
 
     /// Encrypt many blocks with many keys.
@@ -190,7 +146,10 @@ impl AesEncryptor {
     ///
     /// * If the length of `blks` is less than `NM * NK`.
     #[inline(always)]
-    pub fn para_encrypt<const NK: usize, const NM: usize>(keys: &[Self; NK], blks: &mut [Block]) {
+    pub fn para_encrypt<const NK: usize, const NM: usize>(
+        keys: &[Self; NK],
+        blks: &mut [[u8; 16]],
+    ) {
         assert!(blks.len() >= NM * NK);
 
         keys.iter()
@@ -203,20 +162,20 @@ impl AesEncryptor {
 
 #[test]
 fn aes_test() {
-    let aes = AesEncryptor::new(Block::default());
-    let aes1 = AesEncryptor::new(Block::ONES);
+    let aes = AesEncryptor::new([0u8; 16]);
+    let aes1 = AesEncryptor::new([0xffu8; 16]);
 
-    let mut blks = [Block::default(); 4];
-    blks[1] = Block::ONES;
-    blks[3] = Block::ONES;
+    let mut blks = [[0u8; 16]; 4];
+    blks[1] = [0xff; 16];
+    blks[3] = [0xff; 16];
     AesEncryptor::para_encrypt::<2, 2>(&[aes, aes1], &mut blks);
     assert_eq!(
         blks,
         [
-            Block::from((0x2E2B34CA59FA4C883B2C8AEFD44BE966_u128).to_le_bytes()),
-            Block::from((0x4E668D3ED24773FA0A5A85EAC98C5B3F_u128).to_le_bytes()),
-            Block::from((0x2CC9BF3845486489CD5F7D878C25F6A1_u128).to_le_bytes()),
-            Block::from((0x79B93A19527051B230CF80B27C21BFBC_u128).to_le_bytes())
+            0x2E2B34CA59FA4C883B2C8AEFD44BE966_u128.to_le_bytes(),
+            0x4E668D3ED24773FA0A5A85EAC98C5B3F_u128.to_le_bytes(),
+            0x2CC9BF3845486489CD5F7D878C25F6A1_u128.to_le_bytes(),
+            0x79B93A19527051B230CF80B27C21BFBC_u128.to_le_bytes()
         ]
     );
 }

--- a/crates/core/src/block.rs
+++ b/crates/core/src/block.rs
@@ -2,7 +2,6 @@
 
 use clmul::Clmul;
 use core::ops::{BitAnd, BitAndAssign, BitXor, BitXorAssign};
-use hybrid_array::{Array, typenum::consts::U16};
 use itybity::{BitIterable, BitLength, FromBitIterator, GetBit, Lsb0, Msb0};
 use rand::{CryptoRng, Rng, distr::StandardUniform, prelude::Distribution};
 use serde::{Deserialize, Serialize};
@@ -150,43 +149,6 @@ impl Block {
     pub fn lsb(&self) -> bool {
         (self.0[0] & 1) == 1
     }
-
-    /// Let `x0` and `x1` be the lower and higher halves of `x`, respectively.
-    /// This function compute ``sigma( x = x0 || x1 ) = x1 || (x0 xor x1)``.
-    #[inline(always)]
-    pub fn sigma(a: Self) -> Self {
-        let mut x: [u64; 2] = zerocopy::transmute!(a);
-        x[0] ^= x[1];
-        zerocopy::transmute!([x[1], x[0]])
-    }
-
-    /// Converts a block to a [`Array<u8,
-    /// U16>`] from the [`hybrid-array`](https://docs.rs/hybrid-array/latest/hybrid_array/) crate.
-    #[allow(dead_code)]
-    pub(crate) fn as_array(&self) -> &Array<u8, U16> {
-        (&self.0).into()
-    }
-
-    /// Converts a mutable block to a mutable [`Array<u8,
-    /// U16>`] from the [`hybrid-array`](https://docs.rs/hybrid-array/latest/hybrid_array/) crate.
-    pub(crate) fn as_array_mut(&mut self) -> &mut Array<u8, U16> {
-        (&mut self.0).into()
-    }
-
-    /// Converts a slice of blocks to a slice of [`Array<u8,
-    /// U16>`]from the [`hybrid-array`](https://docs.rs/hybrid-array/latest/hybrid_array/) crate.
-    #[allow(dead_code)]
-    pub(crate) fn as_array_slice(slice: &[Self]) -> &[Array<u8, U16>] {
-        let bytes: &[[u8; 16]] = zerocopy::transmute_ref!(slice);
-        Array::cast_slice_from_core(bytes)
-    }
-
-    /// Converts a mutable slice of blocks to a mutable slice of
-    ///  from the [`hybrid-array`](https://docs.rs/hybrid-array/latest/hybrid_array/) crate.
-    pub(crate) fn as_array_mut_slice(slice: &mut [Self]) -> &mut [Array<u8, U16>] {
-        let bytes: &mut [[u8; 16]] = zerocopy::transmute_mut!(slice);
-        Array::cast_slice_from_core_mut(bytes)
-    }
 }
 
 impl Display for Block {
@@ -265,35 +227,6 @@ impl<'a> TryFrom<&'a [u8]> for Block {
 
     fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
         <[u8; 16]>::try_from(value).map(Self::from)
-    }
-}
-
-impl From<Block> for Array<u8, U16> {
-    #[inline]
-    fn from(b: Block) -> Self {
-        b.0.into()
-    }
-}
-
-impl<'a> From<&'a Block> for &'a Array<u8, U16> {
-    #[inline]
-    fn from(b: &'a Block) -> Self {
-        (&b.0).into()
-    }
-}
-
-impl From<Array<u8, U16>> for Block {
-    #[inline]
-    fn from(b: Array<u8, U16>) -> Self {
-        Block::new(b.into())
-    }
-}
-
-impl<'a> From<&'a Array<u8, U16>> for &'a Block {
-    #[inline]
-    fn from(b: &'a Array<u8, U16>) -> Self {
-        let b: &'a [u8; 16] = b.as_ref();
-        b.into()
     }
 }
 
@@ -522,23 +455,6 @@ mod tests {
 
         assert_eq!(c, Block::inn_prdt_no_red(&a, &b));
         assert_eq!(d, Block::inn_prdt_red(&a, &b));
-    }
-
-    #[test]
-    fn sigma_test() {
-        use rand::{Rng, SeedableRng};
-        use rand_chacha::ChaCha12Rng;
-        let mut rng = ChaCha12Rng::from_seed([0; 32]);
-        let mut x: [u8; 16] = rng.random();
-        let bx = Block::sigma(Block::from(x));
-        let (xl, xr) = x.split_at_mut(8);
-
-        for (x, y) in xl.iter_mut().zip(xr.iter_mut()) {
-            *x ^= *y;
-            std::mem::swap(x, y);
-        }
-        let expected_sigma = Block::from(x);
-        assert_eq!(bx, expected_sigma);
     }
 
     #[test]

--- a/crates/core/src/ggm.rs
+++ b/crates/core/src/ggm.rs
@@ -41,7 +41,7 @@ impl<'a> GgmTree<'a> {
 
         let mut buf = vec![Block::ZERO; (1 << depth) - 1];
 
-        let tkprp = TwoKeyPrp::new([Block::ZERO, Block::ONE]);
+        let tkprp = TwoKeyPrp::new([Block::ZERO.to_bytes(), Block::ONE.to_bytes()]);
 
         buf[0] = seed;
         for n in 0..depth - 1 {
@@ -50,11 +50,17 @@ impl<'a> GgmTree<'a> {
 
             let (parents, children) = buf[parents.start..children.end].split_at_mut(width(n));
 
-            tkprp.expand(parents, children);
+            tkprp.expand(
+                zerocopy::transmute_ref!(&*parents),
+                zerocopy::transmute_mut!(children),
+            );
         }
 
         // Expand the last layer.
-        tkprp.expand(&buf[layer(depth - 1)], leaves);
+        tkprp.expand(
+            zerocopy::transmute_ref!(&buf[layer(depth - 1)]),
+            zerocopy::transmute_mut!(leaves),
+        );
 
         Self { depth, buf, leaves }
     }
@@ -83,7 +89,7 @@ impl<'a> GgmTree<'a> {
 
         let mut buf = vec![Block::ZERO; (1 << depth) - 1];
 
-        let tkprp = TwoKeyPrp::new([Block::ZERO, Block::ONE]);
+        let tkprp = TwoKeyPrp::new([Block::ZERO.to_bytes(), Block::ONE.to_bytes()]);
 
         // The path length is equal to the depth of the tree.
         let idx = idx as u32;
@@ -114,13 +120,19 @@ impl<'a> GgmTree<'a> {
 
                 recover(inputs, *sum, offset, select);
 
-                tkprp.expand(inputs, outputs);
+                tkprp.expand(
+                    zerocopy::transmute_ref!(&*inputs),
+                    zerocopy::transmute_mut!(outputs),
+                );
             } else if n == depth - 1 {
                 let inputs = &mut buf[layer(n)];
 
                 recover(inputs, *sum, offset, select);
 
-                tkprp.expand(inputs, leaves);
+                tkprp.expand(
+                    zerocopy::transmute_ref!(&*inputs),
+                    zerocopy::transmute_mut!(leaves),
+                );
             } else if n == depth {
                 recover(leaves, *sum, offset, select);
 

--- a/crates/core/src/lpn.rs
+++ b/crates/core/src/lpn.rs
@@ -50,7 +50,7 @@ impl<const D: usize> LpnEncoder<D> {
             zerocopy::transmute!([pos as u64, i])
         });
 
-        let blocks: &mut [Block; D] = zerocopy::transmute_mut!(&mut index);
+        let blocks: &mut [[u8; 16]; D] = zerocopy::transmute_mut!(&mut index);
         prp.permute_many_blocks(blocks);
         let index: &mut [u32] = index.as_flattened_mut();
 
@@ -71,7 +71,7 @@ impl<const D: usize> LpnEncoder<D> {
         let mut index = (0..block_size)
             .map(|i| -> [u32; 4] { zerocopy::transmute!([pos as u64, i as u64]) })
             .collect::<Vec<[u32; 4]>>();
-        let blocks: &mut [Block] = zerocopy::transmute_mut!(index.as_mut_slice());
+        let blocks: &mut [[u8; 16]] = zerocopy::transmute_mut!(index.as_mut_slice());
         prp.permute_block_inplace(blocks);
         let index: &mut [u32] = index.as_flattened_mut();
 
@@ -96,7 +96,7 @@ impl<const D: usize> LpnEncoder<D> {
     pub fn compute(&self, seed: Block, y: &mut [Block], x: &[Block]) {
         assert_eq!(x.len() as u32, self.k);
         assert!(x.len() >= D);
-        let prp = Prp::new(seed);
+        let prp = Prp::new(seed.to_bytes());
         let size = y.len() - (y.len() % 4);
 
         cfg_if::cfg_if! {
@@ -174,7 +174,7 @@ mod tests {
                 zerocopy::transmute!([pos as u64, i])
             });
 
-            let blocks: &mut [Block; D] = zerocopy::transmute_mut!(&mut index);
+            let blocks: &mut [[u8; 16]; D] = zerocopy::transmute_mut!(&mut index);
             prp.permute_many_blocks(blocks);
             let index: &mut [u32] = index.as_flattened_mut();
 
@@ -192,7 +192,7 @@ mod tests {
         pub(crate) fn compute_naive(&self, seed: Block, y: &mut [Block], x: &[Block]) {
             assert_eq!(x.len() as u32, self.k);
             assert!(x.len() >= D);
-            let prp = Prp::new(seed);
+            let prp = Prp::new(seed.to_bytes());
             let batch_size = y.len() / 4;
 
             for i in 0..batch_size {

--- a/crates/core/src/prg.rs
+++ b/crates/core/src/prg.rs
@@ -37,7 +37,7 @@ impl BlockRngCore for PrgCore {
                 block[..8].copy_from_slice(&counter.to_le_bytes());
                 block[8..].copy_from_slice(&self.stream_id.to_le_bytes());
 
-                Block::from(block)
+                block
             },
         );
         self.aes.encrypt_many_blocks(&mut states);
@@ -50,7 +50,7 @@ impl SeedableRng for PrgCore {
 
     #[inline(always)]
     fn from_seed(seed: Self::Seed) -> Self {
-        let aes = AesEncryptor::new(seed);
+        let aes = AesEncryptor::new(seed.into());
         Self {
             aes,
             state: Default::default(),

--- a/crates/core/src/prp.rs
+++ b/crates/core/src/prp.rs
@@ -1,6 +1,6 @@
 //! An implementation of Pseudo Random Permutation (PRP) based on AES.
 
-use crate::{Block, aes::AesEncryptor};
+use crate::aes::AesEncryptor;
 
 /// Pseudo Random Permutation (PRP) based on AES.
 pub struct Prp(AesEncryptor);
@@ -8,25 +8,19 @@ pub struct Prp(AesEncryptor);
 impl Prp {
     /// Creates a new instance of Prp.
     #[inline(always)]
-    pub fn new(seed: Block) -> Self {
+    pub fn new(seed: [u8; 16]) -> Self {
         Prp(AesEncryptor::new(seed))
-    }
-
-    /// Permute one block.
-    #[inline(always)]
-    pub fn permute_block(&self, blk: Block) -> Block {
-        self.0.encrypt_block(blk)
     }
 
     /// Permute many blocks.
     #[inline(always)]
-    pub fn permute_many_blocks<const N: usize>(&self, blks: &mut [Block; N]) {
+    pub fn permute_many_blocks<const N: usize>(&self, blks: &mut [[u8; 16]; N]) {
         self.0.encrypt_many_blocks(blks)
     }
 
     /// Permute block slice.
     #[inline(always)]
-    pub fn permute_block_inplace(&self, blks: &mut [Block]) {
+    pub fn permute_block_inplace(&self, blks: &mut [[u8; 16]]) {
         self.0.encrypt_blocks(blks);
     }
 }

--- a/crates/core/src/tkprp.rs
+++ b/crates/core/src/tkprp.rs
@@ -1,7 +1,13 @@
 //! Implement the two-key PRG as G(k) = PRF_seed0(k)\xor k || PRF_seed1(k)\xor k
 //! Refer to (<https://www.usenix.org/system/files/conference/nsdi17/nsdi17-wang-frank.pdf>, Page 8)
 
-use crate::{Block, aes::AesEncryptor};
+use crate::aes::AesEncryptor;
+
+/// XOR of two 16-byte blocks.
+#[inline(always)]
+fn xor(a: [u8; 16], b: [u8; 16]) -> [u8; 16] {
+    (u128::from_ne_bytes(a) ^ u128::from_ne_bytes(b)).to_ne_bytes()
+}
 
 /// Struct of two-key prp.
 /// This implementation is adapted from EMP toolkit.
@@ -10,7 +16,7 @@ pub struct TwoKeyPrp([AesEncryptor; 2]);
 impl TwoKeyPrp {
     /// Creates a new instance of TwoKeyPrp.
     #[inline(always)]
-    pub fn new(seeds: [Block; 2]) -> Self {
+    pub fn new(seeds: [[u8; 16]; 2]) -> Self {
         Self([AesEncryptor::new(seeds[0]), AesEncryptor::new(seeds[1])])
     }
 
@@ -28,7 +34,7 @@ impl TwoKeyPrp {
     ///
     /// * `inputs` - The input blocks to expand with the two-key PRP.
     /// * `dest` - The destination slice to write the expanded blocks.
-    pub fn expand(&self, inputs: &[Block], dest: &mut [Block]) {
+    pub fn expand(&self, inputs: &[[u8; 16]], dest: &mut [[u8; 16]]) {
         assert_eq!(
             dest.len(),
             2 * inputs.len(),
@@ -39,15 +45,15 @@ impl TwoKeyPrp {
 
         for (in_chunk, out_chunk) in inputs.chunks(CHUNK).zip(dest.chunks_mut(2 * CHUNK)) {
             let m = in_chunk.len();
-            let mut s0 = [Block::ZERO; CHUNK];
-            let mut s1 = [Block::ZERO; CHUNK];
+            let mut s0 = [[0u8; 16]; CHUNK];
+            let mut s1 = [[0u8; 16]; CHUNK];
             s0[..m].copy_from_slice(in_chunk);
             s1[..m].copy_from_slice(in_chunk);
             self.0[0].encrypt_blocks(&mut s0[..m]);
             self.0[1].encrypt_blocks(&mut s1[..m]);
             for (i, &x) in in_chunk.iter().enumerate() {
-                out_chunk[2 * i] = s0[i] ^ x;
-                out_chunk[2 * i + 1] = s1[i] ^ x;
+                out_chunk[2 * i] = xor(s0[i], x);
+                out_chunk[2 * i + 1] = xor(s1[i], x);
             }
         }
     }

--- a/crates/ot-core/src/ferret/spcot/receiver.rs
+++ b/crates/ot-core/src/ferret/spcot/receiver.rs
@@ -155,11 +155,13 @@ impl SPCOTReceiver {
             )
             .enumerate()
             .map(|(i, (([m0, m1], &t), b))| {
-                let tweak = Block::from((self.counter + i as u128).to_be_bytes());
+                let tweak = (self.counter + i as u128).to_be_bytes();
+                let mut h = t.to_bytes();
+                cipher.tccr(tweak, &mut h);
                 if !b {
-                    cipher.tccr(tweak, t) ^ m1
+                    Block::from(h) ^ m1
                 } else {
-                    cipher.tccr(tweak, t) ^ m0
+                    Block::from(h) ^ m0
                 }
             })
             .collect();

--- a/crates/ot-core/src/ferret/spcot/sender.rs
+++ b/crates/ot-core/src/ferret/spcot/sender.rs
@@ -88,8 +88,8 @@ impl SPCOTSender {
                 } else {
                     [*key, key ^ self.delta]
                 };
-                let tweak = Block::from((self.counter + i as u128).to_be_bytes());
-                cipher.tccr_many(&[tweak, tweak], &mut m);
+                let tweak = (self.counter + i as u128).to_be_bytes();
+                cipher.tccr_many(&[tweak, tweak], zerocopy::transmute_mut!(&mut m));
                 m
             })
             .collect();

--- a/crates/ot-core/src/rot/randomize.rs
+++ b/crates/ot-core/src/rot/randomize.rs
@@ -88,12 +88,14 @@ fn randomize_sender(delta: Block, output: RCOTSenderOutput<Block>) -> ROTSenderO
         .map(|(i, key)| {
             // Transfer ID ensures a unique tweak for each ROT.
             let j = ((id.as_u64() as u128) << 64) + (i as u128);
-            let j = Block::new(j.to_be_bytes());
+            let j = j.to_be_bytes();
 
-            let k0 = cipher.tccr(j, key);
-            let k1 = cipher.tccr(j, key ^ delta);
+            let mut k0 = key.to_bytes();
+            cipher.tccr(j, &mut k0);
+            let mut k1 = (key ^ delta).to_bytes();
+            cipher.tccr(j, &mut k1);
 
-            [k0, k1]
+            [Block::from(k0), Block::from(k1)]
         })
         .collect();
 
@@ -185,9 +187,11 @@ fn randomize_receiver(output: RCOTReceiverOutput<bool, Block>) -> ROTReceiverOut
     iter.for_each(|(i, msg)| {
         // Transfer ID ensures a unique tweak for each ROT.
         let j = ((id.as_u64() as u128) << 64) + (i as u128);
-        let j = Block::new(j.to_be_bytes());
+        let j = j.to_be_bytes();
 
-        *msg = cipher.tccr(j, *msg);
+        let mut h = msg.to_bytes();
+        cipher.tccr(j, &mut h);
+        *msg = Block::from(h);
     });
 
     ROTReceiverOutput { id, choices, msgs }


### PR DESCRIPTION
## Summary

Decouples the low-level AES primitives from the `Block` type so they operate on raw `[u8; 16]` blocks, and switches the single-block hashes to operate **in-place**. This is groundwork for the Ferret rewrite, where the GGM/half-tree expansion will work directly on byte slices.

Net: **126 insertions, 233 deletions**.

## Changes

- **`aes`** — `FixedKeyAes` and `AesEncryptor` take/return `[u8; 16]` / `&mut [[u8; 16]]` instead of `Block`. `tccr` and `encrypt_block` are now **in-place** (`&mut`); the redundant `encrypt_block_inplace` is removed. Private `xor`/array-cast helpers replace the `Block` ops.
- **`prp` / `tkprp`** — fully byte-native (`[u8; 16]`), no `Block` dependency.
- **`prg`** — byte-clean internals; **keeps its `Block` RNG seed/output contract** (it remains the codebase's `Block` RNG, used across many crates) with a single conversion at the AES boundary. Flipping its `Seed`/output to bytes alone would ripple into ~25 unrelated call sites without making `Prg` `Block`-free, so that's intentionally out of scope.

## Dead API removed (orphaned by the refactor)

- `aes`: `cr` / `cr_many` / `ccr` / `ccr_many` (no callers) and the now-unused `sigma` helper. The CR/CCR hash will be re-introduced byte-native when the half-tree needs it, rather than carried as speculative dead code.
- `Block`: `sigma` (+ its test), the four `Block`↔`Array<u8, U16>` cipher-interop `From` impls, and the `as_array*` helpers.
- `prp`: the unused single-block `permute_block`.

## Consumers

`lpn`, `ggm`, `spcot` (sender/receiver), and `rot::randomize` keep their own `Block` APIs and convert at the byte boundary — zero-cost since `Block` is `#[repr(transparent)]`.

## Verification

- `cargo test` green: `mpz-core` (16), `mpz-ot-core` (23/24), plus `mpz-ot`/`mpz-fields`/`mpz-ole-core` in earlier runs.
- `cargo clippy --all-targets` clean for `mpz-core` in both default and `rayon` feature configs.

Note: the LPN throughput-benchmark change is intentionally **not** included here — it'll go in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)