### PR TITLE
fix(fields): route statically-enabled PCLMULQDQ through autodetect

### DIFF
--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -291,13 +291,12 @@ impl ExtensionField<Gf2_128> for Gf2_128 {
 }
 
 cfg_select! {
-    all(target_arch = "x86_64", target_feature = "pclmulqdq") => {
-        mod x86;
-        use x86 as backend;
-    }
     target_arch = "x86_64" => {
-        // Compiled without PCLMULQDQ: detect it at runtime, falling back to
-        // the software backend.
+        // Dispatch to the PCLMULQDQ backend via runtime detection, falling
+        // back to the software backend. When PCLMULQDQ is enabled at compile
+        // time, `cpufeatures` elides the runtime check entirely. (Calling the
+        // `#[target_feature]` functions directly would require `unsafe` even
+        // then, so the static case routes through here too.)
         mod autodetect;
         mod soft;
         mod x86;

--- a/crates/fields/src/gf2_128/autodetect.rs
+++ b/crates/fields/src/gf2_128/autodetect.rs
@@ -1,7 +1,8 @@
-//! Runtime backend selection for GF(2¹²⁸) on x86_64 built without
-//! compile-time PCLMULQDQ: each operation dispatches to the intrinsics
-//! backend when the CPU supports carry-less multiplication, falling back
-//! to the portable software backend otherwise.
+//! Runtime backend selection for GF(2¹²⁸) on x86_64: each operation
+//! dispatches to the intrinsics backend when the CPU supports carry-less
+//! multiplication, falling back to the portable software backend
+//! otherwise. When PCLMULQDQ is enabled at compile time, `cpufeatures`
+//! resolves the check statically and the dispatch disappears.
 #![allow(unsafe_code)]
 
 use super::{Gf2_128, soft, x86};

--- a/crates/fields/src/gf2_128/x86.rs
+++ b/crates/fields/src/gf2_128/x86.rs
@@ -1,9 +1,9 @@
 //! x86_64 PCLMULQDQ fast path for GF(2¹²⁸). Multiply and inner-product
 //! share carry-less multiply (`clmul128`) and reduction (`reduce128`).
 //!
-//! Entry points are `#[target_feature(enable = "pclmulqdq")]`: when the
-//! crate is compiled with the feature they are called directly, otherwise
-//! the `autodetect` backend dispatches to them after runtime detection.
+//! Entry points are `#[target_feature(enable = "pclmulqdq")]` and are
+//! always reached through the `autodetect` backend, which dispatches to
+//! them after (possibly compile-time-resolved) feature detection.
 #![allow(unsafe_code)]
 
 use std::arch::x86_64::*;

--- a/crates/fields/src/lib.rs
+++ b/crates/fields/src/lib.rs
@@ -9,10 +9,9 @@ pub mod gf2_128;
 pub mod gf2_64;
 pub mod p256;
 
-#[cfg(not(any(
-    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-    all(target_arch = "wasm32", target_feature = "simd128"),
-)))]
+// Needed wherever a soft backend is compiled — on x86_64 the Gf2_128 soft
+// fallback exists even when PCLMULQDQ is enabled at compile time.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
 mod bmul;
 
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]


### PR DESCRIPTION
## Problem

Building with a statically enabled `pclmulqdq` target feature (e.g. `RUSTFLAGS="-Ctarget-cpu=native"`) fails to compile `mpz-fields` with E0133. The `Gf2_128` backend selection had a dedicated cfg branch for that case which called the `#[target_feature(enable = "pclmulqdq")]` x86 backend functions directly — but Rust requires an `unsafe` block for such calls even when the feature is enabled in the build configuration.

## Fix

Drop the static branch and always dispatch through `gf2_128/autodetect.rs` on x86_64, which already wraps the backend calls in `unsafe` behind a `cpufeatures` check. When the feature is statically enabled, `cpufeatures` resolves the check at compile time, so the dispatch folds away and the fast path is unchanged.

The `bmul` module's cfg in `lib.rs` is widened to match, since the soft fallback now also compiles in static-feature builds. `Gf2_64` is unaffected: its x86 backend uses safe functions with internal `unsafe` blocks rather than `#[target_feature]`.

## Testing

- `cargo check -p mpz-vm-zk` and `cargo test -p mpz-fields` pass both with and without `RUSTFLAGS="-Ctarget-cpu=native"` (41 tests)
- `cargo clippy -p mpz-fields --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)