### PR TITLE
ci: drop redundant build step, document why clippy needs nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,9 +26,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.7.7
 
-      - name: "Build"
-        run: cargo build
-
       - name: "Test"
         # Run all tests (bins, examples, lib, integration and docs)
         # https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection
@@ -46,6 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Nightly is required: .rustfmt.toml uses unstable options, and clippy
+      # with --all-features builds matrix-transpose's simd-transpose feature,
+      # which needs the nightly-only portable_simd language feature.
       - name: Install Rust Nightly with rustfmt and clippy
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

Two small CI cleanups in `rust.yml`:

- **Remove the standalone `cargo build` step** from the Build and Test job. `cargo test` compiles the same dev-profile code plus the test binaries, so the build step duplicated work on every run.
- **Document why the rustfmt/clippy job uses nightly**, so it doesn't get "simplified" to stable and break CI:
  - `.rustfmt.toml` uses unstable options (`imports_granularity`, `wrap_comments`)
  - clippy runs with `--all-features`, which enables `matrix-transpose`'s `simd-transpose` feature — that requires the nightly-only `portable_simd` language feature and does not compile on stable

No behavioral change to what CI checks.