### PR TITLE
feat(ole-core): maliciously secure OLE impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,13 @@ rand_core_06 = { package = "rand_core", version = "0.6" }
 rand_08 = { package = "rand", version = "0.8" }
 
 # crypto
+crypto-bigint = { version = "0.7", default-features = false, features = [
+    "rand_core",
+    "hybrid-array",
+    "alloc",
+    "serde",
+] }
+crypto-primes = "0.7"
 cipher = "0.5.0-rc.1"
 sha2 = "0.10"
 blake3 = "1.8.2"

--- a/crates/ole-core/Cargo.toml
+++ b/crates/ole-core/Cargo.toml
@@ -21,3 +21,15 @@ mpz-fields.workspace = true
 mpz-core.workspace = true
 mpz-ot-core.workspace = true
 mpz-common = { workspace = true, features = ["future"] }
+
+# dhim (malicious subquadratic OLE): big-integer CRT arithmetic + prime sampling.
+crypto-bigint = { workspace = true }
+crypto-primes = { workspace = true }
+
+[dev-dependencies]
+rand_chacha.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "ole"
+harness = false

--- a/crates/ole-core/benches/ole.rs
+++ b/crates/ole-core/benches/ole.rs
@@ -1,0 +1,168 @@
+//! End-to-end benchmarks for the two OLE constructions, fueled by ideal ROT.
+//!
+//! Both groups produce `N` chosen-input OLEs over P-256, and in both the ideal
+//! ROT correlations (the "fuel") are generated in `iter_batched`'s untimed
+//! setup, so the measurement covers the OLE protocol itself, not ROT
+//! generation.
+//!
+//! - `gilboa` is a semi-honest batched ROLE — `N` random OLEs in a single
+//!   send/recv — followed by the offset exchange that adjusts the random inputs
+//!   to chosen ones (random OLE → OLE). gilboa uses the `IdealROT` +
+//!   `AnySender`/`AnyReceiver` ROT abstraction, so "preflush" means hoisting
+//!   its `flush()` into setup.
+//! - `dhim` is the maliciously secure per-instance protocol, so its group runs
+//!   `N` full six-flight executions in a loop, each fed a
+//!   `preflushed_ideal_rot` pool and each sampling a fresh consistency prime +
+//!   doing the 174-prime CRT weak multiplication (hence the small sample size).
+
+use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use mpz_core::Block;
+use mpz_fields::{UniformRand, p256::P256};
+use mpz_ole_core::{
+    ROLEReceiver, ROLESender,
+    dhim::{
+        OleReceiver, OleSender,
+        config::p256::{P256_PRIMES, config},
+        rot::{BlockToZpReceiver, BlockToZpSender},
+    },
+    gilboa,
+};
+use mpz_ot_core::{
+    ideal::rot::{IdealROT, IdealROTReceiver, IdealROTSender, ideal_rot},
+    rot::{AnyReceiver, AnySender, ROTReceiver, ROTSender},
+};
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Rng;
+
+/// Number of OLEs produced per benchmark sample.
+const N: usize = 1000;
+
+/// `ℓ = Σᵢ ⌈log₂ pᵢ⌉` — the ROT correlations one dhim OLE consumes.
+fn rots_per_ole() -> usize {
+    P256_PRIMES
+        .iter()
+        .map(|&p| (u64::BITS - (p - 1).leading_zeros()) as usize)
+        .sum()
+}
+
+/// An ideal ROT pair pre-flushed with `count` correlations (dhim's split-source
+/// ROT abstraction).
+fn preflushed_ideal_rot(seed: [u8; 16], count: usize) -> (IdealROTSender, IdealROTReceiver) {
+    let (mut sender, mut receiver) = ideal_rot(Block::from(seed));
+    sender.alloc(count).unwrap();
+    receiver.alloc(count).unwrap();
+    let flush = sender.flush().unwrap();
+    receiver.flush(flush).unwrap();
+    (sender, receiver)
+}
+
+/// Semi-honest Gilboa: `N` ROLEs over P-256 in one batched send/recv, then the
+/// offset exchange that adjusts them to chosen inputs.
+fn gilboa(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ole_gilboa");
+    group.throughput(Throughput::Elements(N as u64));
+    let mut rng = ChaCha12Rng::seed_from_u64(0);
+    // Chosen OLE inputs the adjustment pins the random shares to.
+    let a = P256::rand(&mut rng);
+    let b = P256::rand(&mut rng);
+
+    group.bench_function("p256", |bencher| {
+        bencher.iter_batched(
+            || {
+                // Untimed: build the parties and generate the ROT fuel.
+                let ideal = IdealROT::new(Block::random(&mut rng));
+                let mut sender = gilboa::Sender::<_, P256>::new(
+                    Block::random(&mut rng),
+                    AnySender::new(ideal.clone()),
+                );
+                let mut receiver = gilboa::Receiver::<_, P256>::new(AnyReceiver::new(ideal));
+                sender.alloc(N).unwrap();
+                receiver.alloc(N).unwrap();
+                sender.rot_mut().rot_mut().flush().unwrap();
+                (sender, receiver)
+            },
+            |(mut sender, mut receiver)| {
+                // Timed: the Gilboa multiplication + ROLE → OLE adjustment.
+                let msg = sender.send().unwrap();
+                receiver.recv(msg).unwrap();
+
+                let s_out = sender.try_send_role(N).unwrap();
+                let r_out = receiver.try_recv_role(N).unwrap();
+
+                for (s_share, r_share) in s_out.shares.into_iter().zip(r_out.shares) {
+                    let s_adj = s_share.adjust(a);
+                    let r_adj = r_share.adjust(b);
+                    let s_off = s_adj.offset();
+                    let r_off = r_adj.offset();
+                    black_box((s_adj.sender_finish(r_off), r_adj.receiver_finish(s_off)));
+                }
+            },
+            BatchSize::PerIteration,
+        )
+    });
+    group.finish();
+}
+
+/// Maliciously secure DHIM OLE: `N` full six-flight executions over P-256.
+fn dhim(c: &mut Criterion) {
+    let cfg = config();
+    let rots = rots_per_ole();
+    let mut group = c.benchmark_group("ole_dhim");
+    group.throughput(Throughput::Elements(N as u64));
+
+    let mut input_rng = ChaCha12Rng::seed_from_u64(1);
+    let mut srng = ChaCha12Rng::seed_from_u64(2);
+    let mut rrng = ChaCha12Rng::seed_from_u64(3);
+
+    group.bench_function("p256", |bencher| {
+        bencher.iter_batched(
+            // Untimed: one pre-flushed ROT pool per OLE.
+            || -> Vec<(IdealROTSender, IdealROTReceiver)> {
+                (0..N)
+                    .map(|_| preflushed_ideal_rot([7u8; 16], rots))
+                    .collect()
+            },
+            |pools| {
+                // Timed: N full protocol runs (incl. per-OLE prime sampling).
+                for (s_inner, r_inner) in pools {
+                    let mut s_rot = BlockToZpSender::new(s_inner);
+                    let mut r_rot = BlockToZpReceiver::new(r_inner);
+
+                    let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+                    let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+
+                    let a = P256::rand(&mut input_rng);
+                    let b = P256::rand(&mut input_rng);
+                    let x = P256::rand(&mut input_rng);
+
+                    sender.alloc(&mut s_rot).unwrap();
+                    receiver.alloc(&mut r_rot).unwrap();
+
+                    let m1 = receiver.round1(&mut r_rot).unwrap();
+                    let m2 = sender.round1(&mut s_rot, &m1).unwrap();
+                    let m3 = receiver.round2(&m2).unwrap();
+                    let m4 = sender.round2(&m3).unwrap();
+                    let m5 = receiver.round3(x, &m4).unwrap();
+                    let m6 = sender.round3(a, b, &m5).unwrap();
+                    black_box(receiver.finish(&m6).unwrap());
+                }
+            },
+            BatchSize::PerIteration,
+        )
+    });
+    group.finish();
+}
+
+criterion_group! {
+    name = gilboa_benches;
+    config = Criterion::default().sample_size(50);
+    targets = gilboa
+}
+
+criterion_group! {
+    name = dhim_benches;
+    config = Criterion::default().sample_size(10);
+    targets = dhim
+}
+
+criterion_main!(gilboa_benches, dhim_benches);

--- a/crates/ole-core/src/dhim.rs
+++ b/crates/ole-core/src/dhim.rs
@@ -10,10 +10,6 @@
 //!
 //! [ePrint 2025/1722]: https://eprint.iacr.org/2025/1722
 
-// TODO(port): document public items and re-enable these crate-level lints for
-// the dhim subtree. Relaxed for the initial integration pass.
-#![allow(missing_docs, unreachable_pub, dead_code)]
-
 use crypto_bigint::{BoxedUint, NonZero, Resize};
 use hybrid_array::Array;
 use itybity::{FromBitIterator, ToBits};
@@ -252,7 +248,7 @@ mod tests {
     /// messages between an [`OleSender`] and an [`OleReceiver`] (no I/O).
     /// Returns the receiver's output `y` (or an abort).
     #[allow(clippy::too_many_arguments)]
-    pub fn run_ole_local<F, SOt, ROt, SRng, RRng>(
+    fn run_ole_local<F, SOt, ROt, SRng, RRng>(
         config: &'static Config,
         sender_ot: SOt,
         receiver_ot: ROt,
@@ -406,7 +402,7 @@ mod tests {
     /// [`OleSenderError`] / [`OleReceiverError`]; this driver-level enum
     /// unifies the two so one function can shuttle both parties.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum OleError {
+    enum OleError {
         /// The sender failed (only ever out-of-order — it runs no abortable
         /// check).
         Sender(OleSenderError),

--- a/crates/ole-core/src/dhim.rs
+++ b/crates/ole-core/src/dhim.rs
@@ -1,0 +1,439 @@
+//! Maliciously-secure, subquadratic-communication OLE
+//! (Doerner–Haitner–Ishai–Makriyannis, [ePrint 2025/1722]).
+//!
+//! Realizes maliciously-secure OLE over a large prime field with *subquadratic*
+//! communication: on sender input `(a, b) ∈ Z_q²` and receiver input `x ∈ Z_q`
+//! it delivers `y = a·x + b mod q` to the receiver. The product is computed via
+//! CRT decomposition over many small primes plus a per-prime Gilboa-style weak
+//! multiplication (`wmult`), with a fresh-prime consistency check binding the
+//! parties (Protocol 5.38 / `Π′`, secure under Conjecture 5.37).
+//!
+//! [ePrint 2025/1722]: https://eprint.iacr.org/2025/1722
+
+// TODO(port): document public items and re-enable these crate-level lints for
+// the dhim subtree. Relaxed for the initial integration pass.
+#![allow(missing_docs, unreachable_pub, dead_code)]
+
+use crypto_bigint::{BoxedUint, NonZero, Resize};
+use hybrid_array::Array;
+use itybity::{FromBitIterator, ToBits};
+use mpz_core::{commit::Decommitment, hash::Hash};
+use mpz_fields::Field;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+pub mod config;
+pub mod rot;
+
+pub(crate) mod crt;
+pub(crate) mod ring;
+pub(crate) mod rng;
+pub(crate) mod sampler;
+pub(crate) mod wmult;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
+mod receiver;
+mod sender;
+pub use receiver::{OleReceiver, OleReceiverError};
+pub use sender::{OleSender, OleSenderError};
+
+/// Receiver message for round 1.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Round1Recv {
+    /// Every prime's `Wmult` flip bits, concatenated and bit-packed in CRT
+    /// order. The `ℓᵢ` boundaries are recovered from the public primes.
+    pub(crate) flips: Vec<u8>,
+}
+
+impl Round1Recv {
+    /// Flattens one [`wmult::ReceiverMsg`] per prime (in CRT order) into the
+    /// packed wire form.
+    pub(crate) fn pack(msgs: &[wmult::ReceiverMsg]) -> Self {
+        Self {
+            flips: Vec::<u8>::from_lsb0_iter(msgs.iter().flat_map(|m| m.flips.iter().copied())),
+        }
+    }
+
+    /// Splits the packed flips back into per-prime [`wmult::ReceiverMsg`]s,
+    /// using the widths `ℓᵢ = ⌈log₂ pᵢ⌉` from `crt`.
+    pub(crate) fn unpack(
+        &self,
+        crt: &crt::CrtSystem,
+    ) -> Result<Vec<wmult::ReceiverMsg>, PackError> {
+        let widths: Vec<u32> = crt.primes().iter().map(|&p| wmult::ceil_log2(p)).collect();
+        let total_bits: usize = widths.iter().map(|&l| l as usize).sum();
+        let expected = total_bits.div_ceil(8);
+        if self.flips.len() != expected {
+            return Err(PackError::WrongLength {
+                expected,
+                found: self.flips.len(),
+            });
+        }
+        let mut bits = self.flips.iter_lsb0();
+        Ok(widths
+            .iter()
+            .map(|&l| wmult::ReceiverMsg {
+                flips: bits.by_ref().take(l as usize).collect(),
+            })
+            .collect())
+    }
+}
+
+/// Sender message for round 1.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Round1Send {
+    /// Every prime's `Wmult` corrections, packed at `⌈log₂ pᵢ⌉` bits each in
+    /// CRT order. Boundaries are recovered from the public primes.
+    pub(crate) corrections: Vec<u8>,
+}
+
+impl Round1Send {
+    /// Packs each prime's corrections at its own width `ℓᵢ = ⌈log₂ pᵢ⌉`,
+    /// LSB-first.
+    pub(crate) fn pack(msgs: &[wmult::SenderMsg], crt: &crt::CrtSystem) -> Self {
+        let widths: Vec<u32> = crt.primes().iter().map(|&p| wmult::ceil_log2(p)).collect();
+        let bits = msgs.iter().zip(&widths).flat_map(|(m, &l)| {
+            // `itybity`'s `iter_lsb0` borrows its receiver and so can't be
+            // returned from this `flat_map` over owned values; the low `ℓᵢ` bits of
+            // each correction are taken with an explicit shift, and `itybity` packs
+            // the resulting bools into bytes.
+            m.corrections
+                .iter()
+                .flat_map(move |&o| (0..l).map(move |i| (o >> i) & 1 == 1))
+        });
+        Self {
+            corrections: Vec::<u8>::from_lsb0_iter(bits),
+        }
+    }
+
+    /// Splits the packed corrections back into per-prime [`wmult::SenderMsg`]s.
+    pub(crate) fn unpack(&self, crt: &crt::CrtSystem) -> Result<Vec<wmult::SenderMsg>, PackError> {
+        let widths: Vec<u32> = crt.primes().iter().map(|&p| wmult::ceil_log2(p)).collect();
+        let total_bits: usize = widths.iter().map(|&l| (l * l) as usize).sum();
+        let expected = total_bits.div_ceil(8);
+        if self.corrections.len() != expected {
+            return Err(PackError::WrongLength {
+                expected,
+                found: self.corrections.len(),
+            });
+        }
+        let mut bits = self.corrections.iter_lsb0();
+        let mut out = Vec::with_capacity(widths.len());
+        for &l in &widths {
+            let corrections = (0..l)
+                .map(|_| u64::from_lsb0_iter(bits.by_ref().take(l as usize)))
+                .collect();
+            out.push(wmult::SenderMsg { corrections });
+        }
+        Ok(out)
+    }
+}
+
+/// Error from unpacking a flattened round-1 message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackError {
+    /// The blob's byte length disagrees with the length implied by the primes.
+    WrongLength {
+        /// Bytes the prime set requires.
+        expected: usize,
+        /// Bytes the blob actually carried.
+        found: usize,
+    },
+}
+
+impl std::fmt::Display for PackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PackError::WrongLength { expected, found } => write!(
+                f,
+                "packed round-1 blob was {found} bytes, expected {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PackError {}
+
+/// The receiver's `(x'_p, oᴿ_p) = (x', oᴿ) mod p` residues, big-endian bytes.
+pub(crate) type ReceiverResidues = (Vec<u8>, Vec<u8>);
+
+/// Receiver message for round 2.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Round2Recv {
+    /// The sampled fresh prime `r`.
+    pub(crate) r: BoxedUint,
+    /// Commitment to [`ReceiverResidues`] `(x'_p, oᴿ_p)`.
+    pub(crate) commitment: Hash,
+    /// Master seed from which the sender derives each `Wmult`'s per-prime
+    /// permutation `τ`.
+    pub(crate) tau_seed: [u8; 16],
+}
+
+/// Sender message for round 2.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Round2Send {
+    /// `oˢ mod r`.
+    pub(crate) os_mod_r: BoxedUint,
+    /// `a' mod r`.
+    pub(crate) a_prime_mod_r: BoxedUint,
+}
+
+/// Receiver message for round 3.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Round3Recv<F> {
+    /// `δ_x`.
+    pub(crate) delta_x: F,
+    /// Opening, revealing `(x'_p, oᴿ_p)`.
+    pub(crate) opening: Decommitment<ReceiverResidues>,
+}
+
+/// Sender message for round 3.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Round3Send<F> {
+    /// `δ_a = a − a' mod q`.
+    pub(crate) delta_a: F,
+    /// `δ_b = b + oˢ + a'·δ_x mod q`.
+    pub(crate) delta_b: F,
+}
+
+/// Reduces a big integer `v` modulo the field modulus `q` and returns it as a
+/// field element of `F`. Constant-time implementation.
+///
+/// # Panics
+///
+/// Panics if `q` is zero.
+pub(crate) fn reduce_to_field<F: Field>(v: &BoxedUint, q: &BoxedUint) -> F {
+    let precision = v.bits_precision().max(q.bits_precision());
+    let q_nz = NonZero::new(q.clone().resize(precision))
+        .into_option()
+        .expect("q ≠ 0");
+    // `rem_vartime` is variable-time *only* with respect to the divisor (`rhs`) —
+    // for a fixed divisor it is constant-time (crypto-bigint's documented
+    // contract). The divisor here is `q`, the fixed, publicly-known field modulus,
+    // so this reduction runs in time independent of the secret dividend `v`.
+    let reduced = v.clone().resize(precision).rem_vartime(&q_nz); // < q
+
+    let le = reduced.to_le_bytes();
+    let arr = Array::<u8, F::ByteSize>::try_from(&le[..F::BYTE_SIZE])
+        .expect("reduced < q fits in F::BYTE_SIZE bytes");
+    F::try_from(arr).expect("a value < q is a canonical field element")
+}
+
+/// Samples a uniform integer in `[0, 2^nbits)` at the given precision.
+pub(crate) fn random_bits<R: Rng + ?Sized>(rng: &mut R, nbits: u32, precision: u32) -> BoxedUint {
+    let nbytes = nbits.div_ceil(8) as usize;
+    let mut bytes = vec![0u8; nbytes];
+    rng.fill_bytes(&mut bytes);
+    // Clear the bits above `nbits` in the top byte.
+    let rem = nbits % 8;
+    if rem != 0 {
+        bytes[nbytes - 1] &= (1u8 << rem) - 1;
+    }
+    BoxedUint::from_le_slice(&bytes, precision).expect("fits in `precision` bits")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{
+        config::Config,
+        rot::{BlockToZpReceiver, BlockToZpSender},
+        test_utils::{preflushed_ideal_rot, rots_per_ole},
+    };
+    use mpz_core::Block;
+    use mpz_fields::{UniformRand, p256::P256};
+    use mpz_ot_core::rot::{ROTReceiver, ROTSender};
+    use rand::{CryptoRng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+
+    /// Drives one full OLE `Π′` execution locally by shuttling the typed
+    /// messages between an [`OleSender`] and an [`OleReceiver`] (no I/O).
+    /// Returns the receiver's output `y` (or an abort).
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_ole_local<F, SOt, ROt, SRng, RRng>(
+        config: &'static Config,
+        sender_ot: SOt,
+        receiver_ot: ROt,
+        sender_rng: &mut SRng,
+        receiver_rng: &mut RRng,
+        a: F,
+        b: F,
+        x: F,
+    ) -> Result<F, OleError>
+    where
+        F: Field,
+        SOt: ROTSender<[Block; 2]>,
+        ROt: ROTReceiver<bool, Block>,
+        SRng: Rng + ?Sized,
+        RRng: CryptoRng + ?Sized,
+    {
+        let mut sender_rot = BlockToZpSender::new(sender_ot);
+        let mut receiver_rot = BlockToZpReceiver::new(receiver_ot);
+
+        let mut sender = OleSender::new(config, sender_rng);
+        let mut receiver = OleReceiver::new(config, receiver_rng);
+
+        sender.alloc(&mut sender_rot)?;
+        receiver.alloc(&mut receiver_rot)?;
+
+        let m1 = receiver.round1(&mut receiver_rot)?;
+        let m2 = sender.round1(&mut sender_rot, &m1)?;
+        let m3 = receiver.round2(&m2)?;
+        let m4 = sender.round2(&m3)?;
+        let m5 = receiver.round3(x, &m4)?;
+        let m6 = sender.round3(a, b, &m5)?;
+        Ok(receiver.finish(&m6)?)
+    }
+
+    /// `reduce_to_field::<P256>` reduces `q ≡ 0` and round-trips field
+    /// elements, including the wrap `e + q ≡ e`.
+    #[test]
+    fn reduce_to_field_is_correct() {
+        let q = crate::dhim::config::p256::config().q;
+        let mut rng = ChaCha20Rng::seed_from_u64(0);
+        let prec = 1600;
+
+        // q ≡ 0 (mod q): validates the config modulus equals the real P-256 q.
+        assert_eq!(
+            reduce_to_field::<P256>(&q.clone().resize(prec), q),
+            P256::zero()
+        );
+
+        for _ in 0..50 {
+            let e: P256 = P256::rand(&mut rng);
+            // Embed e as a big integer (P256 serializes little-endian).
+            let e_le: [u8; 32] = e.into();
+            let mut e_be = [0u8; 32];
+            for i in 0..32 {
+                e_be[i] = e_le[31 - i];
+            }
+            let e_boxed = BoxedUint::from_be_slice(&e_be, 256).unwrap().resize(prec);
+
+            // e < q reduces to itself, and e + q reduces back to e.
+            assert_eq!(reduce_to_field::<P256>(&e_boxed, q), e);
+            let e_plus_q = e_boxed.wrapping_add(q.clone().resize(prec));
+            assert_eq!(reduce_to_field::<P256>(&e_plus_q, q), e);
+        }
+    }
+
+    /// `random_bits` stays within `[0, 2^nbits)`, sits at the requested
+    /// precision, and (over many draws) does reach its top bit — so it isn't
+    /// trivially small.
+    #[test]
+    fn random_bits_respects_bound() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        for &nbits in &[1u32, 7, 8, 9, 143, 256] {
+            let precision = 512;
+            let mut top_bit_seen = false;
+            for _ in 0..200 {
+                let v = random_bits(&mut rng, nbits, precision);
+                assert!(v.bits() <= nbits, "nbits={nbits}: got {} bits", v.bits());
+                assert_eq!(v.bits_precision(), precision);
+                top_bit_seen |= v.bits() == nbits;
+            }
+            assert!(
+                top_bit_seen,
+                "nbits={nbits}: top bit never set in 200 draws"
+            );
+        }
+    }
+
+    /// Honest end-to-end `Π′`: `y = a·x + b` over `Z_q` for random inputs.
+    #[test]
+    fn honest_ole_outputs_ax_plus_b() {
+        let cfg = crate::dhim::config::p256::config();
+        let mut input_rng = ChaCha20Rng::seed_from_u64(123);
+
+        for k in 0..8u64 {
+            let (send, recv) = preflushed_ideal_rot([k as u8; 16], rots_per_ole(cfg));
+            let mut srng = ChaCha20Rng::seed_from_u64(1000 + k);
+            let mut rrng = ChaCha20Rng::seed_from_u64(2000 + k);
+
+            let a = P256::rand(&mut input_rng);
+            let b = P256::rand(&mut input_rng);
+            let x = P256::rand(&mut input_rng);
+
+            let y = run_ole_local(cfg, send, recv, &mut srng, &mut rrng, a, b, x)
+                .expect("honest execution must not abort");
+
+            assert_eq!(y, a * x + b, "iteration {k}");
+        }
+    }
+
+    /// `pack`/`unpack` round-trip the per-prime `Wmult` messages exactly, and
+    /// the packed blobs are the bit-exact ideal size (`⌈Σℓᵢ / 8⌉` for flips,
+    /// `⌈Σℓᵢ² / 8⌉` for corrections).
+    #[test]
+    fn round1_messages_round_trip_packed() {
+        let crt = crate::dhim::config::p256::config().crt;
+        let l = |p: u64| crate::dhim::wmult::ceil_log2(p) as usize;
+
+        let recv: Vec<wmult::ReceiverMsg> = crt
+            .primes()
+            .iter()
+            .map(|&p| wmult::ReceiverMsg {
+                flips: (0..l(p)).map(|i| i % 3 == 0).collect(),
+            })
+            .collect();
+        let send: Vec<wmult::SenderMsg> = crt
+            .primes()
+            .iter()
+            .map(|&p| wmult::SenderMsg {
+                corrections: (0..l(p)).map(|i| (i as u64 * 7) % p).collect(),
+            })
+            .collect();
+
+        let r1r = Round1Recv::pack(&recv);
+        let r1s = Round1Send::pack(&send, crt);
+
+        let lsum: usize = crt.primes().iter().map(|&p| l(p)).sum();
+        let l2sum: usize = crt.primes().iter().map(|&p| l(p) * l(p)).sum();
+        assert_eq!(r1r.flips.len(), lsum.div_ceil(8), "flips packed size");
+        assert_eq!(
+            r1s.corrections.len(),
+            l2sum.div_ceil(8),
+            "corrections packed size"
+        );
+
+        assert_eq!(r1r.unpack(crt).unwrap(), recv, "flips round-trip");
+        assert_eq!(r1s.unpack(crt).unwrap(), send, "corrections round-trip");
+    }
+
+    /// Error from a local OLE `Π′` run ([`run_ole_local`]): either party can
+    /// fail. In a real deployment each side only ever sees its own
+    /// [`OleSenderError`] / [`OleReceiverError`]; this driver-level enum
+    /// unifies the two so one function can shuttle both parties.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum OleError {
+        /// The sender failed (only ever out-of-order — it runs no abortable
+        /// check).
+        Sender(OleSenderError),
+        /// The receiver failed (consistency-check abort or out-of-order).
+        Receiver(OleReceiverError),
+    }
+
+    impl From<OleSenderError> for OleError {
+        fn from(e: OleSenderError) -> Self {
+            OleError::Sender(e)
+        }
+    }
+
+    impl From<OleReceiverError> for OleError {
+        fn from(e: OleReceiverError) -> Self {
+            OleError::Receiver(e)
+        }
+    }
+
+    impl std::fmt::Display for OleError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                OleError::Sender(e) => write!(f, "{e}"),
+                OleError::Receiver(e) => write!(f, "{e}"),
+            }
+        }
+    }
+
+    impl std::error::Error for OleError {}
+}

--- a/crates/ole-core/src/dhim/config.rs
+++ b/crates/ole-core/src/dhim/config.rs
@@ -1,0 +1,42 @@
+//! Precomputed protocol configurations.
+
+use crypto_bigint::BoxedUint;
+
+use crate::dhim::crt::CrtSystem;
+
+pub mod p256;
+
+/// A concrete parameter set — one row of Table 5.16. Fixes the field size `|q|`
+/// and statistical-security parameter `κ_s`, and records the derived
+/// bit-lengths of the random-prime search range `s_r`, the sender/receiver
+/// randomization domains `s_a`/`s_x`, and the smooth modulus `n`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Params {
+    /// `|q|` — bit length of the field modulus `q`.
+    pub q_bits: u32,
+    /// `κ_s` — statistical security parameter.
+    pub kappa_s: u32,
+    /// `s_r` — bit length of the random-prime search range.
+    pub s_r_bits: u32,
+    /// `|s_a|` — bit length of the sender's randomization domain.
+    pub s_a_bits: u32,
+    /// `|s_x|` — bit length of the receiver's randomization domain.
+    pub s_x_bits: u32,
+    /// `|n|` — bit length of the smooth modulus `n`.
+    pub n_bits: u32,
+}
+
+/// A precomputed protocol configuration for one field.
+#[derive(Clone, Copy)]
+pub struct Config {
+    /// The Table-5.16 parameters for this field size.
+    pub params: Params,
+    /// The CRT system.
+    pub(crate) crt: &'static CrtSystem,
+    /// The field modulus `q`.
+    pub q: &'static BoxedUint,
+    /// The fixed receiver-consistency prime `p` (Protocol 5.14): used for the
+    /// malicious-receiver check. A prime `≥ 2^{κs+3}`, coprime to `q`
+    /// and the CRT primes.
+    pub p: &'static BoxedUint,
+}

--- a/crates/ole-core/src/dhim/config/p256.rs
+++ b/crates/ole-core/src/dhim/config/p256.rs
@@ -1,0 +1,162 @@
+//! Precomputed configuration for the **P-256 base field**.
+
+use std::sync::LazyLock;
+
+use crypto_bigint::BoxedUint;
+
+use crate::dhim::crt::CrtSystem;
+
+use super::{Config, Params};
+
+/// CRT primes for the P-256 config (`|q| = 256`, `κ_s = 40`): the precise
+/// minimal set of primes `> 3` with `∏ pᵢ ≥ 2^(κ_s+3+|s_a|+|s_x|) = 2^1453`.
+///
+/// **NOT** over-provisioned — the first-177-primes default overshoots by ~30
+/// bits / ~3 primes.
+pub const P256_PRIMES: &[u64] = &[
+    5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
+    103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197,
+    199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311,
+    313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431,
+    433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557,
+    563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661,
+    673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809,
+    811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937,
+    941, 947, 953, 967, 971, 977, 983, 991, 997, 1009, 1013, 1019, 1021, 1031, 1033, 1039, 1049,
+];
+
+/// The parameter set; the matching row of Table 5.16.
+pub const P256_KAPPA_S40: Params = Params {
+    q_bits: 256,
+    kappa_s: 40,
+    s_r_bits: 143,
+    s_a_bits: 537,
+    s_x_bits: 873,
+    n_bits: 1460,
+};
+
+/// The CRT system.
+static P256_CRT: LazyLock<CrtSystem> = LazyLock::new(|| CrtSystem::new(P256_PRIMES.to_vec()));
+
+/// The P-256 base field modulus `q = 2²⁵⁶ − 2²²⁴ + 2¹⁹² + 2⁹⁶ − 1`, big-endian.
+const P256_MODULUS_BE: [u8; 32] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+];
+
+/// The P-256 field modulus `q` as a [`BoxedUint`], cached for the process.
+static P256_Q: LazyLock<BoxedUint> =
+    LazyLock::new(|| BoxedUint::from_be_slice(&P256_MODULUS_BE, 256).expect("32 bytes ⇒ 256-bit"));
+
+/// The receiver-consistency prime `p` (Protocol 5.14 step 8a): the smallest
+/// prime `≥ 2^(κ_s+3) = 2^43`, i.e. `2^43 + 29`. Being a ~44-bit prime it is
+/// automatically coprime to `q` (256-bit) and the CRT primes (`≤ 1049`).
+///
+/// `p ≥ 2^(κ_s+3)` is Theorem 5.17's binding bound, and it is sufficient: the
+/// one extra bit over the malicious-receiver bound of the simpler Protocol 4.10
+/// (`p ≥ 2^(κ_s+2)`) is exactly the "slight increment" Claim 5.19 needs for the
+/// two values `{0, n} mod p` that pass the step-8a test. So the smallest such
+/// prime is the minimal valid choice — nothing finer to pin down.
+const P256_P_VALUE: u64 = 8_796_093_022_237;
+static P256_P: LazyLock<BoxedUint> = LazyLock::new(|| BoxedUint::from(P256_P_VALUE));
+
+/// The assembled P-256 config.
+static P256_CONFIG: LazyLock<Config> = LazyLock::new(|| Config {
+    params: P256_KAPPA_S40,
+    crt: &P256_CRT,
+    q: &P256_Q,
+    p: &P256_P,
+});
+
+/// The config for the **P-256 base field**.
+pub fn config() -> &'static Config {
+    &P256_CONFIG
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto_bigint::ConcatenatingMul;
+
+    /// Trial-division primality for the small candidates the search enumerates.
+    fn is_prime(n: u64) -> bool {
+        if n < 2 {
+            return false;
+        }
+        if n.is_multiple_of(2) {
+            return n == 2;
+        }
+        let mut d = 3u64;
+        while d * d <= n {
+            if n.is_multiple_of(d) {
+                return false;
+            }
+            d += 2;
+        }
+        true
+    }
+
+    /// The minimal prefix of primes `> 3` whose product has more than
+    /// `bound_bits` bits — i.e. `∏ pᵢ ≥ 2^bound_bits`. This is the offline
+    /// derivation that produced [`P256_PRIMES`]; kept here as executable
+    /// documentation and the verifier below.
+    fn precise_primes(bound_bits: u32) -> Vec<u64> {
+        let mut primes = Vec::new();
+        let mut product = BoxedUint::from(1u64);
+        let mut candidate = 5u64;
+        loop {
+            if is_prime(candidate) {
+                primes.push(candidate);
+                // `concatenating_mul` widens, so the exact product is preserved.
+                product = product.concatenating_mul(&BoxedUint::from(candidate));
+                if product.bits() > bound_bits {
+                    break;
+                }
+            }
+            candidate += 2;
+        }
+        primes
+    }
+
+    /// The hard-coded [`P256_PRIMES`] is *exactly* the precise minimal CRT
+    /// prime set the binding constraint `n ≥ 2^(κ_s+3)·s_a·s_x` demands —
+    /// recomputed here from the [`Params`](crate::dhim::config::Params) row
+    /// and cross-checked, so the constant and the parameters cannot
+    /// silently drift apart.
+    #[test]
+    fn p256_primes_match_precise_derivation() {
+        let p = P256_KAPPA_S40;
+        let bound_bits = p.kappa_s + 3 + p.s_a_bits + p.s_x_bits;
+        assert_eq!(precise_primes(bound_bits).as_slice(), P256_PRIMES);
+    }
+
+    /// The baked prime set is precise: it clears the binding constraint, is
+    /// minimal (dropping its largest prime falls short), and is trimmed below
+    /// the old first-177 default.
+    #[test]
+    fn p256_basis_is_precise_and_minimal() {
+        let cfg = config();
+        assert_eq!(cfg.crt.num_primes(), P256_PRIMES.len());
+        assert!(
+            cfg.crt.num_primes() < 177,
+            "expected fewer than the over-provisioned 177, got {}",
+            cfg.crt.num_primes()
+        );
+
+        // Binding constraint: n ≥ 2^bound ⟺ |n| > bound.
+        let bound = cfg.params.kappa_s + 3 + cfg.params.s_a_bits + cfg.params.s_x_bits;
+        assert!(
+            cfg.crt.modulus().bits() > bound,
+            "n ({} bits) must clear the binding bound 2^{bound}",
+            cfg.crt.modulus().bits()
+        );
+
+        // Minimality: the prefix without its largest prime must fall short.
+        let one_short = CrtSystem::new(P256_PRIMES[..P256_PRIMES.len() - 1].to_vec());
+        assert!(
+            one_short.modulus().bits() <= bound,
+            "prime set is not minimal: {} primes already suffice",
+            P256_PRIMES.len() - 1
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/crt.rs
+++ b/crates/ole-core/src/dhim/crt.rs
@@ -1,0 +1,341 @@
+//! CRT system.
+
+use crypto_bigint::{BoxedUint, ConcatenatingMul, Limb, NonZero, Reciprocal, Resize};
+
+/// The CRT system for a fixed set of small primes.
+#[derive(Clone)]
+pub struct CrtSystem {
+    /// The CRT moduli `pᵢ`, distinct primes `> 3`, in increasing order.
+    primes: Vec<u64>,
+    /// The smooth modulus `n = ∏ pᵢ`.
+    modulus: BoxedUint,
+    /// `n` as a non-zero divisor, for the modular ops in [`Self::decode`].
+    modulus_nz: NonZero<BoxedUint>,
+    /// Cofactors `Mᵢ = n / pᵢ`.
+    cofactors: Vec<BoxedUint>,
+    /// Inverses `Mᵢ⁻¹ mod pᵢ` (`Mᵢ` reduced mod `pᵢ` first, then inverted).
+    inverses: Vec<u64>,
+    /// Precomputed Barrett reciprocals for single-limb reduction mod each `pᵢ`
+    /// used by [`Self::encode`].
+    reciprocals: Vec<Reciprocal>,
+    /// Shared bit precision of every [`BoxedUint`] in this basis.
+    precision: u32,
+}
+
+impl CrtSystem {
+    /// Builds a system from an explicit list of distinct primes `> 3`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `primes` is empty.
+    pub fn new(primes: Vec<u64>) -> Self {
+        assert!(!primes.is_empty(), "CRT basis needs at least one prime");
+
+        // n = ∏ pᵢ. The running precision grows with each factor; we normalise once at
+        // the end.
+        let mut product = BoxedUint::from(1u64);
+        for &p in &primes {
+            product = product.concatenating_mul(&BoxedUint::from(p));
+        }
+        // Working precision. `decode` sums Σᵢ Mᵢ·tᵢ (each term < n, t terms) into one
+        // wide integer and reduces only once at the end, so the accumulator can
+        // reach up to t·n − 1 < 2^(|n| + ⌈log₂ t⌉). That worst case is a closed
+        // form in public data known right here — the prime set alone, never the
+        // secret residues — so we size the precision to it exactly: |n| + ⌈log₂
+        // t⌉ + 1 bits (the +1 keeps the bound strict), rounded up to a multiple
+        // of 64 so the width is identical on 64-bit and wasm32 (32-bit limb)
+        // targets.
+        let acc_bits = product.bits() + ceil_log2(primes.len() as u32); // ⌈log₂(t·n)⌉
+        let precision = (acc_bits + 1).next_multiple_of(64);
+
+        // Holds by construction; guards a future prime-set or `decode` change from
+        // silently overflowing the accumulator's `wrapping_add`.
+        debug_assert!(
+            precision > acc_bits,
+            "decode accumulator (< t·n, {acc_bits} bits) must fit precision ({precision} bits)"
+        );
+
+        let modulus = at_precision(product, precision);
+        let modulus_nz = NonZero::new(modulus.clone())
+            .into_option()
+            .expect("n = ∏ pᵢ is non-zero");
+
+        let mut cofactors = Vec::with_capacity(primes.len());
+        let mut inverses = Vec::with_capacity(primes.len());
+        let mut reciprocals = Vec::with_capacity(primes.len());
+        for &p in &primes {
+            let recip = Reciprocal::new(NonZero::<Limb>::new_unwrap(Limb::from_u64(p)));
+            // Mᵢ = n / pᵢ (exact: pᵢ | n).
+            let p_nz = nz_prime_at(p, precision);
+            let (cofactor, remainder) = modulus.div_rem(&p_nz);
+            debug_assert!(bool::from(remainder.is_zero()), "pᵢ must divide n");
+            // (Mᵢ mod pᵢ)⁻¹ mod pᵢ.
+            let cofactor_mod_p = cofactor.rem_limb_with_reciprocal(&recip).0;
+            inverses.push(inv_mod_u64(cofactor_mod_p, p));
+            cofactors.push(cofactor);
+            reciprocals.push(recip);
+        }
+
+        Self {
+            primes,
+            modulus,
+            modulus_nz,
+            cofactors,
+            inverses,
+            reciprocals,
+            precision,
+        }
+    }
+
+    /// The CRT moduli `pᵢ`.
+    pub fn primes(&self) -> &[u64] {
+        &self.primes
+    }
+
+    /// The number of primes `t`.
+    pub fn num_primes(&self) -> usize {
+        self.primes.len()
+    }
+
+    /// The smooth modulus `n = ∏ pᵢ`.
+    pub fn modulus(&self) -> &BoxedUint {
+        &self.modulus
+    }
+
+    /// The smooth modulus as a non-zero divisor.
+    pub fn modulus_nz(&self) -> &NonZero<BoxedUint> {
+        &self.modulus_nz
+    }
+
+    /// The shared bit precision of the basis's [`BoxedUint`]s.
+    pub fn precision(&self) -> u32 {
+        self.precision
+    }
+
+    /// Maps `x` to its residue vector `(x mod p₁, …, x mod p_t)`.
+    ///
+    /// `x` may be given at any precision; it is reduced modulo each `pᵢ`
+    /// independently, so values `≥ n` are handled the same as `x mod n`.
+    pub fn encode(&self, x: &BoxedUint) -> Vec<u64> {
+        self.reciprocals
+            .iter()
+            .map(|recip| x.rem_limb_with_reciprocal(recip).0)
+            .collect()
+    }
+
+    /// Reconstructs the unique `x ∈ Z_n` with `x ≡ residues[i] (mod pᵢ)`.
+    ///
+    /// Each `residues[i]` is reduced mod `pᵢ` first, so out-of-range inputs are
+    /// tolerated.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `residues.len() != self.num_primes()`.
+    pub fn decode(&self, residues: &[u64]) -> BoxedUint {
+        assert_eq!(
+            residues.len(),
+            self.primes.len(),
+            "residue count must match the number of primes"
+        );
+
+        // Accumulate Σᵢ tᵢ·Mᵢ in one wide integer without reducing: each
+        // tᵢ·Mᵢ < n and the sum of t terms is < t·n. The basis precision is
+        // sized to exactly this bound (|n| + ⌈log₂ t⌉ + 1 bits; see `new`), so
+        // the accumulator never overflows. A single reduction by n at the end
+        // replaces the t per-term modular multiplications.
+        let mut acc = BoxedUint::zero_with_precision(self.precision);
+        for (((&p, &res), &inv), cof) in self
+            .primes
+            .iter()
+            .zip(residues)
+            .zip(&self.inverses)
+            .zip(&self.cofactors)
+        {
+            // tᵢ = rᵢ · (Mᵢ⁻¹ mod pᵢ)  mod pᵢ  — a single u64 < pᵢ.
+            let ti = mulmod_u64(res % p, inv, p);
+            if ti == 0 {
+                continue;
+            }
+            // term = Mᵢ · tᵢ  (exact: < n; a cheap single-limb multiply).
+            let term = cof * &BoxedUint::from(ti);
+            acc = acc.wrapping_add(&term);
+        }
+        acc.rem_vartime(&self.modulus_nz)
+    }
+}
+
+/// `⌈log₂ n⌉` for `n ≥ 1` — the smallest `k` with `2^k ≥ n`, i.e. the bit width
+/// needed so any value `< n` fits. `ceil_log2(1) = 0`.
+fn ceil_log2(n: u32) -> u32 {
+    debug_assert!(n >= 1, "ceil_log2 is defined for n ≥ 1");
+    u32::BITS - (n - 1).leading_zeros()
+}
+
+/// Normalises `v` to exactly `precision` bits (widening or shortening as
+/// needed). The value must fit in `precision` bits.
+fn at_precision(v: BoxedUint, precision: u32) -> BoxedUint {
+    v.resize(precision)
+}
+
+/// `p` as a non-zero [`BoxedUint`] divisor at the given precision.
+fn nz_prime_at(p: u64, precision: u32) -> NonZero<BoxedUint> {
+    let p_big = at_precision(BoxedUint::from(p), precision);
+    NonZero::new(p_big)
+        .into_option()
+        .expect("a prime > 3 is non-zero")
+}
+
+/// `a · b mod p` for `u64` operands, via a 128-bit intermediate.
+fn mulmod_u64(a: u64, b: u64, p: u64) -> u64 {
+    ((a as u128 * b as u128) % p as u128) as u64
+}
+
+/// `a⁻¹ mod m` for a prime modulus `m`, via the extended Euclidean algorithm.
+///
+/// # Panics (debug)
+///
+/// Debug-asserts that `gcd(a, m) = 1`.
+fn inv_mod_u64(a: u64, m: u64) -> u64 {
+    debug_assert!(m > 1);
+    let (mut t, mut new_t) = (0i128, 1i128);
+    let (mut r, mut new_r) = (m as i128, (a % m) as i128);
+    while new_r != 0 {
+        let q = r / new_r;
+        (t, new_t) = (new_t, t - q * new_t);
+        (r, new_r) = (new_r, r - q * new_r);
+    }
+    debug_assert_eq!(r, 1, "{a} is not invertible mod {m}");
+    let m_i = m as i128;
+    (((t % m_i) + m_i) % m_i) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ceil_log2(n)` is the smallest `k` with `2^k ≥ n` (`0` at `n = 1`).
+    #[test]
+    fn ceil_log2_matches_reference() {
+        assert_eq!(ceil_log2(1), 0);
+        assert_eq!(ceil_log2(2), 1);
+        assert_eq!(ceil_log2(174), 8); // the P-256 CRT-prime count
+        for n in 1u32..4000 {
+            let k = ceil_log2(n);
+            assert!(1u64 << k >= n as u64, "2^{k} < {n}");
+            if k > 0 {
+                assert!(
+                    1u64 << (k - 1) < n as u64,
+                    "{n} ≤ 2^{} — not minimal",
+                    k - 1
+                );
+            }
+        }
+    }
+
+    /// `mulmod_u64` equals the u128 reference, including when `a·b` overflows
+    /// u64.
+    #[test]
+    fn mulmod_u64_matches_reference() {
+        for (a, b, p) in [
+            (0u64, 0u64, 7u64),
+            (3, 4, 5),
+            (6, 6, 7),
+            (1063, 1062, 1063),
+            (u64::MAX, u64::MAX, 1_000_000_007),
+            (1 << 40, 1 << 40, 1_000_003), // a·b ≫ 2⁶⁴
+        ] {
+            assert_eq!(
+                mulmod_u64(a, b, p),
+                ((a as u128 * b as u128) % p as u128) as u64,
+                "a={a} b={b} p={p}"
+            );
+        }
+    }
+
+    /// `inv_mod_u64(a, m)` is the reduced inverse: `a · a⁻¹ ≡ 1 (mod m)` for
+    /// every nonzero `a` over several primes `m`.
+    #[test]
+    fn inv_mod_u64_inverts() {
+        for &m in &[5u64, 7, 97, 1009, 1063] {
+            for a in 1..m {
+                let inv = inv_mod_u64(a, m);
+                assert!(inv < m, "inverse not reduced: a={a} m={m} inv={inv}");
+                assert_eq!(mulmod_u64(a, inv, m), 1, "a={a} m={m}");
+            }
+        }
+    }
+
+    /// Small worked example: n = 5·7·11 = 385.
+    #[test]
+    fn small_example_round_trip() {
+        let basis = CrtSystem::new(vec![5, 7, 11]);
+        assert_eq!(
+            basis.modulus(),
+            &at_precision(BoxedUint::from(385u64), basis.precision())
+        );
+
+        // 100 mod (5,7,11) = (0,2,1)
+        let x = at_precision(BoxedUint::from(100u64), basis.precision());
+        assert_eq!(basis.encode(&x), vec![0, 2, 1]);
+        assert_eq!(basis.decode(&[0, 2, 1]), x);
+    }
+
+    /// `decode` then `encode` is the identity on residue vectors.
+    #[test]
+    fn residues_round_trip() {
+        let basis = CrtSystem::new(crate::dhim::config::p256::P256_PRIMES[..40].to_vec());
+        let primes = basis.primes().to_vec();
+
+        // A deterministic spread of residues in range.
+        let residues: Vec<u64> = primes
+            .iter()
+            .enumerate()
+            .map(|(i, &p)| ((i as u64 * 2654435761) ^ 0x9e37) % p)
+            .collect();
+
+        let x = basis.decode(&residues);
+        assert_eq!(basis.encode(&x), residues);
+
+        // And the defining congruences hold directly.
+        for (i, &p) in primes.iter().enumerate() {
+            // Independent full-division check that encode's reciprocal path agrees.
+            let p_nz = nz_prime_at(p, basis.precision());
+            assert_eq!(x.rem_vartime(&p_nz).as_words()[0], residues[i]);
+        }
+    }
+
+    /// `encode` then `decode` is the identity on `Z_n`, at the production CRT
+    /// basis (the precise [`crate::dhim::config::p256::P256_PRIMES`]); also
+    /// pins down |n|.
+    #[test]
+    fn values_round_trip_full_basis() {
+        let basis = CrtSystem::new(crate::dhim::config::p256::P256_PRIMES.to_vec());
+
+        // The smooth modulus for the |q|=256 set is ~1460 bits.
+        let bits = basis.modulus().bits();
+        assert!(
+            (1400..=1520).contains(&bits),
+            "|n| = {bits} bits, expected ≈1460"
+        );
+
+        // Deterministic pseudo-random x < n (LCG-filled big-endian bytes,
+        // reduced mod n) — no RNG dependency in tests.
+        let mut state = 0x1234_5678_9abc_def0u64;
+        let mut next_byte = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (state >> 33) as u8
+        };
+        let nbytes = (basis.precision() / 8) as usize;
+
+        for _ in 0..20 {
+            let bytes: Vec<u8> = (0..nbytes).map(|_| next_byte()).collect();
+            let raw = BoxedUint::from_be_slice(&bytes, basis.precision()).unwrap();
+            let x = raw.rem_vartime(basis.modulus_nz());
+
+            let residues = basis.encode(&x);
+            assert_eq!(basis.decode(&residues), x);
+        }
+    }
+}

--- a/crates/ole-core/src/dhim/crt.rs
+++ b/crates/ole-core/src/dhim/crt.rs
@@ -4,7 +4,7 @@ use crypto_bigint::{BoxedUint, ConcatenatingMul, Limb, NonZero, Reciprocal, Resi
 
 /// The CRT system for a fixed set of small primes.
 #[derive(Clone)]
-pub struct CrtSystem {
+pub(crate) struct CrtSystem {
     /// The CRT moduli `pᵢ`, distinct primes `> 3`, in increasing order.
     primes: Vec<u64>,
     /// The smooth modulus `n = ∏ pᵢ`.
@@ -28,7 +28,7 @@ impl CrtSystem {
     /// # Panics
     ///
     /// Panics if `primes` is empty.
-    pub fn new(primes: Vec<u64>) -> Self {
+    pub(crate) fn new(primes: Vec<u64>) -> Self {
         assert!(!primes.is_empty(), "CRT basis needs at least one prime");
 
         // n = ∏ pᵢ. The running precision grows with each factor; we normalise once at
@@ -88,27 +88,29 @@ impl CrtSystem {
     }
 
     /// The CRT moduli `pᵢ`.
-    pub fn primes(&self) -> &[u64] {
+    pub(crate) fn primes(&self) -> &[u64] {
         &self.primes
     }
 
     /// The number of primes `t`.
-    pub fn num_primes(&self) -> usize {
+    #[cfg(test)]
+    pub(crate) fn num_primes(&self) -> usize {
         self.primes.len()
     }
 
     /// The smooth modulus `n = ∏ pᵢ`.
-    pub fn modulus(&self) -> &BoxedUint {
+    pub(crate) fn modulus(&self) -> &BoxedUint {
         &self.modulus
     }
 
     /// The smooth modulus as a non-zero divisor.
-    pub fn modulus_nz(&self) -> &NonZero<BoxedUint> {
+    #[cfg(test)]
+    pub(crate) fn modulus_nz(&self) -> &NonZero<BoxedUint> {
         &self.modulus_nz
     }
 
     /// The shared bit precision of the basis's [`BoxedUint`]s.
-    pub fn precision(&self) -> u32 {
+    pub(crate) fn precision(&self) -> u32 {
         self.precision
     }
 
@@ -116,7 +118,7 @@ impl CrtSystem {
     ///
     /// `x` may be given at any precision; it is reduced modulo each `pᵢ`
     /// independently, so values `≥ n` are handled the same as `x mod n`.
-    pub fn encode(&self, x: &BoxedUint) -> Vec<u64> {
+    pub(crate) fn encode(&self, x: &BoxedUint) -> Vec<u64> {
         self.reciprocals
             .iter()
             .map(|recip| x.rem_limb_with_reciprocal(recip).0)
@@ -131,7 +133,7 @@ impl CrtSystem {
     /// # Panics
     ///
     /// Panics if `residues.len() != self.num_primes()`.
-    pub fn decode(&self, residues: &[u64]) -> BoxedUint {
+    pub(crate) fn decode(&self, residues: &[u64]) -> BoxedUint {
         assert_eq!(
             residues.len(),
             self.primes.len(),

--- a/crates/ole-core/src/dhim/receiver.rs
+++ b/crates/ole-core/src/dhim/receiver.rs
@@ -1,0 +1,503 @@
+//! OLE Receiver.
+
+use crypto_bigint::BoxedUint;
+use mpz_core::{
+    commit::{Decommitment, HashCommit},
+    prg::Prg,
+};
+use mpz_fields::Field;
+use rand::CryptoRng;
+
+use crate::dhim::{config::Config, rot::RotReceiverSource};
+
+use super::{ring::Ring, sampler, wmult};
+
+use super::{
+    ReceiverResidues, Round1Recv, Round1Send, Round2Recv, Round2Send, Round3Recv, Round3Send,
+    random_bits, reduce_to_field,
+};
+
+/// OLE Receiver.
+pub struct OleReceiver<F> {
+    /// Protocol config.
+    config: &'static Config,
+    /// The receiver's input point `x`.
+    x: Option<F>,
+    /// Input mask `x'`.
+    x_prime: BoxedUint,
+    /// `x'` reduced into `F` (i.e. `x' mod q`).
+    x_prime_mod_q: F,
+    /// Master `τ` seed.
+    tau_seed: [u8; 16],
+    /// Private PRG, that supplies each `Wmult`'s secret bit `c`.
+    c_rng: Prg,
+    /// One `Wmult` receiver per prime.
+    wmults: Vec<wmult::Receiver>,
+    /// oᴿ.
+    o_r: Option<BoxedUint>,
+    /// Decommitment to `(x'_p, oᴿ_p)`.
+    opening: Option<Decommitment<ReceiverResidues>>,
+    /// Consistency prime `r`.
+    r: BoxedUint,
+    /// The wrap correction `f ∈ {0, n}`, already reduced into `F`.
+    f_q: Option<F>,
+    /// Which round is expected next.
+    state: RoundState,
+}
+
+impl<F: Field> OleReceiver<F> {
+    /// Initializes the receiver.
+    pub fn new<R: CryptoRng + ?Sized>(config: &'static Config, rng: &mut R) -> Self {
+        let basis = config.crt;
+        // x' ←$ [0, 2^|s_x|): wide mask hiding x ∈ Z_q (revealed only as δ_x).
+        let x_prime = random_bits(rng, config.params.s_x_bits, basis.precision());
+        // r ←$ P_{s_r} \ {q}: the fresh consistency prime.
+        let r = sampler::sample_random_prime(rng, config.params.s_r_bits, config.q);
+
+        let x_res = basis.encode(&x_prime);
+        // Reduce x' into F (x' mod q).
+        let x_prime_mod_q = reduce_to_field::<F>(&x_prime, config.q);
+
+        // The receiver owns the τ entropy: it picks one master seed here and
+        // expands it into every per-prime permutation. Only this seed crosses
+        // the wire (in flight 3). The per-instance τ is then handed down into
+        // each `wmult::Receiver`; see `wmult::derive_taus` for why the seam
+        // sits at this layer rather than inside Wmult.
+        let mut tau_seed = [0u8; 16];
+        rng.fill_bytes(&mut tau_seed);
+        let taus = wmult::derive_taus(tau_seed, basis.primes());
+
+        // Build one `Wmult` receiver per prime.
+        let wmults = basis
+            .primes()
+            .iter()
+            .zip(x_res)
+            .zip(taus)
+            .map(|((&p, x), tau)| wmult::Receiver::new(x, p, tau))
+            .collect();
+
+        let mut c_seed = [0u8; 16];
+        rng.fill_bytes(&mut c_seed);
+        let c_rng = Prg::new_with_seed(c_seed);
+        Self {
+            config,
+            x: None,
+            x_prime,
+            x_prime_mod_q,
+            tau_seed,
+            c_rng,
+            wmults,
+            o_r: None,
+            opening: None,
+            r,
+            f_q: None,
+            state: RoundState::Initialized,
+        }
+    }
+
+    /// Allocates resources.
+    pub fn alloc<RS: RotReceiverSource>(&mut self, rot: &mut RS) -> Result<(), OleReceiverError> {
+        self.check_state(RoundState::Initialized)?;
+        for w in &mut self.wmults {
+            w.alloc(rot)?;
+        }
+        self.state = RoundState::Allocated;
+        Ok(())
+    }
+
+    /// Runs round 1 and returns a message to send.
+    pub fn round1<RS>(&mut self, rot: &mut RS) -> Result<Round1Recv, OleReceiverError>
+    where
+        RS: RotReceiverSource,
+    {
+        self.check_state(RoundState::Allocated)?;
+
+        // Protocol 5.14 step 3.
+        let mut wmults = std::mem::take(&mut self.wmults);
+        let mut recv_msgs = Vec::with_capacity(wmults.len());
+        for w in &mut wmults {
+            match w.request(rot, &mut self.c_rng) {
+                Ok(m) => recv_msgs.push(m),
+                Err(e) => {
+                    // Poison: ROT shares may already be consumed, so the
+                    // receiver cannot meaningfully retry this round.
+                    self.state = RoundState::Failed;
+                    return Err(e.into());
+                }
+            }
+        }
+        self.wmults = wmults;
+        self.state = RoundState::Round2;
+        Ok(Round1Recv::pack(&recv_msgs))
+    }
+
+    /// Runs round 2 and returns a message to send.
+    pub fn round2(&mut self, msg: &Round1Send) -> Result<Round2Recv, OleReceiverError> {
+        self.check_state(RoundState::Round2)?;
+
+        let basis = self.config.crt;
+
+        // Unpack the flattened corrections into one response per prime (one
+        // blob-length check, in place of the old per-prime count guard).
+        let send_msgs = match msg.unpack(basis) {
+            Ok(v) => v,
+            Err(e) => {
+                self.state = RoundState::Failed;
+                return Err(e.into());
+            }
+        };
+
+        let wmults = std::mem::take(&mut self.wmults);
+        let mut or_res = Vec::with_capacity(wmults.len());
+
+        // Protocol 5.14 step 3.
+        for (w, m) in wmults.into_iter().zip(send_msgs.iter()) {
+            match w.finish(m) {
+                Ok(z) => or_res.push(z),
+                Err(e) => {
+                    // Poison: the per-prime receivers are consumed, so this
+                    // round cannot be retried.
+                    self.state = RoundState::Failed;
+                    return Err(e.into());
+                }
+            }
+        }
+        let o_r = basis.decode(&or_res);
+
+        // Protocol 5.14 step 5: commit to (x'_p, oᴿ_p) = (x', oᴿ) mod p.
+        let ring_p = Ring::new(self.config.p.clone());
+        let x_p = ring_p
+            .from_uint(&self.x_prime)
+            .to_uint()
+            .to_be_bytes()
+            .to_vec();
+        let o_r_p = ring_p.from_uint(&o_r).to_uint().to_be_bytes().to_vec();
+        let residues: ReceiverResidues = (x_p, o_r_p);
+        let (opening, commitment) = residues.hash_commit();
+        self.opening = Some(opening);
+
+        self.o_r = Some(o_r);
+
+        self.state = RoundState::Round3;
+        Ok(Round2Recv {
+            r: self.r.clone(),
+            commitment,
+            tau_seed: self.tau_seed,
+        })
+    }
+
+    /// Runs round 3 and returns a message to send.
+    pub fn round3(&mut self, x: F, msg: &Round2Send) -> Result<Round3Recv<F>, OleReceiverError> {
+        self.check_state(RoundState::Round3)?;
+        let basis = self.config.crt;
+        let q = self.config.q;
+        let ring_r = Ring::new(self.r.clone());
+
+        let or = ring_r.from_uint(self.o_r.as_ref().expect("round2 must run first"));
+        let x_prime = ring_r.from_uint(&self.x_prime);
+        let os = ring_r.from_uint(&msg.os_mod_r);
+        let a_prime = ring_r.from_uint(&msg.a_prime_mod_r);
+
+        // Protocol 5.14 step 7 a,b.
+        let lhs = &(&or + &os) - &(&a_prime * &x_prime);
+        let f_q = if lhs == ring_r.zero() {
+            F::zero()
+        } else if lhs == ring_r.from_uint(basis.modulus()) {
+            reduce_to_field::<F>(basis.modulus(), q)
+        } else {
+            self.state = RoundState::Failed;
+            return Err(OleReceiverError::ConsistencyCheck);
+        };
+        self.f_q = Some(f_q);
+
+        // Protocol 5.14 step 7 d, and step 7 c.
+        let delta_x = x - self.x_prime_mod_q;
+        let opening = self.opening.take().expect("round2 must run first");
+        self.x = Some(x);
+        self.state = RoundState::Finish;
+        Ok(Round3Recv { delta_x, opening })
+    }
+
+    /// Finishes the protocol and returns the output.
+    pub fn finish(self, msg: &Round3Send<F>) -> Result<F, OleReceiverError> {
+        self.check_state(RoundState::Finish)?;
+        let q = self.config.q;
+        let o_r = self.o_r.expect("round2 must run first");
+        let f_q = self.f_q.expect("round3 must run first");
+        let x = self.x.expect("round3 must run first");
+        Ok(reduce_to_field::<F>(&o_r, q) + msg.delta_b + msg.delta_a * x - f_q)
+    }
+
+    /// Errors with `OutOfOrder` unless the receiver is in `expected`.
+    fn check_state(&self, expected: RoundState) -> Result<(), OleReceiverError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(OleReceiverError::OutOfOrder {
+                expected: expected.name(),
+                found: self.state.name(),
+            })
+        }
+    }
+}
+
+/// Where an [`OleReceiver`] is in its lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RoundState {
+    Initialized,
+    Allocated,
+    Round2,
+    Round3,
+    Finish,
+    Failed,
+}
+
+impl RoundState {
+    const fn name(self) -> &'static str {
+        match self {
+            RoundState::Initialized => "initialized",
+            RoundState::Allocated => "allocated",
+            RoundState::Round2 => "round2",
+            RoundState::Round3 => "round3",
+            RoundState::Finish => "finish",
+            RoundState::Failed => "failed",
+        }
+    }
+}
+
+/// Error returned by an [`OleReceiver`] round.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OleReceiverError {
+    /// A round was called in the wrong state: the method required state
+    /// `expected`, but the receiver was at `found`.
+    OutOfOrder {
+        /// Name of the state the called round required.
+        expected: &'static str,
+        /// Name of the state the receiver was actually in.
+        found: &'static str,
+    },
+    /// The sender's round-1 message could not be unpacked (wrong blob length
+    /// for the CRT prime set).
+    Pack(crate::dhim::PackError),
+    /// A per-prime `Wmult` rejected the sender's response.
+    Wmult(wmult::ReceiverError),
+    /// The mod-`r` consistency check was neither `0` nor `n` — a malicious
+    /// sender used an inconsistent `a'` or `oˢ`.
+    ConsistencyCheck,
+}
+
+impl From<wmult::ReceiverError> for OleReceiverError {
+    fn from(e: wmult::ReceiverError) -> Self {
+        OleReceiverError::Wmult(e)
+    }
+}
+
+impl From<crate::dhim::PackError> for OleReceiverError {
+    fn from(e: crate::dhim::PackError) -> Self {
+        OleReceiverError::Pack(e)
+    }
+}
+
+impl std::fmt::Display for OleReceiverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OleReceiverError::OutOfOrder { expected, found } => write!(
+                f,
+                "OLE receiver called out of order: expected state `{expected}`, was at `{found}`"
+            ),
+            OleReceiverError::Pack(e) => write!(f, "OLE round-1 message malformed: {e}"),
+            OleReceiverError::Wmult(e) => write!(f, "OLE Wmult failed: {e}"),
+            OleReceiverError::ConsistencyCheck => write!(f, "OLE consistency check failed"),
+        }
+    }
+}
+
+impl std::error::Error for OleReceiverError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OleReceiverError::Pack(e) => Some(e),
+            OleReceiverError::Wmult(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{
+        OleSender,
+        rot::{BlockToZpReceiver, BlockToZpSender},
+        test_utils::{preflushed_ideal_rot, rots_per_ole},
+    };
+    use crypto_bigint::Resize;
+    use mpz_fields::{UniformRand, p256::P256};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    /// Runs an honest sender+receiver pair through flight 4, returning the
+    /// receiver poised at `round3` together with the sender's genuine
+    /// [`Round2Send`] opening and a receiver input `x`. The consistency check
+    /// is the only receiver behaviour an honest end-to-end run can't reach,
+    /// so we drive to its doorstep and let each test poke from there.
+    fn drive_to_round3(seed: u64) -> (OleReceiver<P256>, Round2Send, P256) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, r_inner) = preflushed_ideal_rot([seed as u8; 16], count);
+        let mut s_rot = BlockToZpSender::new(s_inner);
+        let mut r_rot = BlockToZpReceiver::new(r_inner);
+
+        let mut srng = ChaCha20Rng::seed_from_u64(1000 + seed);
+        let mut rrng = ChaCha20Rng::seed_from_u64(2000 + seed);
+
+        let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+        let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+
+        sender.alloc(&mut s_rot).expect("sender alloc");
+        receiver.alloc(&mut r_rot).expect("receiver alloc");
+
+        let m1 = receiver.round1(&mut r_rot).expect("receiver round1");
+        let m2 = sender.round1(&mut s_rot, &m1).expect("sender round1");
+        let m3 = receiver.round2(&m2).expect("receiver round2");
+        let m4 = sender.round2(&m3).expect("sender round2");
+
+        let x = P256::rand(&mut rrng);
+        (receiver, m4, x)
+    }
+
+    /// A fresh receiver in the `Initialized` state plus an (unconsumed) ROT
+    /// source, for exercising the state-machine guards in isolation.
+    fn fresh_receiver(seed: u64) -> (OleReceiver<P256>, impl RotReceiverSource) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (_s, r_inner) = preflushed_ideal_rot([seed as u8; 16], count);
+        let rot = BlockToZpReceiver::new(r_inner);
+        let mut rrng = ChaCha20Rng::seed_from_u64(seed);
+        let receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+        (receiver, rot)
+    }
+
+    /// A tampered flight-4 opening makes the mod-`r` discrepancy fall outside
+    /// `{0, n}`, so `round3` aborts with `ConsistencyCheck` — and the failure
+    /// poisons the receiver, so any later call is rejected as out-of-order.
+    #[test]
+    fn consistency_check_aborts_and_poisons() {
+        let (mut receiver, m4, x) = drive_to_round3(7);
+
+        // Bump oˢ mod r by 1: the integer discrepancy (oᴿ + oˢ) − a'·x' no longer
+        // reduces to 0 or n mod r (negligibly unlikely to coincide for this r).
+        let prec = m4.os_mod_r.bits_precision();
+        let tampered = Round2Send {
+            os_mod_r: m4.os_mod_r.wrapping_add(BoxedUint::from(1u64).resize(prec)),
+            a_prime_mod_r: m4.a_prime_mod_r.clone(),
+        };
+
+        assert_eq!(
+            receiver.round3(x, &tampered).unwrap_err(),
+            OleReceiverError::ConsistencyCheck
+        );
+        assert_eq!(
+            receiver.round3(x, &tampered).unwrap_err(),
+            OleReceiverError::OutOfOrder {
+                expected: "round3",
+                found: "failed",
+            }
+        );
+    }
+
+    /// Runs an honest pair through flight 2, returning the receiver poised at
+    /// `round2` and the sender's genuine [`Round1Send`].
+    fn drive_to_round2(seed: u64) -> (OleReceiver<P256>, Round1Send) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, r_inner) = preflushed_ideal_rot([seed as u8; 16], count);
+        let mut s_rot = BlockToZpSender::new(s_inner);
+        let mut r_rot = BlockToZpReceiver::new(r_inner);
+
+        let mut srng = ChaCha20Rng::seed_from_u64(1000 + seed);
+        let mut rrng = ChaCha20Rng::seed_from_u64(2000 + seed);
+
+        let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+        let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+
+        sender.alloc(&mut s_rot).expect("sender alloc");
+        receiver.alloc(&mut r_rot).expect("receiver alloc");
+
+        let m1 = receiver.round1(&mut r_rot).expect("receiver round1");
+        let m2 = sender.round1(&mut s_rot, &m1).expect("sender round1");
+        (receiver, m2)
+    }
+
+    /// A round-1 corrections blob of the wrong length is rejected with
+    /// `Pack(WrongLength)`, and the receiver is poisoned. (With flattened
+    /// packing there is no per-prime structure left to corrupt — any tampering
+    /// shows up as a single blob-length mismatch.)
+    #[test]
+    fn round2_rejects_wrong_correction_length() {
+        let (mut receiver, m2) = drive_to_round2(31);
+        let full = m2.corrections.len();
+        let short = Round1Send {
+            corrections: m2.corrections[..full - 1].to_vec(),
+        };
+        assert_eq!(
+            receiver.round2(&short).unwrap_err(),
+            OleReceiverError::Pack(crate::dhim::PackError::WrongLength {
+                expected: full,
+                found: full - 1,
+            })
+        );
+        assert_eq!(
+            receiver.round2(&short).unwrap_err(),
+            OleReceiverError::OutOfOrder {
+                expected: "round2",
+                found: "failed",
+            }
+        );
+    }
+
+    /// `round1` requires `Allocated`; calling it straight after `new` is
+    /// rejected.
+    #[test]
+    fn round1_before_alloc_is_out_of_order() {
+        let (mut receiver, mut rot) = fresh_receiver(11);
+        assert_eq!(
+            receiver.round1(&mut rot).unwrap_err(),
+            OleReceiverError::OutOfOrder {
+                expected: "allocated",
+                found: "initialized",
+            }
+        );
+    }
+
+    /// `round2` requires `Round2`; calling it before `round1` is rejected (the
+    /// guard fires before the empty message is ever inspected).
+    #[test]
+    fn round2_before_round1_is_out_of_order() {
+        let (mut receiver, _rot) = fresh_receiver(12);
+        let empty = Round1Send {
+            corrections: Vec::new(),
+        };
+        assert_eq!(
+            receiver.round2(&empty).unwrap_err(),
+            OleReceiverError::OutOfOrder {
+                expected: "round2",
+                found: "initialized",
+            }
+        );
+    }
+
+    /// `alloc` is a one-shot `Initialized → Allocated` transition; a second
+    /// call is rejected.
+    #[test]
+    fn alloc_twice_is_out_of_order() {
+        let (mut receiver, mut rot) = fresh_receiver(13);
+        receiver.alloc(&mut rot).expect("first alloc succeeds");
+        assert_eq!(
+            receiver.alloc(&mut rot).unwrap_err(),
+            OleReceiverError::OutOfOrder {
+                expected: "initialized",
+                found: "allocated",
+            }
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/receiver.rs
+++ b/crates/ole-core/src/dhim/receiver.rs
@@ -266,6 +266,10 @@ impl RoundState {
 }
 
 /// Error returned by an [`OleReceiver`] round.
+// `Wmult` carries the internal `wmult::ReceiverError`, which is surfaced only
+// opaquely (Display/source) — `wmult` is a crate-internal module, so the type
+// is intentionally not nameable in the public API.
+#[allow(private_interfaces)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OleReceiverError {
     /// A round was called in the wrong state: the method required state

--- a/crates/ole-core/src/dhim/ring.rs
+++ b/crates/ole-core/src/dhim/ring.rs
@@ -7,7 +7,7 @@ use crypto_bigint::{
 
 /// The residue ring `Z_m` for an odd modulus `m`.
 #[derive(Clone)]
-pub struct Ring {
+pub(crate) struct Ring {
     /// Montgomery parameters for `m`.
     params: BoxedMontyParams,
     /// The modulus `m`.
@@ -23,7 +23,7 @@ impl Ring {
     ///
     /// Panics if `m` is even or zero (the Montgomery backend requires an odd
     /// modulus).
-    pub fn new(modulus: BoxedUint) -> Self {
+    pub(crate) fn new(modulus: BoxedUint) -> Self {
         let precision = modulus.bits_precision();
         let odd = Odd::new(modulus.clone())
             .into_option()
@@ -37,24 +37,27 @@ impl Ring {
     }
 
     /// The modulus `m`.
-    pub fn modulus(&self) -> &BoxedUint {
+    #[cfg(test)]
+    pub(crate) fn modulus(&self) -> &BoxedUint {
         &self.modulus
     }
 
     /// The bit precision of the ring's [`BoxedUint`] representatives.
-    pub fn precision(&self) -> u32 {
+    #[cfg(test)]
+    pub(crate) fn precision(&self) -> u32 {
         self.precision
     }
 
     /// The additive identity `0`.
-    pub fn zero(&self) -> Elem {
+    pub(crate) fn zero(&self) -> Elem {
         Elem {
             inner: BoxedMontyForm::zero(&self.params),
         }
     }
 
     /// The multiplicative identity `1`.
-    pub fn one(&self) -> Elem {
+    #[cfg(test)]
+    pub(crate) fn one(&self) -> Elem {
         Elem {
             inner: BoxedMontyForm::one(&self.params),
         }
@@ -68,7 +71,7 @@ impl Ring {
     // `from_*` reads as a free constructor to clippy, but embedding genuinely
     // needs the ring's Montgomery params, hence `&self`.
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_uint(&self, v: &BoxedUint) -> Elem {
+    pub(crate) fn from_uint(&self, v: &BoxedUint) -> Elem {
         let reduced = if v.bits_precision() > self.precision {
             // Reduce at the input's (wider) precision, then shrink the `< m`
             // result down to the ring precision.
@@ -86,27 +89,29 @@ impl Ring {
     }
 
     /// Embeds a `u64` into the ring.
+    #[cfg(test)]
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_u64(&self, v: u64) -> Elem {
+    pub(crate) fn from_u64(&self, v: u64) -> Elem {
         self.from_uint(&BoxedUint::from(v))
     }
 }
 
 /// An element of a [`Ring`] (`Z_m`).
 #[derive(Clone, PartialEq, Eq)]
-pub struct Elem {
+pub(crate) struct Elem {
     inner: BoxedMontyForm,
 }
 
 impl Elem {
     /// Returns the canonical representative in `[0, m)`.
-    pub fn to_uint(&self) -> BoxedUint {
+    pub(crate) fn to_uint(&self) -> BoxedUint {
         self.inner.retrieve()
     }
 
     /// Returns the multiplicative inverse, or `None` if `self` is not
     /// invertible mod `m`.
-    pub fn inverse(&self) -> Option<Elem> {
+    #[cfg(test)]
+    pub(crate) fn inverse(&self) -> Option<Elem> {
         self.inner
             .invert()
             .into_option()
@@ -114,7 +119,8 @@ impl Elem {
     }
 
     /// Returns `self` raised to the power `exponent`.
-    pub fn pow(&self, exponent: &BoxedUint) -> Elem {
+    #[cfg(test)]
+    pub(crate) fn pow(&self, exponent: &BoxedUint) -> Elem {
         Elem {
             inner: self.inner.pow(exponent),
         }

--- a/crates/ole-core/src/dhim/ring.rs
+++ b/crates/ole-core/src/dhim/ring.rs
@@ -1,0 +1,288 @@
+//! Runtime-modulus residue ring `Z_m` for an odd modulus `m`.
+
+use crypto_bigint::{
+    BoxedUint, NonZero, Odd, Resize,
+    modular::{BoxedMontyForm, BoxedMontyParams},
+};
+
+/// The residue ring `Z_m` for an odd modulus `m`.
+#[derive(Clone)]
+pub struct Ring {
+    /// Montgomery parameters for `m`.
+    params: BoxedMontyParams,
+    /// The modulus `m`.
+    modulus: BoxedUint,
+    /// Shared bit precision of every [`BoxedUint`] representative in this ring.
+    precision: u32,
+}
+
+impl Ring {
+    /// Creates `Z_m` for an odd modulus `m`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `m` is even or zero (the Montgomery backend requires an odd
+    /// modulus).
+    pub fn new(modulus: BoxedUint) -> Self {
+        let precision = modulus.bits_precision();
+        let odd = Odd::new(modulus.clone())
+            .into_option()
+            .expect("residue-ring modulus must be odd and non-zero");
+        let params = BoxedMontyParams::new(odd);
+        Self {
+            params,
+            modulus,
+            precision,
+        }
+    }
+
+    /// The modulus `m`.
+    pub fn modulus(&self) -> &BoxedUint {
+        &self.modulus
+    }
+
+    /// The bit precision of the ring's [`BoxedUint`] representatives.
+    pub fn precision(&self) -> u32 {
+        self.precision
+    }
+
+    /// The additive identity `0`.
+    pub fn zero(&self) -> Elem {
+        Elem {
+            inner: BoxedMontyForm::zero(&self.params),
+        }
+    }
+
+    /// The multiplicative identity `1`.
+    pub fn one(&self) -> Elem {
+        Elem {
+            inner: BoxedMontyForm::one(&self.params),
+        }
+    }
+
+    /// Embeds a big integer `v` into the ring, reducing it by the ring modulus.
+    /// Non-constant-time implementation.
+    ///
+    /// `v` may be given at **any** precision — in particular wider than the
+    /// ring's own.
+    // `from_*` reads as a free constructor to clippy, but embedding genuinely
+    // needs the ring's Montgomery params, hence `&self`.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_uint(&self, v: &BoxedUint) -> Elem {
+        let reduced = if v.bits_precision() > self.precision {
+            // Reduce at the input's (wider) precision, then shrink the `< m`
+            // result down to the ring precision.
+            let m_wide = self.modulus.clone().resize(v.bits_precision());
+            let m_wide_nz = NonZero::new(m_wide)
+                .into_option()
+                .expect("residue-ring modulus is non-zero");
+            v.rem_vartime(&m_wide_nz).resize(self.precision)
+        } else {
+            v.clone().resize(self.precision)
+        };
+        Elem {
+            inner: BoxedMontyForm::new(reduced, &self.params),
+        }
+    }
+
+    /// Embeds a `u64` into the ring.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_u64(&self, v: u64) -> Elem {
+        self.from_uint(&BoxedUint::from(v))
+    }
+}
+
+/// An element of a [`Ring`] (`Z_m`).
+#[derive(Clone, PartialEq, Eq)]
+pub struct Elem {
+    inner: BoxedMontyForm,
+}
+
+impl Elem {
+    /// Returns the canonical representative in `[0, m)`.
+    pub fn to_uint(&self) -> BoxedUint {
+        self.inner.retrieve()
+    }
+
+    /// Returns the multiplicative inverse, or `None` if `self` is not
+    /// invertible mod `m`.
+    pub fn inverse(&self) -> Option<Elem> {
+        self.inner
+            .invert()
+            .into_option()
+            .map(|inner| Elem { inner })
+    }
+
+    /// Returns `self` raised to the power `exponent`.
+    pub fn pow(&self, exponent: &BoxedUint) -> Elem {
+        Elem {
+            inner: self.inner.pow(exponent),
+        }
+    }
+}
+
+impl core::fmt::Debug for Elem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Elem({:?})", self.inner.retrieve())
+    }
+}
+
+/// Generates the owned and borrowed forms of a binary operator, dispatching to
+/// [`BoxedMontyForm`]'s by-reference operator impls (which borrow both operands
+/// rather than consume them).
+macro_rules! impl_binop {
+    ($trait:ident, $method:ident) => {
+        impl core::ops::$trait<Elem> for Elem {
+            type Output = Elem;
+            fn $method(self, rhs: Elem) -> Elem {
+                Elem {
+                    inner: core::ops::$trait::$method(&self.inner, &rhs.inner),
+                }
+            }
+        }
+        impl core::ops::$trait<&Elem> for &Elem {
+            type Output = Elem;
+            fn $method(self, rhs: &Elem) -> Elem {
+                Elem {
+                    inner: core::ops::$trait::$method(&self.inner, &rhs.inner),
+                }
+            }
+        }
+    };
+}
+
+impl_binop!(Add, add);
+impl_binop!(Sub, sub);
+impl_binop!(Mul, mul);
+
+impl core::ops::Neg for Elem {
+    type Output = Elem;
+    fn neg(self) -> Elem {
+        Elem {
+            inner: core::ops::Neg::neg(&self.inner),
+        }
+    }
+}
+
+impl core::ops::Neg for &Elem {
+    type Output = Elem;
+    fn neg(self) -> Elem {
+        Elem {
+            inner: core::ops::Neg::neg(&self.inner),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{crt::CrtSystem, rng::Compat};
+    use crypto_bigint::{ConcatenatingMul, RandomMod};
+    use mpz_core::prg::Prg;
+    use rand::RngCore;
+
+    /// Samples a uniformly random element of `ring`.
+    fn random_elem<R: RngCore + ?Sized>(ring: &Ring, rng: &mut R) -> Elem {
+        let v = BoxedUint::random_mod_vartime(&mut Compat(rng), &ring_modulus_nz(ring));
+        ring.from_uint(&v)
+    }
+
+    /// A small odd-prime ring checked against `u128` reference arithmetic.
+    #[test]
+    fn small_prime_ring_axioms() {
+        let m = 97u64;
+        let ring = Ring::new(BoxedUint::from(m));
+
+        let red = |e: &Elem| -> u64 { e.to_uint().as_words().first().copied().unwrap_or(0) };
+
+        for a in 0..m {
+            for b in 0..m {
+                let ea = ring.from_u64(a);
+                let eb = ring.from_u64(b);
+                assert_eq!(red(&(&ea + &eb)), (a + b) % m);
+                assert_eq!(red(&(&ea - &eb)), (a + m - b) % m);
+                assert_eq!(red(&(&ea * &eb)), (a * b) % m);
+            }
+            let ea = ring.from_u64(a);
+            assert_eq!(red(&(-&ea)), (m - a) % m);
+        }
+    }
+
+    #[test]
+    fn inverse_and_pow() {
+        let ring = Ring::new(BoxedUint::from(97u64));
+        let one = ring.one();
+
+        // a · a⁻¹ = 1 for every non-zero a.
+        for a in 1..97u64 {
+            let ea = ring.from_u64(a);
+            let inv = ea.inverse().expect("non-zero is invertible mod prime");
+            assert_eq!(&ea * &inv, one);
+        }
+        // 0 is not invertible.
+        assert!(ring.zero().inverse().is_none());
+
+        // 2^10 = 1024 ≡ 51 (mod 97).
+        let two = ring.from_u64(2);
+        assert_eq!(two.pow(&BoxedUint::from(10u64)), ring.from_u64(1024 % 97));
+    }
+
+    /// Z_n over the smooth modulus: ring axioms and sampling stay in range.
+    #[test]
+    fn smooth_modulus_ring() {
+        let basis = CrtSystem::new(crate::dhim::config::p256::P256_PRIMES.to_vec());
+        let ring = Ring::new(basis.modulus().clone());
+        let mut rng = Prg::new_with_seed([0u8; 16]);
+
+        let zero = ring.zero();
+        let one = ring.one();
+
+        for _ in 0..50 {
+            let a = random_elem(&ring, &mut rng);
+            let b = random_elem(&ring, &mut rng);
+
+            // Sampled representatives are reduced.
+            assert!(a.to_uint() < *ring.modulus());
+
+            // Ring axioms.
+            assert_eq!(&a + &b, &b + &a);
+            assert_eq!(&(&a - &b) + &b, a.clone());
+            assert_eq!(&a + &(-&a), zero);
+            assert_eq!(&a * &one, a.clone());
+            assert_eq!(&a * &b, &b * &a);
+        }
+
+        // Multiplication agrees with a direct mod-n bigint multiply.
+        let a = random_elem(&ring, &mut rng);
+        let b = random_elem(&ring, &mut rng);
+        let prod_direct = a
+            .to_uint()
+            .concatenating_mul(&b.to_uint())
+            .rem_vartime(&ring_modulus_nz(&ring));
+        assert_eq!((&a * &b).to_uint(), prod_direct.resize(ring.precision()));
+    }
+
+    fn ring_modulus_nz(ring: &Ring) -> NonZero<BoxedUint> {
+        NonZero::new(ring.modulus().clone())
+            .into_option()
+            .expect("ring modulus is non-zero")
+    }
+
+    /// Reducing a wide `Z_n`-sized value into a small ring (`Z_r`-style) must
+    /// agree with a direct big-integer remainder — i.e. no high-bit truncation.
+    #[test]
+    fn reduce_wide_input_into_small_ring() {
+        let basis = CrtSystem::new(crate::dhim::config::p256::P256_PRIMES.to_vec()); // |n| ≈ 1458 bits
+        let big = basis.modulus().clone(); // a genuine ~1458-bit value
+
+        let small = Ring::new(BoxedUint::from(1_000_003u64)); // a prime ≪ n
+        let embedded = small.from_uint(&big);
+
+        // Direct reference: big mod 1_000_003, computed at the wide precision.
+        let m_wide = BoxedUint::from(1_000_003u64).resize(big.bits_precision());
+        let m_nz = NonZero::new(m_wide).into_option().unwrap();
+        let expected = big.rem_vartime(&m_nz).resize(small.precision());
+
+        assert_eq!(embedded.to_uint(), expected);
+    }
+}

--- a/crates/ole-core/src/dhim/rng.rs
+++ b/crates/ole-core/src/dhim/rng.rs
@@ -1,0 +1,39 @@
+//! RNG version bridge.
+//!
+//! mpz rides `rand_core` 0.9, but the `crypto-bigint` / `crypto-primes` 0.7
+//! line moved to `rand_core` 0.10 — so their RNG traits are distinct types and
+//! an mpz RNG can't be handed to `random_prime` / `random_mod_vartime`
+//! directly.
+//!
+//! In `rand_core` 0.10 the core trait is the fallible [`TryRng`], with
+//! `Rng: TryRng<Error = Infallible>` and `CryptoRng: Rng + TryCryptoRng` both
+//! blanket-implemented. [`Compat`] implements `TryRng`/`TryCryptoRng` over a
+//! `rand_core` 0.9 RNG (whose methods are infallible), so it picks up `Rng` and
+//! `CryptoRng` automatically.
+
+use core::convert::Infallible;
+
+use crypto_bigint::rand_core::{TryCryptoRng, TryRng};
+
+/// Wraps a `rand_core` 0.9 RNG `R` so it satisfies crypto-bigint's `rand_core`
+/// 0.10 `Rng`/`CryptoRng` bounds.
+pub(crate) struct Compat<R: ?Sized>(pub(crate) R);
+
+impl<R: rand::RngCore + ?Sized> TryRng for Compat<R> {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.0.next_u32())
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.0.next_u64())
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.fill_bytes(dst);
+        Ok(())
+    }
+}
+
+impl<R: rand::CryptoRng + ?Sized> TryCryptoRng for Compat<R> {}

--- a/crates/ole-core/src/dhim/rot.rs
+++ b/crates/ole-core/src/dhim/rot.rs
@@ -1,0 +1,227 @@
+//! Random OT correlations over `Z_p` (Functionality 3.11).
+
+use std::collections::VecDeque;
+
+use crypto_bigint::{Limb, NonZero, Reciprocal, U128};
+use mpz_core::Block;
+use mpz_ot_core::rot::{ROTReceiver, ROTSender};
+
+/// One ROT correlation over `Z_p`, the **sender's** view.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RotSenderShare {
+    /// Message for choice bit `0`.
+    pub a0: u64,
+    /// Message for choice bit `1`.
+    pub a1: u64,
+}
+
+/// One ROT correlation over `Z_p`, the **receiver's** view.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RotReceiverShare {
+    /// The (random) choice bit `i`.
+    pub choice: bool,
+    /// The selected message `a_i`.
+    pub msg: u64,
+}
+
+/// A source of ROT **sender**-shares over `Z_p`, supplied externally.
+pub trait RotSenderSource {
+    /// Allocates `count` ROT correlations.
+    fn alloc(&mut self, count: usize);
+
+    /// Consumes and returns the next sender-share for a ROT over `Z_p`.
+    fn next_sender(&mut self, p: u64) -> RotSenderShare;
+}
+
+/// A source of ROT **receiver**-shares over `Z_p`, supplied externally.
+pub trait RotReceiverSource {
+    /// Allocates `count` ROT correlations.
+    fn alloc(&mut self, count: usize);
+
+    /// Consumes and returns the next receiver-share for a ROT over `Z_p`.
+    fn next_receiver(&mut self, p: u64) -> RotReceiverShare;
+}
+
+/// Exclusive upper bound on prime values indexed into [`BARRETT_RECIPROCALS`].
+/// Must exceed the largest CRT prime any config uses (P-256's largest is 1049).
+const BARRETT_MAX: usize = 1056;
+
+/// Barrett reciprocals for every divisor `v ∈ [1, BARRETT_MAX)`, indexed by
+/// value.
+static BARRETT_RECIPROCALS: [Reciprocal; BARRETT_MAX] = {
+    let mut t = [Reciprocal::default(); BARRETT_MAX];
+    let mut v = 1usize;
+    while v < BARRETT_MAX {
+        t[v] = Reciprocal::new(NonZero::<Limb>::new_unwrap(Limb::from_u64(v as u64)));
+        v += 1;
+    }
+    t
+};
+
+/// Reduces a 128-bit ROT message into `Z_p`. Assumes `p < BARRETT_MAX`.
+fn block_mod_p(b: Block, p: u64) -> u64 {
+    U128::from_le_slice(&b.to_bytes())
+        .rem_limb_with_reciprocal(&BARRETT_RECIPROCALS[p as usize])
+        .0
+}
+
+/// Sender-side adapter that turns wide (128-bit) random-OT correlations into
+/// the small per-prime `Z_p` shares the protocol consumes.
+pub struct BlockToZpSender<S> {
+    /// The wrapped provider of wide (128-bit) ROT sender-correlations.
+    inner: S,
+    /// Correlations pulled from `inner` but not yet dispensed: refilled in one
+    /// drain when empty, popped one per `next_sender`.
+    buf: VecDeque<[Block; 2]>,
+}
+
+impl<S: ROTSender<[Block; 2]>> BlockToZpSender<S> {
+    /// Wraps an mpz ROT sender provider.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            buf: VecDeque::new(),
+        }
+    }
+}
+
+impl<S: ROTSender<[Block; 2]>> RotSenderSource for BlockToZpSender<S> {
+    fn alloc(&mut self, count: usize) {
+        self.inner.alloc(count).expect("ROT sender alloc");
+    }
+
+    fn next_sender(&mut self, p: u64) -> RotSenderShare {
+        if self.buf.is_empty() {
+            // The pool is pre-flushed all-or-nothing, so drain everything the
+            // provider has in one pull; exhaustion is the only failure mode.
+            let n = self.inner.available();
+            assert!(n > 0, "ROT provider exhausted: pre-flush more correlations");
+            let out = self
+                .inner
+                .try_send_rot(n)
+                .expect("try_send_rot from a filled pool");
+            self.buf.extend(out.keys);
+        }
+        let [k0, k1] = self.buf.pop_front().expect("buffer refilled above");
+        RotSenderShare {
+            a0: block_mod_p(k0, p),
+            a1: block_mod_p(k1, p),
+        }
+    }
+}
+
+/// Receiver-side adapter that turns wide (128-bit) random-OT correlations into
+/// the small per-prime `Z_p` shares the protocol consumes.
+pub struct BlockToZpReceiver<R> {
+    /// The wrapped provider of wide (128-bit) ROT receiver-correlations.
+    inner: R,
+    /// `(choice, msg)` pairs pulled from `inner` but not yet dispensed:
+    /// refilled in one drain when empty, popped one per `next_receiver`.
+    buf: VecDeque<(bool, Block)>,
+}
+
+impl<R: ROTReceiver<bool, Block>> BlockToZpReceiver<R> {
+    /// Wraps an mpz ROT receiver provider.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            buf: VecDeque::new(),
+        }
+    }
+}
+
+impl<R: ROTReceiver<bool, Block>> RotReceiverSource for BlockToZpReceiver<R> {
+    fn alloc(&mut self, count: usize) {
+        self.inner.alloc(count).expect("ROT receiver alloc");
+    }
+
+    fn next_receiver(&mut self, p: u64) -> RotReceiverShare {
+        if self.buf.is_empty() {
+            // The pool is pre-flushed all-or-nothing, so drain everything the
+            // provider has in one pull; exhaustion is the only failure mode.
+            let n = self.inner.available();
+            assert!(n > 0, "ROT provider exhausted: pre-flush more correlations");
+            let out = self
+                .inner
+                .try_recv_rot(n)
+                .expect("try_recv_rot from a filled pool");
+            self.buf.extend(out.choices.into_iter().zip(out.msgs));
+        }
+        let (choice, msg) = self.buf.pop_front().expect("buffer refilled above");
+        RotReceiverShare {
+            choice,
+            msg: block_mod_p(msg, p),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{config::p256::P256_PRIMES, test_utils::preflushed_ideal_rot};
+
+    /// `block_mod_p` agrees with a direct `u128 % p` over boundary values and
+    /// the extreme CRT primes — pinning the Barrett-reciprocal reduction
+    /// path (including the little-endian interpretation of the block
+    /// bytes).
+    #[test]
+    fn block_mod_p_matches_reference() {
+        let values: [u128; 7] = [
+            0,
+            1,
+            u128::MAX,
+            1u128 << 64,
+            0x0123_4567_89ab_cdef_fedc_ba98_7654_3210,
+            12_345_678_901_234_567_890,
+            (1u128 << 127) | 1,
+        ];
+        // Smallest, a mid-range, and the largest P-256 prime.
+        for &p in &[5u64, 257, 1049] {
+            for &v in &values {
+                let b = Block::from(v.to_le_bytes());
+                assert_eq!(block_mod_p(b, p), (v % p as u128) as u64, "v={v}, p={p}");
+
+                // An exact multiple of p reduces to 0.
+                let mult = (v / p as u128) * p as u128;
+                assert_eq!(block_mod_p(Block::from(mult.to_le_bytes()), p), 0, "p={p}");
+            }
+        }
+    }
+
+    /// The Barrett table is large enough for every production CRT prime, so
+    /// `block_mod_p`'s `BARRETT_RECIPROCALS[p]` can never index out of bounds.
+    /// Promotes the comment on `BARRETT_MAX` to a checked invariant.
+    #[test]
+    fn barrett_table_covers_all_primes() {
+        let max_prime = *P256_PRIMES.iter().max().expect("non-empty prime set");
+        assert!(
+            (max_prime as usize) < BARRETT_MAX,
+            "largest CRT prime {max_prime} must be < BARRETT_MAX {BARRETT_MAX}"
+        );
+    }
+
+    /// The core ROT-over-`Z_p` guarantee, end-to-end through both adapters: the
+    /// receiver's reduced message equals the sender's message at the receiver's
+    /// choice bit, and every value lands in `[0, p)`. Also exercises the
+    /// drain-all-then-pop buffer path (one pull feeds all `COUNT` draws).
+    #[test]
+    fn adapters_preserve_rot_correlation() {
+        const COUNT: usize = 64;
+        for (seed, &p) in [5u64, 257, 1049].iter().enumerate() {
+            let (s_inner, r_inner) = preflushed_ideal_rot([seed as u8; 16], COUNT);
+            let mut sender = BlockToZpSender::new(s_inner);
+            let mut receiver = BlockToZpReceiver::new(r_inner);
+
+            for i in 0..COUNT {
+                let s = sender.next_sender(p);
+                let r = receiver.next_receiver(p);
+
+                assert!(s.a0 < p && s.a1 < p, "sender shares < p (i={i}, p={p})");
+                assert!(r.msg < p, "receiver msg < p (i={i}, p={p})");
+
+                let expected = if r.choice { s.a1 } else { s.a0 };
+                assert_eq!(r.msg, expected, "ROT selection wrong (i={i}, p={p})");
+            }
+        }
+    }
+}

--- a/crates/ole-core/src/dhim/sampler.rs
+++ b/crates/ole-core/src/dhim/sampler.rs
@@ -1,0 +1,97 @@
+//! Random-prime sampler.
+
+use crate::dhim::rng::Compat;
+use crypto_bigint::BoxedUint;
+use crypto_primes::{Flavor, random_prime};
+use rand::{CryptoRng, RngCore};
+
+/// Samples a uniformly random `bit_length`-bit prime `r`, excluding `q`.
+///
+/// # Panics
+///
+/// Panics if `bit_length` is too small to admit a prime
+/// with the top bit set.
+pub fn sample_random_prime<R: RngCore + CryptoRng + ?Sized>(
+    rng: &mut R,
+    bit_length: u32,
+    q: &BoxedUint,
+) -> BoxedUint {
+    let mut rng = Compat(rng);
+    loop {
+        let r: BoxedUint = random_prime(&mut rng, Flavor::Any, bit_length);
+        // `BoxedUint`'s `==` is value-based even across differing precisions,
+        // so `r` and `q` can be compared directly — no need to resize either to
+        // a common precision first.
+        if r != *q {
+            return r;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::crt::CrtSystem;
+    use crypto_bigint::{NonZero, Resize};
+    use crypto_primes::is_prime as cp_is_prime;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    /// Miller–Rabin primality test for a [`BoxedUint`] (delegates to
+    /// `crypto-primes`).
+    pub fn is_prime(candidate: &BoxedUint) -> bool {
+        cp_is_prime(Flavor::Any, candidate)
+    }
+
+    #[test]
+    fn samples_exact_bit_length_primes() {
+        let mut rng = ChaCha20Rng::seed_from_u64(7);
+        let q = BoxedUint::from(0u64); // never matches a prime
+        for _ in 0..10 {
+            let r = sample_random_prime(&mut rng, 143, &q);
+            assert_eq!(r.bits(), 143, "MSB set ⇒ exactly 143 bits");
+            assert!(is_prime(&r));
+        }
+    }
+
+    #[test]
+    fn coprime_to_smooth_modulus() {
+        let mut rng = ChaCha20Rng::seed_from_u64(1);
+        let basis = CrtSystem::new(crate::dhim::config::p256::P256_PRIMES.to_vec());
+        let q = BoxedUint::from(0u64);
+
+        let r = sample_random_prime(&mut rng, 143, &q);
+
+        // r ∤ n (r is far larger than any prime factor of n), so gcd(r, n) = 1.
+        let r_wide = r.clone().resize(basis.precision());
+        let r_nz = NonZero::new(r_wide).into_option().unwrap();
+        let n_mod_r = basis.modulus().rem_vartime(&r_nz);
+        assert!(!bool::from(n_mod_r.is_zero()));
+    }
+
+    #[test]
+    fn excludes_q() {
+        // Sample once, then re-sample with the same seed while excluding the
+        // first result: the exclusion must force a different prime.
+        let r1 = sample_random_prime(
+            &mut ChaCha20Rng::seed_from_u64(9),
+            32,
+            &BoxedUint::from(0u64),
+        );
+        let r2 = sample_random_prime(&mut ChaCha20Rng::seed_from_u64(9), 32, &r1);
+
+        assert!(is_prime(&r1) && is_prime(&r2));
+        assert_ne!(r1, r2, "the excluded prime must not be returned");
+    }
+
+    /// `BoxedUint`'s `==` is value-based across differing precisions — the
+    /// property `sample_random_prime`'s `q` exclusion relies on.
+    #[test]
+    fn boxed_uint_equality_is_value_based() {
+        let five_small = BoxedUint::from(5u64); // 64-bit precision
+        let five_wide = BoxedUint::from(5u64).resize(512);
+        let seven = BoxedUint::from(7u64);
+        assert_eq!(five_small, five_wide);
+        assert_ne!(five_small, seven);
+    }
+}

--- a/crates/ole-core/src/dhim/sampler.rs
+++ b/crates/ole-core/src/dhim/sampler.rs
@@ -11,7 +11,7 @@ use rand::{CryptoRng, RngCore};
 ///
 /// Panics if `bit_length` is too small to admit a prime
 /// with the top bit set.
-pub fn sample_random_prime<R: RngCore + CryptoRng + ?Sized>(
+pub(crate) fn sample_random_prime<R: RngCore + CryptoRng + ?Sized>(
     rng: &mut R,
     bit_length: u32,
     q: &BoxedUint,
@@ -39,7 +39,7 @@ mod tests {
 
     /// Miller–Rabin primality test for a [`BoxedUint`] (delegates to
     /// `crypto-primes`).
-    pub fn is_prime(candidate: &BoxedUint) -> bool {
+    pub(crate) fn is_prime(candidate: &BoxedUint) -> bool {
         cp_is_prime(Flavor::Any, candidate)
     }
 

--- a/crates/ole-core/src/dhim/sampler.rs
+++ b/crates/ole-core/src/dhim/sampler.rs
@@ -28,6 +28,12 @@ pub(crate) fn sample_random_prime<R: RngCore + CryptoRng + ?Sized>(
     }
 }
 
+/// Returns `true` iff `r` is a valid consistency prime — i.e. `r ∈
+/// 𝒫_{s_r}\{q}`: a prime of exactly `bit_length` bits, not equal to `q`.
+pub(crate) fn is_valid_consistency_prime(r: &BoxedUint, bit_length: u32, q: &BoxedUint) -> bool {
+    r.bits() == bit_length && r != q && crypto_primes::is_prime(Flavor::Any, r)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ole-core/src/dhim/sender.rs
+++ b/crates/ole-core/src/dhim/sender.rs
@@ -1,0 +1,505 @@
+//! OLE Sender.
+
+use crypto_bigint::BoxedUint;
+use mpz_core::hash::Hash;
+use mpz_fields::Field;
+use rand::Rng;
+
+use crate::dhim::{config::Config, rot::RotSenderSource};
+
+use super::{ring::Ring, wmult};
+
+use super::{
+    Round1Recv, Round1Send, Round2Recv, Round2Send, Round3Recv, Round3Send, random_bits,
+    reduce_to_field,
+};
+
+/// OLE Sender.
+pub struct OleSender<F> {
+    /// Protocol config.
+    config: &'static Config,
+    /// Input mask `a'`.
+    a_prime: BoxedUint,
+    /// `a'` reduced into `F`.
+    a_prime_mod_q: F,
+    /// One `Wmult` sender per prime.
+    wmults: Vec<wmult::Sender>,
+    /// oˢ.
+    o_s: Option<BoxedUint>,
+    /// The receiver's commitment to `(x'_p, oᴿ_p)`.
+    commitment: Option<Hash>,
+    /// Which round is expected next.
+    state: SenderState,
+}
+
+impl<F: Field> OleSender<F> {
+    /// Initializes the sender.
+    pub fn new<R: Rng + ?Sized>(config: &'static Config, rng: &mut R) -> Self {
+        let basis = config.crt;
+        // a' ←$ [0, 2^|s_a|): wide mask hiding a ∈ Z_q.
+        let a_prime = random_bits(rng, config.params.s_a_bits, basis.precision());
+
+        let a_res = basis.encode(&a_prime);
+        // Reduce a' into F (a' mod q).
+        let a_prime_mod_q = reduce_to_field::<F>(&a_prime, config.q);
+
+        // Build one `Wmult` sender per prime.
+        let wmults = basis
+            .primes()
+            .iter()
+            .zip(a_res)
+            .map(|(&p, a)| wmult::Sender::new(a, p))
+            .collect();
+        Self {
+            config,
+            a_prime,
+            a_prime_mod_q,
+            wmults,
+            o_s: None,
+            commitment: None,
+            state: SenderState::Initialized,
+        }
+    }
+
+    /// Allocates resources.
+    pub fn alloc<SS: RotSenderSource>(&mut self, rot: &mut SS) -> Result<(), OleSenderError> {
+        self.check_state(SenderState::Initialized)?;
+        for w in &mut self.wmults {
+            w.alloc(rot)?;
+        }
+        self.state = SenderState::Allocated;
+        Ok(())
+    }
+
+    /// Runs round 1 and returns a message to send.
+    pub fn round1<SS>(
+        &mut self,
+        rot: &mut SS,
+        msg: &Round1Recv,
+    ) -> Result<Round1Send, OleSenderError>
+    where
+        SS: RotSenderSource,
+    {
+        self.check_state(SenderState::Allocated)?;
+
+        // Unpack the flattened flips into one request per prime (one blob-length
+        // check, in place of the old per-prime count guard).
+        let recv_msgs = match msg.unpack(self.config.crt) {
+            Ok(v) => v,
+            Err(e) => {
+                self.state = SenderState::Failed;
+                return Err(e.into());
+            }
+        };
+
+        // Protocol 5.14 step 3 (OT phase of Protocol 5.11): produce the COT
+        // corrections. `τ` is not yet known — the receiver reveals it only
+        // after these corrections are fixed (Protocol 5.11 step 3) — so oˢ is
+        // deferred to round 2; each `Wmult` keeps its pads internally.
+        let mut send_msgs = Vec::with_capacity(self.wmults.len());
+        for (w, m_in) in self.wmults.iter_mut().zip(recv_msgs.iter()) {
+            let m = match w.respond(rot, m_in) {
+                Ok(m) => m,
+                Err(e) => {
+                    // Poison: ROT shares may already be consumed, so the
+                    // sender cannot meaningfully retry this round.
+                    self.state = SenderState::Failed;
+                    return Err(e.into());
+                }
+            };
+            send_msgs.push(m);
+        }
+
+        self.state = SenderState::Round2;
+        Ok(Round1Send::pack(&send_msgs, self.config.crt))
+    }
+
+    /// Runs round 2 and returns a message to send.
+    pub fn round2(&mut self, msg: &Round2Recv) -> Result<Round2Send, OleSenderError> {
+        self.check_state(SenderState::Round2)?;
+
+        let basis = self.config.crt;
+
+        // Protocol 5.11 step 3: `τ` arrives now that the corrections are
+        // fixed; compute oˢ (Protocol 5.14 step 3).
+        let taus = wmult::derive_taus(msg.tau_seed, basis.primes());
+        let os_res: Result<Vec<u64>, _> = self
+            .wmults
+            .iter()
+            .zip(&taus)
+            .map(|(w, tau)| w.output(tau))
+            .collect();
+        let os_res = match os_res {
+            Ok(v) => v,
+            Err(e) => {
+                self.state = SenderState::Failed;
+                return Err(e.into());
+            }
+        };
+        let o_s = basis.decode(&os_res);
+
+        // Protocol 5.14 step 6 and Protocol 5.38 step 3.
+        let ring_r = Ring::new(msg.r.clone());
+        let os_mod_r = ring_r.from_uint(&o_s).to_uint();
+        let a_prime_mod_r = ring_r.from_uint(&self.a_prime).to_uint();
+
+        self.o_s = Some(o_s);
+
+        self.commitment = Some(msg.commitment);
+
+        self.state = SenderState::Round3;
+        Ok(Round2Send {
+            os_mod_r,
+            a_prime_mod_r,
+        })
+    }
+
+    /// Runs round 3 and returns a message to send.
+    pub fn round3(self, a: F, b: F, msg: &Round3Recv<F>) -> Result<Round3Send<F>, OleSenderError> {
+        self.check_state(SenderState::Round3)?;
+        let q = self.config.q;
+        let crt = self.config.crt;
+        let o_s = self.o_s.expect("round2 must run first");
+
+        // Protocol 5.14 step 8a.
+        let commitment = self.commitment.expect("round2 must run first");
+        msg.opening
+            .verify(&commitment)
+            .map_err(|_| OleSenderError::ConsistencyCheck)?;
+        let (x_p_bytes, o_r_p_bytes) = msg.opening.data();
+        let ring_p = Ring::new(self.config.p.clone());
+        let prec = self.config.p.bits_precision();
+
+        // Reduce the opened residues into Z_p; reject ill-formed bytes rather than
+        // panic.
+        let x_p = ring_p.from_uint(
+            &BoxedUint::from_be_slice(x_p_bytes, prec)
+                .map_err(|_| OleSenderError::ConsistencyCheck)?,
+        );
+        let o_r_p = ring_p.from_uint(
+            &BoxedUint::from_be_slice(o_r_p_bytes, prec)
+                .map_err(|_| OleSenderError::ConsistencyCheck)?,
+        );
+        let lhs = &(&o_r_p + &ring_p.from_uint(&o_s)) - &(&ring_p.from_uint(&self.a_prime) * &x_p);
+        if lhs != ring_p.zero() && lhs != ring_p.from_uint(crt.modulus()) {
+            return Err(OleSenderError::ConsistencyCheck);
+        }
+
+        // a' mod q was reduced into F back in `new`.
+        let a_prime_f = self.a_prime_mod_q;
+        // The line (a, b) enters here: δ_a = a − a', δ_b = b + oˢ + a'·δ_x.
+        let delta_a = a - a_prime_f;
+        let delta_b = b + reduce_to_field::<F>(&o_s, q) + a_prime_f * msg.delta_x;
+        Ok(Round3Send { delta_a, delta_b })
+    }
+
+    /// Errors with `OutOfOrder` unless the sender is in `expected`.
+    fn check_state(&self, expected: SenderState) -> Result<(), OleSenderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(OleSenderError::OutOfOrder {
+                expected: expected.name(),
+                found: self.state.name(),
+            })
+        }
+    }
+}
+
+/// Where an [`OleSender`] is in its lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SenderState {
+    Initialized,
+    Allocated,
+    Round2,
+    Round3,
+    Failed,
+}
+
+impl SenderState {
+    const fn name(self) -> &'static str {
+        match self {
+            SenderState::Initialized => "initialized",
+            SenderState::Allocated => "allocated",
+            SenderState::Round2 => "round2",
+            SenderState::Round3 => "round3",
+            SenderState::Failed => "failed",
+        }
+    }
+}
+
+/// Error returned by an [`OleSender`] round.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OleSenderError {
+    /// A round was called in the wrong state: the method required state
+    /// `expected`, but the sender was at `found`.
+    OutOfOrder {
+        /// Name of the state the called round required.
+        expected: &'static str,
+        /// Name of the state the sender was actually in.
+        found: &'static str,
+    },
+    /// The receiver's round-1 message could not be unpacked (wrong blob
+    /// length for the CRT prime set).
+    Pack(crate::dhim::PackError),
+    /// A per-prime `Wmult` rejected the receiver's request.
+    Wmult(wmult::SenderError),
+    /// The mod-`p` consistency check (step 8a) failed.
+    ConsistencyCheck,
+}
+
+impl From<wmult::SenderError> for OleSenderError {
+    fn from(e: wmult::SenderError) -> Self {
+        OleSenderError::Wmult(e)
+    }
+}
+
+impl From<crate::dhim::PackError> for OleSenderError {
+    fn from(e: crate::dhim::PackError) -> Self {
+        OleSenderError::Pack(e)
+    }
+}
+
+impl std::fmt::Display for OleSenderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OleSenderError::OutOfOrder { expected, found } => write!(
+                f,
+                "OLE sender called out of order: expected state `{expected}`, was at `{found}`"
+            ),
+            OleSenderError::Pack(e) => write!(f, "OLE round-1 message malformed: {e}"),
+            OleSenderError::Wmult(e) => write!(f, "OLE Wmult failed: {e}"),
+            OleSenderError::ConsistencyCheck => write!(f, "OLE consistency check failed"),
+        }
+    }
+}
+
+impl std::error::Error for OleSenderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OleSenderError::Pack(e) => Some(e),
+            OleSenderError::Wmult(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{
+        OleReceiver, ReceiverResidues,
+        rot::{BlockToZpReceiver, BlockToZpSender},
+        test_utils::{preflushed_ideal_rot, rots_per_ole},
+    };
+    use mpz_core::commit::HashCommit;
+    use mpz_fields::p256::P256;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    /// A fresh sender in the `Initialized` state plus an (unconsumed) ROT
+    /// source, for exercising the state-machine guards in isolation.
+    fn fresh_sender(seed: u64) -> (OleSender<P256>, impl RotSenderSource) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, _r) = preflushed_ideal_rot([seed as u8; 16], count);
+        let rot = BlockToZpSender::new(s_inner);
+        let mut srng = ChaCha20Rng::seed_from_u64(seed);
+        let sender = OleSender::<P256>::new(cfg, &mut srng);
+        (sender, rot)
+    }
+
+    /// `round1` requires `Allocated`; calling it straight after `new` is
+    /// rejected (the guard fires before the message or ROT source is
+    /// touched).
+    #[test]
+    fn round1_before_alloc_is_out_of_order() {
+        let (mut sender, mut rot) = fresh_sender(21);
+        let dummy = Round1Recv { flips: Vec::new() };
+        assert_eq!(
+            sender.round1(&mut rot, &dummy).unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "allocated",
+                found: "initialized",
+            }
+        );
+    }
+
+    /// `alloc` is a one-shot `Initialized → Allocated` transition; a second
+    /// call is rejected.
+    #[test]
+    fn alloc_twice_is_out_of_order() {
+        let (mut sender, mut rot) = fresh_sender(22);
+        sender.alloc(&mut rot).expect("first alloc succeeds");
+        assert_eq!(
+            sender.alloc(&mut rot).unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "initialized",
+                found: "allocated",
+            }
+        );
+    }
+
+    /// A round-1 flips blob of the wrong length is rejected with
+    /// `Pack(WrongLength)`, and the sender is poisoned (no partial ROT
+    /// consumption can be retried).
+    #[test]
+    fn round1_rejects_wrong_flip_length() {
+        use crate::dhim::{PackError, wmult::ceil_log2};
+
+        let (mut sender, mut rot) = fresh_sender(25);
+        sender.alloc(&mut rot).expect("alloc succeeds");
+
+        let cfg = crate::dhim::config::p256::config();
+        let expected = cfg
+            .crt
+            .primes()
+            .iter()
+            .map(|&p| ceil_log2(p) as usize)
+            .sum::<usize>()
+            .div_ceil(8);
+        let short = Round1Recv { flips: Vec::new() };
+        assert_eq!(
+            sender.round1(&mut rot, &short).unwrap_err(),
+            OleSenderError::Pack(PackError::WrongLength { expected, found: 0 })
+        );
+        assert_eq!(
+            sender.round1(&mut rot, &short).unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "allocated",
+                found: "failed",
+            }
+        );
+    }
+
+    /// `round2` requires `Round2`; calling it before `round1` is rejected.
+    #[test]
+    fn round2_before_round1_is_out_of_order() {
+        let (mut sender, _rot) = fresh_sender(23);
+        let dummy = Round2Recv {
+            r: BoxedUint::from(5u64),
+            commitment: mpz_core::hash::Hash::from([0u8; 32]),
+            tau_seed: [0u8; 16],
+        };
+        assert_eq!(
+            sender.round2(&dummy).unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "round2",
+                found: "initialized",
+            }
+        );
+    }
+
+    /// `round3` requires `Round3`; calling it before `round2` is rejected (it
+    /// consumes `self`, so this is a one-shot check).
+    #[test]
+    fn round3_before_round2_is_out_of_order() {
+        let (sender, _rot) = fresh_sender(24);
+        let dummy = Round3Recv {
+            delta_x: P256::zero(),
+            opening: mpz_core::commit::Decommitment::new((Vec::new(), Vec::new())),
+        };
+        assert_eq!(
+            sender
+                .round3(P256::zero(), P256::zero(), &dummy)
+                .unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "round3",
+                found: "initialized",
+            }
+        );
+    }
+
+    /// Drives an honest sender+receiver through flight 4, returning the sender
+    /// poised at `round3` (with the receiver's genuine commitment stashed), the
+    /// receiver poised at `round3`, and the sender's flight-4 message `m4`.
+    fn drive_to_round3(seed: u64) -> (OleSender<P256>, OleReceiver<P256>, Round2Send) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, r_inner) = preflushed_ideal_rot([seed as u8; 16], count);
+        let mut s_rot = BlockToZpSender::new(s_inner);
+        let mut r_rot = BlockToZpReceiver::new(r_inner);
+        let mut srng = ChaCha20Rng::seed_from_u64(1000 + seed);
+        let mut rrng = ChaCha20Rng::seed_from_u64(2000 + seed);
+
+        let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+        let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+        sender.alloc(&mut s_rot).expect("sender alloc");
+        receiver.alloc(&mut r_rot).expect("receiver alloc");
+
+        let m1 = receiver.round1(&mut r_rot).expect("receiver round1");
+        let m2 = sender.round1(&mut s_rot, &m1).expect("sender round1");
+        let m3 = receiver.round2(&m2).expect("receiver round2");
+        let m4 = sender.round2(&m3).expect("sender round2"); // stashes the genuine commitment
+        (sender, receiver, m4)
+    }
+
+    /// Step 8a (binding): an opening that doesn't match the receiver's round-2
+    /// commitment is rejected — a malicious receiver can't swap in different
+    /// `(x'_p, oᴿ_p)` after committing.
+    #[test]
+    fn step8a_rejects_opening_mismatching_commitment() {
+        let (sender, mut receiver, m4) = drive_to_round3(7);
+        let m5 = receiver.round3(P256::zero(), &m4).expect("receiver round3");
+
+        // Re-commit to *different* residues; its commitment won't match the one
+        // the sender stashed, so the opening fails to verify.
+        let other: ReceiverResidues = (vec![9u8; 8], vec![9u8; 8]);
+        let (other_opening, _) = other.hash_commit();
+        let tampered = Round3Recv {
+            delta_x: m5.delta_x,
+            opening: other_opening,
+        };
+        assert_eq!(
+            sender
+                .round3(P256::zero(), P256::zero(), &tampered)
+                .unwrap_err(),
+            OleSenderError::ConsistencyCheck
+        );
+    }
+
+    /// Step 8a (arithmetic): a *validly opened* commitment to residues that
+    /// violate `oᴿ_p + oˢ − a'·x'_p ∈ {0, n} mod p` is rejected — the
+    /// malicious-receiver (large-input) defense. We inject a commitment to
+    /// bogus residues `(x'_p, oᴿ_p) = (1, 1)` and open it honestly.
+    #[test]
+    fn step8a_rejects_inconsistent_residues() {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, r_inner) = preflushed_ideal_rot([8u8; 16], count);
+        let mut s_rot = BlockToZpSender::new(s_inner);
+        let mut r_rot = BlockToZpReceiver::new(r_inner);
+        let mut srng = ChaCha20Rng::seed_from_u64(8);
+        let mut rrng = ChaCha20Rng::seed_from_u64(108);
+
+        let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+        let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+        sender.alloc(&mut s_rot).unwrap();
+        receiver.alloc(&mut r_rot).unwrap();
+
+        let m1 = receiver.round1(&mut r_rot).unwrap();
+        let m2 = sender.round1(&mut s_rot, &m1).unwrap();
+        let m3 = receiver.round2(&m2).unwrap();
+
+        // Inject a commitment to bogus residues (1, 1); the sender stashes it.
+        let bogus: ReceiverResidues = (1u64.to_be_bytes().to_vec(), 1u64.to_be_bytes().to_vec());
+        let (opening, commitment) = bogus.hash_commit();
+        let m3_bad = Round2Recv {
+            r: m3.r.clone(),
+            commitment,
+            tau_seed: m3.tau_seed,
+        };
+        sender.round2(&m3_bad).unwrap();
+
+        let m5_bad = Round3Recv {
+            delta_x: P256::zero(),
+            opening,
+        };
+        assert_eq!(
+            sender
+                .round3(P256::zero(), P256::zero(), &m5_bad)
+                .unwrap_err(),
+            OleSenderError::ConsistencyCheck
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/sender.rs
+++ b/crates/ole-core/src/dhim/sender.rs
@@ -7,7 +7,7 @@ use rand::Rng;
 
 use crate::dhim::{config::Config, rot::RotSenderSource};
 
-use super::{ring::Ring, wmult};
+use super::{ring::Ring, sampler, wmult};
 
 use super::{
     Round1Recv, Round1Send, Round2Recv, Round2Send, Round3Recv, Round3Send, random_bits,
@@ -117,6 +117,16 @@ impl<F: Field> OleSender<F> {
     /// Runs round 2 and returns a message to send.
     pub fn round2(&mut self, msg: &Round2Recv) -> Result<Round2Send, OleSenderError> {
         self.check_state(SenderState::Round2)?;
+
+        // Protocol 5.38 step 2 has the receiver send `r ←$ 𝒫_{s_r}\{q}` in the
+        // clear; unlike Protocol 5.14 there is no `Cmt&ModRvl`
+        // functionality to fence the domain, so the **sender** must
+        // reject an out-of-domain `r`.
+        if !sampler::is_valid_consistency_prime(&msg.r, self.config.params.s_r_bits, self.config.q)
+        {
+            self.state = SenderState::Failed;
+            return Err(OleSenderError::InvalidConsistencyPrime);
+        }
 
         let basis = self.config.crt;
 
@@ -250,6 +260,8 @@ pub enum OleSenderError {
     Wmult(wmult::SenderError),
     /// The mod-`p` consistency check (step 8a) failed.
     ConsistencyCheck,
+    /// The receiver-supplied consistency prime `r` was not in `𝒫_{s_r}\{q}`.
+    InvalidConsistencyPrime,
 }
 
 impl From<wmult::SenderError> for OleSenderError {
@@ -274,6 +286,12 @@ impl std::fmt::Display for OleSenderError {
             OleSenderError::Pack(e) => write!(f, "OLE round-1 message malformed: {e}"),
             OleSenderError::Wmult(e) => write!(f, "OLE Wmult failed: {e}"),
             OleSenderError::ConsistencyCheck => write!(f, "OLE consistency check failed"),
+            OleSenderError::InvalidConsistencyPrime => {
+                write!(
+                    f,
+                    "OLE consistency prime r is out of domain (not in 𝒫_{{s_r}}\\{{q}})"
+                )
+            }
         }
     }
 }
@@ -296,6 +314,7 @@ mod tests {
         rot::{BlockToZpReceiver, BlockToZpSender},
         test_utils::{preflushed_ideal_rot, rots_per_ole},
     };
+    use crypto_bigint::Resize;
     use mpz_core::commit::HashCommit;
     use mpz_fields::p256::P256;
     use rand::SeedableRng;
@@ -504,6 +523,82 @@ mod tests {
                 .round3(P256::zero(), P256::zero(), &m5_bad)
                 .unwrap_err(),
             OleSenderError::ConsistencyCheck
+        );
+    }
+
+    /// Drives an honest sender+receiver to the point where the sender is poised
+    /// at `round2`, returning that sender together with the receiver's genuine
+    /// flight-3 [`Round2Recv`] (so a test can tamper only the field it
+    /// targets).
+    fn drive_sender_to_round2(seed: u64) -> (OleSender<P256>, Round2Recv) {
+        let cfg = crate::dhim::config::p256::config();
+        let count = rots_per_ole(cfg);
+        let (s_inner, r_inner) = preflushed_ideal_rot([seed as u8; 16], count);
+        let mut s_rot = BlockToZpSender::new(s_inner);
+        let mut r_rot = BlockToZpReceiver::new(r_inner);
+        let mut srng = ChaCha20Rng::seed_from_u64(1000 + seed);
+        let mut rrng = ChaCha20Rng::seed_from_u64(2000 + seed);
+
+        let mut sender = OleSender::<P256>::new(cfg, &mut srng);
+        let mut receiver = OleReceiver::<P256>::new(cfg, &mut rrng);
+        sender.alloc(&mut s_rot).expect("sender alloc");
+        receiver.alloc(&mut r_rot).expect("receiver alloc");
+
+        let m1 = receiver.round1(&mut r_rot).expect("receiver round1");
+        let m2 = sender.round1(&mut s_rot, &m1).expect("sender round1");
+        let m3 = receiver.round2(&m2).expect("receiver round2");
+        (sender, m3)
+    }
+
+    /// Malicious-receiver key-recovery defense (Protocol 5.38 step 2): a
+    /// receiver that sends `r = q` instead of an `s_r`-bit prime is
+    /// rejected. Without the domain check the sender would return `a' mod
+    /// q`, which the receiver combines with `δ_a = a − a' mod q` (flight 6)
+    /// to recover the sender's secret `a`. `q` is `|q|`-bit (256), so it
+    /// fails the `s_r`-bit (143) length arm of the test. The abort poisons
+    /// the sender.
+    #[test]
+    fn round2_rejects_r_equal_to_q() {
+        let (mut sender, m3) = drive_sender_to_round2(42);
+        let cfg = crate::dhim::config::p256::config();
+
+        let bad = Round2Recv {
+            r: cfg.q.clone(),
+            commitment: m3.commitment,
+            tau_seed: m3.tau_seed,
+        };
+        assert_eq!(
+            sender.round2(&bad).unwrap_err(),
+            OleSenderError::InvalidConsistencyPrime
+        );
+        // Poisoned: any retry is rejected as out-of-order.
+        assert_eq!(
+            sender.round2(&bad).unwrap_err(),
+            OleSenderError::OutOfOrder {
+                expected: "round2",
+                found: "failed",
+            }
+        );
+    }
+
+    /// The domain test also rejects a *composite* `r` of the correct
+    /// bit-length, exercising the primality arm (not just the length arm).
+    /// `(honest prime) − 1` is even — hence composite — and still `s_r`
+    /// bits.
+    #[test]
+    fn round2_rejects_non_prime_r() {
+        let (mut sender, m3) = drive_sender_to_round2(43);
+        let prec = m3.r.bits_precision();
+        let composite = m3.r.wrapping_sub(BoxedUint::from(1u64).resize(prec));
+
+        let bad = Round2Recv {
+            r: composite,
+            commitment: m3.commitment,
+            tau_seed: m3.tau_seed,
+        };
+        assert_eq!(
+            sender.round2(&bad).unwrap_err(),
+            OleSenderError::InvalidConsistencyPrime
         );
     }
 }

--- a/crates/ole-core/src/dhim/sender.rs
+++ b/crates/ole-core/src/dhim/sender.rs
@@ -229,6 +229,10 @@ impl SenderState {
 }
 
 /// Error returned by an [`OleSender`] round.
+// `Wmult` carries the internal `wmult::SenderError`, which is surfaced only
+// opaquely (Display/source) — `wmult` is a crate-internal module, so the type
+// is intentionally not nameable in the public API.
+#[allow(private_interfaces)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OleSenderError {
     /// A round was called in the wrong state: the method required state

--- a/crates/ole-core/src/dhim/test_utils.rs
+++ b/crates/ole-core/src/dhim/test_utils.rs
@@ -1,0 +1,182 @@
+//! Ideal / in-memory ROT sources.
+
+use mpz_core::{Block, prg::Prg};
+use mpz_ot_core::{
+    ideal::rot::{IdealROTReceiver, IdealROTSender, ideal_rot},
+    rot::{ROTReceiver, ROTSender},
+};
+use rand::RngCore;
+
+use crate::dhim::{
+    config::Config,
+    rot::{RotReceiverShare, RotReceiverSource, RotSenderShare, RotSenderSource},
+};
+
+/// Total ROT correlations one OLE over `basis` consumes.
+pub fn rots_per_ole(config: &Config) -> usize {
+    config
+        .crt
+        .primes()
+        .iter()
+        .map(|&p| (u64::BITS - (p - 1).leading_zeros()) as usize)
+        .sum()
+}
+
+/// Draws one correlation `(a₀, a₁, choice)` deterministically from `prg`.
+///
+/// Both party views are derived from the *same* draw, so any two streams seeded
+/// identically and advanced in lockstep stay consistent.
+fn draw(prg: &mut Prg, p: u64) -> (u64, u64, bool) {
+    let a0 = draw_zp(prg, p);
+    let a1 = draw_zp(prg, p);
+    let choice = (draw_byte(prg) & 1) == 1;
+    (a0, a1, choice)
+}
+
+fn draw_zp(prg: &mut Prg, p: u64) -> u64 {
+    let mut b = [0u8; 8];
+    prg.fill_bytes(&mut b);
+    // Negligible modulo bias for p ≤ 1063 ≪ 2⁶⁴; ample for an ideal source.
+    u64::from_le_bytes(b) % p
+}
+
+fn draw_byte(prg: &mut Prg) -> u8 {
+    let mut b = [0u8; 1];
+    prg.fill_bytes(&mut b);
+    b[0]
+}
+
+/// In-memory ideal ROT source (Functionality 3.11) for tests and local
+/// simulation. Returns the **paired** sender and receiver views together, so
+/// consistency is guaranteed by construction.
+pub struct IdealRot {
+    prg: Prg,
+}
+
+impl IdealRot {
+    /// Creates an ideal source seeded by `seed`.
+    pub fn new(seed: [u8; 16]) -> Self {
+        Self {
+            prg: Prg::new_with_seed(seed),
+        }
+    }
+
+    /// Draws the next ROT correlation over `Z_p`, returning `(sender,
+    /// receiver)` views that satisfy `receiver.msg = if receiver.choice {
+    /// sender.a1 } else { sender.a0 }`.
+    pub fn next(&mut self, p: u64) -> (RotSenderShare, RotReceiverShare) {
+        let (a0, a1, choice) = draw(&mut self.prg, p);
+        let msg = if choice { a1 } else { a0 };
+        (RotSenderShare { a0, a1 }, RotReceiverShare { choice, msg })
+    }
+}
+
+/// Ideal ROT **sender** stream (one party's view of a shared correlation pool).
+pub struct IdealRotSender {
+    prg: Prg,
+}
+
+/// Ideal ROT **receiver** stream (one party's view of a shared correlation
+/// pool).
+pub struct IdealRotReceiver {
+    prg: Prg,
+}
+
+/// Creates a consistent ideal sender/receiver pair from a shared `seed`.
+///
+/// Both streams derive identical correlations as long as they are advanced in
+/// lockstep (same sequence of `next_*` calls with the same primes) — which the
+/// upper-layer protocols do by construction.
+pub fn ideal_rot_pair(seed: [u8; 16]) -> (IdealRotSender, IdealRotReceiver) {
+    (
+        IdealRotSender {
+            prg: Prg::new_with_seed(seed),
+        },
+        IdealRotReceiver {
+            prg: Prg::new_with_seed(seed),
+        },
+    )
+}
+
+impl RotSenderSource for IdealRotSender {
+    // PRG-backed infinite stream: correlations are drawn on demand, so there is
+    // nothing to pre-allocate.
+    fn alloc(&mut self, _count: usize) {}
+
+    fn next_sender(&mut self, p: u64) -> RotSenderShare {
+        let (a0, a1, _choice) = draw(&mut self.prg, p);
+        RotSenderShare { a0, a1 }
+    }
+}
+
+impl RotReceiverSource for IdealRotReceiver {
+    // PRG-backed infinite stream: nothing to pre-allocate.
+    fn alloc(&mut self, _count: usize) {}
+
+    fn next_receiver(&mut self, p: u64) -> RotReceiverShare {
+        let (a0, a1, choice) = draw(&mut self.prg, p);
+        let msg = if choice { a1 } else { a0 };
+        RotReceiverShare { choice, msg }
+    }
+}
+
+/// Builds a **pre-flushed** ideal ROT pair with `count` correlations ready to
+/// consume, for tests and benchmarks.
+pub fn preflushed_ideal_rot(seed: [u8; 16], count: usize) -> (IdealROTSender, IdealROTReceiver) {
+    let (mut sender, mut receiver) = ideal_rot(Block::from(seed));
+    sender.alloc(count).expect("alloc sender");
+    receiver.alloc(count).expect("alloc receiver");
+    let flush = sender.flush().expect("sender has pending correlations");
+    receiver.flush(flush).expect("receiver flush matches");
+    (sender, receiver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::rot::{RotReceiverSource, RotSenderSource};
+
+    #[test]
+    fn paired_shares_are_consistent() {
+        let mut pool = IdealRot::new([1u8; 16]);
+        for &p in &[5u64, 97, 1063] {
+            for _ in 0..200 {
+                let (s, r) = pool.next(p);
+                assert!(s.a0 < p && s.a1 < p);
+                assert_eq!(r.msg, if r.choice { s.a1 } else { s.a0 });
+            }
+        }
+    }
+
+    #[test]
+    fn split_streams_stay_in_lockstep() {
+        let (mut send, mut recv) = ideal_rot_pair([42u8; 16]);
+        for &p in &[7u64, 101, 1009] {
+            for _ in 0..200 {
+                let s = send.next_sender(p);
+                let r = recv.next_receiver(p);
+                assert!(s.a0 < p && s.a1 < p);
+                assert_eq!(r.msg, if r.choice { s.a1 } else { s.a0 });
+            }
+        }
+    }
+
+    #[test]
+    fn choice_bit_is_not_constant() {
+        let (mut send, mut recv) = ideal_rot_pair([7u8; 16]);
+        let mut zeros = 0;
+        let mut ones = 0;
+        for _ in 0..500 {
+            let _ = send.next_sender(1063);
+            if recv.next_receiver(1063).choice {
+                ones += 1;
+            } else {
+                zeros += 1;
+            }
+        }
+        assert!(
+            zeros > 50 && ones > 50,
+            "choice bit looks degenerate: {zeros}/{ones}"
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/wmult.rs
+++ b/crates/ole-core/src/dhim/wmult.rs
@@ -1,0 +1,221 @@
+//! Weak multiplication over a single prime `p` (Protocol 5.11).
+//!
+//! `Wmult_p` (Functionality 5.10) is a weak OLE over `Z_p`: on sender input
+//! `a` and receiver input `x` it produces an additive sharing of the product:
+//!
+//! z_S + z_R ≡ a · x   (mod p),
+//!
+//! with `z_S` held by the sender and `z_R` by the receiver.
+
+use mpz_core::prg::Prg;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+mod cot;
+mod receiver;
+mod sender;
+mod zp;
+
+pub use receiver::{Receiver, ReceiverError};
+pub use sender::{Sender, SenderError};
+
+/// A bit permutation `τ` for one `Wmult` (`ℓ = ⌈log₂ p⌉` entries).
+///
+/// `τ` maps a **processing slot** `i ∈ {0,…,ℓ−1}` — the i-th COT consumed, in
+/// order — to the **bit position** `τ(i) ∈ {0,…,ℓ−1}` of the value that slot
+/// handles: slot `i` reads bit `τ(i)` of its input and contributes weight
+/// `2^{τ(i)}`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Tau(Vec<usize>);
+
+impl Tau {
+    /// Samples a permutation of `{0,…,ℓ−1}` from `rng` — an unbiased
+    /// Fisher–Yates.
+    fn from_rng<R: Rng + ?Sized>(rng: &mut R, l: usize) -> Self {
+        use rand::seq::SliceRandom;
+        let mut tau: Vec<usize> = (0..l).collect();
+        tau.shuffle(rng);
+        Tau(tau)
+    }
+
+    /// ℓ — the number of slots / bit positions.
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// The bit position `τ(i)` handled by slot `i`.
+    fn bit_position(&self, slot: usize) -> usize {
+        self.0[slot]
+    }
+
+    /// The weight slot `i` contributes: `2^{τ(i)} mod p`.
+    fn weight(&self, slot: usize) -> u64 {
+        //Already `< p`, since `τ(i) ≤ ℓ−1` and `2^{ℓ−1} < p`.
+        1u64 << self.bit_position(slot)
+    }
+
+    /// The bits of `value` reordered into processing-slot order: entry `i` is
+    /// bit `τ(i)` of `value` (`value` must fit in `ℓ` bits).
+    fn permuted_bits(&self, value: u64) -> Vec<bool> {
+        (0..self.len())
+            .map(|i| (value >> self.bit_position(i)) & 1 == 1)
+            .collect()
+    }
+}
+
+/// The receiver → sender message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiverMsg {
+    /// COT flip bit `fᵢ = λᵢ ⊕ iᵢ` for each of the `ℓ` positions.
+    pub flips: Vec<bool>,
+}
+
+/// The sender → receiver message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SenderMsg {
+    /// `oᵢ = a₁ − a₀ − a mod p` for each of the `ℓ` positions.
+    pub corrections: Vec<u64>,
+}
+
+/// `⌈log₂ p⌉` for `p ≥ 2` — the number of bit positions / OTs a single `Wmult`
+/// over `p` consumes (and the count each side reserves in `alloc`). It is also
+/// the per-prime field width the round-1 packing uses: `ℓᵢ` flip bits, and
+/// `ℓᵢ` corrections of `ℓᵢ` bits each.
+pub(crate) fn ceil_log2(p: u64) -> u32 {
+    debug_assert!(p >= 2);
+    u64::BITS - (p - 1).leading_zeros()
+}
+
+/// Derives the per-prime permutations `(τ₁,…,τ_t)` for one OLE from a single
+/// `master` seed.
+///
+/// # Why `τ` is owned by the layer above, not by each [`Receiver`]
+///
+/// In Protocol 5.11 `τ` is the *receiver's* randomness, sent to the sender in
+/// step 3 — so the natural encapsulation would have each [`Receiver`] sample
+/// and emit its own `τ`. We deliberately don't: the receiver chooses one
+/// 16-byte master seed, both parties expand it here into all `t` permutations,
+/// and only that seed travels the wire. Sending `t` independent permutations
+/// instead would cost ~0.9–2.5 KB against a ~1.77 KB total for `|q| = 256`.
+pub fn derive_taus(master: [u8; 16], primes: &[u64]) -> Vec<Tau> {
+    let mut prg = Prg::new_with_seed(master);
+    primes
+        .iter()
+        .map(|&p| Tau::from_rng(&mut prg, ceil_log2(p) as usize))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::test_utils::ideal_rot_pair;
+    use mpz_core::prg::Prg;
+
+    /// Runs one full Wmult over `p` with inputs `(a, x)` and returns
+    /// `(z_S, z_R)`.
+    fn run(seed: [u8; 16], rseed: [u8; 16], a: u64, x: u64, p: u64) -> (u64, u64) {
+        let (mut send, mut recv) = ideal_rot_pair(seed);
+        let mut rng = Prg::new_with_seed(rseed);
+        // Both parties derive the same τ from a shared master seed.
+        let tau = derive_taus([0x5Au8; 16], &[p]).remove(0);
+
+        let mut receiver = Receiver::new(x, p, tau.clone());
+        receiver.alloc(&mut recv).expect("receiver alloc");
+        let rmsg = receiver.request(&mut recv, &mut rng).expect("request");
+        let mut sender = Sender::new(a, p);
+        sender.alloc(&mut send).expect("sender alloc");
+        let smsg = sender.respond(&mut send, &rmsg).expect("ℓ flips");
+        // τ reaches the sender only after its corrections are fixed.
+        let z_s = sender.output(&tau).expect("output");
+        let z_r = receiver.finish(&smsg).expect("ℓ corrections");
+        (z_s, z_r)
+    }
+
+    /// The defining relation: `z_S + z_R ≡ a·x (mod p)` for all inputs.
+    #[test]
+    fn wmult_relation_holds() {
+        for &p in &[5u64, 7, 13, 97, 1009, 1063] {
+            for a in (0..p).step_by(((p / 23) + 1) as usize) {
+                for x in 0..p {
+                    let (z_s, z_r) = run([11u8; 16], [22u8; 16], a, x, p);
+                    assert_eq!((z_s + z_r) % p, (a * x) % p, "p={p} a={a} x={x}");
+                }
+            }
+        }
+    }
+
+    /// Correctness must be independent of the receiver's randomness (`c`, `τ`).
+    #[test]
+    fn relation_independent_of_receiver_randomness() {
+        let p = 1063;
+        let (a, x) = (777, 432);
+        for s in 0u8..20 {
+            let (z_s, z_r) = run([s; 16], [s.wrapping_add(100); 16], a, x, p);
+            assert_eq!((z_s + z_r) % p, (a * x) % p);
+        }
+    }
+
+    /// `Tau::from_rng` yields a genuine permutation of `{0,…,ℓ−1}`, and a PRG
+    /// re-keyed from the same seed reproduces the same `τ` (both parties derive
+    /// the same permutation).
+    #[test]
+    fn from_rng_is_a_permutation() {
+        let p = 1063;
+        let l = ceil_log2(p) as usize;
+        let identity = (0..l).collect::<Vec<_>>();
+
+        for s in 0u8..50 {
+            let tau = Tau::from_rng(&mut Prg::new_with_seed([s; 16]), l);
+            let again = Tau::from_rng(&mut Prg::new_with_seed([s; 16]), l);
+            assert_eq!(tau, again, "deterministic in seed");
+            let mut seen: Vec<usize> = (0..l).map(|i| tau.bit_position(i)).collect();
+            seen.sort_unstable();
+            assert_eq!(seen, identity);
+        }
+    }
+
+    /// `Tau::permuted_bits` reorders the low ℓ bits of `value` by `τ`: output
+    /// slot `i` carries bit `τ(i)`. Checked independently of `τ` by a popcount
+    /// invariant, and as a lossless bijection by scattering each output bit
+    /// back to its source position `τ(i)` — which must recover `value`.
+    #[test]
+    fn permuted_bits_reorders_by_tau() {
+        let l = ceil_log2(1063) as usize; // ℓ for the largest CRT prime (11 bits)
+        let mask = (1u64 << l) - 1;
+        for s in 0u8..32 {
+            let tau = Tau::from_rng(&mut Prg::new_with_seed([s; 16]), l);
+            for value in [0, 1, 0b1010_0101, mask, (s as u64 * 37) & mask] {
+                let bits = tau.permuted_bits(value);
+                assert_eq!(bits.len(), l);
+
+                // τ only moves bits, so the set-bit count is preserved.
+                assert_eq!(
+                    bits.iter().filter(|&&b| b).count() as u32,
+                    value.count_ones()
+                );
+
+                // Scatter output bit `i` back to position `τ(i)` ⇒ recover `value`.
+                let recovered: u64 = bits
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &b)| (b as u64) << tau.bit_position(i))
+                    .sum();
+                assert_eq!(recovered, value, "s={s} value={value:#b}");
+            }
+        }
+    }
+
+    /// `ceil_log2(p)` is the smallest `ℓ` with `2^ℓ ≥ p` — i.e. `ℓ` COTs cover
+    /// every residue `< p`.
+    #[test]
+    fn ceil_log2_matches_reference() {
+        assert_eq!(ceil_log2(2), 1);
+        assert_eq!(ceil_log2(5), 3);
+        assert_eq!(ceil_log2(1063), 11); // largest CRT prime
+        for p in 2u64..4000 {
+            let l = ceil_log2(p);
+            assert!(1u64 << l >= p, "2^{l} < {p}");
+            assert!(1u64 << (l - 1) < p, "{p} ≤ 2^{} — not minimal", l - 1);
+        }
+    }
+}

--- a/crates/ole-core/src/dhim/wmult.rs
+++ b/crates/ole-core/src/dhim/wmult.rs
@@ -16,8 +16,8 @@ mod receiver;
 mod sender;
 mod zp;
 
-pub use receiver::{Receiver, ReceiverError};
-pub use sender::{Sender, SenderError};
+pub(crate) use receiver::{Receiver, ReceiverError};
+pub(crate) use sender::{Sender, SenderError};
 
 /// A bit permutation `τ` for one `Wmult` (`ℓ = ⌈log₂ p⌉` entries).
 ///
@@ -26,7 +26,7 @@ pub use sender::{Sender, SenderError};
 /// handles: slot `i` reads bit `τ(i)` of its input and contributes weight
 /// `2^{τ(i)}`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Tau(Vec<usize>);
+pub(crate) struct Tau(Vec<usize>);
 
 impl Tau {
     /// Samples a permutation of `{0,…,ℓ−1}` from `rng` — an unbiased
@@ -65,16 +65,16 @@ impl Tau {
 
 /// The receiver → sender message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ReceiverMsg {
+pub(crate) struct ReceiverMsg {
     /// COT flip bit `fᵢ = λᵢ ⊕ iᵢ` for each of the `ℓ` positions.
-    pub flips: Vec<bool>,
+    pub(crate) flips: Vec<bool>,
 }
 
 /// The sender → receiver message.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SenderMsg {
+pub(crate) struct SenderMsg {
     /// `oᵢ = a₁ − a₀ − a mod p` for each of the `ℓ` positions.
-    pub corrections: Vec<u64>,
+    pub(crate) corrections: Vec<u64>,
 }
 
 /// `⌈log₂ p⌉` for `p ≥ 2` — the number of bit positions / OTs a single `Wmult`
@@ -97,7 +97,7 @@ pub(crate) fn ceil_log2(p: u64) -> u32 {
 /// 16-byte master seed, both parties expand it here into all `t` permutations,
 /// and only that seed travels the wire. Sending `t` independent permutations
 /// instead would cost ~0.9–2.5 KB against a ~1.77 KB total for `|q| = 256`.
-pub fn derive_taus(master: [u8; 16], primes: &[u64]) -> Vec<Tau> {
+pub(crate) fn derive_taus(master: [u8; 16], primes: &[u64]) -> Vec<Tau> {
     let mut prg = Prg::new_with_seed(master);
     primes
         .iter()

--- a/crates/ole-core/src/dhim/wmult/cot.rs
+++ b/crates/ole-core/src/dhim/wmult/cot.rs
@@ -1,0 +1,106 @@
+//! Correlated OT over `Z_p` from random OT (Protocol 3.15).
+
+use crate::dhim::rot::{RotReceiverShare, RotSenderShare};
+
+use super::zp;
+
+/// The sender → receiver correction message `o` of Protocol 3.15.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Correction {
+    /// `o = a₁ − a₀ − δ mod p` (after the conditional swap).
+    pub o: u64,
+}
+
+/// **Receiver, step 1.** Returns the bit `f = choice ⊕ i` to send to the
+/// sender, where `i = rot.choice` is the ROT's random selection.
+pub fn receiver_flip(rot: &RotReceiverShare, choice: bool) -> bool {
+    choice ^ rot.choice
+}
+
+/// **Sender, step 2.** Consumes the ROT sender-share and the offset `δ`,
+/// applies the conditional swap dictated by `f`, and returns:
+///
+/// * the sender's `COT_p` output `a₀` (the random pad), and
+/// * the [`Correction`] `o` to send to the receiver.
+///
+/// Requires `delta < p` (and the ROT messages reduced mod `p`).
+pub fn sender_step(rot: RotSenderShare, delta: u64, f: bool, p: u64) -> (u64, Correction) {
+    debug_assert!(delta < p && rot.a0 < p && rot.a1 < p);
+    let (a0, a1) = if f {
+        (rot.a1, rot.a0)
+    } else {
+        (rot.a0, rot.a1)
+    };
+    // o = a₁ − a₀ − δ  (mod p)
+    let o = zp::sub(zp::sub(a1, a0, p), delta, p);
+    (a0, Correction { o })
+}
+
+/// **Receiver, step 3.** Consumes the ROT receiver-share, its real `choice`,
+/// and the sender's [`Correction`], and returns the `COT_p` output
+/// `a₀ + choice·δ`.
+pub fn receiver_output(rot: RotReceiverShare, choice: bool, corr: Correction, p: u64) -> u64 {
+    debug_assert!(rot.msg < p && corr.o < p);
+    if choice {
+        zp::sub(rot.msg, corr.o, p)
+    } else {
+        rot.msg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::test_utils::IdealRot;
+
+    /// End-to-end Protocol 3.15: drive one COT from one ideal ROT and check the
+    /// `COT_p` relation `receiver_out = sender_a₀ + choice·δ`.
+    fn run_one(pool: &mut IdealRot, p: u64, delta: u64, choice: bool) -> (u64, u64) {
+        let (s_share, r_share) = pool.next(p);
+        let f = receiver_flip(&r_share, choice);
+        let (sender_a0, corr) = sender_step(s_share, delta, f, p);
+        let receiver_out = receiver_output(r_share, choice, corr, p);
+        (sender_a0, receiver_out)
+    }
+
+    #[test]
+    fn cot_relation_holds() {
+        let mut pool = IdealRot::new([9u8; 16]);
+        // Deterministic spread of (delta, choice) over several primes.
+        for &p in &[5u64, 7, 13, 97, 1009, 1063] {
+            for k in 0..(2 * p) {
+                let delta = k % p;
+                let choice = (k / p) % 2 == 1;
+                let (a0, out) = run_one(&mut pool, p, delta, choice);
+                let expected = (a0 + (choice as u64 * delta) % p) % p;
+                assert_eq!(out, expected, "p={p} delta={delta} choice={choice}");
+            }
+        }
+    }
+
+    /// Same end-to-end check, but driven through the split [`ideal_rot_pair`]
+    /// sources (the consume-from-pool boundary the upper layers use).
+    #[test]
+    fn cot_relation_holds_via_split_sources() {
+        use crate::dhim::{
+            rot::{RotReceiverSource, RotSenderSource},
+            test_utils::ideal_rot_pair,
+        };
+
+        let (mut send, mut recv) = ideal_rot_pair([5u8; 16]);
+        for &p in &[5u64, 97, 1009, 1063] {
+            for k in 0..(2 * p) {
+                let delta = k % p;
+                let choice = (k / p) % 2 == 1;
+
+                let s_share = send.next_sender(p);
+                let r_share = recv.next_receiver(p);
+                let f = receiver_flip(&r_share, choice);
+                let (a0, corr) = sender_step(s_share, delta, f, p);
+                let out = receiver_output(r_share, choice, corr, p);
+
+                assert_eq!(out, (a0 + (choice as u64 * delta) % p) % p);
+            }
+        }
+    }
+}

--- a/crates/ole-core/src/dhim/wmult/cot.rs
+++ b/crates/ole-core/src/dhim/wmult/cot.rs
@@ -6,14 +6,14 @@ use super::zp;
 
 /// The sender → receiver correction message `o` of Protocol 3.15.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Correction {
+pub(crate) struct Correction {
     /// `o = a₁ − a₀ − δ mod p` (after the conditional swap).
-    pub o: u64,
+    pub(crate) o: u64,
 }
 
 /// **Receiver, step 1.** Returns the bit `f = choice ⊕ i` to send to the
 /// sender, where `i = rot.choice` is the ROT's random selection.
-pub fn receiver_flip(rot: &RotReceiverShare, choice: bool) -> bool {
+pub(crate) fn receiver_flip(rot: &RotReceiverShare, choice: bool) -> bool {
     choice ^ rot.choice
 }
 
@@ -24,7 +24,7 @@ pub fn receiver_flip(rot: &RotReceiverShare, choice: bool) -> bool {
 /// * the [`Correction`] `o` to send to the receiver.
 ///
 /// Requires `delta < p` (and the ROT messages reduced mod `p`).
-pub fn sender_step(rot: RotSenderShare, delta: u64, f: bool, p: u64) -> (u64, Correction) {
+pub(crate) fn sender_step(rot: RotSenderShare, delta: u64, f: bool, p: u64) -> (u64, Correction) {
     debug_assert!(delta < p && rot.a0 < p && rot.a1 < p);
     let (a0, a1) = if f {
         (rot.a1, rot.a0)
@@ -39,7 +39,12 @@ pub fn sender_step(rot: RotSenderShare, delta: u64, f: bool, p: u64) -> (u64, Co
 /// **Receiver, step 3.** Consumes the ROT receiver-share, its real `choice`,
 /// and the sender's [`Correction`], and returns the `COT_p` output
 /// `a₀ + choice·δ`.
-pub fn receiver_output(rot: RotReceiverShare, choice: bool, corr: Correction, p: u64) -> u64 {
+pub(crate) fn receiver_output(
+    rot: RotReceiverShare,
+    choice: bool,
+    corr: Correction,
+    p: u64,
+) -> u64 {
     debug_assert!(rot.msg < p && corr.o < p);
     if choice {
         zp::sub(rot.msg, corr.o, p)

--- a/crates/ole-core/src/dhim/wmult/receiver.rs
+++ b/crates/ole-core/src/dhim/wmult/receiver.rs
@@ -1,0 +1,271 @@
+//! Weak multiplication receiver.
+
+use rand::Rng;
+
+use crate::dhim::rot::{RotReceiverShare, RotReceiverSource};
+
+use super::{
+    ReceiverMsg, SenderMsg, Tau, ceil_log2,
+    cot::{self, Correction},
+};
+
+/// Weak multiplication receiver.
+pub struct Receiver {
+    /// Receiver input residue `x` (`x < p`).
+    x: u64,
+    /// The prime modulus.
+    p: u64,
+    /// Bit permutation `τ` (see [`Tau`]).
+    tau: Tau,
+    /// Chosen bits `λ`.
+    choices: Vec<bool>,
+    // Consumed ROT shares.
+    rot: Vec<RotReceiverShare>,
+    /// Which step is expected next.
+    state: ReceiverState,
+}
+
+impl Receiver {
+    /// Creates a `Wmult_p` receiver.
+    ///
+    /// # Arguments
+    ///
+    /// * `x` — the receiver's input residue, `x < p`.
+    /// * `p` — the CRT prime modulus this Wmult operates over.
+    /// * `tau` — the precomputed bit permutation `τ` (must have `⌈log₂ p⌉`
+    ///   entries).
+    pub fn new(x: u64, p: u64, tau: Tau) -> Self {
+        debug_assert!(x < p);
+        debug_assert_eq!(tau.len(), ceil_log2(p) as usize, "τ must have ℓ entries");
+        Self {
+            x,
+            p,
+            tau,
+            choices: Vec::new(),
+            rot: Vec::new(),
+            state: ReceiverState::Initialized,
+        }
+    }
+
+    /// Allocates resources.
+    pub fn alloc<S: RotReceiverSource>(&mut self, rot: &mut S) -> Result<(), ReceiverError> {
+        self.check_state(ReceiverState::Initialized)?;
+        rot.alloc(ceil_log2(self.p) as usize);
+        self.state = ReceiverState::Allocated;
+        Ok(())
+    }
+
+    /// Builds the receiver's request.
+    pub fn request<S: RotReceiverSource, R: Rng + ?Sized>(
+        &mut self,
+        rot: &mut S,
+        rng: &mut R,
+    ) -> Result<ReceiverMsg, ReceiverError> {
+        self.check_state(ReceiverState::Allocated)?;
+        let l = self.tau.len();
+
+        // Step 1a: choose c. If x + p ≥ 2^ℓ, c must be 0 to keep x + c·p < 2^ℓ;
+        // otherwise c is a uniform bit drawn from the private RNG.
+        let pow_l = 1u64 << l;
+        let c = if self.x + self.p >= pow_l {
+            0
+        } else {
+            rng.random::<bool>() as u64
+        };
+        let value = self.x + c * self.p; // < 2^ℓ, so it fits in ℓ bits
+
+        // Step 1b: reshuffle the bits of `value` into τ-permuted order.
+        let choices = self.tau.permuted_bits(value);
+
+        // Consume ℓ ROT receiver-shares and form the COT flip bits.
+        let mut rot_shares = Vec::with_capacity(l);
+        let mut flips = Vec::with_capacity(l);
+        for &choice in &choices {
+            let share = rot.next_receiver(self.p);
+            flips.push(cot::receiver_flip(&share, choice));
+            rot_shares.push(share);
+        }
+
+        self.choices = choices;
+        self.rot = rot_shares;
+        self.state = ReceiverState::Requested;
+        Ok(ReceiverMsg { flips })
+    }
+
+    /// Finishes the protocol and returns the output. Consumes the receiver.
+    pub fn finish(self, msg: &SenderMsg) -> Result<u64, ReceiverError> {
+        self.check_state(ReceiverState::Requested)?;
+        let l = self.tau.len();
+        if msg.corrections.len() != l {
+            return Err(ReceiverError::CorrectionCount {
+                expected: l,
+                found: msg.corrections.len(),
+            });
+        }
+
+        // Accumulate Σᵢ 2^{τ(i)}·zᵢ raw and reduce once: weights are distinct
+        // powers of two summing to 2^ℓ−1 and each zᵢ < p, so the sum is bounded
+        // by (2^ℓ−1)(p−1) < 2²² ≪ 2⁶⁴ — no overflow, no per-term reduction.
+        let mut acc = 0u64;
+        for i in 0..l {
+            let z_i = cot::receiver_output(
+                self.rot[i],
+                self.choices[i],
+                Correction {
+                    o: msg.corrections[i],
+                },
+                self.p,
+            );
+            acc += self.tau.weight(i) * z_i;
+        }
+        Ok(acc % self.p)
+    }
+
+    /// Errors with `OutOfOrder` unless the receiver is in `expected`.
+    fn check_state(&self, expected: ReceiverState) -> Result<(), ReceiverError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(ReceiverError::OutOfOrder {
+                expected: expected.name(),
+                found: self.state.name(),
+            })
+        }
+    }
+}
+
+/// Where a [`Receiver`] is in its lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReceiverState {
+    Initialized,
+    Allocated,
+    Requested,
+}
+
+impl ReceiverState {
+    const fn name(self) -> &'static str {
+        match self {
+            ReceiverState::Initialized => "initialized",
+            ReceiverState::Allocated => "allocated",
+            ReceiverState::Requested => "requested",
+        }
+    }
+}
+
+/// Error returned by a [`Receiver`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiverError {
+    /// A step was called in the wrong state: the method required state
+    /// `expected`, but the receiver was at `found`.
+    OutOfOrder {
+        /// Name of the state the called step required.
+        expected: &'static str,
+        /// Name of the state the receiver was actually in.
+        found: &'static str,
+    },
+    /// The sender's response carried the wrong number of corrections.
+    CorrectionCount {
+        /// `ℓ`, the number of corrections the prime requires.
+        expected: usize,
+        /// The number of corrections the response carried.
+        found: usize,
+    },
+}
+
+impl std::fmt::Display for ReceiverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReceiverError::OutOfOrder { expected, found } => write!(
+                f,
+                "Wmult receiver called out of order: expected state `{expected}`, was at `{found}`"
+            ),
+            ReceiverError::CorrectionCount { expected, found } => write!(
+                f,
+                "Wmult response carried {found} corrections, expected ℓ = {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ReceiverError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{test_utils::ideal_rot_pair, wmult::derive_taus};
+    use mpz_core::prg::Prg;
+
+    /// Drives a receiver to the `Requested` state over an ideal ROT stream.
+    fn requested(p: u64) -> Receiver {
+        let tau = derive_taus([7u8; 16], &[p]).remove(0);
+        let (_send, mut recv) = ideal_rot_pair([7u8; 16]);
+        let mut rng = Prg::new_with_seed([9u8; 16]);
+        let mut receiver = Receiver::new(5, p, tau);
+        receiver.alloc(&mut recv).expect("alloc");
+        receiver.request(&mut recv, &mut rng).expect("request");
+        receiver
+    }
+
+    /// A response with the wrong number of corrections is rejected — once the
+    /// receiver has actually issued its request.
+    #[test]
+    fn finish_rejects_wrong_correction_count() {
+        let p = 1063u64; // ℓ = 11
+        for found in [0usize, 10, 12] {
+            let receiver = requested(p);
+            let bad = SenderMsg {
+                corrections: vec![0; found],
+            };
+            assert_eq!(
+                receiver.finish(&bad).unwrap_err(),
+                ReceiverError::CorrectionCount {
+                    expected: 11,
+                    found,
+                }
+            );
+        }
+    }
+
+    /// `request` requires `Allocated`, `finish` requires `Requested`, and
+    /// `alloc` is a one-shot `Initialized → Allocated` transition.
+    #[test]
+    fn steps_are_state_guarded() {
+        let p = 1063u64;
+        let tau = derive_taus([2u8; 16], &[p]).remove(0);
+        let (_send, mut recv) = ideal_rot_pair([4u8; 16]);
+        let mut rng = Prg::new_with_seed([5u8; 16]);
+        let mut receiver = Receiver::new(3, p, tau);
+
+        // request before alloc.
+        assert_eq!(
+            receiver.request(&mut recv, &mut rng).unwrap_err(),
+            ReceiverError::OutOfOrder {
+                expected: "allocated",
+                found: "initialized",
+            }
+        );
+
+        receiver.alloc(&mut recv).expect("alloc");
+
+        // second alloc.
+        assert_eq!(
+            receiver.alloc(&mut recv).unwrap_err(),
+            ReceiverError::OutOfOrder {
+                expected: "initialized",
+                found: "allocated",
+            }
+        );
+
+        // finish before request (consumes the receiver).
+        let bad = SenderMsg {
+            corrections: vec![0; 11],
+        };
+        assert_eq!(
+            receiver.finish(&bad).unwrap_err(),
+            ReceiverError::OutOfOrder {
+                expected: "requested",
+                found: "allocated",
+            }
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/wmult/receiver.rs
+++ b/crates/ole-core/src/dhim/wmult/receiver.rs
@@ -10,7 +10,7 @@ use super::{
 };
 
 /// Weak multiplication receiver.
-pub struct Receiver {
+pub(crate) struct Receiver {
     /// Receiver input residue `x` (`x < p`).
     x: u64,
     /// The prime modulus.
@@ -34,7 +34,7 @@ impl Receiver {
     /// * `p` — the CRT prime modulus this Wmult operates over.
     /// * `tau` — the precomputed bit permutation `τ` (must have `⌈log₂ p⌉`
     ///   entries).
-    pub fn new(x: u64, p: u64, tau: Tau) -> Self {
+    pub(crate) fn new(x: u64, p: u64, tau: Tau) -> Self {
         debug_assert!(x < p);
         debug_assert_eq!(tau.len(), ceil_log2(p) as usize, "τ must have ℓ entries");
         Self {
@@ -48,7 +48,7 @@ impl Receiver {
     }
 
     /// Allocates resources.
-    pub fn alloc<S: RotReceiverSource>(&mut self, rot: &mut S) -> Result<(), ReceiverError> {
+    pub(crate) fn alloc<S: RotReceiverSource>(&mut self, rot: &mut S) -> Result<(), ReceiverError> {
         self.check_state(ReceiverState::Initialized)?;
         rot.alloc(ceil_log2(self.p) as usize);
         self.state = ReceiverState::Allocated;
@@ -56,12 +56,13 @@ impl Receiver {
     }
 
     /// Builds the receiver's request.
-    pub fn request<S: RotReceiverSource, R: Rng + ?Sized>(
+    pub(crate) fn request<S: RotReceiverSource, R: Rng + ?Sized>(
         &mut self,
         rot: &mut S,
         rng: &mut R,
     ) -> Result<ReceiverMsg, ReceiverError> {
         self.check_state(ReceiverState::Allocated)?;
+
         let l = self.tau.len();
 
         // Step 1a: choose c. If x + p ≥ 2^ℓ, c must be 0 to keep x + c·p < 2^ℓ;
@@ -93,8 +94,9 @@ impl Receiver {
     }
 
     /// Finishes the protocol and returns the output. Consumes the receiver.
-    pub fn finish(self, msg: &SenderMsg) -> Result<u64, ReceiverError> {
+    pub(crate) fn finish(self, msg: &SenderMsg) -> Result<u64, ReceiverError> {
         self.check_state(ReceiverState::Requested)?;
+
         let l = self.tau.len();
         if msg.corrections.len() != l {
             return Err(ReceiverError::CorrectionCount {
@@ -154,7 +156,7 @@ impl ReceiverState {
 
 /// Error returned by a [`Receiver`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReceiverError {
+pub(crate) enum ReceiverError {
     /// A step was called in the wrong state: the method required state
     /// `expected`, but the receiver was at `found`.
     OutOfOrder {

--- a/crates/ole-core/src/dhim/wmult/sender.rs
+++ b/crates/ole-core/src/dhim/wmult/sender.rs
@@ -1,0 +1,258 @@
+//! Weak multiplication sender.
+
+use crate::dhim::rot::RotSenderSource;
+
+use super::{ReceiverMsg, SenderMsg, Tau, ceil_log2, cot, zp};
+
+/// Weak multiplication sender.
+pub struct Sender {
+    /// Sender input residue `a` (`a < p`).
+    a: u64,
+    /// The prime modulus.
+    p: u64,
+    /// Per-slot COT pads `δᵢ`, stored by [`Sender::respond`] until `τ`
+    /// arrives and [`Sender::output`] consumes them.
+    pads: Vec<u64>,
+    /// Which step is expected next.
+    state: SenderState,
+}
+
+impl Sender {
+    /// Creates a new sender.
+    ///
+    /// # Arguments
+    ///
+    /// * `a` — the sender's input residue, `a < p`.
+    /// * `p` — the CRT prime modulus.
+    pub fn new(a: u64, p: u64) -> Self {
+        debug_assert!(a < p);
+        Self {
+            a,
+            p,
+            pads: Vec::new(),
+            state: SenderState::Initialized,
+        }
+    }
+
+    /// Allocates resources.
+    ///
+    /// # Errors
+    ///
+    /// [`SenderError::OutOfOrder`] unless the sender is freshly initialized.
+    pub fn alloc<S: RotSenderSource>(&mut self, rot: &mut S) -> Result<(), SenderError> {
+        self.check_state(SenderState::Initialized)?;
+
+        rot.alloc(ceil_log2(self.p) as usize);
+        self.state = SenderState::Allocated;
+        Ok(())
+    }
+
+    /// Processes the receiver request, returning the message for the
+    /// receiver.
+    ///
+    /// # Arguments
+    ///
+    /// * `rot` — the ROT sender-share source.
+    /// * `msg` — the receiver's request ([`ReceiverMsg`]).
+    pub fn respond<S: RotSenderSource>(
+        &mut self,
+        rot: &mut S,
+        msg: &ReceiverMsg,
+    ) -> Result<SenderMsg, SenderError> {
+        self.check_state(SenderState::Allocated)?;
+
+        let l = ceil_log2(self.p) as usize;
+        if msg.flips.len() != l {
+            self.state = SenderState::Failed;
+            return Err(SenderError::FlipCount {
+                expected: l,
+                found: msg.flips.len(),
+            });
+        }
+
+        let mut corrections = Vec::with_capacity(l);
+        let mut pads = Vec::with_capacity(l);
+        for i in 0..l {
+            let share = rot.next_sender(self.p);
+            // COT_p with sender offset δ = a; δ_i is the returned random pad.
+            let (delta_i, corr) = cot::sender_step(share, self.a, msg.flips[i], self.p);
+            corrections.push(corr.o);
+            pads.push(delta_i);
+        }
+
+        self.pads = pads;
+        self.state = SenderState::Responded;
+        Ok(SenderMsg { corrections })
+    }
+
+    /// Computes the sender's output `z_S = −Σᵢ 2^{τ(i)}·δᵢ mod p`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tau` does not have exactly `ℓ` entries.
+    pub fn output(&self, tau: &Tau) -> Result<u64, SenderError> {
+        self.check_state(SenderState::Responded)?;
+
+        let l = ceil_log2(self.p) as usize;
+        assert_eq!(tau.len(), l, "τ must have ℓ entries");
+
+        // Accumulate Σᵢ 2^{τ(i)}·δᵢ raw, then reduce and negate once: weights
+        // are distinct powers of two summing to 2^ℓ−1 and each δᵢ < p, so the
+        // sum is bounded by (2^ℓ−1)(p−1) < 2²² ≪ 2⁶⁴ — no overflow, no
+        // per-term reduction.
+        let mut acc = 0u64;
+        for (i, &delta_i) in self.pads.iter().enumerate() {
+            acc += tau.weight(i) * delta_i; // 2^{τ(i)}·δ_i, raw
+        }
+        Ok(zp::neg(acc % self.p, self.p)) // −Σ mod p
+    }
+
+    /// Errors with `OutOfOrder` unless the sender is in `expected`.
+    fn check_state(&self, expected: SenderState) -> Result<(), SenderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(SenderError::OutOfOrder {
+                expected: expected.name(),
+                found: self.state.name(),
+            })
+        }
+    }
+}
+
+/// Where a [`Sender`] is in its lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SenderState {
+    Initialized,
+    Allocated,
+    Responded,
+    Failed,
+}
+
+impl SenderState {
+    const fn name(self) -> &'static str {
+        match self {
+            SenderState::Initialized => "initialized",
+            SenderState::Allocated => "allocated",
+            SenderState::Responded => "responded",
+            SenderState::Failed => "failed",
+        }
+    }
+}
+
+/// Error returned by a [`Sender`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SenderError {
+    /// A step was called in the wrong state: the method required state
+    /// `expected`, but the sender was at `found`.
+    OutOfOrder {
+        /// Name of the state the called step required.
+        expected: &'static str,
+        /// Name of the state the sender was actually in.
+        found: &'static str,
+    },
+    /// The receiver's request carried the wrong number of flip bits.
+    FlipCount {
+        /// `ℓ`, the number of flip bits the prime requires.
+        expected: usize,
+        /// The number of flip bits the request carried.
+        found: usize,
+    },
+}
+
+impl std::fmt::Display for SenderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SenderError::OutOfOrder { expected, found } => write!(
+                f,
+                "Wmult sender called out of order: expected state `{expected}`, was at `{found}`"
+            ),
+            SenderError::FlipCount { expected, found } => write!(
+                f,
+                "Wmult request carried {found} flip bits, expected ℓ = {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SenderError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dhim::{test_utils::ideal_rot_pair, wmult::derive_taus};
+
+    /// A request with the wrong number of flips is rejected — before any ROT
+    /// share is consumed — and poisons the sender, so `output` is then
+    /// rejected as out-of-order. A fresh sender is used per case since the
+    /// first rejection is terminal.
+    #[test]
+    fn respond_rejects_wrong_flip_count() {
+        let p = 1063u64; // ℓ = 11
+        let tau = derive_taus([1u8; 16], &[p]).remove(0);
+        for found in [0usize, 10, 12] {
+            let (mut send, _recv) = ideal_rot_pair([3u8; 16]);
+            let mut sender = Sender::new(42, p);
+            sender.alloc(&mut send).expect("alloc");
+
+            let bad = ReceiverMsg {
+                flips: vec![false; found],
+            };
+            assert_eq!(
+                sender.respond(&mut send, &bad).unwrap_err(),
+                SenderError::FlipCount {
+                    expected: 11,
+                    found,
+                }
+            );
+            assert_eq!(
+                sender.output(&tau).unwrap_err(),
+                SenderError::OutOfOrder {
+                    expected: "responded",
+                    found: "failed",
+                }
+            );
+        }
+    }
+
+    /// `respond` requires `Allocated`, `output` requires `Responded`, and
+    /// `alloc` is a one-shot `Initialized → Allocated` transition.
+    #[test]
+    fn steps_are_state_guarded() {
+        let p = 1063u64;
+        let (mut send, _recv) = ideal_rot_pair([4u8; 16]);
+        let mut sender = Sender::new(7, p);
+        let tau = derive_taus([2u8; 16], &[p]).remove(0);
+
+        // respond before alloc.
+        let msg = ReceiverMsg {
+            flips: vec![false; 11],
+        };
+        assert_eq!(
+            sender.respond(&mut send, &msg).unwrap_err(),
+            SenderError::OutOfOrder {
+                expected: "allocated",
+                found: "initialized",
+            }
+        );
+
+        // output before respond.
+        sender.alloc(&mut send).expect("alloc");
+        assert_eq!(
+            sender.output(&tau).unwrap_err(),
+            SenderError::OutOfOrder {
+                expected: "responded",
+                found: "allocated",
+            }
+        );
+
+        // second alloc.
+        assert_eq!(
+            sender.alloc(&mut send).unwrap_err(),
+            SenderError::OutOfOrder {
+                expected: "initialized",
+                found: "allocated",
+            }
+        );
+    }
+}

--- a/crates/ole-core/src/dhim/wmult/sender.rs
+++ b/crates/ole-core/src/dhim/wmult/sender.rs
@@ -5,7 +5,7 @@ use crate::dhim::rot::RotSenderSource;
 use super::{ReceiverMsg, SenderMsg, Tau, ceil_log2, cot, zp};
 
 /// Weak multiplication sender.
-pub struct Sender {
+pub(crate) struct Sender {
     /// Sender input residue `a` (`a < p`).
     a: u64,
     /// The prime modulus.
@@ -24,7 +24,7 @@ impl Sender {
     ///
     /// * `a` — the sender's input residue, `a < p`.
     /// * `p` — the CRT prime modulus.
-    pub fn new(a: u64, p: u64) -> Self {
+    pub(crate) fn new(a: u64, p: u64) -> Self {
         debug_assert!(a < p);
         Self {
             a,
@@ -39,7 +39,7 @@ impl Sender {
     /// # Errors
     ///
     /// [`SenderError::OutOfOrder`] unless the sender is freshly initialized.
-    pub fn alloc<S: RotSenderSource>(&mut self, rot: &mut S) -> Result<(), SenderError> {
+    pub(crate) fn alloc<S: RotSenderSource>(&mut self, rot: &mut S) -> Result<(), SenderError> {
         self.check_state(SenderState::Initialized)?;
 
         rot.alloc(ceil_log2(self.p) as usize);
@@ -54,7 +54,7 @@ impl Sender {
     ///
     /// * `rot` — the ROT sender-share source.
     /// * `msg` — the receiver's request ([`ReceiverMsg`]).
-    pub fn respond<S: RotSenderSource>(
+    pub(crate) fn respond<S: RotSenderSource>(
         &mut self,
         rot: &mut S,
         msg: &ReceiverMsg,
@@ -90,7 +90,7 @@ impl Sender {
     /// # Panics
     ///
     /// Panics if `tau` does not have exactly `ℓ` entries.
-    pub fn output(&self, tau: &Tau) -> Result<u64, SenderError> {
+    pub(crate) fn output(&self, tau: &Tau) -> Result<u64, SenderError> {
         self.check_state(SenderState::Responded)?;
 
         let l = ceil_log2(self.p) as usize;
@@ -142,7 +142,7 @@ impl SenderState {
 
 /// Error returned by a [`Sender`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SenderError {
+pub(crate) enum SenderError {
     /// A step was called in the wrong state: the method required state
     /// `expected`, but the sender was at `found`.
     OutOfOrder {

--- a/crates/ole-core/src/dhim/wmult/zp.rs
+++ b/crates/ole-core/src/dhim/wmult/zp.rs
@@ -1,0 +1,35 @@
+//! Arithmetic in `Z_p` for a small prime `p`, over `u64`.
+//!
+//! All CRT moduli `pᵢ` satisfy `p ≤ 1063 < 2¹¹`, so operands stay well below
+//! `2³²`: additions never overflow `u64`.
+
+/// `a − b mod p`. Requires `a, b < p`.
+#[inline]
+pub(crate) fn sub(a: u64, b: u64, p: u64) -> u64 {
+    debug_assert!(a < p && b < p);
+    (a + p - b) % p
+}
+
+/// `−a mod p`. Requires `a < p`.
+#[inline]
+pub(crate) fn neg(a: u64, p: u64) -> u64 {
+    debug_assert!(a < p);
+    if a == 0 { 0 } else { p - a }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_reference() {
+        for &p in &[5u64, 7, 97, 1063] {
+            for a in 0..p {
+                for b in 0..p {
+                    assert_eq!(sub(a, b, p), (a + p - b) % p);
+                }
+                assert_eq!(neg(a, p), (p - a) % p);
+            }
+        }
+    }
+}

--- a/crates/ole-core/src/gilboa.rs
+++ b/crates/ole-core/src/gilboa.rs
@@ -1,0 +1,172 @@
+//! Semi-honest OLE via Gilboa's OT-based multiplication.
+//!
+//! Realizes (random) OLE over a field `F` by bit-decomposing the inputs and
+//! consuming `F::BIT_SIZE` random OTs per OLE (Gilboa, CRYPTO'99): one ROT per
+//! bit, the sender's masked correlations weighted by `2^i` to recover an
+//! additive sharing of the product `a·b`. Semi-honest only.
+
+mod receiver;
+mod sender;
+
+pub use receiver::{Receiver, ReceiverError};
+pub use sender::{Sender, SenderError};
+
+use hybrid_array::Array;
+use itybity::ToBits;
+use mpz_fields::Field;
+use serde::{Deserialize, Serialize};
+
+use crate::OLEShare;
+
+impl<F> OLEShare<F>
+where
+    F: Field,
+{
+    /// Creates a new OLE share for the sender.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - Input value, `a`.
+    /// * `masks` - Masks for the correlation.
+    #[inline]
+    pub(crate) fn new_ole_sender(
+        input: F,
+        masks: Array<[F; 2], F::BitSize>,
+    ) -> (Self, MaskedCorrelation<F>) {
+        // Compute additive share, `x`.
+        let add = masks
+            .as_slice()
+            .iter()
+            .enumerate()
+            .fold(F::zero(), |acc, (i, &[zero, _])| {
+                acc + F::two_pow(i as u32) * zero
+            });
+
+        let share = Self {
+            // Sender negates their additive share.
+            add: -add,
+            mul: input,
+        };
+
+        let masked = MaskedCorrelation(Array::from_fn(|i| {
+            let [zero, one] = masks[i];
+            zero - one + input
+        }));
+
+        (share, masked)
+    }
+
+    /// Creates a new OLE share for the receiver.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - Input value, `b`.
+    /// * `masks` - Chosen correlation masks.
+    /// * `corr` - Masked correlation from the sender.
+    #[inline]
+    pub(crate) fn new_ole_receiver(
+        input: F,
+        masks: Array<F, F::BitSize>,
+        corr: MaskedCorrelation<F>,
+    ) -> Self {
+        let delta_i = input.iter_lsb0();
+        let t_delta_i = masks.iter();
+        let corr = corr.0.iter();
+
+        // Compute additive share, `y`.
+        let add = delta_i.zip(corr).zip(t_delta_i).enumerate().fold(
+            F::zero(),
+            |acc, (i, ((delta, &u), &t))| {
+                let delta = if delta { F::one() } else { F::zero() };
+                acc + F::two_pow(i as u32) * (delta * u + t)
+            },
+        );
+
+        Self { add, mul: input }
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+pub struct SenderMasks<F: Field> {
+    pub masks: Vec<MaskedCorrelation<F>>,
+}
+
+/// Masked correlation of the sender.
+///
+/// This is the correlation which is sent to the receiver.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MaskedCorrelation<F: Field>(pub(crate) Array<F, F::BitSize>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ROLEReceiver, ROLEReceiverOutput, ROLESender, ROLESenderOutput, test::assert_ole};
+    use mpz_core::Block;
+    use mpz_fields::{gf2_128::Gf2_128, p256::P256};
+    use mpz_ot_core::{
+        ideal::rot::IdealROT,
+        rot::{AnyReceiver, AnySender},
+    };
+    use rand::{SeedableRng, distr::StandardUniform, prelude::Distribution, rngs::StdRng};
+
+    #[test]
+    fn test_ole_p256() {
+        test_ole::<P256>();
+    }
+
+    #[test]
+    fn test_ole_gf2_128() {
+        test_ole::<Gf2_128>();
+    }
+
+    fn test_ole<F: Field>()
+    where
+        StandardUniform: Distribution<F>,
+    {
+        let count = 8;
+        let mut rng = StdRng::seed_from_u64(0);
+        let ideal_rot = IdealROT::new(Block::random(&mut rng));
+
+        let rot_sender = AnySender::new(ideal_rot.clone());
+        let rot_receiver = AnyReceiver::new(ideal_rot);
+
+        let (mut sender, mut receiver) = (
+            Sender::<_, F>::new(Block::random(&mut rng), rot_sender),
+            Receiver::<_, F>::new(rot_receiver),
+        );
+
+        sender.alloc(count).unwrap();
+        receiver.alloc(count).unwrap();
+
+        assert!(sender.wants_send());
+        assert!(receiver.wants_recv());
+
+        sender.rot_mut().rot_mut().flush().unwrap();
+
+        let msg = sender.send().unwrap();
+        receiver.recv(msg).unwrap();
+
+        assert!(!sender.wants_send());
+        assert!(!receiver.wants_recv());
+        assert_eq!(sender.available(), count);
+        assert_eq!(receiver.available(), count);
+
+        let ROLESenderOutput {
+            id: sender_id,
+            shares: sender_shares,
+        } = sender.try_send_role(8).unwrap();
+        let ROLEReceiverOutput {
+            id: receiver_id,
+            shares: receiver_shares,
+        } = receiver.try_recv_role(8).unwrap();
+
+        assert_eq!(sender_id, receiver_id);
+        sender_shares
+            .into_iter()
+            .zip(receiver_shares)
+            .for_each(|(s, r)| {
+                assert_ole(s, r);
+            })
+    }
+}

--- a/crates/ole-core/src/gilboa/receiver.rs
+++ b/crates/ole-core/src/gilboa/receiver.rs
@@ -1,113 +1,123 @@
-//! ROLE sender.
+//! ROLE receiver.
 
 use std::collections::VecDeque;
 
 use hybrid_array::Array;
-use rand::SeedableRng;
 
 use mpz_common::future::{MaybeDone, Sender as OutputSender, new_output};
-use mpz_core::{Block, prg::Prg};
 use mpz_fields::Field;
-use mpz_ot_core::rot::{ROTSender, ROTSenderOutput};
+use mpz_ot_core::rot::{ROTReceiver, ROTReceiverOutput};
 
-use crate::{OLEId, OLEShare, ROLESender, ROLESenderOutput, SenderMasks};
+use super::SenderMasks;
+use crate::{OLEId, OLEShare, ROLEReceiver, ROLEReceiverOutput};
 
 #[derive(Debug)]
 struct Queued<F> {
     count: usize,
-    sender: OutputSender<ROLESenderOutput<F>>,
+    sender: OutputSender<ROLEReceiverOutput<F>>,
 }
 
-/// ROLE Sender wrapping a random OT sender.
+/// ROLE receiver wrapping a random OT receiver.
 #[derive(Debug)]
-pub struct Sender<T, F> {
+pub struct Receiver<T, F> {
     id: OLEId,
     alloc: usize,
     /// The total count of ROLEs in the `queue`.
     pending: usize,
     queue: VecDeque<Queued<F>>,
     rot: T,
-    prg: Prg,
     role: Vec<OLEShare<F>>,
 }
 
-impl<T, F> Sender<T, F> {
-    /// Creates a new ROLE sender.
+impl<T, F> Receiver<T, F> {
+    /// Creates a new ROLE receiver.
     ///
     /// # Arguments
     ///
-    /// * `seed` - Random seed for the sender.
-    /// * `rot` - Random OT sender.
-    pub fn new(seed: Block, rot: T) -> Self {
+    /// * `rot` - Random OT receiver.
+    pub fn new(rot: T) -> Self {
         Self {
             id: OLEId::default(),
             alloc: 0,
             pending: 0,
             queue: VecDeque::new(),
             rot,
-            prg: Prg::from_seed(seed),
             role: Vec::new(),
         }
     }
 
-    /// Returns the random OT sender.
+    /// Returns the random OT receiver.
     pub fn rot(&self) -> &T {
         &self.rot
     }
 
-    /// Returns a mutable reference to the random OT sender.
+    /// Returns a mutable reference to the random OT receiver.
     pub fn rot_mut(&mut self) -> &mut T {
         &mut self.rot
     }
 
-    /// Returns the random OT sender.
+    /// Returns the random OT receiver.
     pub fn into_inner(self) -> T {
         self.rot
     }
 }
 
-impl<T, F> Sender<T, F>
+impl<T, F> Receiver<T, F>
 where
-    T: ROTSender<[F; 2]>,
+    T: ROTReceiver<bool, F>,
     F: Field,
 {
-    /// Returns `true` if the sender wants to send.
-    pub fn wants_send(&self) -> bool {
+    /// Returns `true` if the receiver wants to receive.
+    pub fn wants_recv(&self) -> bool {
         self.alloc > 0
     }
 
-    /// Evaluates the OLEs as the sender.
-    pub fn send(&mut self) -> Result<SenderMasks<F>, SenderError> {
+    /// Receives the OLEs.
+    pub fn recv(&mut self, msg: SenderMasks<F>) -> Result<(), ReceiverError> {
+        let SenderMasks { masks } = msg;
+
         let count = self.alloc;
         if self.pending > count {
-            return Err(SenderError(ErrorRepr::InsufficientOle {
+            return Err(ReceiverError(ErrorRepr::InsufficientOle {
                 count: self.pending,
                 available: count,
             }));
+        } else if masks.len() != count {
+            return Err(ReceiverError(ErrorRepr::WrongCount {
+                expected: count,
+                actual: masks.len(),
+            }));
         }
 
-        let ROTSenderOutput { keys: masks, .. } = self
+        let ROTReceiverOutput {
+            choices,
+            msgs: corr,
+            ..
+        } = self
             .rot
-            .try_send_rot(count * F::BIT_SIZE)
-            .map_err(SenderError::ot)?;
+            .try_recv_rot(count * F::BIT_SIZE)
+            .map_err(ReceiverError::ot)?;
 
-        let (shares, masks): (Vec<_>, Vec<_>) = masks
+        let shares: Vec<OLEShare<F>> = choices
             .chunks(F::BIT_SIZE)
-            .map(|masks| {
-                OLEShare::new_ole_sender(
-                    F::rand(&mut self.prg),
-                    Array::try_from(masks)
+            .zip(corr.chunks(F::BIT_SIZE))
+            .zip(masks)
+            .map(|((bits, corr), mask)| {
+                OLEShare::new_ole_receiver(
+                    F::from_lsb0_iter(bits.iter().copied()),
+                    Array::<F, F::BitSize>::try_from(corr)
                         .expect("slice should have length of bit size of field element"),
+                    mask,
                 )
             })
-            .unzip();
+            .collect();
 
         let mut i = 0;
         for Queued { count, sender } in self.queue.drain(..) {
             let shares = shares[i..i + count].to_vec();
             i += count;
 
-            sender.send(ROLESenderOutput {
+            sender.send(ROLEReceiverOutput {
                 id: self.id.next(),
                 shares,
             });
@@ -118,22 +128,22 @@ where
         self.alloc = 0;
         self.pending = 0;
 
-        Ok(SenderMasks { masks })
+        Ok(())
     }
 }
 
-impl<T, F> ROLESender<F> for Sender<T, F>
+impl<T, F> ROLEReceiver<F> for Receiver<T, F>
 where
-    T: ROTSender<[F; 2]>,
+    T: ROTReceiver<bool, F>,
     F: Field,
 {
-    type Error = SenderError;
-    type Future = MaybeDone<ROLESenderOutput<F>>;
+    type Error = ReceiverError;
+    type Future = MaybeDone<ROLEReceiverOutput<F>>;
 
-    fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
+    fn alloc(&mut self, count: usize) -> Result<(), ReceiverError> {
         self.rot
             .alloc(count * F::BIT_SIZE)
-            .map_err(SenderError::ot)?;
+            .map_err(ReceiverError::ot)?;
 
         self.alloc += count;
 
@@ -144,9 +154,9 @@ where
         self.role.len()
     }
 
-    fn try_send_role(&mut self, count: usize) -> Result<ROLESenderOutput<F>, Self::Error> {
+    fn try_recv_role(&mut self, count: usize) -> Result<ROLEReceiverOutput<F>, Self::Error> {
         if count > self.role.len() {
-            return Err(SenderError(ErrorRepr::InsufficientOle {
+            return Err(ReceiverError(ErrorRepr::InsufficientOle {
                 count,
                 available: self.role.len(),
             }));
@@ -154,13 +164,13 @@ where
 
         let shares = self.role.drain(..count).collect();
 
-        Ok(ROLESenderOutput {
+        Ok(ROLEReceiverOutput {
             id: self.id.next(),
             shares,
         })
     }
 
-    fn queue_send_role(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
+    fn queue_recv_role(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
         let (sender, recv) = new_output();
 
         self.pending += count;
@@ -170,12 +180,12 @@ where
     }
 }
 
-/// Error for [`Sender`].
+/// Error for [`Receiver`].
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
-pub struct SenderError(#[from] ErrorRepr);
+pub struct ReceiverError(#[from] ErrorRepr);
 
-impl SenderError {
+impl ReceiverError {
     fn ot<E>(err: E) -> Self
     where
         E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
@@ -190,4 +200,6 @@ enum ErrorRepr {
     Ot(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("insufficient OLE, wanted: {count}, available: {available}")]
     InsufficientOle { count: usize, available: usize },
+    #[error("sender sent wrong number of OLEs, expected: {expected}, actual: {actual}")]
+    WrongCount { expected: usize, actual: usize },
 }

--- a/crates/ole-core/src/gilboa/sender.rs
+++ b/crates/ole-core/src/gilboa/sender.rs
@@ -1,122 +1,114 @@
-//! ROLE receiver.
+//! ROLE sender.
 
 use std::collections::VecDeque;
 
 use hybrid_array::Array;
+use rand::SeedableRng;
 
 use mpz_common::future::{MaybeDone, Sender as OutputSender, new_output};
+use mpz_core::{Block, prg::Prg};
 use mpz_fields::Field;
-use mpz_ot_core::rot::{ROTReceiver, ROTReceiverOutput};
+use mpz_ot_core::rot::{ROTSender, ROTSenderOutput};
 
-use crate::{OLEId, OLEShare, ROLEReceiver, ROLEReceiverOutput, SenderMasks};
+use super::SenderMasks;
+use crate::{OLEId, OLEShare, ROLESender, ROLESenderOutput};
 
 #[derive(Debug)]
 struct Queued<F> {
     count: usize,
-    sender: OutputSender<ROLEReceiverOutput<F>>,
+    sender: OutputSender<ROLESenderOutput<F>>,
 }
 
-/// ROLE receiver wrapping a random OT receiver.
+/// ROLE Sender wrapping a random OT sender.
 #[derive(Debug)]
-pub struct Receiver<T, F> {
+pub struct Sender<T, F> {
     id: OLEId,
     alloc: usize,
     /// The total count of ROLEs in the `queue`.
     pending: usize,
     queue: VecDeque<Queued<F>>,
     rot: T,
+    prg: Prg,
     role: Vec<OLEShare<F>>,
 }
 
-impl<T, F> Receiver<T, F> {
-    /// Creates a new ROLE receiver.
+impl<T, F> Sender<T, F> {
+    /// Creates a new ROLE sender.
     ///
     /// # Arguments
     ///
-    /// * `rot` - Random OT receiver.
-    pub fn new(rot: T) -> Self {
+    /// * `seed` - Random seed for the sender.
+    /// * `rot` - Random OT sender.
+    pub fn new(seed: Block, rot: T) -> Self {
         Self {
             id: OLEId::default(),
             alloc: 0,
             pending: 0,
             queue: VecDeque::new(),
             rot,
+            prg: Prg::from_seed(seed),
             role: Vec::new(),
         }
     }
 
-    /// Returns the random OT receiver.
+    /// Returns the random OT sender.
     pub fn rot(&self) -> &T {
         &self.rot
     }
 
-    /// Returns a mutable reference to the random OT receiver.
+    /// Returns a mutable reference to the random OT sender.
     pub fn rot_mut(&mut self) -> &mut T {
         &mut self.rot
     }
 
-    /// Returns the random OT receiver.
+    /// Returns the random OT sender.
     pub fn into_inner(self) -> T {
         self.rot
     }
 }
 
-impl<T, F> Receiver<T, F>
+impl<T, F> Sender<T, F>
 where
-    T: ROTReceiver<bool, F>,
+    T: ROTSender<[F; 2]>,
     F: Field,
 {
-    /// Returns `true` if the receiver wants to receive.
-    pub fn wants_recv(&self) -> bool {
+    /// Returns `true` if the sender wants to send.
+    pub fn wants_send(&self) -> bool {
         self.alloc > 0
     }
 
-    /// Receives the OLEs.
-    pub fn recv(&mut self, msg: SenderMasks<F>) -> Result<(), ReceiverError> {
-        let SenderMasks { masks } = msg;
-
+    /// Evaluates the OLEs as the sender.
+    pub fn send(&mut self) -> Result<SenderMasks<F>, SenderError> {
         let count = self.alloc;
         if self.pending > count {
-            return Err(ReceiverError(ErrorRepr::InsufficientOle {
+            return Err(SenderError(ErrorRepr::InsufficientOle {
                 count: self.pending,
                 available: count,
             }));
-        } else if masks.len() != count {
-            return Err(ReceiverError(ErrorRepr::WrongCount {
-                expected: count,
-                actual: masks.len(),
-            }));
         }
 
-        let ROTReceiverOutput {
-            choices,
-            msgs: corr,
-            ..
-        } = self
+        let ROTSenderOutput { keys: masks, .. } = self
             .rot
-            .try_recv_rot(count * F::BIT_SIZE)
-            .map_err(ReceiverError::ot)?;
+            .try_send_rot(count * F::BIT_SIZE)
+            .map_err(SenderError::ot)?;
 
-        let shares: Vec<OLEShare<F>> = choices
+        let (shares, masks): (Vec<_>, Vec<_>) = masks
             .chunks(F::BIT_SIZE)
-            .zip(corr.chunks(F::BIT_SIZE))
-            .zip(masks)
-            .map(|((bits, corr), mask)| {
-                OLEShare::new_ole_receiver(
-                    F::from_lsb0_iter(bits.iter().copied()),
-                    Array::<F, F::BitSize>::try_from(corr)
+            .map(|masks| {
+                OLEShare::new_ole_sender(
+                    F::rand(&mut self.prg),
+                    Array::try_from(masks)
                         .expect("slice should have length of bit size of field element"),
-                    mask,
                 )
             })
-            .collect();
+            .unzip();
 
         let mut i = 0;
         for Queued { count, sender } in self.queue.drain(..) {
             let shares = shares[i..i + count].to_vec();
             i += count;
 
-            sender.send(ROLEReceiverOutput {
+            sender.send(ROLESenderOutput {
                 id: self.id.next(),
                 shares,
             });
@@ -127,22 +119,22 @@ where
         self.alloc = 0;
         self.pending = 0;
 
-        Ok(())
+        Ok(SenderMasks { masks })
     }
 }
 
-impl<T, F> ROLEReceiver<F> for Receiver<T, F>
+impl<T, F> ROLESender<F> for Sender<T, F>
 where
-    T: ROTReceiver<bool, F>,
+    T: ROTSender<[F; 2]>,
     F: Field,
 {
-    type Error = ReceiverError;
-    type Future = MaybeDone<ROLEReceiverOutput<F>>;
+    type Error = SenderError;
+    type Future = MaybeDone<ROLESenderOutput<F>>;
 
-    fn alloc(&mut self, count: usize) -> Result<(), ReceiverError> {
+    fn alloc(&mut self, count: usize) -> Result<(), Self::Error> {
         self.rot
             .alloc(count * F::BIT_SIZE)
-            .map_err(ReceiverError::ot)?;
+            .map_err(SenderError::ot)?;
 
         self.alloc += count;
 
@@ -153,9 +145,9 @@ where
         self.role.len()
     }
 
-    fn try_recv_role(&mut self, count: usize) -> Result<ROLEReceiverOutput<F>, Self::Error> {
+    fn try_send_role(&mut self, count: usize) -> Result<ROLESenderOutput<F>, Self::Error> {
         if count > self.role.len() {
-            return Err(ReceiverError(ErrorRepr::InsufficientOle {
+            return Err(SenderError(ErrorRepr::InsufficientOle {
                 count,
                 available: self.role.len(),
             }));
@@ -163,13 +155,13 @@ where
 
         let shares = self.role.drain(..count).collect();
 
-        Ok(ROLEReceiverOutput {
+        Ok(ROLESenderOutput {
             id: self.id.next(),
             shares,
         })
     }
 
-    fn queue_recv_role(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
+    fn queue_send_role(&mut self, count: usize) -> Result<Self::Future, Self::Error> {
         let (sender, recv) = new_output();
 
         self.pending += count;
@@ -179,12 +171,12 @@ where
     }
 }
 
-/// Error for [`Receiver`].
+/// Error for [`Sender`].
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
-pub struct ReceiverError(#[from] ErrorRepr);
+pub struct SenderError(#[from] ErrorRepr);
 
-impl ReceiverError {
+impl SenderError {
     fn ot<E>(err: E) -> Self
     where
         E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
@@ -199,6 +191,4 @@ enum ErrorRepr {
     Ot(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("insufficient OLE, wanted: {count}, available: {available}")]
     InsufficientOle { count: usize, available: usize },
-    #[error("sender sent wrong number of OLEs, expected: {expected}, actual: {actual}")]
-    WrongCount { expected: usize, actual: usize },
 }

--- a/crates/ole-core/src/lib.rs
+++ b/crates/ole-core/src/lib.rs
@@ -11,27 +11,32 @@
 //! It's often easier to frame OLE as producing an additive sharing of a
 //! product, where the sender knows `(a, x)` and the receiver knows `(b, y)`
 //! such that `ab = x + y`. This representation is used in [`OLEShare`].
+//!
+//! # Constructions
+//!
+//! The crate root holds the shared functionality ([`OLEShare`], [`OLEId`], the
+//! [`ROLESender`]/[`ROLEReceiver`] traits, [`Adjust`], the ideal functionality,
+//! and test utilities). Each concrete construction lives in its own module:
+//!
+//! - [`gilboa`] — semi-honest OLE from Gilboa's OT-based multiplication.
+//! - [`dhim`] — maliciously-secure, subquadratic-communication OLE.
 
 #![deny(missing_docs, unreachable_pub, unused_must_use)]
 #![deny(unsafe_code)]
 #![deny(clippy::all)]
 
 mod adjust;
+pub mod dhim;
+pub mod gilboa;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod ideal;
-mod receiver;
 mod role;
-mod sender;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test;
 
 pub use adjust::{Adjust, Offset};
-pub use receiver::{Receiver, ReceiverError};
 pub use role::{ROLEReceiver, ROLEReceiverOutput, ROLESender, ROLESenderOutput};
-pub use sender::{Sender, SenderError};
 
-use hybrid_array::Array;
-use itybity::ToBits;
 use mpz_fields::Field;
 use serde::{Deserialize, Serialize};
 
@@ -71,156 +76,8 @@ impl<F> OLEShare<F>
 where
     F: Field,
 {
-    /// Creates a new OLE share for the sender.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - Input value, `a`.
-    /// * `masks` - Masks for the correlation.
-    #[inline]
-    pub(crate) fn new_ole_sender(
-        input: F,
-        masks: Array<[F; 2], F::BitSize>,
-    ) -> (Self, MaskedCorrelation<F>) {
-        // Compute additive share, `x`.
-        let add = masks
-            .as_slice()
-            .iter()
-            .enumerate()
-            .fold(F::zero(), |acc, (i, &[zero, _])| {
-                acc + F::two_pow(i as u32) * zero
-            });
-
-        let share = Self {
-            // Sender negates their additive share.
-            add: -add,
-            mul: input,
-        };
-
-        let masked = MaskedCorrelation(Array::from_fn(|i| {
-            let [zero, one] = masks[i];
-            zero - one + input
-        }));
-
-        (share, masked)
-    }
-
-    /// Creates a new OLE share for the receiver.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - Input value, `b`.
-    /// * `masks` - Chosen correlation masks.
-    /// * `corr` - Masked correlation from the sender.
-    #[inline]
-    pub(crate) fn new_ole_receiver(
-        input: F,
-        masks: Array<F, F::BitSize>,
-        corr: MaskedCorrelation<F>,
-    ) -> Self {
-        let delta_i = input.iter_lsb0();
-        let t_delta_i = masks.iter();
-        let corr = corr.0.iter();
-
-        // Compute additive share, `y`.
-        let add = delta_i.zip(corr).zip(t_delta_i).enumerate().fold(
-            F::zero(),
-            |acc, (i, ((delta, &u), &t))| {
-                let delta = if delta { F::one() } else { F::zero() };
-                acc + F::two_pow(i as u32) * (delta * u + t)
-            },
-        );
-
-        Self { add, mul: input }
-    }
-
     /// Adjusts the multiplicative share to the target.
     pub fn adjust(self, target: F) -> Adjust<F> {
         Adjust::new(target, self)
-    }
-}
-
-#[allow(missing_docs)]
-#[derive(Serialize, Deserialize)]
-pub struct SenderMasks<F: Field> {
-    pub masks: Vec<MaskedCorrelation<F>>,
-}
-
-/// Masked correlation of the sender.
-///
-/// This is the correlation which is sent to the receiver.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MaskedCorrelation<F: Field>(pub(crate) Array<F, F::BitSize>);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mpz_core::Block;
-    use mpz_fields::{gf2_128::Gf2_128, p256::P256};
-    use mpz_ot_core::{
-        ideal::rot::IdealROT,
-        rot::{AnyReceiver, AnySender},
-    };
-    use rand::{SeedableRng, distr::StandardUniform, prelude::Distribution, rngs::StdRng};
-    use test::assert_ole;
-
-    #[test]
-    fn test_ole_p256() {
-        test_ole::<P256>();
-    }
-
-    #[test]
-    fn test_ole_gf2_128() {
-        test_ole::<Gf2_128>();
-    }
-
-    fn test_ole<F: Field>()
-    where
-        StandardUniform: Distribution<F>,
-    {
-        let count = 8;
-        let mut rng = StdRng::seed_from_u64(0);
-        let ideal_rot = IdealROT::new(Block::random(&mut rng));
-
-        let rot_sender = AnySender::new(ideal_rot.clone());
-        let rot_receiver = AnyReceiver::new(ideal_rot);
-
-        let (mut sender, mut receiver) = (
-            Sender::<_, F>::new(Block::random(&mut rng), rot_sender),
-            Receiver::<_, F>::new(rot_receiver),
-        );
-
-        sender.alloc(count).unwrap();
-        receiver.alloc(count).unwrap();
-
-        assert!(sender.wants_send());
-        assert!(receiver.wants_recv());
-
-        sender.rot_mut().rot_mut().flush().unwrap();
-
-        let msg = sender.send().unwrap();
-        receiver.recv(msg).unwrap();
-
-        assert!(!sender.wants_send());
-        assert!(!receiver.wants_recv());
-        assert_eq!(sender.available(), count);
-        assert_eq!(receiver.available(), count);
-
-        let ROLESenderOutput {
-            id: sender_id,
-            shares: sender_shares,
-        } = sender.try_send_role(8).unwrap();
-        let ROLEReceiverOutput {
-            id: receiver_id,
-            shares: receiver_shares,
-        } = receiver.try_recv_role(8).unwrap();
-
-        assert_eq!(sender_id, receiver_id);
-        sender_shares
-            .into_iter()
-            .zip(receiver_shares)
-            .for_each(|(s, r)| {
-                assert_ole(s, r);
-            })
     }
 }

--- a/crates/ole/src/receiver.rs
+++ b/crates/ole/src/receiver.rs
@@ -3,8 +3,10 @@ use serio::{Deserialize, stream::IoStreamExt};
 
 use mpz_common::{Context, Flush};
 use mpz_fields::Field;
-use mpz_ole_core::gilboa::{Receiver as Core, ReceiverError as CoreError};
-use mpz_ole_core::{ROLEReceiver, ROLEReceiverOutput};
+use mpz_ole_core::{
+    ROLEReceiver, ROLEReceiverOutput,
+    gilboa::{Receiver as Core, ReceiverError as CoreError},
+};
 use mpz_ot::rot::ROTReceiver;
 
 /// ROLE receiver wrapping a random OT receiver.

--- a/crates/ole/src/receiver.rs
+++ b/crates/ole/src/receiver.rs
@@ -3,9 +3,8 @@ use serio::{Deserialize, stream::IoStreamExt};
 
 use mpz_common::{Context, Flush};
 use mpz_fields::Field;
-use mpz_ole_core::{
-    ROLEReceiver, ROLEReceiverOutput, Receiver as Core, ReceiverError as CoreError,
-};
+use mpz_ole_core::gilboa::{Receiver as Core, ReceiverError as CoreError};
+use mpz_ole_core::{ROLEReceiver, ROLEReceiverOutput};
 use mpz_ot::rot::ROTReceiver;
 
 /// ROLE receiver wrapping a random OT receiver.

--- a/crates/ole/src/sender.rs
+++ b/crates/ole/src/sender.rs
@@ -4,7 +4,8 @@ use serio::{Serialize, SinkExt};
 use mpz_common::{Context, Flush};
 use mpz_core::Block;
 use mpz_fields::Field;
-use mpz_ole_core::{ROLESender, ROLESenderOutput, Sender as Core, SenderError as CoreError};
+use mpz_ole_core::gilboa::{Sender as Core, SenderError as CoreError};
+use mpz_ole_core::{ROLESender, ROLESenderOutput};
 use mpz_ot::rot::ROTSender;
 
 /// ROLE sender wrapping a random OT sender.

--- a/crates/ole/src/sender.rs
+++ b/crates/ole/src/sender.rs
@@ -4,8 +4,10 @@ use serio::{Serialize, SinkExt};
 use mpz_common::{Context, Flush};
 use mpz_core::Block;
 use mpz_fields::Field;
-use mpz_ole_core::gilboa::{Sender as Core, SenderError as CoreError};
-use mpz_ole_core::{ROLESender, ROLESenderOutput};
+use mpz_ole_core::{
+    ROLESender, ROLESenderOutput,
+    gilboa::{Sender as Core, SenderError as CoreError},
+};
 use mpz_ot::rot::ROTSender;
 
 /// ROLE sender wrapping a random OT sender.


### PR DESCRIPTION
This PR adds a 3-round OLE protocol `dhim` based on Maliciously-secure, subquadratic-communication (Doerner–Haitner–Ishai–Makriyannis, [ePrint 2025/1722]).

## Benchmarks 


  | Protocol | Security | Time / 1000 OLEs | Throughput | Per OLE |
  |----------|----------|------------------|------------|---------|
  | `gilboa` | semi-honest (batched ROLE + adjustment) | **203.97 ms** | **4.90K OLE/s** | ≈ 204 µs |
  | `dhim`   | malicious (per-instance, ×1000)          | **367.56 ms** | **2.72K OLE/s** | ≈ 368 µs |
