### PR TITLE
Fix lint checks on aarch64 hosts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,15 +51,12 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt, clippy
-          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2.7.7
 
-      - name: "Check formatting"
-        run: cargo +nightly fmt --check --all
-
-      - name: Run Clippy
-        run: cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
+      - name: "Check formatting and clippy"
+        # Same script developers run locally
+        run: ./lint.sh
 
   miri:
     if: ( ! github.event.pull_request.draft )

--- a/crates/circuits/src/sha256.rs
+++ b/crates/circuits/src/sha256.rs
@@ -126,9 +126,9 @@ fn maj<C: Context<Field = Gf2>>(
 fn constant_word<C: Context<Field = Gf2>>(ctx: &mut C, v: u32) -> Word<C::Wire> {
     let zero = ctx.constant(Gf2::ZERO);
     let mut out = [zero; 32];
-    for i in 0..32 {
+    for (i, wire) in out.iter_mut().enumerate() {
         let bit = (v >> i) & 1 != 0;
-        out[i] = ctx.constant(Gf2(bit));
+        *wire = ctx.constant(Gf2(bit));
     }
     out
 }

--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -203,10 +203,7 @@ impl crate::Accumulator for Gf2_128Accumulator {
     fn from_field(value: Gf2_128) -> Self {
         // A reduced element is already `< x¹²⁸`, so it sits entirely in `lo`;
         // reducing `(value, 0)` is the identity.
-        Self {
-            lo: value.0,
-            hi: 0,
-        }
+        Self { lo: value.0, hi: 0 }
     }
 
     #[inline]

--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -239,11 +239,11 @@ pub trait Field:
 /// [`reduce`](Accumulator::reduce).
 ///
 /// An accumulator is an additive group homomorphic to the field under
-/// [`reduce`](Accumulator::reduce): [`zero`](Accumulator::zero) is the identity,
-/// [`merge`](Accumulator::merge) adds two accumulators (e.g. partial sums from
-/// parallel chunks), [`add_product`](Accumulator::add_product) folds in one
-/// product, and reducing yields the field sum of everything folded in. That is,
-/// for any elements,
+/// [`reduce`](Accumulator::reduce): [`zero`](Accumulator::zero) is the
+/// identity, [`merge`](Accumulator::merge) adds two accumulators (e.g. partial
+/// sums from parallel chunks), [`add_product`](Accumulator::add_product) folds
+/// in one product, and reducing yields the field sum of everything folded in.
+/// That is, for any elements,
 ///
 /// ```text
 /// { let mut acc = A::zero();
@@ -252,10 +252,10 @@ pub trait Field:
 ///   acc.reduce() }                 ==   a * b + c * d
 /// ```
 ///
-/// For binary extension fields the unreduced form is the XOR of the double-width
-/// carry-less products, reduced once modulo the irreducible polynomial. For
-/// fields with no cheaper unreduced form, [`NaiveAccumulator`] reduces eagerly
-/// and the deferral is a no-op.
+/// For binary extension fields the unreduced form is the XOR of the
+/// double-width carry-less products, reduced once modulo the irreducible
+/// polynomial. For fields with no cheaper unreduced form, [`NaiveAccumulator`]
+/// reduces eagerly and the deferral is a no-op.
 pub trait Accumulator: Copy {
     /// The field whose products this accumulates and to which it reduces.
     type Field: Field;

--- a/crates/matrix-transpose/src/lib.rs
+++ b/crates/matrix-transpose/src/lib.rs
@@ -1,11 +1,14 @@
 #![cfg_attr(feature = "simd-transpose", feature(portable_simd))]
 
+// The SIMD implementation is portable, but the lane count is tuned per
+// architecture: 32 lanes on x86_64 (AVX2-sized registers), 16 lanes
+// (128-bit registers, e.g. NEON or simd128) everywhere else.
 #[cfg(feature = "simd-transpose")]
 #[cfg(target_arch = "x86_64")]
 pub const LANE_COUNT: usize = 32;
 
 #[cfg(feature = "simd-transpose")]
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(target_arch = "x86_64"))]
 pub const LANE_COUNT: usize = 16;
 
 #[cfg(not(feature = "simd-transpose"))]

--- a/crates/matrix-transpose/src/simd.rs
+++ b/crates/matrix-transpose/src/simd.rs
@@ -1,15 +1,14 @@
 use super::{LANE_COUNT, TransposeError};
 use std::{
     ops::ShlAssign,
-    simd::{Simd, SimdElement},
+    simd::{Simd, SimdElement, cmp::SimdPartialOrd},
 };
 
 /// SIMD version for bit-level transposition
 ///
 /// Assumes an LSB0 bit encoding of the matrix.
 /// This SIMD implementation additionally requires that the matrix has at least
-/// 16 (WASM) or 32 (x86_64) columns and rows
-#[cfg(any(target_arch = "x86_64", target_arch = "wasm32"))]
+/// `LANE_COUNT` columns and rows
 pub fn transpose_bits(matrix: &mut [u8], rows: usize) -> Result<(), TransposeError> {
     // Check that number of rows is not smaller than LANE_COUNT
     if rows < LANE_COUNT {
@@ -80,15 +79,9 @@ where
 /// Assumes an LSB0 bit encoding of the matrix.
 /// This function is an implementation of the bit-level transpose in
 /// https://docs.rs/oblivious-transfer/latest/oblivious_transfer/extension/fn.transpose128.html
-/// Caller has to make sure that columns is a multiple of 16 or 32
-#[cfg(any(target_arch = "x86_64", target_arch = "wasm32"))]
+/// Caller has to make sure that columns is a multiple of `LANE_COUNT`
 #[inline]
 pub unsafe fn bitmask_shift_unchecked(matrix: &mut [u8], columns: usize) {
-    #[cfg(target_arch = "wasm32")]
-    use std::arch::wasm32::u8x16_bitmask;
-    #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::_mm256_movemask_epi8;
-
     matrix.iter_mut().for_each(|b| *b = b.reverse_bits());
     let simd_one = Simd::<u8, LANE_COUNT>::splat(1);
     let mut s: Simd<u8, LANE_COUNT>;
@@ -97,13 +90,13 @@ pub unsafe fn bitmask_shift_unchecked(matrix: &mut [u8], columns: usize) {
         for _ in 0..8 {
             for chunk in unsafe { row.as_chunks_unchecked_mut::<LANE_COUNT>() } {
                 s = Simd::from_array(*chunk);
-                #[cfg(target_arch = "x86_64")]
-                let high_bits = unsafe { _mm256_movemask_epi8(s.reverse().into()) };
-                #[cfg(target_arch = "wasm32")]
-                let high_bits = u8x16_bitmask(s.reverse().into());
-                let high_bits: Vec<u8> = high_bits
-                    .to_be_bytes()
-                    .into_iter()
+                // Extract the MSB of every lane into a bitmask, lane 0 in the
+                // least significant bit (the portable equivalent of x86
+                // movemask / wasm bitmask, lowered to those instructions
+                // where available).
+                let high_bits = s.reverse().simd_ge(Simd::splat(0x80)).to_bitmask();
+                let high_bits: Vec<u8> = high_bits.to_be_bytes()[8 - LANE_COUNT / 8..]
+                    .iter()
                     .map(|b| b.reverse_bits())
                     .collect();
                 shifted_row.extend_from_slice(&high_bits);

--- a/crates/ot-core/benches/ot.rs
+++ b/crates/ot-core/benches/ot.rs
@@ -94,32 +94,32 @@ fn ferret(c: &mut Criterion) {
             let config = FerretConfig::builder().build().unwrap();
 
             b.iter(|| {
-                    let cot = IdealRCOT::new(rng.random(), delta);
-                    let mut sender = ferret::Sender::new(rng.random(), config.clone(), cot.clone());
-                    let mut receiver = ferret::Receiver::new(rng.random(), config.clone(), cot);
+                let cot = IdealRCOT::new(rng.random(), delta);
+                let mut sender = ferret::Sender::new(rng.random(), config.clone(), cot.clone());
+                let mut receiver = ferret::Receiver::new(rng.random(), config.clone(), cot);
 
-                    let init = receiver.initialize().unwrap();
-                    sender.initialize(init).unwrap();
-                    sender.alloc_bootstrap().unwrap();
-                    receiver.alloc_bootstrap().unwrap();
-                    sender.acquire_cot().flush().unwrap();
-                    receiver.acquire_cot().flush().unwrap();
-                    sender.alloc(n).unwrap();
-                    receiver.alloc(n).unwrap();
+                let init = receiver.initialize().unwrap();
+                sender.initialize(init).unwrap();
+                sender.alloc_bootstrap().unwrap();
+                receiver.alloc_bootstrap().unwrap();
+                sender.acquire_cot().flush().unwrap();
+                receiver.acquire_cot().flush().unwrap();
+                sender.alloc(n).unwrap();
+                receiver.alloc(n).unwrap();
 
-                    while sender.wants_extend() && receiver.wants_extend() {
-                        sender.start_extend().unwrap();
-                        let msg = receiver.start_extend().unwrap();
-                        let msg = sender.extend(msg).unwrap();
-                        let msg = receiver.extend(msg).unwrap();
-                        let msg = sender.check(msg).unwrap();
-                        receiver.finish_extend(msg).unwrap();
-                        sender.finish_extend().unwrap();
-                    }
+                while sender.wants_extend() && receiver.wants_extend() {
+                    sender.start_extend().unwrap();
+                    let msg = receiver.start_extend().unwrap();
+                    let msg = sender.extend(msg).unwrap();
+                    let msg = receiver.extend(msg).unwrap();
+                    let msg = sender.check(msg).unwrap();
+                    receiver.finish_extend(msg).unwrap();
+                    sender.finish_extend().unwrap();
+                }
 
-                    black_box((sender, receiver));
-                })
-            });
+                black_box((sender, receiver));
+            })
+        });
     }
 }
 

--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -108,7 +108,8 @@ fn default_parameter_selector(available: usize, additional: usize) -> LpnParamet
 /// Returns the number of COTs needed to execute an iteration with the given
 /// parameters.
 fn iteration_cost(params: LpnParameters) -> usize {
-    // In our chosen parameters, we always set n divisible by t and n/t is a power of 2.
+    // In our chosen parameters, we always set n divisible by t and n/t is a power
+    // of 2.
     assert!(params.n.is_multiple_of(params.t) && (params.n / params.t).is_power_of_two());
     params.t * ((params.n / params.t).ilog2() as usize) + params.k + CSP
 }

--- a/crates/ot-core/src/ferret/mpcot/receiver.rs
+++ b/crates/ot-core/src/ferret/mpcot/receiver.rs
@@ -12,9 +12,7 @@ pub(crate) struct MPCOTReceiver<T: state::State = Initialized> {
 impl MPCOTReceiver {
     /// Creates a new Receiver.
     pub(crate) fn new() -> Self {
-        MPCOTReceiver {
-            state: Initialized,
-        }
+        MPCOTReceiver { state: Initialized }
     }
 }
 

--- a/crates/ot-core/src/ferret/mpcot/sender.rs
+++ b/crates/ot-core/src/ferret/mpcot/sender.rs
@@ -12,9 +12,7 @@ pub(crate) struct MPCOTSender<T: state::State = Initialized> {
 impl MPCOTSender {
     /// Creates a new Sender.
     pub(crate) fn new() -> Self {
-        MPCOTSender {
-            state: Initialized,
-        }
+        MPCOTSender { state: Initialized }
     }
 }
 

--- a/crates/vm-circuits/src/gadgets.rs
+++ b/crates/vm-circuits/src/gadgets.rs
@@ -1,18 +1,18 @@
 use mpz_circuits::Context;
 use mpz_fields::{Field, gf2::Gf2};
 
+mod advice;
 mod arith;
 mod bits;
 mod compare;
 mod count;
 mod divrem;
-mod advice;
 mod shift;
 
+pub(crate) use advice::*;
 pub(crate) use arith::*;
 pub(crate) use bits::*;
 pub(crate) use compare::*;
 pub(crate) use count::*;
 pub(crate) use divrem::*;
-pub(crate) use advice::*;
 pub(crate) use shift::*;

--- a/crates/vm-circuits/src/gadgets/advice.rs
+++ b/crates/vm-circuits/src/gadgets/advice.rs
@@ -2,13 +2,17 @@
 
 use super::*;
 
+/// Quotient and remainder wires returned by the division advice gadgets.
+type DivRemResult<C, const N: usize> =
+    Result<([<C as Context>::Wire; N], [<C as Context>::Wire; N]), <C as Context>::Error>;
+
 pub(crate) fn divrem_u_advice_n<C: Context<Field = Gf2>, const N: usize>(
     ctx: &mut C,
     a: [C::Wire; N],
     b: [C::Wire; N],
     q: [C::Wire; N],
     r: [C::Wire; N],
-) -> Result<([C::Wire; N], [C::Wire; N]), C::Error> {
+) -> DivRemResult<C, N> {
     let qb = mul_n(ctx, q, b);
     let sum = add_n(ctx, qb, r);
     let diff = xor_arr(ctx, sum, a);
@@ -26,7 +30,7 @@ pub(crate) fn divrem_s_advice_n<C: Context<Field = Gf2>, const N: usize>(
     b: [C::Wire; N],
     q: [C::Wire; N],
     r: [C::Wire; N],
-) -> Result<([C::Wire; N], [C::Wire; N]), C::Error> {
+) -> DivRemResult<C, N> {
     let qb = mul_n(ctx, q, b);
     let sum = add_n(ctx, qb, r);
     let diff = xor_arr(ctx, sum, a);
@@ -110,7 +114,10 @@ pub(crate) fn divrem_u_advice_values(a: u64, b: u64, n: usize) -> (u64, u64) {
     let mask = if n == 64 { u64::MAX } else { (1u64 << n) - 1 };
     let a = a & mask;
     let b = b & mask;
-    if b == 0 { (0, a) } else { (a / b, a % b) }
+    match a.checked_div(b) {
+        Some(q) => (q, a % b),
+        None => (0, a),
+    }
 }
 
 /// Quotient and remainder of signed `a / b` over `n` bits, returned as

--- a/crates/vm-circuits/src/gadgets/arith.rs
+++ b/crates/vm-circuits/src/gadgets/arith.rs
@@ -91,10 +91,10 @@ pub(crate) fn schoolbook_full_dyn<C: Context<Field = Gf2>>(
     let total = na + nb;
     let z = zero(ctx);
     let mut acc = vec![z; total];
-    for j in 0..nb {
+    for (j, &bj) in b.iter().enumerate() {
         let mut partial = Vec::with_capacity(na);
-        for i in 0..na {
-            partial.push(ctx.mul(a[i], b[j]));
+        for &ai in a {
+            partial.push(ctx.mul(ai, bj));
         }
         add_at_offset(ctx, &mut acc, &partial, j);
     }
@@ -204,8 +204,6 @@ pub(crate) fn mul_n<C: Context<Field = Gf2>, const N: usize>(
 ) -> [C::Wire; N] {
     let full = karatsuba_full(ctx, &a, &b);
     let mut out = a;
-    for i in 0..N {
-        out[i] = full[i];
-    }
+    out.copy_from_slice(&full[..N]);
     out
 }

--- a/crates/vm-circuits/src/gadgets/compare.rs
+++ b/crates/vm-circuits/src/gadgets/compare.rs
@@ -8,8 +8,8 @@ pub(crate) fn eqz_n<C: Context<Field = Gf2>, const N: usize>(
 ) -> C::Wire {
     let one_w = one(ctx);
     let mut acc = ctx.add(a[0], one_w);
-    for i in 1..N {
-        let inv = ctx.add(a[i], one_w);
+    for &w in &a[1..] {
+        let inv = ctx.add(w, one_w);
         acc = ctx.mul(acc, inv);
     }
     acc

--- a/crates/vm-circuits/src/gadgets/count.rs
+++ b/crates/vm-circuits/src/gadgets/count.rs
@@ -8,9 +8,9 @@ pub(crate) fn popcnt_n<C: Context<Field = Gf2>, const N: usize>(
 ) -> [C::Wire; N] {
     let z = zero(ctx);
     let mut count: [C::Wire; N] = [z; N];
-    for i in 0..N {
+    for bit in a {
         let mut inc = [z; N];
-        inc[0] = a[i];
+        inc[0] = bit;
         count = add_n(ctx, count, inc);
     }
     count
@@ -46,8 +46,7 @@ pub(crate) fn ctz_n<C: Context<Field = Gf2>, const N: usize>(
     let z = zero(ctx);
     let mut count: [C::Wire; N] = [z; N];
     let mut done = z;
-    for i in 0..N {
-        let bit = a[i];
+    for bit in a {
         let not_done = not(ctx, done);
         let inc_bit = {
             let not_bit = not(ctx, bit);
@@ -68,9 +67,7 @@ pub(crate) fn sign_extend_low_in_place<C: Context<Field = Gf2>, const N: usize>(
 ) -> [C::Wire; N] {
     let sign = a[m - 1];
     let mut out = [sign; N];
-    for i in 0..m {
-        out[i] = a[i];
-    }
+    out[..m].copy_from_slice(&a[..m]);
     out
 }
 

--- a/crates/vm-circuits/src/gadgets/divrem.rs
+++ b/crates/vm-circuits/src/gadgets/divrem.rs
@@ -12,9 +12,7 @@ pub(crate) fn divrem_u_n<C: Context<Field = Gf2>, const N: usize>(
     let mut r: [C::Wire; N] = [z; N];
     for i in (0..N).rev() {
         let mut new_r = [z; N];
-        for j in 1..N {
-            new_r[j] = r[j - 1];
-        }
+        new_r[1..].copy_from_slice(&r[..N - 1]);
         new_r[0] = a[i];
         let (diff, borrow) = sub_with_borrow_n(ctx, new_r, b);
         let success = not(ctx, borrow);

--- a/crates/vm-circuits/src/gadgets/shift.rs
+++ b/crates/vm-circuits/src/gadgets/shift.rs
@@ -5,9 +5,7 @@ use super::*;
 pub(crate) fn shift_left_const<W: Copy, const N: usize>(a: [W; N], k: usize, fill: W) -> [W; N] {
     let mut out = [fill; N];
     if k < N {
-        for i in 0..(N - k) {
-            out[i + k] = a[i];
-        }
+        out[k..].copy_from_slice(&a[..N - k]);
     }
     out
 }
@@ -15,9 +13,7 @@ pub(crate) fn shift_left_const<W: Copy, const N: usize>(a: [W; N], k: usize, fil
 pub(crate) fn shift_right_const<W: Copy, const N: usize>(a: [W; N], k: usize, fill: W) -> [W; N] {
     let mut out = [fill; N];
     if k < N {
-        for i in k..N {
-            out[i - k] = a[i];
-        }
+        out[..N - k].copy_from_slice(&a[k..]);
     }
     out
 }
@@ -52,9 +48,9 @@ where
 {
     let log2_n = N.trailing_zeros() as usize;
     let mut result = a;
-    for k in 0..log2_n {
+    for (k, &bk) in b.iter().enumerate().take(log2_n) {
         let shifted = shift_const(result, 1 << k);
-        result = mux_arr(ctx, b[k], shifted, result);
+        result = mux_arr(ctx, bk, shifted, result);
     }
     result
 }
@@ -91,7 +87,7 @@ pub(crate) fn rotl_n<C: Context<Field = Gf2>, const N: usize>(
     a: [C::Wire; N],
     b: [C::Wire; N],
 ) -> [C::Wire; N] {
-    barrel_shift(ctx, a, b, |arr, k| rotate_left_const(arr, k))
+    barrel_shift(ctx, a, b, rotate_left_const)
 }
 
 pub(crate) fn rotr_n<C: Context<Field = Gf2>, const N: usize>(
@@ -99,5 +95,5 @@ pub(crate) fn rotr_n<C: Context<Field = Gf2>, const N: usize>(
     a: [C::Wire; N],
     b: [C::Wire; N],
 ) -> [C::Wire; N] {
-    barrel_shift(ctx, a, b, |arr, k| rotate_right_const(arr, k))
+    barrel_shift(ctx, a, b, rotate_right_const)
 }

--- a/crates/vm-circuits/src/harness.rs
+++ b/crates/vm-circuits/src/harness.rs
@@ -3,16 +3,16 @@ use mpz_fields::gf2::Gf2;
 
 pub(crate) fn to_bits<const N: usize>(v: u64) -> [Gf2; N] {
     let mut out = [Gf2(false); N];
-    for i in 0..N {
-        out[i] = Gf2((v >> i) & 1 != 0);
+    for (i, bit) in out.iter_mut().enumerate() {
+        *bit = Gf2((v >> i) & 1 != 0);
     }
     out
 }
 
 pub(crate) fn from_bits<const N: usize>(b: [Gf2; N]) -> u64 {
     let mut v = 0u64;
-    for i in 0..N {
-        if b[i].0 {
+    for (i, bit) in b.iter().enumerate() {
+        if bit.0 {
             v |= 1u64 << i;
         }
     }
@@ -71,7 +71,6 @@ pub(crate) fn prng() -> impl Iterator<Item = u64> {
         Some(state)
     })
 }
-
 
 pub(crate) fn pairs_u64(n: usize) -> Vec<(u64, u64)> {
     let mut p = prng();

--- a/crates/vm-circuits/src/insn.rs
+++ b/crates/vm-circuits/src/insn.rs
@@ -3,8 +3,7 @@ use mpz_circuits::Context;
 use mpz_circuits::MaybeConst;
 #[cfg(test)]
 use mpz_fields::Field;
-use mpz_fields::gf2::Gf2;
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_vm_memory::{I32, I64};
 
 pub trait CircuitContext: Context<Wire = Gf2_128, Field = Gf2> {}

--- a/crates/vm-circuits/src/insn/count.rs
+++ b/crates/vm-circuits/src/insn/count.rs
@@ -138,30 +138,22 @@ mod tests {
     #[test]
     fn costs_match_gate_counts() {
         assert_cost!(I32Clz::COST, |ctx| I32Clz::eval(ctx, dummy_i32()));
-        assert_cost!(I32Clz::COST_WITH_ADVICE - I32Clz::ADVICE, |ctx| I32Clz::eval_with_advice(
-            ctx,
-            dummy_i32(),
-            dummy_i32()
-        ));
+        assert_cost!(I32Clz::COST_WITH_ADVICE - I32Clz::ADVICE, |ctx| {
+            I32Clz::eval_with_advice(ctx, dummy_i32(), dummy_i32())
+        });
         assert_cost!(I32Ctz::COST, |ctx| I32Ctz::eval(ctx, dummy_i32()));
-        assert_cost!(I32Ctz::COST_WITH_ADVICE - I32Ctz::ADVICE, |ctx| I32Ctz::eval_with_advice(
-            ctx,
-            dummy_i32(),
-            dummy_i32()
-        ));
+        assert_cost!(I32Ctz::COST_WITH_ADVICE - I32Ctz::ADVICE, |ctx| {
+            I32Ctz::eval_with_advice(ctx, dummy_i32(), dummy_i32())
+        });
         assert_cost!(I32Popcnt::COST, |ctx| I32Popcnt::eval(ctx, dummy_i32()));
         assert_cost!(I64Clz::COST, |ctx| I64Clz::eval(ctx, dummy_i64()));
-        assert_cost!(I64Clz::COST_WITH_ADVICE - I64Clz::ADVICE, |ctx| I64Clz::eval_with_advice(
-            ctx,
-            dummy_i64(),
-            dummy_i64()
-        ));
+        assert_cost!(I64Clz::COST_WITH_ADVICE - I64Clz::ADVICE, |ctx| {
+            I64Clz::eval_with_advice(ctx, dummy_i64(), dummy_i64())
+        });
         assert_cost!(I64Ctz::COST, |ctx| I64Ctz::eval(ctx, dummy_i64()));
-        assert_cost!(I64Ctz::COST_WITH_ADVICE - I64Ctz::ADVICE, |ctx| I64Ctz::eval_with_advice(
-            ctx,
-            dummy_i64(),
-            dummy_i64()
-        ));
+        assert_cost!(I64Ctz::COST_WITH_ADVICE - I64Ctz::ADVICE, |ctx| {
+            I64Ctz::eval_with_advice(ctx, dummy_i64(), dummy_i64())
+        });
         assert_cost!(I64Popcnt::COST, |ctx| I64Popcnt::eval(ctx, dummy_i64()));
     }
 }

--- a/crates/vm-circuits/src/insn/value_tests.rs
+++ b/crates/vm-circuits/src/insn/value_tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use mpz_circuits::Context;
-use mpz_fields::gf2::Gf2;
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_vm_memory::{I32, I64};
 
 struct EvalCtx;
@@ -28,7 +27,11 @@ impl Context for EvalCtx {
     }
 
     fn assert_const(&mut self, v: Gf2_128, expected: Gf2) -> Result<(), ()> {
-        let exp = if expected.0 { Gf2_128::ONE } else { Gf2_128::ZERO };
+        let exp = if expected.0 {
+            Gf2_128::ONE
+        } else {
+            Gf2_128::ZERO
+        };
         if v == exp { Ok(()) } else { Err(()) }
     }
 }
@@ -139,7 +142,11 @@ fn eval_const_lowering() {
             );
             if k != 0 {
                 assert_eq!(
-                    i32_out(I32DivU::eval_const_divisor(&mut EvalCtx, i32_in(a), k as i32)),
+                    i32_out(I32DivU::eval_const_divisor(
+                        &mut EvalCtx,
+                        i32_in(a),
+                        k as i32
+                    )),
                     a / k
                 );
             }
@@ -158,7 +165,11 @@ fn const_shift_amount() {
                 "shl v={v:#x} n={n}"
             );
             assert_eq!(
-                i32_out(I32ShrU::eval_const_amount(&mut EvalCtx, i32_in(v), n as i32)),
+                i32_out(I32ShrU::eval_const_amount(
+                    &mut EvalCtx,
+                    i32_in(v),
+                    n as i32
+                )),
                 v.wrapping_shr(m),
                 "shr_u v={v:#x} n={n}"
             );
@@ -188,7 +199,11 @@ fn const_shift_amount() {
                 "i64 shl v={v:#x} n={n}"
             );
             assert_eq!(
-                i64_out(I64ShrU::eval_const_amount(&mut EvalCtx, i64_in(v), n as i64)),
+                i64_out(I64ShrU::eval_const_amount(
+                    &mut EvalCtx,
+                    i64_in(v),
+                    n as i64
+                )),
                 v.wrapping_shr(m),
                 "i64 shr_u v={v:#x} n={n}"
             );
@@ -244,10 +259,7 @@ fn conversions() {
             i64_out(I64Extend32S::eval(&mut EvalCtx, i64_in(v))),
             ((v as i64) << 32 >> 32) as u64
         );
-        assert_eq!(
-            i32_out(I32WrapI64::eval(&mut EvalCtx, i64_in(v))),
-            v as u32
-        );
+        assert_eq!(i32_out(I32WrapI64::eval(&mut EvalCtx, i64_in(v))), v as u32);
     }
 }
 
@@ -296,16 +308,28 @@ fn divrem_advice_roundtrip() {
             let (q, r) = I32DivU::advice_values(a, b);
             assert_eq!(
                 i32_out(
-                    I32DivU::eval_with_advice(&mut EvalCtx, i32_in(a), i32_in(b), i32_in(q as u32), i32_in(r as u32))
-                        .expect("honest")
+                    I32DivU::eval_with_advice(
+                        &mut EvalCtx,
+                        i32_in(a),
+                        i32_in(b),
+                        i32_in(q),
+                        i32_in(r)
+                    )
+                    .expect("honest")
                 ),
                 a / b
             );
             let (q, r) = I32RemU::advice_values(a, b);
             assert_eq!(
                 i32_out(
-                    I32RemU::eval_with_advice(&mut EvalCtx, i32_in(a), i32_in(b), i32_in(q as u32), i32_in(r as u32))
-                        .expect("honest")
+                    I32RemU::eval_with_advice(
+                        &mut EvalCtx,
+                        i32_in(a),
+                        i32_in(b),
+                        i32_in(q),
+                        i32_in(r)
+                    )
+                    .expect("honest")
                 ),
                 a % b
             );
@@ -313,16 +337,28 @@ fn divrem_advice_roundtrip() {
             let (q, r) = I32DivS::advice_values(sa, sb);
             assert_eq!(
                 i32_out(
-                    I32DivS::eval_with_advice(&mut EvalCtx, i32_in(a), i32_in(b), i32_in(q as u32), i32_in(r as u32))
-                        .expect("honest")
+                    I32DivS::eval_with_advice(
+                        &mut EvalCtx,
+                        i32_in(a),
+                        i32_in(b),
+                        i32_in(q as u32),
+                        i32_in(r as u32)
+                    )
+                    .expect("honest")
                 ) as i32,
                 sa.wrapping_div(sb)
             );
             let (q, r) = I32RemS::advice_values(sa, sb);
             assert_eq!(
                 i32_out(
-                    I32RemS::eval_with_advice(&mut EvalCtx, i32_in(a), i32_in(b), i32_in(q as u32), i32_in(r as u32))
-                        .expect("honest")
+                    I32RemS::eval_with_advice(
+                        &mut EvalCtx,
+                        i32_in(a),
+                        i32_in(b),
+                        i32_in(q as u32),
+                        i32_in(r as u32)
+                    )
+                    .expect("honest")
                 ) as i32,
                 sa.wrapping_rem(sb)
             );
@@ -336,8 +372,14 @@ fn divrem_advice_roundtrip() {
             let (q, r) = I64DivU::advice_values(a, b);
             assert_eq!(
                 i64_out(
-                    I64DivU::eval_with_advice(&mut EvalCtx, i64_in(a), i64_in(b), i64_in(q as u64), i64_in(r as u64))
-                        .expect("honest")
+                    I64DivU::eval_with_advice(
+                        &mut EvalCtx,
+                        i64_in(a),
+                        i64_in(b),
+                        i64_in(q),
+                        i64_in(r)
+                    )
+                    .expect("honest")
                 ),
                 a / b
             );
@@ -370,10 +412,12 @@ fn count_advice_roundtrip() {
 
 #[test]
 fn advice_soundness_rejects_dishonest() {
-    let bad = I32DivU::eval_with_advice(&mut EvalCtx, i32_in(100), i32_in(7), i32_in(0), i32_in(100));
+    let bad =
+        I32DivU::eval_with_advice(&mut EvalCtx, i32_in(100), i32_in(7), i32_in(0), i32_in(100));
     assert!(bad.is_err(), "r >= b must be rejected");
 
-    let bad = I32DivU::eval_with_advice(&mut EvalCtx, i32_in(100), i32_in(7), i32_in(13), i32_in(2));
+    let bad =
+        I32DivU::eval_with_advice(&mut EvalCtx, i32_in(100), i32_in(7), i32_in(13), i32_in(2));
     assert!(bad.is_err(), "q*b + r != a must be rejected");
 
     let h = I32Clz::advice_values(0xF0) ^ 1;

--- a/crates/vm-circuits/src/spec_tests/arith.rs
+++ b/crates/vm-circuits/src/spec_tests/arith.rs
@@ -1,5 +1,8 @@
-use crate::harness::{from_bits, run_bin, to_bits};
-use crate::{add_n, mul_n, sub_n};
+use crate::{
+    add_n,
+    harness::{from_bits, run_bin, to_bits},
+    mul_n, sub_n,
+};
 use mpz_circuits::{Context, WitnessCtx};
 use mpz_fields::gf2::Gf2;
 use proptest::prelude::*;

--- a/crates/vm-circuits/src/spec_tests/compare.rs
+++ b/crates/vm-circuits/src/spec_tests/compare.rs
@@ -1,5 +1,8 @@
-use crate::harness::{run_bin_bit, run_un_bit};
-use crate::{eq_n, eqz_n, lt_s_n, lt_u_n, ne_n, not};
+use crate::{
+    eq_n, eqz_n,
+    harness::{run_bin_bit, run_un_bit},
+    lt_s_n, lt_u_n, ne_n, not,
+};
 use mpz_circuits::Context;
 use mpz_fields::gf2::Gf2;
 use proptest::prelude::*;

--- a/crates/vm-circuits/src/spec_tests/count_convert.rs
+++ b/crates/vm-circuits/src/spec_tests/count_convert.rs
@@ -1,7 +1,7 @@
-use crate::harness::{from_bits, run_conv, run_un, to_bits};
 use crate::{
-    clz_advice_n, clz_advice_values, clz_n, ctz_advice_n, ctz_advice_values, ctz_n, popcnt_advice_n,
-    popcnt_advice_values, popcnt_n,
+    clz_advice_n, clz_advice_values, clz_n, ctz_advice_n, ctz_advice_values, ctz_n,
+    harness::{from_bits, run_conv, run_un, to_bits},
+    popcnt_advice_n, popcnt_advice_values, popcnt_n,
 };
 use mpz_circuits::{Context, WitnessCtx};
 use mpz_fields::gf2::Gf2;
@@ -22,9 +22,7 @@ fn popcnt_w<C: Context<Field = Gf2>, const N: usize>(ctx: &mut C, a: [C::Wire; N
 fn sign_extend<W: Copy, const N: usize>(a: [W; N], m: usize) -> [W; N] {
     let sign = a[m - 1];
     let mut out = [sign; N];
-    for i in 0..m {
-        out[i] = a[i];
-    }
+    out[..m].copy_from_slice(&a[..m]);
     out
 }
 
@@ -352,9 +350,7 @@ proptest! {
         let got = run_conv::<_, 32, 64>(|_c, a| {
             let sign = a[31];
             let mut out = [sign; 64];
-            for i in 0..32 {
-                out[i] = a[i];
-            }
+            out[..32].copy_from_slice(&a);
             out
         }, v as u64);
         prop_assert_eq!(got, v as i32 as i64 as u64, "extend_s v={:#x}", v);
@@ -365,9 +361,7 @@ proptest! {
         let got = run_conv::<_, 32, 64>(|c, a| {
             let z = crate::zero(c);
             let mut out = [z; 64];
-            for i in 0..32 {
-                out[i] = a[i];
-            }
+            out[..32].copy_from_slice(&a);
             out
         }, v as u64);
         prop_assert_eq!(got, v as u64, "extend_u v={:#x}", v);
@@ -545,9 +539,7 @@ fn wrap_extend_boundaries() {
                 |_c, a| {
                     let sign = a[31];
                     let mut out = [sign; 64];
-                    for i in 0..32 {
-                        out[i] = a[i];
-                    }
+                    out[..32].copy_from_slice(&a);
                     out
                 },
                 v as u64
@@ -560,9 +552,7 @@ fn wrap_extend_boundaries() {
                 |c, a| {
                     let z = crate::zero(c);
                     let mut out = [z; 64];
-                    for i in 0..32 {
-                        out[i] = a[i];
-                    }
+                    out[..32].copy_from_slice(&a);
                     out
                 },
                 v as u64

--- a/crates/vm-circuits/src/spec_tests/div_rem.rs
+++ b/crates/vm-circuits/src/spec_tests/div_rem.rs
@@ -1,6 +1,8 @@
-use crate::harness::{from_bits, pairs_u64, run_bin, to_bits};
-use crate::{divrem_s_advice_n, divrem_s_advice_values, divrem_u_advice_n, divrem_u_advice_values};
-use crate::{divrem_s_n, divrem_u_n};
+use crate::{
+    divrem_s_advice_n, divrem_s_advice_values, divrem_s_n, divrem_u_advice_n,
+    divrem_u_advice_values, divrem_u_n,
+    harness::{from_bits, pairs_u64, run_bin, to_bits},
+};
 use mpz_circuits::{Context, WitnessCtx};
 use mpz_fields::gf2::Gf2;
 use proptest::prelude::*;

--- a/crates/vm-core/src/arithmetic.rs
+++ b/crates/vm-core/src/arithmetic.rs
@@ -1,4 +1,3 @@
-
 use mpz_vm_ir::{BinaryOp, InstructionArith, Reg, UnaryOp};
 
 use crate::{Error, MaybeTrap, Trap, Value};

--- a/crates/vm-core/src/call.rs
+++ b/crates/vm-core/src/call.rs
@@ -16,16 +16,17 @@ pub struct Call {
 
 /// An argument supplied to a function call.
 ///
-/// Each variant determines both the value and its [`Visibility`](crate::Visibility):
-/// whether it is known to the caller, shared publicly, or hidden from the
-/// caller entirely.
+/// Each variant determines both the value and its
+/// [`Visibility`](crate::Visibility): whether it is known to the caller, shared
+/// publicly, or hidden from the caller entirely.
 #[derive(Debug, Clone)]
 pub enum Param {
     /// A private argument whose value is known to the caller but kept secret.
     Private(Value),
     /// A public argument whose value is known to all parties.
     Public(Value),
-    /// A blinded argument of the given type whose value is unknown to the caller.
+    /// A blinded argument of the given type whose value is unknown to the
+    /// caller.
     Blind(ValType),
 }
 

--- a/crates/vm-core/src/error.rs
+++ b/crates/vm-core/src/error.rs
@@ -1,5 +1,4 @@
-use crate::trap::Trap;
-use crate::value::ValueError;
+use crate::{trap::Trap, value::ValueError};
 
 /// The error type of `mpz-vm-core`.
 ///

--- a/crates/vm-core/src/lib.rs
+++ b/crates/vm-core/src/lib.rs
@@ -3,9 +3,9 @@
 //!
 //! The crate splits execution into a deterministic, party-agnostic
 //! [`Thread`] interpreter and an embedder that drives it. A thread steps
-//! through an [`mpz_vm_ir`] [`Module`], emitting a stream of [`Directive`]s that
-//! describe the abstract operations to perform. Operations whose operands are
-//! [`Visibility::Private`] or [`Visibility::Blind`] are expressed
+//! through an [`mpz_vm_ir`] [`Module`], emitting a stream of [`Directive`]s
+//! that describe the abstract operations to perform. Operations whose operands
+//! are [`Visibility::Private`] or [`Visibility::Blind`] are expressed
 //! symbolically through [`Operand`] and [`Op`]; operations on
 //! [`Visibility::Public`] data are evaluated concretely in-thread.
 //!
@@ -20,8 +20,8 @@
 //!   [`StepResult`] on each [`Thread::step`], which is passed the shared
 //!   [`Module`] and mutable [`Global`] state.
 //! - When a thread cannot proceed without external input it returns
-//!   [`StepResult::Blocked`] carrying a [`Pending`] request, which the
-//!   embedder satisfies with the matching `Thread::resolve_*` method.
+//!   [`StepResult::Blocked`] carrying a [`Pending`] request, which the embedder
+//!   satisfies with the matching `Thread::resolve_*` method.
 
 pub(crate) mod analysis;
 pub(crate) mod arithmetic;
@@ -84,9 +84,9 @@ pub enum Write<'a> {
 /// effects for a particular execution backend.
 pub trait Vm {
     /// The error type this VM reports. Each backend defines its own, expressing
-    /// the conditions it can actually encounter (interpreter faults, traps, I/O,
-    /// and whatever it deems unsupported) without funnelling through a shared
-    /// umbrella.
+    /// the conditions it can actually encounter (interpreter faults, traps,
+    /// I/O, and whatever it deems unsupported) without funnelling through a
+    /// shared umbrella.
     type Error: core::error::Error;
 
     /// Writes `w` into memory at byte offset `ptr`.
@@ -140,9 +140,9 @@ pub trait Vm {
     /// [`write`](Self::write) and [`reveal`](Self::reveal) stage their effects
     /// for the next exchange, which normally happens at the start of the next
     /// [`call`](Self::call). `commit` performs that exchange on demand: queued
-    /// inputs are committed and queued reveals are opened up front. With nothing
-    /// left pending, a subsequent [`call_local`](Self::call_local) can run with
-    /// no further communication.
+    /// inputs are committed and queued reveals are opened up front. With
+    /// nothing left pending, a subsequent [`call_local`](Self::call_local)
+    /// can run with no further communication.
     ///
     /// # Errors
     ///
@@ -156,18 +156,18 @@ pub trait Vm {
     /// without an `io` context.
     ///
     /// Unlike [`call`](Self::call), this performs no communication with other
-    /// parties: it runs the function only while every step can be evaluated from
-    /// values this party already holds. It is intended for functions whose
-    /// inputs are all public (or have already been committed via
+    /// parties: it runs the function only while every step can be evaluated
+    /// from values this party already holds. It is intended for functions
+    /// whose inputs are all public (or have already been committed via
     /// [`commit`](Self::commit)).
     ///
     /// # Errors
     ///
     /// Returns [`Self::Error`] if the call would require communication — for
-    /// example when private or blind inputs remain uncommitted, when a reveal is
-    /// pending, or when execution reaches a symbolic operation that cannot be
-    /// resolved locally — in addition to the usual failures: an invalid
-    /// `func_idx`, a signature mismatch, or a trap.
+    /// example when private or blind inputs remain uncommitted, when a reveal
+    /// is pending, or when execution reaches a symbolic operation that
+    /// cannot be resolved locally — in addition to the usual failures: an
+    /// invalid `func_idx`, a signature mismatch, or a trap.
     fn call_local(
         &mut self,
         func_idx: u32,

--- a/crates/vm-core/src/memory.rs
+++ b/crates/vm-core/src/memory.rs
@@ -77,10 +77,10 @@ impl Memory {
             return Err(Trap::MemoryOutOfBounds);
         }
 
-        if let Some(max) = self.max_size {
-            if new_size as u64 > max * 65536 {
-                return Err(Trap::MemoryOutOfBounds);
-            }
+        if let Some(max) = self.max_size
+            && new_size as u64 > max * 65536
+        {
+            return Err(Trap::MemoryOutOfBounds);
         }
 
         self.data.resize(new_size, 0);

--- a/crates/vm-core/src/taint.rs
+++ b/crates/vm-core/src/taint.rs
@@ -1,4 +1,3 @@
-
 use crate::bitset::BitSet;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/vm-core/src/thread.rs
+++ b/crates/vm-core/src/thread.rs
@@ -7,23 +7,23 @@
 //! happened.
 //!
 //! When the interpreter reaches an operation whose outcome depends on data this
-//! party does not hold — a symbolic branch condition or a host/import call — the
-//! thread blocks and reports a [`Pending`] condition. The embedder supplies the
-//! missing decision through the matching `resolve_*` method
-//! ([`Thread::resolve_branch`] or [`Thread::resolve_host_call`]) before stepping
-//! again.
+//! party does not hold — a symbolic branch condition or a host/import call —
+//! the thread blocks and reports a [`Pending`] condition. The embedder supplies
+//! the missing decision through the matching `resolve_*` method
+//! ([`Thread::resolve_branch`] or [`Thread::resolve_host_call`]) before
+//! stepping again.
 //!
 //! An operation that may trap on operands this party cannot inspect (an integer
 //! divide/remainder with an unheld operand) does not block: it is emitted as an
-//! ordinary [`Directive`] and execution continues as if it did not trap. Whether
-//! it actually trapped is decided externally by correlating its operation index
-//! (see [`Thread::op_counter`]) against the trap a peer reports.
+//! ordinary [`Directive`] and execution continues as if it did not trap.
+//! Whether it actually trapped is decided externally by correlating its
+//! operation index (see [`Thread::op_counter`]) against the trap a peer
+//! reports.
 //!
 //! All execution runs against a [`Context`], which pairs the [`Module`] being
 //! interpreted with the mutable [`Global`] state it operates on.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::taint::{Class, Taints};
 use mpz_vm_ir::{
@@ -70,15 +70,16 @@ pub enum Pending {
     HostCall {
         /// The index of the called function.
         func_idx: u32,
-        /// The register that receives the return value, if the call returns one.
+        /// The register that receives the return value, if the call returns
+        /// one.
         dst: Option<Reg>,
         /// The call arguments, so the embedder can service the host call.
         args: Vec<Operand>,
     },
     /// An indirect call whose table index is symbolic and not held by this
     /// party, so the dispatch target cannot be chosen locally. The embedder
-    /// resolves it with [`Thread::resolve_call_indirect`] supplying the concrete
-    /// index.
+    /// resolves it with [`Thread::resolve_call_indirect`] supplying the
+    /// concrete index.
     CallIndirect {
         /// The absolute register holding the symbolic table index.
         table_idx: Reg,
@@ -197,10 +198,11 @@ enum PrivateCfExit {
 /// A stepwise interpreter for a single call into a module.
 ///
 /// A thread maintains its own call stack and register file and is driven by
-/// repeated calls to [`step`](Self::step). Construct one with [`new`](Self::new),
-/// begin a call with [`call`](Self::call), then step until a [`StepResult::Done`]
-/// or [`StepResult::Trapped`] is observed, resolving any [`StepResult::Blocked`]
-/// conditions with [`resolve`](Self::resolve) along the way.
+/// repeated calls to [`step`](Self::step). Construct one with
+/// [`new`](Self::new), begin a call with [`call`](Self::call), then step until
+/// a [`StepResult::Done`] or [`StepResult::Trapped`] is observed, resolving any
+/// [`StepResult::Blocked`] conditions with [`resolve`](Self::resolve) along the
+/// way.
 #[derive(Debug)]
 pub struct Thread {
     call_stack: Vec<Frame>,
@@ -213,12 +215,19 @@ pub struct Thread {
     private_cf: Option<PrivateCfExit>,
     deferred_complete: bool,
     deferred_trap: Option<Trap>,
-    /// A concrete value supplied by `resolve_call_indirect`/`resolve_memory_grow`
-    /// to re-run the blocked instruction with.
+    /// A concrete value supplied by
+    /// `resolve_call_indirect`/`resolve_memory_grow` to re-run the blocked
+    /// instruction with.
     resolved: Option<i32>,
     /// Per-function branch side-effect analysis, computed lazily on first entry
     /// to a function and cached by function index.
     analysis: HashMap<u32, Arc<FunctionAnalysis>>,
+}
+
+impl Default for Thread {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Thread {
@@ -407,12 +416,7 @@ impl Thread {
     /// [`Error::InvalidFunction`] if it does not refer to a local
     /// function, and [`Error::Unimplemented`] if the function returns more
     /// than one value.
-    pub fn call(
-        &mut self,
-        module: &Module,
-        global: &mut Global,
-        call: Call,
-    ) -> Result<(), Error> {
+    pub fn call(&mut self, module: &Module, global: &mut Global, call: Call) -> Result<(), Error> {
         let cx = &mut Context { module, global };
         let Call { func_idx, params } = call;
 
@@ -423,7 +427,7 @@ impl Thread {
         let Function::Local(func) = cx
             .module
             .function(func_idx)
-            .ok_or_else(|| Error::UndefinedFunction(func_idx))?
+            .ok_or(Error::UndefinedFunction(func_idx))?
         else {
             return Err(Error::InvalidFunction(func_idx));
         };
@@ -484,11 +488,7 @@ impl Thread {
     /// [`Error::InvalidFunction`], [`Error::UndefinedFunction`], or
     /// [`Error::Unimplemented`] when the operation being executed cannot be
     /// interpreted.
-    pub fn step(
-        &mut self,
-        module: &Module,
-        global: &mut Global,
-    ) -> Result<StepResult, Error> {
+    pub fn step(&mut self, module: &Module, global: &mut Global) -> Result<StepResult, Error> {
         // An imported call is emitted as a directive and only then marked
         // pending. If the embedder steps again without resolving it, re-surface
         // it as blocked rather than erroring.
@@ -666,13 +666,14 @@ impl Thread {
                     self.deferred_complete = true;
                     (None, None)
                 } else {
-                    (
-                        popped.reg_result,
-                        Some((popped.reg_base, popped.num_regs)),
-                    )
+                    (popped.reg_result, Some((popped.reg_base, popped.num_regs)))
                 };
                 self.op_counter += 1;
-                Ok(StepResult::Directive(Directive::Return { dst, src, reclaim }))
+                Ok(StepResult::Directive(Directive::Return {
+                    dst,
+                    src,
+                    reclaim,
+                }))
             }
             FrameStepResult::Blocked(pending) => {
                 self.pending = Some(pending.clone());
@@ -764,8 +765,11 @@ impl Thread {
         // shrink the register file back to this frame's base so a later call at
         // the same depth reuses them. This bounds the register file by the live
         // call stack rather than by total calls made.
-        self.reg_taints
-            .set_range(frame.reg_base.as_u32(), frame.num_regs as usize, Class::Public);
+        self.reg_taints.set_range(
+            frame.reg_base.as_u32(),
+            frame.num_regs as usize,
+            Class::Public,
+        );
         self.registers.truncate(frame.reg_base.index());
         Ok(frame)
     }
@@ -847,7 +851,9 @@ impl Frame {
     fn mark_all_memory_blind(&self, cx: &mut Context<'_>) {
         if let Some(memory) = cx.global.memory() {
             let len = memory.len();
-            cx.global.memory_taints_mut().set_range(0, len, Class::Blind);
+            cx.global
+                .memory_taints_mut()
+                .set_range(0, len, Class::Blind);
         }
     }
 
@@ -883,6 +889,7 @@ impl Frame {
         self.ip += 1;
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn step(
         &mut self,
         cx: &mut Context<'_>,
@@ -1349,17 +1356,17 @@ impl Frame {
                     self.advance_ip();
                     return Ok(FrameStepResult::Directive(d));
                 }
-                let (dst, val) =
-                    match arithmetic::execute(instr, |reg| Ok(registers[reg_base + reg.index()]))?
-                    {
-                        Ok(pair) => pair,
-                        Err(trap) => {
-                            return Ok(FrameStepResult::Trapped {
-                                directive: None,
-                                trap,
-                            });
-                        }
-                    };
+                let (dst, val) = match arithmetic::execute(instr, |reg| {
+                    Ok(registers[reg_base + reg.index()])
+                })? {
+                    Ok(pair) => pair,
+                    Err(trap) => {
+                        return Ok(FrameStepResult::Trapped {
+                            directive: None,
+                            trap,
+                        });
+                    }
+                };
                 self.set_clear(registers, taints, dst, val);
                 self.advance_ip();
             }
@@ -1535,6 +1542,7 @@ impl Frame {
         Ok(FrameStepResult::Directive(d))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn do_store(
         &mut self,
         cx: &mut Context<'_>,
@@ -1553,13 +1561,11 @@ impl Frame {
             if !self.is_available(taints, addr) {
                 // The destination is unknown to this party: conservatively mark
                 // the whole memory taints and taints, emit, don't write.
-                if mark_all_sym_on_sym_addr {
-                    if let Some(memory) = cx.global.memory() {
-                        let len = memory.len();
-                        cx.global
-                            .memory_taints_mut()
-                            .set_range(0, len, Class::Blind);
-                    }
+                if mark_all_sym_on_sym_addr && let Some(memory) = cx.global.memory() {
+                    let len = memory.len();
+                    cx.global
+                        .memory_taints_mut()
+                        .set_range(0, len, Class::Blind);
                 }
                 self.advance_ip();
                 return Ok(FrameStepResult::Directive(store_op));
@@ -1672,7 +1678,6 @@ impl Frame {
             }
         }
     }
-
 
     fn jump_to(&mut self, target: BlockId) {
         self.current_block = target;
@@ -1829,6 +1834,7 @@ impl Frame {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_symbolic_branch(
         &mut self,
         cx: &mut Context<'_>,
@@ -1847,11 +1853,11 @@ impl Frame {
         }
 
         // Taint all memory if any store exists in the branch region.
-        if region.has_memory_store {
-            if let Some(memory) = cx.global.memory() {
-                let len = memory.len();
-                cx.global.memory_taints_mut().mark_symbolic_range(0, len);
-            }
+        if region.has_memory_store
+            && let Some(memory) = cx.global.memory()
+        {
+            let len = memory.len();
+            cx.global.memory_taints_mut().mark_symbolic_range(0, len);
         }
 
         // Mark registers written in the branch region as symbolic.
@@ -1916,16 +1922,18 @@ fn read_value(mem: &Memory, kind: LoadKind, addr: u32) -> MaybeTrap<Value> {
         LoadKind::I64 => mem.read_i64(addr).map(Value::from),
         LoadKind::F32 => mem.read_f32(addr).map(Value::from),
         LoadKind::F64 => mem.read_f64(addr).map(Value::from),
-        LoadKind::I32Load8S
-        | LoadKind::I32Load8U
-        | LoadKind::I32Load16S
-        | LoadKind::I32Load16U => mem.read_i32_partial(addr, byte_size, signed).map(Value::from),
+        LoadKind::I32Load8S | LoadKind::I32Load8U | LoadKind::I32Load16S | LoadKind::I32Load16U => {
+            mem.read_i32_partial(addr, byte_size, signed)
+                .map(Value::from)
+        }
         LoadKind::I64Load8S
         | LoadKind::I64Load8U
         | LoadKind::I64Load16S
         | LoadKind::I64Load16U
         | LoadKind::I64Load32S
-        | LoadKind::I64Load32U => mem.read_i64_partial(addr, byte_size, signed).map(Value::from),
+        | LoadKind::I64Load32U => mem
+            .read_i64_partial(addr, byte_size, signed)
+            .map(Value::from),
     }
 }
 
@@ -2072,7 +2080,10 @@ mod tests {
                 StepResult::Trapped { .. } => panic!("a blind divisor must not self-trap"),
             }
         }
-        assert!(div_index.is_some(), "should have emitted the div_u directive");
+        assert!(
+            div_index.is_some(),
+            "should have emitted the div_u directive"
+        );
     }
 
     #[test]
@@ -2083,9 +2094,7 @@ mod tests {
         let mut trapped = false;
         loop {
             let pre_counter = thread.op_counter();
-            let result = {
-                thread.step(&module, &mut global).expect("step")
-            };
+            let result = { thread.step(&module, &mut global).expect("step") };
             match result {
                 StepResult::Trapped {
                     index,
@@ -2155,9 +2164,7 @@ mod tests {
         let mut trapped = false;
         loop {
             let pre = thread.op_counter();
-            let result = {
-                thread.step(&module, &mut global).expect("step")
-            };
+            let result = { thread.step(&module, &mut global).expect("step") };
             match result {
                 StepResult::Trapped {
                     index,
@@ -2194,7 +2201,9 @@ mod tests {
             let mut trapped = false;
             loop {
                 let result = {
-                    thread.step(&module, &mut global).expect("step is Ok even on a trap")
+                    thread
+                        .step(&module, &mut global)
+                        .expect("step is Ok even on a trap")
                 };
                 match result {
                     StepResult::Trapped {

--- a/crates/vm-ideal/src/lib.rs
+++ b/crates/vm-ideal/src/lib.rs
@@ -99,8 +99,8 @@ enum WriteKind {
 /// An ideal-functionality [`Vm`] instance bound to a single [`Module`].
 ///
 /// An `Instance` owns the module's [`Global`] state. Inputs supplied through
-/// [`write`](Vm::write) and reveals requested through [`reveal`](Vm::reveal) are
-/// staged and not exchanged until the next [`call`](Vm::call), after which
+/// [`write`](Vm::write) and reveals requested through [`reveal`](Vm::reveal)
+/// are staged and not exchanged until the next [`call`](Vm::call), after which
 /// execution runs to completion locally because every value is available to the
 /// ideal functionality.
 pub struct Instance {
@@ -136,8 +136,8 @@ impl Instance {
     ///
     /// # Errors
     ///
-    /// Returns a [`IdealError`] if the module declares an unsupported or invalid
-    /// import, or if the global state cannot be initialized.
+    /// Returns a [`IdealError`] if the module declares an unsupported or
+    /// invalid import, or if the global state cannot be initialized.
     pub fn new(module: Module) -> Result<Self, IdealError> {
         validate_imports(&module)?;
         let global = Global::new(&module)?;
@@ -191,7 +191,9 @@ impl Instance {
             .function(func_idx)
             .ok_or(IdealError::Core(CoreError::UndefinedFunction(func_idx)))?;
         let func = match func {
-            Function::Import(_) => return Err(IdealError::Core(CoreError::InvalidFunction(func_idx))),
+            Function::Import(_) => {
+                return Err(IdealError::Core(CoreError::InvalidFunction(func_idx)));
+            }
             Function::Local(func) => func,
         };
         if func.func_type().results.len() > 1 {
@@ -275,7 +277,10 @@ impl Instance {
             let mut mem_to_send: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
 
             {
-                let memory = self.global.memory().ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
+                let memory = self
+                    .global
+                    .memory()
+                    .ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
                 for range in self.pending_private.iter() {
                     let len = (range.end - range.start) as usize;
                     mem_to_send.insert(
@@ -310,12 +315,17 @@ impl Instance {
             let received_mem: BTreeMap<u32, Vec<u8>> = io.io_mut().expect_next().await?;
 
             {
-                let memory = self.global.memory_mut().ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
+                let memory = self
+                    .global
+                    .memory_mut()
+                    .ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
                 for range in &recv_ranges {
                     let len = (range.end - range.start) as usize;
                     if let Some(data) = received_mem.get(&range.start) {
                         debug_assert_eq!(data.len(), len, "recv region length should match");
-                        memory.write_bytes(range.start, data).map_err(IdealError::Trap)?;
+                        memory
+                            .write_bytes(range.start, data)
+                            .map_err(IdealError::Trap)?;
                     }
                 }
             }
@@ -401,7 +411,11 @@ impl Instance {
             Some(Function::Import(import)) => {
                 (import.module().to_string(), import.name().to_string())
             }
-            _ => return Err(IdealError::Internal("host call to non-import function".into())),
+            _ => {
+                return Err(IdealError::Internal(
+                    "host call to non-import function".into(),
+                ));
+            }
         };
         let arg_value = |i: usize| -> Option<Value> {
             match args.get(i) {
@@ -418,7 +432,10 @@ impl Instance {
                 let iovs = arg_i32(1) as u32;
                 let iovs_len = arg_i32(2) as u32;
                 let nwritten_ptr = arg_i32(3) as u32;
-                let memory = self.global.memory_mut().ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
+                let memory = self
+                    .global
+                    .memory_mut()
+                    .ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
                 let mut total = 0u32;
                 for i in 0..iovs_len {
                     let iov = iovs + i * 8;
@@ -427,7 +444,9 @@ impl Instance {
                     let lb = memory.read_bytes(iov + 4, 4).map_err(IdealError::Trap)?;
                     let len = u32::from_le_bytes([lb[0], lb[1], lb[2], lb[3]]);
                     if fd == 1 || fd == 2 {
-                        let data = memory.read_bytes(ptr, len as usize).map_err(IdealError::Trap)?;
+                        let data = memory
+                            .read_bytes(ptr, len as usize)
+                            .map_err(IdealError::Trap)?;
                         if let Ok(s) = std::str::from_utf8(data) {
                             eprint!("{s}");
                         }
@@ -460,7 +479,10 @@ impl Instance {
                 Ok(())
             }
             // Scalar wait: return the staged value, now public.
-            ("vc", "reveal_i32_wait" | "reveal_i64_wait" | "reveal_f32_wait" | "reveal_f64_wait") => {
+            (
+                "vc",
+                "reveal_i32_wait" | "reveal_i64_wait" | "reveal_f32_wait" | "reveal_f64_wait",
+            ) => {
                 let handle = arg_i32(0);
                 match self.reveal_handles.remove(&handle) {
                     Some(RevealEntry::Scalar(value)) => {
@@ -500,7 +522,7 @@ impl Instance {
                 Ok(r) => r,
                 Err(e) => {
                     let e: IdealError = e.into();
-                    self.dump_error(&thread, &e);
+                    self.dump_error(thread, &e);
                     return Err(e);
                 }
             };
@@ -512,9 +534,7 @@ impl Instance {
                     self.service_host_call(thread, func_idx, &args)?;
                 }
                 StepResult::Blocked(
-                    Pending::Branch
-                    | Pending::CallIndirect { .. }
-                    | Pending::MemoryGrow { .. },
+                    Pending::Branch | Pending::CallIndirect { .. } | Pending::MemoryGrow { .. },
                 ) => {
                     // The ideal functionality holds every value (private inputs
                     // are shared on exchange), so symbolic branches, indirect-call
@@ -536,8 +556,9 @@ impl Instance {
     /// that would require communication in a real multi-party backend.
     ///
     /// Host calls are still serviced (the ideal functionality holds every
-    /// value, so reveals are local), but a symbolic [`Op`], a private branch, or
-    /// a block on an unheld value reports [`IdealError::RequiresCommunication`].
+    /// value, so reveals are local), but a symbolic [`Op`], a private branch,
+    /// or a block on an unheld value reports
+    /// [`IdealError::RequiresCommunication`].
     fn run_loop_local(&mut self, thread: &mut Thread) -> Result<Option<Value>, IdealError> {
         loop {
             let result = match thread.step(&self.module, &mut self.global) {
@@ -588,17 +609,18 @@ impl Vm for Instance {
 
     /// Stages a [`Write`] of `len` bytes at `ptr` for the next exchange.
     ///
-    /// The destination region is recorded as pending with the visibility implied
-    /// by `w`. For [`Write::Private`] and [`Write::Public`] the supplied bytes
-    /// are copied into linear memory immediately; for [`Write::Blind`] only the
-    /// region is reserved, to be filled in during the exchange. Staging a region
-    /// overrides any previous pending visibility for the overlapping bytes.
+    /// The destination region is recorded as pending with the visibility
+    /// implied by `w`. For [`Write::Private`] and [`Write::Public`] the
+    /// supplied bytes are copied into linear memory immediately; for
+    /// [`Write::Blind`] only the region is reserved, to be filled in during
+    /// the exchange. Staging a region overrides any previous pending
+    /// visibility for the overlapping bytes.
     ///
     /// # Errors
     ///
-    /// Returns [`IdealError::Internal`] if the region `ptr..ptr + len` overflows
-    /// the address space, or [`IdealError::Core`] if the module has no
-    /// linear memory to receive the bytes.
+    /// Returns [`IdealError::Internal`] if the region `ptr..ptr + len`
+    /// overflows the address space, or [`IdealError::Core`] if the module
+    /// has no linear memory to receive the bytes.
     fn write(&mut self, ptr: u32, w: Write<'_>) -> Result<(), IdealError> {
         let (kind, len) = match w {
             Write::Private(data) => (WriteKind::Private, data.len()),
@@ -608,7 +630,10 @@ impl Vm for Instance {
         let range = range_for(ptr, len)?;
 
         if let Write::Private(data) | Write::Public(data) = w {
-            let memory = self.global.memory_mut().ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
+            let memory = self
+                .global
+                .memory_mut()
+                .ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
             memory.write_bytes(ptr, data).map_err(IdealError::Trap)?;
         }
 
@@ -625,8 +650,8 @@ impl Vm for Instance {
     ///
     /// # Errors
     ///
-    /// Returns [`IdealError::Internal`] if the region `ptr..ptr + len` overflows
-    /// the address space.
+    /// Returns [`IdealError::Internal`] if the region `ptr..ptr + len`
+    /// overflows the address space.
     fn reveal(&mut self, ptr: u32, len: usize) -> Result<(), IdealError> {
         let range = range_for(ptr, len)?;
         self.apply_pending(range, WriteKind::Reveal);
@@ -635,9 +660,9 @@ impl Vm for Instance {
 
     /// Returns the `len` bytes of linear memory starting at `ptr`.
     ///
-    /// Only fully public, settled memory may be read: the region must contain no
-    /// symbolic (tainted) bytes and must not overlap a pending blind region
-    /// whose contents have not yet been received.
+    /// Only fully public, settled memory may be read: the region must contain
+    /// no symbolic (tainted) bytes and must not overlap a pending blind
+    /// region whose contents have not yet been received.
     ///
     /// # Errors
     ///
@@ -660,11 +685,15 @@ impl Vm for Instance {
                 )));
             }
         }
-        let memory = self.global.memory().ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
+        let memory = self
+            .global
+            .memory()
+            .ok_or(IdealError::Core(CoreError::MemoryNotDefined))?;
         memory.read_bytes(ptr, len).map_err(IdealError::Trap)
     }
 
-    /// Calls the function at `func_idx` with `params` and runs it to completion.
+    /// Calls the function at `func_idx` with `params` and runs it to
+    /// completion.
     ///
     /// Any pending memory regions and private or blind parameters are exchanged
     /// over `io` before execution begins; the ideal functionality then runs the
@@ -725,8 +754,8 @@ impl Vm for Instance {
     /// Returns [`IdealError::RequiresCommunication`] if `params` carry private
     /// or blind values, if any private/blind/reveal region is still pending, or
     /// if execution reaches a step that is not locally resolvable. Otherwise
-    /// returns a [`IdealError`] for an invalid `func_idx`, a signature mismatch,
-    /// or a trap.
+    /// returns a [`IdealError`] for an invalid `func_idx`, a signature
+    /// mismatch, or a trap.
     fn call_local(
         &mut self,
         func_idx: u32,
@@ -784,9 +813,9 @@ fn range_for(ptr: u32, len: usize) -> Result<Range<u32>, IdealError> {
 ///
 /// # Errors
 ///
-/// Returns [`IdealError::UnsupportedImport`] for an import the ideal VM does not
-/// service, or [`IdealError::ImportSignatureMismatch`] for a serviced import
-/// declared with an unexpected signature.
+/// Returns [`IdealError::UnsupportedImport`] for an import the ideal VM does
+/// not service, or [`IdealError::ImportSignatureMismatch`] for a serviced
+/// import declared with an unexpected signature.
 fn validate_imports(module: &Module) -> Result<(), IdealError> {
     for func in module.functions() {
         let Function::Import(import) = func else {

--- a/crates/vm-ideal/tests/behavior.rs
+++ b/crates/vm-ideal/tests/behavior.rs
@@ -8,9 +8,9 @@ use futures::{
     future::{join, try_join},
 };
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::Module;
 use mpz_vm_core::{Param, Vm, Write, value::Value};
 use mpz_vm_ideal::{IdealError, Instance};
+use mpz_vm_ir::Module;
 use mpz_vm_test_harness::behavior::{
     Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index, parse_module,
 };
@@ -91,7 +91,10 @@ impl MemVm for IdealPair {
                 }
                 MemStep::Commit => {
                     let (mut ctx_a, mut ctx_b) = test_st_context(8);
-                    block_on(try_join(self.a.commit(&mut ctx_a), self.b.commit(&mut ctx_b)))?;
+                    block_on(try_join(
+                        self.a.commit(&mut ctx_a),
+                        self.b.commit(&mut ctx_b),
+                    ))?;
                 }
                 MemStep::CallLocal { func, args } => {
                     let idx = func_index(self.a.module(), func)
@@ -158,10 +161,16 @@ fn call_local_rejects_symbolic_execution() {
     )
     .unwrap();
     let mut pair = IdealPair::instantiate(&module).unwrap();
-    pair.a.write(0, Write::Private(&7i32.to_le_bytes())).unwrap();
+    pair.a
+        .write(0, Write::Private(&7i32.to_le_bytes()))
+        .unwrap();
     pair.b.write(0, Write::Blind(4)).unwrap();
     let (mut ctx_a, mut ctx_b) = test_st_context(8);
-    block_on(try_join(pair.a.commit(&mut ctx_a), pair.b.commit(&mut ctx_b))).unwrap();
+    block_on(try_join(
+        pair.a.commit(&mut ctx_a),
+        pair.b.commit(&mut ctx_b),
+    ))
+    .unwrap();
     let idx = func_index(pair.a.module(), "loadadd").unwrap();
     let err = pair.a.call_local(idx, vec![]).unwrap_err();
     assert!(

--- a/crates/vm-ideal/tests/host_calls.rs
+++ b/crates/vm-ideal/tests/host_calls.rs
@@ -20,8 +20,8 @@ fn func_idx(module: &Module, name: &str) -> u32 {
 }
 
 /// A guest that builds a WASI iovec for a 3-byte string and calls `fd_write` to
-/// stdout, returning the call's errno. The ideal VM must service the import (read
-/// the iovec, emit the bytes, write `nwritten`) and report success.
+/// stdout, returning the call's errno. The ideal VM must service the import
+/// (read the iovec, emit the bytes, write `nwritten`) and report success.
 #[test]
 fn fd_write_host_call_is_serviced() {
     let wat = r#"
@@ -47,9 +47,9 @@ fn fd_write_host_call_is_serviced() {
     assert_eq!(out, Some(Value::I32(0)), "fd_write should report errno 0");
 }
 
-/// A guest that reveals a scalar and waits for it. The ideal VM stages the value
-/// under a handle on `reveal_i32` and returns it on `reveal_i32_wait`, so the
-/// two-phase reveal round-trips to the original value.
+/// A guest that reveals a scalar and waits for it. The ideal VM stages the
+/// value under a handle on `reveal_i32` and returns it on `reveal_i32_wait`, so
+/// the two-phase reveal round-trips to the original value.
 #[test]
 fn scalar_reveal_round_trips() {
     let wat = r#"
@@ -66,12 +66,16 @@ fn scalar_reveal_round_trips() {
     let (mut ctx, _) = test_st_context(8);
 
     let out = block_on(vm.call(&mut ctx, idx, vec![])).unwrap();
-    assert_eq!(out, Some(Value::I32(42)), "reveal/wait should return the value");
+    assert_eq!(
+        out,
+        Some(Value::I32(42)),
+        "reveal/wait should return the value"
+    );
 }
 
-/// A guest that reveals a byte range in memory and then reads it back. The ideal
-/// VM marks the range public on `reveal_bytes_wait`; the bytes are already in
-/// place, so the subsequent load observes them.
+/// A guest that reveals a byte range in memory and then reads it back. The
+/// ideal VM marks the range public on `reveal_bytes_wait`; the bytes are
+/// already in place, so the subsequent load observes them.
 #[test]
 fn byte_reveal_marks_range_public() {
     let wat = r#"
@@ -91,5 +95,9 @@ fn byte_reveal_marks_range_public() {
     let (mut ctx, _) = test_st_context(8);
 
     let out = block_on(vm.call(&mut ctx, idx, vec![])).unwrap();
-    assert_eq!(out, Some(Value::I32(7)), "revealed bytes should be readable");
+    assert_eq!(
+        out,
+        Some(Value::I32(7)),
+        "revealed bytes should be readable"
+    );
 }

--- a/crates/vm-ideal/tests/spec_runner.rs
+++ b/crates/vm-ideal/tests/spec_runner.rs
@@ -3,9 +3,9 @@
 
 use futures::{executor::block_on, future::try_join};
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::Module;
 use mpz_vm_core::{Param, Vm, value::Value};
 use mpz_vm_ideal::{IdealError, Instance};
+use mpz_vm_ir::Module;
 use mpz_vm_test_harness::{SpecConfig, SpecVm};
 
 /// A pair of ideal-VM instances (single party each, exchanging over an

--- a/crates/vm-ir/src/lib.rs
+++ b/crates/vm-ir/src/lib.rs
@@ -3,12 +3,7 @@ mod parser;
 #[cfg(test)]
 mod tests;
 
-use std::{
-    collections::HashMap,
-    fmt,
-    ops::Add,
-    sync::Arc,
-};
+use std::{collections::HashMap, fmt, ops::Add, sync::Arc};
 
 use thiserror::Error;
 
@@ -505,10 +500,7 @@ pub struct Element {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ElementKind {
     Passive,
-    Active {
-        table_index: u32,
-        offset: ConstExpr,
-    },
+    Active { table_index: u32, offset: ConstExpr },
     Declared,
 }
 

--- a/crates/vm-ir/src/parser.rs
+++ b/crates/vm-ir/src/parser.rs
@@ -3,9 +3,7 @@ mod const_expr;
 mod sections;
 mod translate;
 
-use wasmparser::{
-    BinaryReader, CompositeInnerType, Parser, Payload, TypeRef,
-};
+use wasmparser::{BinaryReader, CompositeInnerType, Parser, Payload, TypeRef};
 
 use crate::{
     Data, Element, Export, FuncType, Function, Global, GlobalType, ImportedFunction, Local,
@@ -262,14 +260,14 @@ pub fn parse_module(bytes: &[u8]) -> Result<Module> {
     }
 
     // Validate data count if present
-    if let Some(count) = data_count {
-        if data.len() != count as usize {
-            return Err(ValidationError::DataCountMismatch {
-                expected: count,
-                actual: data.len() as u32,
-            }
-            .into());
+    if let Some(count) = data_count
+        && data.len() != count as usize
+    {
+        return Err(ValidationError::DataCountMismatch {
+            expected: count,
+            actual: data.len() as u32,
         }
+        .into());
     }
 
     Ok(Module {

--- a/crates/vm-ir/src/parser/const_expr.rs
+++ b/crates/vm-ir/src/parser/const_expr.rs
@@ -21,9 +21,7 @@ pub(super) fn parse_const_expr(reader: &mut BinaryReader) -> Result<ConstExpr> {
             RefFunc { function_index } => ConstExpr::RefFunc(*function_index),
             End => continue,
             _ => {
-                return Err(
-                    UnsupportedFeature::ConstExprInstruction(format!("{:?}", op)).into(),
-                );
+                return Err(UnsupportedFeature::ConstExprInstruction(format!("{:?}", op)).into());
             }
         };
         if expr.is_some() {
@@ -54,9 +52,7 @@ pub(super) fn parse_elem_expr(reader: &mut BinaryReader) -> Result<Vec<Instructi
             },
             End => continue,
             _ => {
-                return Err(
-                    UnsupportedFeature::ElemExprInstruction(format!("{:?}", op)).into(),
-                );
+                return Err(UnsupportedFeature::ElemExprInstruction(format!("{:?}", op)).into());
             }
         };
         instrs.push(instr);

--- a/crates/vm-ir/src/parser/translate.rs
+++ b/crates/vm-ir/src/parser/translate.rs
@@ -2,12 +2,14 @@ use wasmparser::{BinaryReader, BlockType as WasmBlockType, Operator};
 
 use crate::{
     BasicBlock, BinaryArith, BinaryOp, BlockId, Error, FuncType, FunctionBody, Instruction,
-    InstructionArith, LoadKind, MemArg, Reg, Result, StoreKind, Terminator, UnaryArith,
-    UnaryOp, UnsupportedFeature, ValidationError,
+    InstructionArith, LoadKind, MemArg, Reg, Result, StoreKind, Terminator, UnaryArith, UnaryOp,
+    UnsupportedFeature, ValidationError,
 };
 
-use super::cfg::{Scope, get_br_join, get_br_target};
-use super::sections::parse_heap_type;
+use super::{
+    cfg::{Scope, get_br_join, get_br_target},
+    sections::parse_heap_type,
+};
 
 /// Translator from stack-based WASM to CFG-based register instructions.
 pub(super) struct Translator {
@@ -174,9 +176,10 @@ impl Translator {
     /// When the value was just produced into a temporary, the producing
     /// instruction is redirected to write the local directly and the copy is
     /// elided. For `tee`, the stack slot then aliases the local register — the
-    /// same aliasing `local.get` already relies on, so later reads need no copy.
-    /// This removes the produce-then-copy pair that `local.set`/`local.tee`
-    /// would otherwise emit for nearly every computed local.
+    /// same aliasing `local.get` already relies on, so later reads need no
+    /// copy. This removes the produce-then-copy pair that
+    /// `local.set`/`local.tee` would otherwise emit for nearly every
+    /// computed local.
     ///
     /// The peephole only fires when it is provably safe: the source is a
     /// temporary produced by the immediately preceding instruction, and the
@@ -294,15 +297,14 @@ impl Translator {
 
         if let Some(result_reg) = scope.block_result_reg {
             // Copy fall-through result to unified register
-            if !self.unreachable {
-                if let Some(&src_reg) = self.reg_stack.last() {
-                    if src_reg != result_reg {
-                        self.emit(Instruction::Copy {
-                            dst: result_reg,
-                            src: src_reg,
-                        });
-                    }
-                }
+            if !self.unreachable
+                && let Some(&src_reg) = self.reg_stack.last()
+                && src_reg != result_reg
+            {
+                self.emit(Instruction::Copy {
+                    dst: result_reg,
+                    src: src_reg,
+                });
             }
 
             // Finish current arm with jump to join
@@ -383,15 +385,14 @@ impl Translator {
 
         if let Some(result_reg) = scope.block_result_reg {
             // Copy fall-through result to unified register
-            if !self.unreachable {
-                if let Some(&src_reg) = self.reg_stack.last() {
-                    if src_reg != result_reg {
-                        self.emit(Instruction::Copy {
-                            dst: result_reg,
-                            src: src_reg,
-                        });
-                    }
-                }
+            if !self.unreachable
+                && let Some(&src_reg) = self.reg_stack.last()
+                && src_reg != result_reg
+            {
+                self.emit(Instruction::Copy {
+                    dst: result_reg,
+                    src: src_reg,
+                });
             }
 
             if !self.unreachable {
@@ -604,17 +605,15 @@ fn translate_operator(
             let then_was_reachable = !t.unreachable;
 
             // Copy then-branch result to unified register if needed
-            if let Some(result_reg) = block_result_reg {
-                if then_was_reachable {
-                    if let Some(&src_reg) = t.reg_stack.last() {
-                        if src_reg != result_reg {
-                            t.emit(Instruction::Copy {
-                                dst: result_reg,
-                                src: src_reg,
-                            });
-                        }
-                    }
-                }
+            if let Some(result_reg) = block_result_reg
+                && then_was_reachable
+                && let Some(&src_reg) = t.reg_stack.last()
+                && src_reg != result_reg
+            {
+                t.emit(Instruction::Copy {
+                    dst: result_reg,
+                    src: src_reg,
+                });
             }
 
             // Finish then block with jump to join
@@ -653,10 +652,10 @@ fn translate_operator(
             let values: Vec<Reg> = (0..arity).map(|_| t.pop()).collect::<Result<Vec<_>>>()?;
 
             // Copy to target block's result register
-            if let (Some(&src), Some(dst)) = (values.first(), t.branch_result_reg(depth)) {
-                if src != dst {
-                    t.emit(Instruction::Copy { dst, src });
-                }
+            if let (Some(&src), Some(dst)) = (values.first(), t.branch_result_reg(depth))
+                && src != dst
+            {
+                t.emit(Instruction::Copy { dst, src });
             }
 
             match get_br_target(&t.scopes, depth)? {
@@ -682,10 +681,10 @@ fn translate_operator(
             }
 
             // Copy to target block's result register
-            if let (Some(&src), Some(dst)) = (values.first(), t.branch_result_reg(depth)) {
-                if src != dst {
-                    t.emit(Instruction::Copy { dst, src });
-                }
+            if let (Some(&src), Some(dst)) = (values.first(), t.branch_result_reg(depth))
+                && src != dst
+            {
+                t.emit(Instruction::Copy { dst, src });
             }
 
             match get_br_target(&t.scopes, depth)? {
@@ -737,10 +736,11 @@ fn translate_operator(
             if let Some(&src) = values.first() {
                 let mut seen = std::collections::HashSet::new();
                 for &depth in target_vec.iter().chain(std::iter::once(&table.default())) {
-                    if let Some(dst) = t.branch_result_reg(depth) {
-                        if src != dst && seen.insert(dst) {
-                            t.emit(Instruction::Copy { dst, src });
-                        }
+                    if let Some(dst) = t.branch_result_reg(depth)
+                        && src != dst
+                        && seen.insert(dst)
+                    {
+                        t.emit(Instruction::Copy { dst, src });
                     }
                 }
             }

--- a/crates/vm-ir/tests/control_flow.rs
+++ b/crates/vm-ir/tests/control_flow.rs
@@ -75,7 +75,8 @@ fn find_call_indirect(block: &mpz_vm_ir::BasicBlock) -> Option<&Instruction> {
         .find(|i| matches!(i, Instruction::CallIndirect { .. }))
 }
 
-/// Collect the destination register of the const writing `val` (i32), if present.
+/// Collect the destination register of the const writing `val` (i32), if
+/// present.
 fn i32_const_dst(block: &mpz_vm_ir::BasicBlock, val: i32) -> Option<Reg> {
     block.body.iter().find_map(|i| match i {
         Instruction::I32Const { dst, val: v } if *v == val => Some(*dst),
@@ -106,7 +107,10 @@ fn test_basic_block() {
     // exact register feeding the continuation is an allocation detail; assert
     // the structure (const present, Jump terminator) instead.
     let b0 = &body.blocks[0];
-    assert!(i32_const_dst(b0, 42).is_some(), "i32.const 42 should be present");
+    assert!(
+        i32_const_dst(b0, 42).is_some(),
+        "i32.const 42 should be present"
+    );
     assert!(matches!(b0.terminator, Terminator::Jump { .. }));
 
     // The block's result is carried through to a Return.
@@ -128,7 +132,10 @@ fn test_block_with_br() {
     // The const is produced, and `br 0` exits the block with a Jump. Register
     // numbers are an allocation detail.
     let b0 = &body.blocks[0];
-    assert!(i32_const_dst(b0, 42).is_some(), "i32.const 42 should be present");
+    assert!(
+        i32_const_dst(b0, 42).is_some(),
+        "i32.const 42 should be present"
+    );
     assert!(matches!(b0.terminator, Terminator::Jump { .. }));
 }
 
@@ -214,7 +221,12 @@ fn test_return_with_value() {
     // data-flow rather than hard-coding the register number.
     let b0 = &body.blocks[0];
     let const_dst = i32_const_dst(b0, 42).expect("i32.const 42 should be present");
-    assert_eq!(b0.terminator, Terminator::Return { values: vec![const_dst] });
+    assert_eq!(
+        b0.terminator,
+        Terminator::Return {
+            values: vec![const_dst]
+        }
+    );
 }
 
 #[test]
@@ -238,7 +250,11 @@ fn test_i64_identity() {
     // Copy). The observable property is that the function returns exactly one
     // value, and that value is the parameter register (reg 0).
     let returned = return_values(body);
-    assert_eq!(returned, vec![Reg(0)], "should return the param register unchanged");
+    assert_eq!(
+        returned,
+        vec![Reg(0)],
+        "should return the param register unchanged"
+    );
 }
 
 #[test]
@@ -459,7 +475,11 @@ fn test_call_indirect_i64() {
     };
     assert_eq!(*type_index, 0);
     assert_eq!(*table_index, 0);
-    assert_eq!(*table_idx, Reg(0), "table index operand is the i32 param (reg 0)");
+    assert_eq!(
+        *table_idx,
+        Reg(0),
+        "table index operand is the i32 param (reg 0)"
+    );
     assert_eq!(args, &vec![Reg(1)], "call arg is the i64 param (reg 1)");
     let call_dst = dst.expect("call to a value-returning type should have a dst");
 

--- a/crates/vm-memory/src/auth.rs
+++ b/crates/vm-memory/src/auth.rs
@@ -396,9 +396,9 @@ mod tests {
     #[test]
     fn i32_le_bytes_round_trip() {
         let mut bytes = [Byte::new([bit(0); 8]); 4];
-        for i in 0..4 {
-            for j in 0..8 {
-                bytes[i].bits_mut()[j] = bit(((i * 8 + j) as u128) + 1);
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            for (j, b) in byte.bits_mut().iter_mut().enumerate() {
+                *b = bit(((i * 8 + j) as u128) + 1);
             }
         }
         let v = I32::from_le_bytes(bytes);
@@ -408,9 +408,9 @@ mod tests {
     #[test]
     fn i64_le_bytes_round_trip() {
         let mut bytes = [Byte::new([bit(0); 8]); 8];
-        for i in 0..8 {
-            for j in 0..8 {
-                bytes[i].bits_mut()[j] = bit(((i * 8 + j) as u128) + 1);
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            for (j, b) in byte.bits_mut().iter_mut().enumerate() {
+                *b = bit(((i * 8 + j) as u128) + 1);
             }
         }
         let v = I64::from_le_bytes(bytes);

--- a/crates/vm-memory/src/lib.rs
+++ b/crates/vm-memory/src/lib.rs
@@ -8,20 +8,18 @@
 //!   mirroring `mpz_vm_core::Value`.
 //! - [`Registers<T>`] — sparse register file keyed by absolute `Reg`. Generic
 //!   over the cell type for testability.
-//! - [`LinearMemory<W>`] — sparse byte-addressed memory keyed by `u32`,
-//!   storing one [`Byte<W>`] per address plus the public-0/1 wires. Exposes
-//!   typed accessors implementing the WASM load/store instruction set for the
-//!   family of instructions that are pure wire routing (concat, slice,
-//!   zero-extend, sign-extend).
+//! - [`LinearMemory<W>`] — sparse byte-addressed memory keyed by `u32`, storing
+//!   one [`Byte<W>`] per address plus the public-0/1 wires. Exposes typed
+//!   accessors implementing the WASM load/store instruction set for the family
+//!   of instructions that are pure wire routing (concat, slice, zero-extend,
+//!   sign-extend).
 
 mod auth;
 mod memory;
 mod registers;
 mod state;
 
-pub use auth::{
-    AuthValue, AuthValueType, AuthValueWidth, Bit, Byte, F32, F64, I32, I64, Wire,
-};
+pub use auth::{AuthValue, AuthValueType, AuthValueWidth, Bit, Byte, F32, F64, I32, I64, Wire};
 pub use memory::LinearMemory;
 pub use mpz_vm_ir::ValType;
 pub use registers::Registers;

--- a/crates/vm-memory/src/memory.rs
+++ b/crates/vm-memory/src/memory.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 
 use mpz_fields::gf2_128::Gf2_128;
 
-use crate::auth::{Bit, Byte, Wire, F32, F64, I32, I64};
+use crate::auth::{Bit, Byte, F32, F64, I32, I64, Wire};
 
 /// Sparse byte-addressed linear memory keyed by absolute byte address,
 /// storing one [`Byte<W>`] per tainted address. Carries the public-0 and
@@ -160,62 +160,160 @@ impl<W: Wire> LinearMemory<W> {
 
     /// Mixed `i32.load`.
     pub fn load_i32_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I32<W>> {
-        Some(I32::from_le_bytes(self.read_bytes::<4>(addr, concrete, symbolic_mask)?))
+        Some(I32::from_le_bytes(self.read_bytes::<4>(
+            addr,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load`.
     pub fn load_i64_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64::from_le_bytes(self.read_bytes::<8>(addr, concrete, symbolic_mask)?))
+        Some(I64::from_le_bytes(self.read_bytes::<8>(
+            addr,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i32.load8_u`.
     pub fn load_i32_8u_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I32<W>> {
-        Some(I32(self.load_extended::<32>(addr, 1, ExtendKind::Zero, concrete, symbolic_mask)?))
+        Some(I32(self.load_extended::<32>(
+            addr,
+            1,
+            ExtendKind::Zero,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i32.load8_s`.
     pub fn load_i32_8s_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I32<W>> {
-        Some(I32(self.load_extended::<32>(addr, 1, ExtendKind::Sign, concrete, symbolic_mask)?))
+        Some(I32(self.load_extended::<32>(
+            addr,
+            1,
+            ExtendKind::Sign,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i32.load16_u`.
-    pub fn load_i32_16u_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I32<W>> {
-        Some(I32(self.load_extended::<32>(addr, 2, ExtendKind::Zero, concrete, symbolic_mask)?))
+    pub fn load_i32_16u_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I32<W>> {
+        Some(I32(self.load_extended::<32>(
+            addr,
+            2,
+            ExtendKind::Zero,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i32.load16_s`.
-    pub fn load_i32_16s_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I32<W>> {
-        Some(I32(self.load_extended::<32>(addr, 2, ExtendKind::Sign, concrete, symbolic_mask)?))
+    pub fn load_i32_16s_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I32<W>> {
+        Some(I32(self.load_extended::<32>(
+            addr,
+            2,
+            ExtendKind::Sign,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load8_u`.
     pub fn load_i64_8u_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 1, ExtendKind::Zero, concrete, symbolic_mask)?))
+        Some(I64(self.load_extended::<64>(
+            addr,
+            1,
+            ExtendKind::Zero,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load8_s`.
     pub fn load_i64_8s_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 1, ExtendKind::Sign, concrete, symbolic_mask)?))
+        Some(I64(self.load_extended::<64>(
+            addr,
+            1,
+            ExtendKind::Sign,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load16_u`.
-    pub fn load_i64_16u_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 2, ExtendKind::Zero, concrete, symbolic_mask)?))
+    pub fn load_i64_16u_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I64<W>> {
+        Some(I64(self.load_extended::<64>(
+            addr,
+            2,
+            ExtendKind::Zero,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load16_s`.
-    pub fn load_i64_16s_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 2, ExtendKind::Sign, concrete, symbolic_mask)?))
+    pub fn load_i64_16s_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I64<W>> {
+        Some(I64(self.load_extended::<64>(
+            addr,
+            2,
+            ExtendKind::Sign,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load32_u`.
-    pub fn load_i64_32u_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 4, ExtendKind::Zero, concrete, symbolic_mask)?))
+    pub fn load_i64_32u_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I64<W>> {
+        Some(I64(self.load_extended::<64>(
+            addr,
+            4,
+            ExtendKind::Zero,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// Mixed `i64.load32_s`.
-    pub fn load_i64_32s_mixed(&self, addr: u32, concrete: u64, symbolic_mask: u8) -> Option<I64<W>> {
-        Some(I64(self.load_extended::<64>(addr, 4, ExtendKind::Sign, concrete, symbolic_mask)?))
+    pub fn load_i64_32s_mixed(
+        &self,
+        addr: u32,
+        concrete: u64,
+        symbolic_mask: u8,
+    ) -> Option<I64<W>> {
+        Some(I64(self.load_extended::<64>(
+            addr,
+            4,
+            ExtendKind::Sign,
+            concrete,
+            symbolic_mask,
+        )?))
     }
 
     /// `i32.store`: 4 little-endian bytes.
@@ -269,13 +367,7 @@ impl<W: Wire> LinearMemory<W> {
     /// bit `i` of `symbolic_mask` is set, otherwise built as a transient public
     /// byte from `concrete` (no map insertion). Returns `None` for an absent
     /// committed byte.
-    fn mixed_byte(
-        &self,
-        addr: u32,
-        i: usize,
-        concrete: u64,
-        symbolic_mask: u8,
-    ) -> Option<Byte<W>> {
+    fn mixed_byte(&self, addr: u32, i: usize, concrete: u64, symbolic_mask: u8) -> Option<Byte<W>> {
         if symbolic_mask & (1 << i) != 0 {
             self.inner.get(&(addr + i as u32)).copied()
         } else {
@@ -301,8 +393,9 @@ impl<W: Wire> LinearMemory<W> {
 
     /// Read `n_bytes` consecutive bytes starting at `addr` (each committed or
     /// public per `symbolic_mask`) and extend to `[Bit; N]` per `kind`.
-    /// Zero-extension fills with the public-0 bit; sign-extension replicates the
-    /// high bit of the last byte (bit 7 of the byte at `addr + n_bytes - 1`).
+    /// Zero-extension fills with the public-0 bit; sign-extension replicates
+    /// the high bit of the last byte (bit 7 of the byte at `addr + n_bytes
+    /// - 1`).
     fn load_extended<const N: usize>(
         &self,
         addr: u32,

--- a/crates/vm-sys/src/lib.rs
+++ b/crates/vm-sys/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! A program compiled to wasm and run inside the VC VM links against this crate
 //! to invoke the VM's VCI host calls, imported from the `vc` module. The VCI
-//! operation is [`reveal`](Reveal::reveal): disclosing a value the program holds
-//! — concrete or symbolic — so that it becomes public. It is two-phase:
+//! operation is [`reveal`](Reveal::reveal): disclosing a value the program
+//! holds — concrete or symbolic — so that it becomes public. It is two-phase:
 //! `reveal` returns a handle immediately and the handle's `wait` blocks for the
 //! result, which lets a program batch and pipeline reveals.
 //!
@@ -101,8 +101,8 @@ impl_scalar!(f64, reveal_f64, reveal_f64_wait);
 
 /// A pending reveal of a byte region.
 ///
-/// Borrows the region until the reveal completes, so it cannot be reallocated or
-/// mutated while in flight. The disclosure is in place; [`wait`](Self::wait)
+/// Borrows the region until the reveal completes, so it cannot be reallocated
+/// or mutated while in flight. The disclosure is in place; [`wait`](Self::wait)
 /// hands the region back.
 pub struct PendingBytes<'a> {
     handle: i32,

--- a/crates/vm-test-harness/src/behavior.rs
+++ b/crates/vm-test-harness/src/behavior.rs
@@ -15,8 +15,8 @@
 //! [`Vm::reveal`]: mpz_vm_core::Vm::reveal
 //! [`Vm::read`]: mpz_vm_core::Vm::read
 
-use mpz_vm_ir::{ExportKind, Module};
 use mpz_vm_core::value::Value;
+use mpz_vm_ir::{ExportKind, Module};
 
 /// A two-party implementation exercised through the memory I/O surface.
 ///
@@ -63,8 +63,8 @@ pub enum MemStep {
     /// Both parties queue a reveal of `ptr..ptr+len`. Takes effect on the next
     /// flush, after which the range is concrete.
     Reveal { ptr: u32, len: usize },
-    /// Both parties flush pending writes and reveals via [`Vm::commit`], with no
-    /// function call. Records no observation: it is a pure flush.
+    /// Both parties flush pending writes and reveals via [`Vm::commit`], with
+    /// no function call. Records no observation: it is a pure flush.
     ///
     /// [`Vm::commit`]: mpz_vm_core::Vm::commit
     Commit,
@@ -75,13 +75,15 @@ pub enum MemStep {
     /// [`Vm::call_local`]: mpz_vm_core::Vm::call_local
     CallLocal { func: String, args: Vec<Value> },
     /// Invoke the exported function `func` with public `args` on both parties.
-    /// Flushes any pending writes/reveals first. Records a [`Observation::Call`]
-    /// with each party's return value. A no-op export flushes without computing.
+    /// Flushes any pending writes/reveals first. Records a
+    /// [`Observation::Call`] with each party's return value. A no-op export
+    /// flushes without computing.
     Call { func: String, args: Vec<Value> },
-    /// Like [`MemStep::Call`], but both parties are driven to completion even if
-    /// one errors, and the step records whether they *agreed* on a valid result
-    /// ([`Observation::Agreement`]). Used to assert that inconsistent inputs are
-    /// not silently reconciled into a single accepted answer.
+    /// Like [`MemStep::Call`], but both parties are driven to completion even
+    /// if one errors, and the step records whether they *agreed* on a valid
+    /// result ([`Observation::Agreement`]). Used to assert that
+    /// inconsistent inputs are not silently reconciled into a single
+    /// accepted answer.
     CheckedCall { func: String, args: Vec<Value> },
     /// Both parties read `ptr..ptr+len`. Records a [`Observation::Read`] with
     /// each party's outcome (bytes, or a failure for a symbolic/pending range).
@@ -359,8 +361,9 @@ fn consistent_public_checked_call() -> Scenario {
     }
 }
 
-/// Inconsistent public writes: the two parties are fed different "public" bytes.
-/// A checked call must surface the divergence rather than silently agree.
+/// Inconsistent public writes: the two parties are fed different "public"
+/// bytes. A checked call must surface the divergence rather than silently
+/// agree.
 fn inconsistent_public_write_disagrees() -> Scenario {
     Scenario {
         name: "inconsistent_public_write_disagrees",
@@ -381,9 +384,10 @@ fn inconsistent_public_write_disagrees() -> Scenario {
 }
 
 /// Inconsistent public bytes feeding an *authenticated* op (added to a private
-/// value). A prover/verifier implementation rejects this cryptographically — the
-/// divergent public wire breaks the proof — while a plain reference implementation
-/// simply computes different results; either way the parties must not agree.
+/// value). A prover/verifier implementation rejects this cryptographically —
+/// the divergent public wire breaks the proof — while a plain reference
+/// implementation simply computes different results; either way the parties
+/// must not agree.
 fn inconsistent_public_feeds_authenticated_op() -> Scenario {
     let wat = r#"(module
         (memory 1)
@@ -474,8 +478,8 @@ fn commit_reveal_separate_rounds() -> Scenario {
 }
 
 /// A private write committed up front via `commit` is then consumed by a full
-/// proving `call`: the committed memory wires persist across rounds and feed the
-/// later computation, which returns the right value on both parties.
+/// proving `call`: the committed memory wires persist across rounds and feed
+/// the later computation, which returns the right value on both parties.
 fn commit_then_call_consumes_memory() -> Scenario {
     let wat = r#"(module
         (memory 1)

--- a/crates/vm-test-harness/src/lib.rs
+++ b/crates/vm-test-harness/src/lib.rs
@@ -16,8 +16,8 @@
 //! mpz_vm_test_harness::wasm_spec_tests!(MyPair, mpz_vm_test_harness::SpecConfig::default());
 //! ```
 
-use mpz_vm_ir::Module;
 use mpz_vm_core::{Param, value::Value};
+use mpz_vm_ir::Module;
 use wast::{
     Wast, WastArg, WastDirective, WastExecute, WastRet,
     core::{WastArgCore, WastRetCore},
@@ -30,16 +30,17 @@ pub mod suites;
 /// A two-party implementation under test.
 ///
 /// Party A holds private inputs as [`Param::Private`]; party B sees them as
-/// [`Param::Blind`]. Both parties must agree on the result (or both trap/error).
+/// [`Param::Blind`]. Both parties must agree on the result (or both
+/// trap/error).
 pub trait SpecVm: Sized {
     /// The error type reported by a run.
     type Error: core::error::Error;
 
     /// Labels of the configurations this implementation wants exercised. Every
     /// suite is run once per variant, so the same conformance corpus stresses
-    /// each one. Most implementations keep the single default; an implementation
-    /// with tunable internals (e.g. proof chunking) can return several to drive
-    /// the whole spec through each configuration.
+    /// each one. Most implementations keep the single default; an
+    /// implementation with tunable internals (e.g. proof chunking) can
+    /// return several to drive the whole spec through each configuration.
     ///
     /// The strings are opaque to the harness and passed back to
     /// [`instantiate`](Self::instantiate).
@@ -48,15 +49,16 @@ pub trait SpecVm: Sized {
     }
 
     /// Construct a fresh party pair for `module` under the named `variant` (one
-    /// of the strings returned by [`variants`](Self::variants)). Called once per
-    /// `(module)` directive and again whenever the harness resets after a trap
-    /// or failure. `Err` carries a human-readable reason recorded as a skip.
+    /// of the strings returned by [`variants`](Self::variants)). Called once
+    /// per `(module)` directive and again whenever the harness resets after
+    /// a trap or failure. `Err` carries a human-readable reason recorded as
+    /// a skip.
     fn instantiate(module: &Module, variant: &str) -> Result<Self, String>;
 
-    /// Run `func_idx` on both parties with the given per-party params, returning
-    /// each party's optional return value. An `Err` from either party is
-    /// surfaced as a single [`Self::Error`] (the harness then classifies it via
-    /// [`Self::is_expected_unsupported`]).
+    /// Run `func_idx` on both parties with the given per-party params,
+    /// returning each party's optional return value. An `Err` from either
+    /// party is surfaced as a single [`Self::Error`] (the harness then
+    /// classifies it via [`Self::is_expected_unsupported`]).
     fn run(
         &mut self,
         func_idx: u32,
@@ -93,14 +95,14 @@ impl Privacy {
             Privacy::AllPublic => false,
             Privacy::One(idx) => i == idx,
             Privacy::AllPrivate => true,
-            Privacy::Alternating => i % 2 == 0,
+            Privacy::Alternating => i.is_multiple_of(2),
         }
     }
 
     /// Whether this pattern is worth running on an invocation with `n_args`
     /// arguments. Patterns that would degenerate into one already covered by
-    /// another pass (or by the all-public pass) are skipped, so the extra passes
-    /// only do real work on invocations they actually distinguish.
+    /// another pass (or by the all-public pass) are skipped, so the extra
+    /// passes only do real work on invocations they actually distinguish.
     fn runs_invocation(self, n_args: usize) -> bool {
         match self {
             Privacy::AllPublic => true,
@@ -753,7 +755,9 @@ fn run_assert_trap<V: SpecVm>(
     let (args_a, args_b) = split_args(args, privacy);
 
     match vm.run(func_idx, args_a, args_b) {
-        Ok(_) => Err(SkipReason::Failed("expected trap but succeeded".to_string())),
+        Ok(_) => Err(SkipReason::Failed(
+            "expected trap but succeeded".to_string(),
+        )),
         Err(e) => match classify::<V>(e) {
             // An expected/unsupported error is still a skip, not a satisfied
             // trap.

--- a/crates/vm-zk/benches/vm.rs
+++ b/crates/vm-zk/benches/vm.rs
@@ -41,7 +41,11 @@ fn rcot_stack(seed: u64) -> (VerifierSvole, ProverSvole) {
     let verifier = ferret::Sender::new(
         ferret::FerretConfig::default(),
         rng.random(),
-        kos::Sender::new(kos::SenderConfig::default(), delta, chou_orlandi::Receiver::new()),
+        kos::Sender::new(
+            kos::SenderConfig::default(),
+            delta,
+            chou_orlandi::Receiver::new(),
+        ),
     );
     let prover = ferret::Receiver::new(
         ferret::FerretConfig::default(),
@@ -168,7 +172,10 @@ fn run_reading(wl: &Workload, read: Option<(u32, usize)>) -> (Option<Value>, Opt
             alloc_args(),
             alloc_args(),
         );
-        assert_eq!(rp, rv, "cabi_realloc must return the same pointer on both sides");
+        assert_eq!(
+            rp, rv,
+            "cabi_realloc must return the same pointer on both sides"
+        );
         let ptr = match rp {
             Some(Value::I32(p)) => p as u32,
             other => panic!("cabi_realloc returned {other:?}"),

--- a/crates/vm-zk/src/capture.rs
+++ b/crates/vm-zk/src/capture.rs
@@ -144,12 +144,12 @@ pub(crate) fn capture_chunk(
             } => {
                 // If the prover announced a trap index, a verifier reaching the
                 // trap locally must land on the same op.
-                if let Some((announced, _)) = &announced_trap {
-                    if *announced != index {
-                        return Err(ZkVmError::Internal(format!(
-                            "local trap at index {index} but prover announced {announced}"
-                        )));
-                    }
+                if let Some((announced, _)) = &announced_trap
+                    && *announced != index
+                {
+                    return Err(ZkVmError::Internal(format!(
+                        "local trap at index {index} but prover announced {announced}"
+                    )));
                 }
                 return Ok(ChunkCapture {
                     trace,
@@ -210,28 +210,25 @@ pub(crate) fn capture_chunk(
             }
         };
 
-        match &directive {
-            Directive::Op(op) => {
-                cost += cost::op_cost(op)?;
-            }
-            _ => {}
+        if let Directive::Op(op) = &directive {
+            cost += cost::op_cost(op)?;
         }
 
         trace.push(directive);
 
-        if let Some(c) = cap {
-            if cost >= c {
-                return Ok(ChunkCapture {
-                    trace,
-                    cost,
-                    done: false,
-                    result: None,
-                    result_symbolic: false,
-                    trap: None,
-                    reveal_actions,
-                    reveals,
-                });
-            }
+        if let Some(c) = cap
+            && cost >= c
+        {
+            return Ok(ChunkCapture {
+                trace,
+                cost,
+                done: false,
+                result: None,
+                result_symbolic: false,
+                trap: None,
+                reveal_actions,
+                reveals,
+            });
         }
     }
 }
@@ -239,11 +236,11 @@ pub(crate) fn capture_chunk(
 /// Steps `thread` to completion using only local work, rejecting any step that
 /// would require a proving round (and thus communication with the other party).
 ///
-/// Public computation is reproduced in-thread and runs to a [`StepResult::Done`]
-/// or a trap. A symbolic [`Op`](mpz_vm_core::Op), a private branch, or a host
-/// call (every zk-vm host call is a reveal) reports
-/// [`ZkVmError::RequiresCommunication`]; the remaining directives — local calls,
-/// returns, and public branches — are in-thread control flow.
+/// Public computation is reproduced in-thread and runs to a
+/// [`StepResult::Done`] or a trap. A symbolic [`Op`](mpz_vm_core::Op), a
+/// private branch, or a host call (every zk-vm host call is a reveal) reports
+/// [`ZkVmError::RequiresCommunication`]; the remaining directives — local
+/// calls, returns, and public branches — are in-thread control flow.
 pub(crate) fn run_local(
     module: &Module,
     global: &mut Global,

--- a/crates/vm-zk/src/commit.rs
+++ b/crates/vm-zk/src/commit.rs
@@ -1,4 +1,3 @@
-
 use mpz_vm_core::{Error as CoreError, Global, Param, Reg, value::Value};
 use mpz_zk_core::{ProverExecute, VerifierExecute};
 use rangeset::set::RangeSet;
@@ -95,14 +94,20 @@ pub(crate) fn commit_memory_prover(
     if pending.cost_bits() == 0 {
         return Ok(());
     }
-    let mem = global.memory().ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
+    let mem = global
+        .memory()
+        .ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
     for range in pending.ranges() {
         let len = (range.end - range.start) as usize;
-        let bytes = mem.read_bytes(range.start, len).map_err(ZkVmError::Trap)?.to_vec();
+        let bytes = mem
+            .read_bytes(range.start, len)
+            .map_err(ZkVmError::Trap)?
+            .to_vec();
         for (i, value) in bytes.into_iter().enumerate() {
             let addr = range.start + i as u32;
-            let byte_bits =
-                Byte::new(core::array::from_fn(|bit_idx| Bit(exec.input((value >> bit_idx) & 1 != 0))));
+            let byte_bits = Byte::new(core::array::from_fn(|bit_idx| {
+                Bit(exec.input((value >> bit_idx) & 1 != 0))
+            }));
             auth.memory.set_byte(addr, byte_bits);
         }
     }

--- a/crates/vm-zk/src/cost.rs
+++ b/crates/vm-zk/src/cost.rs
@@ -4,8 +4,8 @@
 //! selecting the constant-specialized variant when an operand is public (the
 //! same choice `replay` makes when emitting the circuit).
 
-use mpz_vm_ir::{BinaryOp, UnaryOp};
 use mpz_vm_core::{Op, Operand};
+use mpz_vm_ir::{BinaryOp, UnaryOp};
 
 use mpz_vm_circuits as circ;
 

--- a/crates/vm-zk/src/error.rs
+++ b/crates/vm-zk/src/error.rs
@@ -1,7 +1,6 @@
-
+use mpz_vm_core::{Error as CoreError, Reg, Trap};
 use mpz_vm_ir::ValType;
 use mpz_vm_memory::{AuthValueType, AuthValueWidth};
-use mpz_vm_core::{Error as CoreError, Reg, Trap};
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/crates/vm-zk/src/finalize.rs
+++ b/crates/vm-zk/src/finalize.rs
@@ -1,4 +1,3 @@
-
 use mpz_circuits::Context;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_vm_core::{Reg, value::Value};

--- a/crates/vm-zk/src/host.rs
+++ b/crates/vm-zk/src/host.rs
@@ -1,16 +1,16 @@
 //! Servicing of guest VCI reveal host calls during capture.
 //!
-//! When the thread blocks on a `vc::reveal_*` import, [`service_reveal`] records
-//! a [`RevealEvent`] into the captured trace and returns the value to resolve
-//! the call with. The event is opened in-order during replay against the live
-//! authenticated state, so a scalar's source register still holds its MAC at the
-//! reveal point (the free-list cannot have recycled it yet).
+//! When the thread blocks on a `vc::reveal_*` import, [`service_reveal`]
+//! records a [`RevealEvent`] into the captured trace and returns the value to
+//! resolve the call with. The event is opened in-order during replay against
+//! the live authenticated state, so a scalar's source register still holds its
+//! MAC at the reveal point (the free-list cannot have recycled it yet).
 //!
 //! Disclosure is eager: a `reveal_*` call commits its value to the chunk's
 //! announced payloads immediately, keyed by a unique reveal id; the matching
 //! `*_wait` only retrieves it. The id is allocated from a counter that advances
-//! identically on both parties (lockstep capture), so the handle the guest holds
-//! is the verifier's lookup key.
+//! identically on both parties (lockstep capture), so the handle the guest
+//! holds is the verifier's lookup key.
 
 use std::collections::BTreeMap;
 
@@ -66,11 +66,12 @@ pub(crate) enum RevealEvent {
 /// Per-execution reveal state, owned by the prover/verifier across chunks.
 #[derive(Debug, Default)]
 pub(crate) struct RevealState {
-    /// Monotonic reveal-id counter; identical on both parties (lockstep capture).
+    /// Monotonic reveal-id counter; identical on both parties (lockstep
+    /// capture).
     next_id: u32,
-    /// Every payload disclosed so far, keyed by reveal id. The prover fills this
-    /// as it services reveals; the verifier merges each chunk's announced
-    /// payloads before capturing it.
+    /// Every payload disclosed so far, keyed by reveal id. The prover fills
+    /// this as it services reveals; the verifier merges each chunk's
+    /// announced payloads before capturing it.
     payloads: BTreeMap<u32, RevealPayload>,
 }
 
@@ -89,7 +90,12 @@ impl RevealState {
 
     /// Records a disclosed payload (prover side) both for replay lookups and in
     /// `new` to announce in this chunk's message.
-    fn disclose(&mut self, new: &mut BTreeMap<u32, RevealPayload>, id: u32, payload: RevealPayload) {
+    fn disclose(
+        &mut self,
+        new: &mut BTreeMap<u32, RevealPayload>,
+        id: u32,
+        payload: RevealPayload,
+    ) {
         self.payloads.insert(id, payload.clone());
         new.insert(id, payload);
     }
@@ -98,12 +104,13 @@ impl RevealState {
 /// Services a reveal host call surfaced during capture.
 ///
 /// Returns the trace event to record (if any) and the value to resolve the host
-/// call with (the handle for a `reveal`, the revealed value for a scalar `wait`,
-/// nothing for a byte `wait`). The prover inserts newly disclosed payloads into
-/// `new` (to announce) and into its own `payloads`; the verifier reads them from
-/// `payloads`, pre-merged from the chunk message. Byte waits apply their effect
-/// — making the range public and (verifier) materializing its bytes — to
-/// `global` directly and carry no trace event.
+/// call with (the handle for a `reveal`, the revealed value for a scalar
+/// `wait`, nothing for a byte `wait`). The prover inserts newly disclosed
+/// payloads into `new` (to announce) and into its own `payloads`; the verifier
+/// reads them from `payloads`, pre-merged from the chunk message. Byte waits
+/// apply their effect — making the range public and (verifier) materializing
+/// its bytes — to `global` directly and carry no trace event.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn service_reveal(
     role: Role,
     state: &mut RevealState,
@@ -243,7 +250,11 @@ fn handle_dst(dst: Option<Reg>) -> Result<Reg> {
 fn handle_arg(args: &[Operand]) -> Result<u32> {
     let v = match args.first() {
         Some(Operand::Concrete(v)) | Some(Operand::Symbol { value: Some(v), .. }) => *v,
-        _ => return Err(ZkVmError::Internal("reveal wait handle is not available".into())),
+        _ => {
+            return Err(ZkVmError::Internal(
+                "reveal wait handle is not available".into(),
+            ));
+        }
     };
     v.as_i32()
         .map(|h| h as u32)

--- a/crates/vm-zk/src/lib.rs
+++ b/crates/vm-zk/src/lib.rs
@@ -1,4 +1,5 @@
-//! A zero-knowledge virtual machine for proving execution of `mpz-vm-ir` modules.
+//! A zero-knowledge virtual machine for proving execution of `mpz-vm-ir`
+//! modules.
 //!
 //! This crate provides the two parties of a designated-verifier
 //! zero-knowledge proof of program execution. A program is expressed as an

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -28,8 +28,9 @@ use crate::{
 ///
 /// The prover holds the private witness and produces a proof that the module
 /// was executed correctly without revealing that witness. It implements the
-/// [`Vm`] trait, through which a program is loaded with inputs ([`write`](Vm::write)),
-/// run ([`call`](Vm::call)), and queried ([`read`](Vm::read), [`reveal`](Vm::reveal)).
+/// [`Vm`] trait, through which a program is loaded with inputs
+/// ([`write`](Vm::write)), run ([`call`](Vm::call)), and queried
+/// ([`read`](Vm::read), [`reveal`](Vm::reveal)).
 ///
 /// The type parameter `T` is the correlated-randomness channel shared with the
 /// verifier.
@@ -128,8 +129,8 @@ where
     ///
     /// Returns [`ZkVmError::Core`] if the module defines no memory,
     /// [`ZkVmError::Trap`] if the write falls outside the bounds of memory, and
-    /// [`ZkVmError::Unsupported`] for a [`Write::Blind`] input, which the prover
-    /// cannot supply.
+    /// [`ZkVmError::Unsupported`] for a [`Write::Blind`] input, which the
+    /// prover cannot supply.
     fn write(&mut self, ptr: u32, w: Write<'_>) -> Result<(), ZkVmError> {
         let memory = self
             .global
@@ -204,9 +205,10 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`ZkVmError::InvalidFunction`] if `func_idx` does not name a local
-    /// function. Returns a [`ZkVmError`] if proving fails or communication over
-    /// `io` fails, and [`ZkVmError::Trap`] if execution is proven to trap.
+    /// Returns [`ZkVmError::InvalidFunction`] if `func_idx` does not name a
+    /// local function. Returns a [`ZkVmError`] if proving fails or
+    /// communication over `io` fails, and [`ZkVmError::Trap`] if execution
+    /// is proven to trap.
     #[tracing::instrument(level = "info", skip(self, io, params), fields(func_idx, num_params = params.len(), chunk_cap = ?self.chunk_cap))]
     async fn call(
         &mut self,
@@ -578,8 +580,8 @@ where
     /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private
     /// or blind values, if inputs or reveals remain queued (commit them first),
     /// or if execution reaches authenticated work. Otherwise returns
-    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or [`ZkVmError::Trap`]
-    /// on a trap.
+    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or
+    /// [`ZkVmError::Trap`] on a trap.
     fn call_local(
         &mut self,
         func_idx: u32,

--- a/crates/vm-zk/src/replay.rs
+++ b/crates/vm-zk/src/replay.rs
@@ -18,8 +18,8 @@
 use itybity::{GetBit, Lsb0};
 use mpz_circuits::Context;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
-use mpz_vm_ir::{BinaryOp, LoadKind, MemArg, Module, StoreKind, UnaryOp};
 use mpz_vm_core::{Directive, Op, Operand, Reg, Trap, ValType, value::Value};
+use mpz_vm_ir::{BinaryOp, LoadKind, MemArg, Module, StoreKind, UnaryOp};
 use mpz_zk_core::{ProverExecute, VerifierExecute};
 
 use mpz_vm_memory::{AuthState, AuthValue, Bit, I32, I64};
@@ -593,20 +593,46 @@ fn mem_load(
     let eff = eff_addr(addr, memarg)?;
     let m = &auth.memory;
     let av: AuthValue = match kind {
-        I32 => m.load_i32_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64 => m.load_i64_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I32Load8U => m.load_i32_8u_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I32Load8S => m.load_i32_8s_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I32Load16U => m.load_i32_16u_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I32Load16S => m.load_i32_16s_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load8U => m.load_i64_8u_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load8S => m.load_i64_8s_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load16U => m.load_i64_16u_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load16S => m.load_i64_16s_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load32U => m.load_i64_32u_mixed(eff, concrete, symbolic_mask).map(Into::into),
-        I64Load32S => m.load_i64_32s_mixed(eff, concrete, symbolic_mask).map(Into::into),
+        I32 => m
+            .load_i32_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64 => m
+            .load_i64_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I32Load8U => m
+            .load_i32_8u_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I32Load8S => m
+            .load_i32_8s_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I32Load16U => m
+            .load_i32_16u_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I32Load16S => m
+            .load_i32_16s_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load8U => m
+            .load_i64_8u_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load8S => m
+            .load_i64_8s_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load16U => m
+            .load_i64_16u_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load16S => m
+            .load_i64_16s_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load32U => m
+            .load_i64_32u_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
+        I64Load32S => m
+            .load_i64_32s_mixed(eff, concrete, symbolic_mask)
+            .map(Into::into),
         F32 | F64 => {
-            return Err(ZkVmError::Internal("zk-vm: float load not supported".into()));
+            return Err(ZkVmError::Internal(
+                "zk-vm: float load not supported".into(),
+            ));
         }
     }
     .ok_or(ZkVmError::MemAuthMissing { addr: eff })?;
@@ -637,7 +663,9 @@ where
         I64Store16 => auth.memory.store_i64_16(eff, av.try_as_i64()?),
         I64Store32 => auth.memory.store_i64_32(eff, av.try_as_i64()?),
         F32 | F64 => {
-            return Err(ZkVmError::Internal("zk-vm: float store not supported".into()));
+            return Err(ZkVmError::Internal(
+                "zk-vm: float store not supported".into(),
+            ));
         }
     }
     Ok(())
@@ -795,7 +823,11 @@ where
     C: Context<Wire = Gf2_128, Field = Gf2>,
     C::Error: core::fmt::Debug,
 {
-    let all_ones = if width == 64 { u64::MAX } else { (1u64 << width) - 1 };
+    let all_ones = if width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
     let int_min = 1u64 << (width - 1);
     assert_const_bits(ctx, rhs, width, all_ones)?;
     assert_const_bits(ctx, lhs, width, int_min)

--- a/crates/vm-zk/src/reveal.rs
+++ b/crates/vm-zk/src/reveal.rs
@@ -1,4 +1,3 @@
-
 use std::ops::Range;
 
 use mpz_circuits::Context;

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -62,7 +62,7 @@ where
         // Pointer-bit convention: delta.lsb must be 1 so the per-wire
         // identity `mac.lsb XOR key.lsb == bit * delta.lsb` holds bitwise.
         if delta.to_inner() & 1 != 1 {
-            return Err(ZkVmError::DeltaLsb.into());
+            return Err(ZkVmError::DeltaLsb);
         }
         let zk = mpz_zk_core::Verifier::new(delta);
         let auth = AuthState::new(Bit(zk.public_bit(false)), Bit(zk.public_bit(true)));
@@ -273,8 +273,7 @@ where
             if outcome.trap_at.is_some() != outcome.trap.is_some() {
                 return Err(ZkVmError::Internal(
                     "trap outcome inconsistent: trap_at and trap must agree".into(),
-                )
-                .into());
+                ));
             }
             // Merge the announced reveal payloads before capture so the verifier
             // can resolve this chunk's reveals (and any later wait) in lockstep.
@@ -312,8 +311,7 @@ where
                     if outcome.trap.as_ref() != Some(&point.trap) {
                         return Err(ZkVmError::Internal(
                             "announced trap reason does not match proven trap".into(),
-                        )
-                        .into());
+                        ));
                     }
                     trapped = Some(point.trap.clone());
                     break;
@@ -350,8 +348,7 @@ where
                     "commit adjust short: got {} want {}",
                     adjust.len(),
                     execute_bits
-                ))
-                .into());
+                )));
             }
             let chi: [u8; 32] = rand::rng().random();
             io.io_mut()
@@ -457,8 +454,7 @@ where
                 if outcome.trap.as_ref() != Some(&point.trap) {
                     return Err(ZkVmError::Internal(
                         "announced trap reason does not match proven trap".into(),
-                    )
-                    .into());
+                    ));
                 }
                 trapped = Some(point.trap.clone());
                 break;
@@ -491,9 +487,9 @@ where
     ///
     /// This mirrors the prover's [`commit`](crate::Prover::commit): a single
     /// proving round commits the wires of every pending [`Write::Blind`] region
-    /// and verifies the prover's opening of every pending [`reveal`](Vm::reveal)
-    /// range, leaving nothing queued. The committed memory wires persist and are
-    /// consumed by a later [`call`](Vm::call).
+    /// and verifies the prover's opening of every pending
+    /// [`reveal`](Vm::reveal) range, leaving nothing queued. The committed
+    /// memory wires persist and are consumed by a later [`call`](Vm::call).
     ///
     /// # Errors
     ///
@@ -596,11 +592,11 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private or
-    /// blind values, if inputs or reveals remain queued (commit them first), or
-    /// if execution reaches authenticated work. Otherwise returns
-    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or [`ZkVmError::Trap`]
-    /// on a trap.
+    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private
+    /// or blind values, if inputs or reveals remain queued (commit them
+    /// first), or if execution reaches authenticated work. Otherwise
+    /// returns [`ZkVmError::InvalidFunction`] for a bad `func_idx` or
+    /// [`ZkVmError::Trap`] on a trap.
     fn call_local(
         &mut self,
         func_idx: u32,

--- a/crates/vm-zk/tests/add.rs
+++ b/crates/vm-zk/tests/add.rs
@@ -7,9 +7,9 @@ mod common;
 
 use futures::{executor::block_on, future::join};
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::{ExportKind, Module};
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
+use mpz_vm_ir::{ExportKind, Module};
 use mpz_vm_zk::{Prover, Verifier};
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -25,9 +25,10 @@ fn func_idx(module: &Module, name: &str) -> u32 {
 }
 
 // An all-public, non-trapping call does zero authenticated work (no committed
-// inputs, no gates), so both sides must skip the allocate/commit/challenge/proof
-// exchange in lockstep. `join` (not `try_join`) and `block_on` give a hang
-// nowhere to hide: if either side blocks, the test never returns.
+// inputs, no gates), so both sides must skip the
+// allocate/commit/challenge/proof exchange in lockstep. `join` (not `try_join`)
+// and `block_on` give a hang nowhere to hide: if either side blocks, the test
+// never returns.
 #[test]
 fn test_add_public_no_deadlock() {
     common::init_tracing();

--- a/crates/vm-zk/tests/mem_behavior.rs
+++ b/crates/vm-zk/tests/mem_behavior.rs
@@ -13,9 +13,9 @@ use futures::{
 };
 use mpz_common::context::test_st_context;
 use mpz_core::Block;
-use mpz_vm_ir::Module;
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, Write, value::Value};
+use mpz_vm_ir::Module;
 use mpz_vm_test_harness::behavior::{
     Agreement, MemStep, MemVm, Observation, ReadOutcome, func_index, parse_module,
 };
@@ -135,7 +135,10 @@ fn read_outcome(result: Result<&[u8], ZkVmError>) -> ReadOutcome {
     }
 }
 
-fn agreement(a: Result<Option<Value>, ZkVmError>, b: Result<Option<Value>, ZkVmError>) -> Agreement {
+fn agreement(
+    a: Result<Option<Value>, ZkVmError>,
+    b: Result<Option<Value>, ZkVmError>,
+) -> Agreement {
     match (a, b) {
         (Ok(a), Ok(b)) if a == b => Agreement::Agreed,
         _ => Agreement::Disagreed,

--- a/crates/vm-zk/tests/ops.rs
+++ b/crates/vm-zk/tests/ops.rs
@@ -1,6 +1,7 @@
 //! Integration tests that route a PRIVATE value through linear memory under the
 //! real prover/verifier protocol — store an authenticated value, load it back
-//! (incl. partial widths and sign/zero extension), and check both parties agree.
+//! (incl. partial widths and sign/zero extension), and check both parties
+//! agree.
 //!
 //! Plain op/result correctness (arithmetic, bitwise, compare, count, div/rem,
 //! conversions, call-arg propagation) with private inputs is covered far more
@@ -13,9 +14,9 @@ mod common;
 
 use futures::{executor::block_on, future::join};
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::{ExportKind, Module};
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Trap, Vm, value::Value};
+use mpz_vm_ir::{ExportKind, Module};
 use mpz_vm_zk::{Prover, Verifier, ZkVmError};
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -62,12 +63,13 @@ fn run_private(wat: &str, func: &str, inputs: &[Value], expected: Value) {
         async { verifier.call(&mut ctx_v, idx, v_params).await.unwrap() },
     ));
 
-    assert_eq!(result_p, Some(expected.clone()), "prover result for `{func}`");
+    assert_eq!(result_p, Some(expected), "prover result for `{func}`");
     assert_eq!(result_v, Some(expected), "verifier result for `{func}`");
 }
 
 /// A module that stores its private param at a fixed address and loads it back:
-/// `(func (param ty) (result ty) i32.const 16 local.get 0 <store> i32.const 16 <load>)`.
+/// `(func (param ty) (result ty) i32.const 16 local.get 0 <store> i32.const 16
+/// <load>)`.
 fn mem_roundtrip_module(ty: &str, store: &str, load: &str) -> String {
     format!(
         "(module (memory 1) \
@@ -110,16 +112,21 @@ fn i32_mem_partial_widths_private() {
 fn i64_mem_partial_widths_private() {
     // store32 then load32_s of 0x8000_0000 -> sign-extended to i64.
     let s = mem_roundtrip_module("i64", "i64.store32", "i64.load32_s");
-    run_private(&s, "f", &[Value::I64(0x8000_0000)], Value::I64(-0x8000_0000));
+    run_private(
+        &s,
+        "f",
+        &[Value::I64(0x8000_0000)],
+        Value::I64(-0x8000_0000),
+    );
     let u = mem_roundtrip_module("i64", "i64.store32", "i64.load32_u");
     run_private(&u, "f", &[Value::I64(0x8000_0000)], Value::I64(0x8000_0000));
 }
 
 /// Run `func` on both sides expecting it to trap. The prover holds the operands
 /// and self-discovers the trap; the verifier's operands are blind, so it cannot
-/// decide the trap locally and must detect it by matching the prover's announced
-/// trap index against the emitted (could-trap) directive. Asserts both sides
-/// surface `expected`.
+/// decide the trap locally and must detect it by matching the prover's
+/// announced trap index against the emitted (could-trap) directive. Asserts
+/// both sides surface `expected`.
 fn run_private_trap(wat: &str, func: &str, inputs: &[Value], expected: Trap) {
     common::init_tracing();
     let binary = wat::parse_str(wat).expect("valid WAT");
@@ -158,7 +165,12 @@ fn run_private_trap(wat: &str, func: &str, inputs: &[Value], expected: Trap) {
 fn div_u_by_zero_traps_private() {
     let wat = "(module (func $f (export \"f\") (param i32 i32) (result i32) \
                local.get 0 local.get 1 i32.div_u))";
-    run_private_trap(wat, "f", &[Value::I32(6), Value::I32(0)], Trap::DivideByZero);
+    run_private_trap(
+        wat,
+        "f",
+        &[Value::I32(6), Value::I32(0)],
+        Trap::DivideByZero,
+    );
 }
 
 #[test]

--- a/crates/vm-zk/tests/public_output.rs
+++ b/crates/vm-zk/tests/public_output.rs
@@ -7,9 +7,9 @@ mod common;
 
 use futures::{executor::block_on, future::join};
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::{ExportKind, Module, ValType};
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
+use mpz_vm_ir::{ExportKind, Module, ValType};
 use mpz_vm_zk::{Prover, Verifier};
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/vm-zk/tests/reveal.rs
+++ b/crates/vm-zk/tests/reveal.rs
@@ -1,9 +1,9 @@
 //! End-to-end tests of guest VCI reveal: a program that reveals private data
 //! must disclose it to the blind verifier, with the disclosure bound to the
-//! committed witness. Each scalar case runs the same program on the prover (with
-//! a private input) and the blind verifier, asserting both return the expected
-//! value — so a verifier that failed to learn the reveal, or learned a wrong
-//! value, fails the test.
+//! committed witness. Each scalar case runs the same program on the prover
+//! (with a private input) and the blind verifier, asserting both return the
+//! expected value — so a verifier that failed to learn the reveal, or learned a
+//! wrong value, fails the test.
 
 mod common;
 
@@ -35,10 +35,10 @@ fn blind(v: &Value) -> Param {
     }
 }
 
-/// Runs `func` on the prover (with `inputs` as private parameters) and the blind
-/// verifier (the same inputs as blinds), under `chunk_cap`, asserting both
-/// return `expected`. The verifier assertion is the substance: it only holds if
-/// the reveal disclosed the value to the party that never held it.
+/// Runs `func` on the prover (with `inputs` as private parameters) and the
+/// blind verifier (the same inputs as blinds), under `chunk_cap`, asserting
+/// both return `expected`. The verifier assertion is the substance: it only
+/// holds if the reveal disclosed the value to the party that never held it.
 fn run(wat: &str, func: &str, inputs: &[Value], expected: Value, chunk_cap: Option<usize>) {
     common::init_tracing();
     let module = Module::parse(&wat::parse_str(wat).expect("valid WAT")).expect("valid module");
@@ -66,7 +66,7 @@ fn run(wat: &str, func: &str, inputs: &[Value], expected: Value, chunk_cap: Opti
         async { verifier.call(&mut ctx_v, idx, v_params).await.unwrap() },
     ));
 
-    assert_eq!(result_p, Some(expected.clone()), "prover result for `{func}`");
+    assert_eq!(result_p, Some(expected), "prover result for `{func}`");
     assert_eq!(
         result_v,
         Some(expected),
@@ -88,10 +88,10 @@ fn scalar_reveal_discloses_private_input() {
     run(wat, "disclose", &[Value::I32(42)], Value::I32(42), None);
 }
 
-/// A revealed value is public, so the program can branch on it — the only way to
-/// get data-dependent control flow in zk-vm, which rejects private branching. If
-/// the reveal failed to make the value public, the verifier would block on the
-/// branch and the call would error.
+/// A revealed value is public, so the program can branch on it — the only way
+/// to get data-dependent control flow in zk-vm, which rejects private
+/// branching. If the reveal failed to make the value public, the verifier would
+/// block on the branch and the call would error.
 #[test]
 fn revealed_value_drives_a_branch() {
     let wat = r#"

--- a/crates/vm-zk/tests/spec.rs
+++ b/crates/vm-zk/tests/spec.rs
@@ -3,15 +3,15 @@
 //!
 //! `spec_all` runs the entire WASM core spec suite through the real
 //! prover/verifier protocol. The zkVM supports only a subset of WebAssembly, so
-//! the harness is configured to treat unsupported ops, private control flow, and
-//! symbolic value/address errors as expected skips rather than failures.
+//! the harness is configured to treat unsupported ops, private control flow,
+//! and symbolic value/address errors as expected skips rather than failures.
 
 use futures::{executor::block_on, future::try_join};
 use mpz_common::context::test_st_context;
 use mpz_core::Block;
-use mpz_vm_ir::Module;
 use mpz_ot::ideal::rcot::{IdealRCOTReceiver, IdealRCOTSender, ideal_rcot};
 use mpz_vm_core::{Param, Vm, value::Value};
+use mpz_vm_ir::Module;
 use mpz_vm_test_harness::{SpecConfig, SpecVm, run_suite, suites};
 use mpz_vm_zk::{Prover, Verifier, ZkVmError};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/crates/vm-zk/tests/streaming_dense.rs
+++ b/crates/vm-zk/tests/streaming_dense.rs
@@ -6,9 +6,9 @@ mod common;
 
 use futures::{executor::block_on, future::join};
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::{ExportKind, Module, ValType};
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
+use mpz_vm_ir::{ExportKind, Module, ValType};
 use mpz_vm_zk::{Prover, Verifier};
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/vm-zk/tests/unsupported.rs
+++ b/crates/vm-zk/tests/unsupported.rs
@@ -5,9 +5,9 @@ mod common;
 
 use futures::executor::block_on;
 use mpz_common::context::test_st_context;
-use mpz_vm_ir::{ExportKind, Module};
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
+use mpz_vm_ir::{ExportKind, Module};
 use mpz_vm_zk::{Prover, ZkVmError};
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/vole-core/src/ideal/rvole.rs
+++ b/crates/vole-core/src/ideal/rvole.rs
@@ -286,9 +286,7 @@ where
             seed,
             offset: 0,
             delta: None,
-            value_rng: SmallRng::seed_from_u64(
-                seed.wrapping_add(RECEIVER_VALUE_SEED_OFFSET),
-            ),
+            value_rng: SmallRng::seed_from_u64(seed.wrapping_add(RECEIVER_VALUE_SEED_OFFSET)),
             pending: 0,
             values: Vec::new(),
             macs: Vec::new(),
@@ -419,10 +417,7 @@ where
         self.values.len()
     }
 
-    fn try_recv_vole(
-        &mut self,
-        count: usize,
-    ) -> Result<RVOLEReceiverOutput<W, E>, Self::Error> {
+    fn try_recv_vole(&mut self, count: usize) -> Result<RVOLEReceiverOutput<W, E>, Self::Error> {
         if count > self.values.len() {
             return Err(IdealRVOLEError::new(format!(
                 "not enough RVOLEs: available={}, requested={}",
@@ -554,7 +549,10 @@ mod tests {
         let msg = sender.flush().expect("should have message");
         receiver.flush(msg).unwrap();
 
-        let sender_out = sender_fut.try_recv().unwrap().expect("resolved after flush");
+        let sender_out = sender_fut
+            .try_recv()
+            .unwrap()
+            .expect("resolved after flush");
         let receiver_out = receiver_fut
             .try_recv()
             .unwrap()

--- a/crates/vole-core/src/ideal/rvope.rs
+++ b/crates/vole-core/src/ideal/rvope.rs
@@ -46,8 +46,7 @@ fn generate_polynomials<E: Field>(
                 .map(|_| {
                     let mut buf: Array<u8, E::ByteSize> = Array::default();
                     rng.fill_bytes(buf.as_mut_slice());
-                    E::try_from(buf)
-                        .expect("uniform bytes should yield a valid field element")
+                    E::try_from(buf).expect("uniform bytes should yield a valid field element")
                 })
                 .collect()
         })

--- a/crates/vole-core/src/ideal/vole.rs
+++ b/crates/vole-core/src/ideal/vole.rs
@@ -359,10 +359,7 @@ where
                     let _ = mem::take(&mut self.values);
                     mem::take(&mut self.macs)
                 } else {
-                    let _ = self
-                        .values
-                        .drain(..queued_count)
-                        .collect::<Vec<_>>();
+                    let _ = self.values.drain(..queued_count).collect::<Vec<_>>();
                     self.macs.drain(..queued_count).collect()
                 };
                 qsender.send(VOLEReceiverOutput {

--- a/crates/vole-core/src/rvole.rs
+++ b/crates/vole-core/src/rvole.rs
@@ -81,10 +81,7 @@ pub trait RVOLEReceiver<W: Field, E: ExtensionField<W>> {
     /// # Arguments
     ///
     /// * `count` - Number of preprocessed RVOLEs to consume.
-    fn try_recv_vole(
-        &mut self,
-        count: usize,
-    ) -> Result<RVOLEReceiverOutput<W, E>, Self::Error>;
+    fn try_recv_vole(&mut self, count: usize) -> Result<RVOLEReceiverOutput<W, E>, Self::Error>;
 
     /// Queues `count` RVOLEs for receiving.
     ///

--- a/crates/vole-core/src/vole/derandomize.rs
+++ b/crates/vole-core/src/vole/derandomize.rs
@@ -441,12 +441,8 @@ mod tests {
         // pool consumed in matching order.
         let b1 = sender.try_send_vole(R1).unwrap();
         let b2 = sender.try_send_vole(R2).unwrap();
-        let k1_new: Vec<Gf2_128> = (0..R1)
-            .map(|j| b1.keys[j] - a1.diffs[j] * delta)
-            .collect();
-        let k2_new: Vec<Gf2_128> = (0..R2)
-            .map(|j| b2.keys[j] - a2.diffs[j] * delta)
-            .collect();
+        let k1_new: Vec<Gf2_128> = (0..R1).map(|j| b1.keys[j] - a1.diffs[j] * delta).collect();
+        let k2_new: Vec<Gf2_128> = (0..R2).map(|j| b2.keys[j] - a2.diffs[j] * delta).collect();
         assert_vole(delta, &k1_new, &t1, &o1.macs);
         assert_vole(delta, &k2_new, &t2, &o2.macs);
     }

--- a/crates/zk-core/benches/sha256.rs
+++ b/crates/zk-core/benches/sha256.rs
@@ -103,7 +103,9 @@ fn setup_inputs(num_blocks: usize) -> BenchInputs {
 
     let (delta, raw_keys, choices, macs) = sample_rcot(&mut rng, total);
 
-    let input_adjust: Vec<bool> = (0..input_count).map(|i| input_bits[i] ^ choices[i]).collect();
+    let input_adjust: Vec<bool> = (0..input_count)
+        .map(|i| input_bits[i] ^ choices[i])
+        .collect();
     let input_mac_wires: Vec<Gf2_128> = (0..input_count)
         .map(|i| set_lsb(macs[i], input_bits[i]))
         .collect();
@@ -135,7 +137,9 @@ fn setup_inputs(num_blocks: usize) -> BenchInputs {
     let mut gate_adjust = gate_masks.clone();
     let mut prover = Prover::new();
     {
-        let mut exec = prover.execute(&mut gate_adjust, &gate_macs).expect("execute");
+        let mut exec = prover
+            .execute(&mut gate_adjust, &gate_macs)
+            .expect("execute");
         let _ = sha256_chain(&mut exec, state_p, &msg_p);
         exec.finish().expect("finish");
     }
@@ -166,7 +170,9 @@ fn run_prover(inputs: &BenchInputs, num_blocks: usize) {
     let mut masks = inputs.gate_masks.clone();
     let mut prover = Prover::new();
     {
-        let mut exec = prover.execute(&mut masks, &inputs.gate_macs).expect("execute");
+        let mut exec = prover
+            .execute(&mut masks, &inputs.gate_macs)
+            .expect("execute");
         let _ = sha256_chain(&mut exec, state, &msg_blocks);
         exec.finish().expect("finish");
     }

--- a/crates/zk-core/src/check.rs
+++ b/crates/zk-core/src/check.rs
@@ -1,4 +1,3 @@
-
 use itybity::{GetBit, Lsb0};
 use mpz_fields::{Field, gf2_128::Gf2_128};
 use rand_chacha::{

--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -1,4 +1,5 @@
-//! Core building blocks for the designated-verifier zero-knowledge proof system.
+//! Core building blocks for the designated-verifier zero-knowledge proof
+//! system.
 //!
 //! The protocol runs a boolean circuit between a [`Prover`] and a [`Verifier`].
 //! Evaluating the circuit on each side records the information needed to prove
@@ -26,7 +27,8 @@ pub use verifier::{Verifier, VerifierExecute};
 use mpz_core::bitvec::BitVec;
 use mpz_fields::gf2_128::Gf2_128;
 
-/// A specialized [`Result`](core::result::Result) type for this crate's operations.
+/// A specialized [`Result`](core::result::Result) type for this crate's
+/// operations.
 ///
 /// Defaults the error type to [`Error`].
 pub type Result<T, E = Error> = core::result::Result<T, E>;
@@ -285,9 +287,7 @@ mod tests {
         let bad_adjust = vec![false; i.gate_keys.len() - 1];
 
         let mut verifier = Verifier::new(i.delta);
-        let Error(repr) = verifier
-            .execute(&i.gate_keys, &bad_adjust)
-            .unwrap_err();
+        let Error(repr) = verifier.execute(&i.gate_keys, &bad_adjust).unwrap_err();
         assert!(matches!(repr, ErrorRepr::TapeLength { .. }));
     }
 

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -1,4 +1,3 @@
-
 use blake3::Hasher;
 use itybity::{GetBit, Lsb0};
 use mpz_circuits::Context;
@@ -34,11 +33,7 @@ impl Prover {
 
     /// MAC of a public bit: [`MAC_ONE`] for `true`, [`MAC_ZERO`] for `false`.
     pub fn public_bit(&self, bit: bool) -> Gf2_128 {
-        if bit {
-            MAC_ONE
-        } else {
-            MAC_ZERO
-        }
+        if bit { MAC_ONE } else { MAC_ZERO }
     }
 
     /// Returns a [`ProverExecute`] context for evaluating a circuit.
@@ -124,10 +119,7 @@ impl ProverExecute<'_> {
             .masks
             .get_mut(i)
             .expect("mask tape exhausted during input");
-        let mut mac = *self
-            .macs
-            .get(i)
-            .expect("mac tape exhausted during input");
+        let mut mac = *self.macs.get(i).expect("mac tape exhausted during input");
         *slot ^= bit;
         set_lsb(&mut mac, bit);
         self.cursor = i + 1;

--- a/crates/zk-core/src/util.rs
+++ b/crates/zk-core/src/util.rs
@@ -1,4 +1,3 @@
-
 use mpz_fields::gf2_128::Gf2_128;
 
 #[inline]

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -1,4 +1,3 @@
-
 use blake3::Hasher;
 use mpz_circuits::Context;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
@@ -43,20 +42,16 @@ impl Verifier {
     /// Key of a public bit: `key_one` (`MAC_ONE + delta`) for `true`,
     /// `key_zero` ([`MAC_ZERO`]) for `false`.
     pub fn public_bit(&self, bit: bool) -> Gf2_128 {
-        if bit {
-            self.key_one
-        } else {
-            self.key_zero
-        }
+        if bit { self.key_one } else { self.key_zero }
     }
 
-    /// Begins evaluating a circuit, returning a [`VerifierExecute`] that records
-    /// evaluation state into this verifier.
+    /// Begins evaluating a circuit, returning a [`VerifierExecute`] that
+    /// records evaluation state into this verifier.
     ///
     /// `keys` is the tape of verifier keys, one entry per input bit and per AND
-    /// gate, consumed in evaluation order. `adjust` is the corresponding tape of
-    /// adjustment bits received from the prover; each entry selects whether the
-    /// matching key is offset by `delta`.
+    /// gate, consumed in evaluation order. `adjust` is the corresponding tape
+    /// of adjustment bits received from the prover; each entry selects
+    /// whether the matching key is offset by `delta`.
     ///
     /// # Errors
     ///
@@ -146,10 +141,7 @@ impl VerifierExecute<'_> {
     /// Panics if the key or adjustment tape has been exhausted.
     pub fn input(&mut self) -> Gf2_128 {
         let i = self.cursor;
-        let raw = *self
-            .keys
-            .get(i)
-            .expect("key tape exhausted during input");
+        let raw = *self.keys.get(i).expect("key tape exhausted during input");
         let adj = *self
             .adjust
             .get(i)
@@ -162,8 +154,8 @@ impl VerifierExecute<'_> {
 
     /// Returns the verifier key for a public input wire carrying `bit`.
     ///
-    /// Public inputs consume no tape entries, since their value is known to both
-    /// parties.
+    /// Public inputs consume no tape entries, since their value is known to
+    /// both parties.
     pub fn input_public(&self, bit: bool) -> Gf2_128 {
         if bit { *self.key_one } else { *self.key_zero }
     }

--- a/crates/zk-core/tests/sha256.rs
+++ b/crates/zk-core/tests/sha256.rs
@@ -166,9 +166,7 @@ fn sha256_quicksilver_batch_check_accepts() {
 
     let mut verifier = Verifier::new(delta);
     let verifier_out = {
-        let mut exec = verifier
-            .execute(&gate_keys, &gate_masks)
-            .expect("execute");
+        let mut exec = verifier.execute(&gate_keys, &gate_masks).expect("execute");
         let msg_v: [Gf2_128; 512] = core::array::from_fn(|i| input_key_wires[i]);
         let state_v: [Gf2_128; 256] = core::array::from_fn(|i| input_key_wires[512 + i]);
         let out = sha256_compress(&mut exec, msg_v, state_v);

--- a/lint.sh
+++ b/lint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# This script is used to run checks before committing changes to the repository.
-# It is a good approximation of what CI will do.
+# Formatting and lint checks for the workspace. CI runs this same script
+# (see .github/workflows/rust.yml), so passing locally means the Rustfmt
+# and Clippy job will pass too.
 
 # Fail if any command fails
 set -e


### PR DESCRIPTION
Running the pre-commit checks on an Apple Silicon machine failed. This PR makes them pass on every architecture and keeps local checks aligned with CI.

- **fix(matrix-transpose):** the `simd-transpose` feature only compiled on x86_64/wasm32; it now uses portable SIMD's `Mask::to_bitmask` and compiles on every target with identical output and unchanged x86_64 codegen (`pmovmskb` verified in release asm). Also removes a latent illegal-instruction fault: `_mm256_movemask_epi8` (AVX2) was called without a target-feature gate or runtime detection.
- **style:** fix the clippy lints flagged by current nightly and reformat with current nightly rustfmt (the v2 branch is not covered by CI, so drift had accumulated).
- **ci:** rename `pre-commit-check.sh` to `lint.sh` and run it from the Rustfmt and Clippy CI job, so CI and local checks use the same script.

Verified: `./lint.sh` passes on aarch64-apple-darwin; matrix-transpose tests pass on native aarch64 (SIMD + scalar) and on x86_64 via Rosetta 2; wasm32 compiles; `cargo +stable check --workspace --all-targets` passes; test suites of all touched crates pass.

Note: since the lint toolchain floats, CI on `v2` would need the workflow triggers extended (currently `dev` only) for this job to run on this branch.