### PR TITLE
ci: run on pull requests to any branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches: [dev]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Pull requests targeting long-lived branches other than `dev` (e.g. `v2`) currently get no CI. Remove the base-branch filter from the `pull_request` trigger so every PR runs CI, matching the trigger configuration of the `tlsn` repo. Pushes still trigger only on `dev`, so there are no duplicate push+PR runs.