### PR TITLE
feat(zk-core,fields): composite QuickSilver poly check + GF(2^64) circuits

### DIFF
--- a/crates/fields/src/gf2_128.rs
+++ b/crates/fields/src/gf2_128.rs
@@ -11,7 +11,9 @@ use std::ops::{Add, Mul, Neg, Sub};
 
 use mpz_core::Block;
 
-use crate::{ExtensionField, Field, FieldError, gf2::Gf2};
+use std::sync::LazyLock;
+
+use crate::{ExtensionField, Field, FieldError, gf2::Gf2, gf2_64::Gf2_64};
 
 /// A type for holding field elements of Gf(2^128).
 #[derive(
@@ -290,6 +292,59 @@ impl ExtensionField<Gf2_128> for Gf2_128 {
     }
 }
 
+/// A root in GF(2^128) of `Gf2_64`'s modulus `q(x) = x^64 + x^4 + x^3 + x + 1`,
+/// i.e. the image of the `Gf2_64` generator `x` under the subfield embedding
+/// GF(2^64) ↪ GF(2^128). Derived once by the `derive_gf2_64_embedding` test.
+const GF2_64_EMBED_ROOT: u128 = 0xb2fa_452a_ba89_6b2a_bf36_31f0_bfe3_992a;
+
+/// The embedding map as a basis `[r^0, r^1, …, r^63]`: `embed(b) = Σ bᵢ·rⁱ`,
+/// the GF(2)-linear extension of `x ↦ r`. Built once from
+/// [`GF2_64_EMBED_ROOT`].
+static GF2_64_EMBED_BASIS: LazyLock<[Gf2_128; 64]> = LazyLock::new(|| {
+    let r = Gf2_128::new(GF2_64_EMBED_ROOT);
+    let mut basis = [Gf2_128::ONE; 64];
+    for i in 1..64 {
+        basis[i] = basis[i - 1] * r;
+    }
+    basis
+});
+
+/// Monomial basis `[1, x]` of GF(2^128) as a degree-2 extension of the
+/// embedded GF(2^64): `x = Gf2_128::new(2)` lies outside the subfield, so
+/// `{1, x}` is a GF(2^64)-basis (verified in `derive_gf2_64_embedding`).
+static MONOMIAL_BASIS_GF2_64: [Gf2_128; 2] = [Gf2_128::new(1), Gf2_128::new(2)];
+
+impl ExtensionField<Gf2_64> for Gf2_128 {
+    const MONOMIAL_BASIS: &'static [Self] = &MONOMIAL_BASIS_GF2_64;
+
+    /// The subfield injection GF(2^64) ↪ GF(2^128): the GF(2)-linear extension
+    /// of `x ↦ r` (a root of GF(2^64)'s modulus), which is a field
+    /// homomorphism.
+    ///
+    /// Constant-time masked XOR: each basis term is gated by
+    /// `acc ^= basis[i] & mask_from_bit(i)` — no data-dependent branches, so
+    /// witness values stay branch-free on the prover hot path (reached via
+    /// [`scale_by_subfield`](Self::scale_by_subfield)).
+    #[inline]
+    fn embed(base: Gf2_64) -> Self {
+        let bits = base.0;
+        let basis = &*GF2_64_EMBED_BASIS;
+        let mut acc = 0u128;
+        for (i, &b) in basis.iter().enumerate() {
+            // `(bits >> i) & 1` is 0 or 1; `wrapping_neg()` gives 0 or
+            // `u128::MAX`, zeroing the term when bit `i` is unset.
+            let mask = (((bits >> i) & 1) as u128).wrapping_neg();
+            acc ^= b.to_inner() & mask;
+        }
+        Gf2_128::new(acc)
+    }
+
+    #[inline]
+    fn scale_by_subfield(self, base: Gf2_64) -> Self {
+        self * Self::embed(base)
+    }
+}
+
 cfg_select! {
     target_arch = "x86_64" => {
         // Dispatch to the PCLMULQDQ backend via runtime detection, falling
@@ -389,7 +444,7 @@ impl FromBitIterator for Gf2_128 {
 mod tests {
     use super::Gf2_128;
     use crate::{
-        Field,
+        ExtensionField, Field,
         gf2::Gf2,
         tests::{
             test_extension_field_subfield_inner_product, test_field_accumulator,
@@ -399,6 +454,184 @@ mod tests {
             test_field_set_bit_msb0, test_field_square,
         },
     };
+
+    /// One-time derivation of the GF(2^64) ↪ GF(2^128) embedding constant: a
+    /// root in GF(2^128) of `Gf2_64`'s modulus `q(x) = x^64 + x^4 + x^3 + x +
+    /// 1`. Run with `--nocapture` and bake the printed value as a constant.
+    ///
+    /// Cantor equal-degree root finding: `q` splits into 64 distinct linear
+    /// factors over GF(2^128); the trace map `Tr(a·x) = Σ_{i<128} (a·x)^(2^i)`
+    /// down to GF(2) splits the factors by `Tr(a·root) ∈ {0,1}`, and repeated
+    /// gcds isolate one linear factor.
+    #[test]
+    #[ignore = "one-time derivation; prints the embedding constant"]
+    fn derive_gf2_64_embedding() {
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+
+        type P = Vec<Gf2_128>; // coeffs low→high, no trailing zeros
+
+        fn norm(mut p: P) -> P {
+            while p.last() == Some(&Gf2_128::ZERO) {
+                p.pop();
+            }
+            p
+        }
+        fn deg(p: &P) -> isize {
+            p.len() as isize - 1
+        }
+        fn add(a: &P, b: &P) -> P {
+            let n = a.len().max(b.len());
+            norm(
+                (0..n)
+                    .map(|i| {
+                        *a.get(i).unwrap_or(&Gf2_128::ZERO) + *b.get(i).unwrap_or(&Gf2_128::ZERO)
+                    })
+                    .collect(),
+            )
+        }
+        fn scale(a: &P, s: Gf2_128) -> P {
+            norm(a.iter().map(|&c| c * s).collect())
+        }
+        fn mul(a: &P, b: &P) -> P {
+            if a.is_empty() || b.is_empty() {
+                return vec![];
+            }
+            let mut out = vec![Gf2_128::ZERO; a.len() + b.len() - 1];
+            for (i, &x) in a.iter().enumerate() {
+                for (j, &y) in b.iter().enumerate() {
+                    out[i + j] = out[i + j] + x * y;
+                }
+            }
+            norm(out)
+        }
+        // Remainder of `a` modulo monic-able `m` (leading coeff inverted).
+        fn rem(a: &P, m: &P) -> P {
+            let mut a = norm(a.clone());
+            let lead_inv = m.last().unwrap().inverse().unwrap();
+            while deg(&a) >= deg(m) && !a.is_empty() {
+                let shift = (deg(&a) - deg(m)) as usize;
+                let factor = *a.last().unwrap() * lead_inv;
+                let mut sub = vec![Gf2_128::ZERO; shift];
+                sub.extend(m.iter().map(|&c| c * factor));
+                a = add(&a, &sub);
+            }
+            a
+        }
+        fn gcd(mut a: P, mut b: P) -> P {
+            a = norm(a);
+            b = norm(b);
+            while !b.is_empty() {
+                let r = rem(&a, &b);
+                a = b;
+                b = r;
+            }
+            if let Some(&lead) = a.last() {
+                let inv = lead.inverse().unwrap();
+                a = scale(&a, inv);
+            }
+            a
+        }
+
+        // q(x) = x^64 + x^4 + x^3 + x + 1.
+        let mut q = vec![Gf2_128::ZERO; 65];
+        for i in [0usize, 1, 3, 4, 64] {
+            q[i] = Gf2_128::ONE;
+        }
+
+        // x^(2^i) mod q for i = 0..128.
+        let mut xpow = vec![vec![Gf2_128::ZERO, Gf2_128::ONE]]; // x
+        for i in 1..128 {
+            let sq = mul(&xpow[i - 1], &xpow[i - 1]);
+            xpow.push(rem(&sq, &q));
+        }
+
+        // Split `f` until a linear factor (one root) is isolated.
+        fn split(f: &P, xpow: &[P], q: &P, rng: &mut StdRng) -> Gf2_128 {
+            if deg(f) == 1 {
+                // f = c1·x + c0  ⇒  root = c0 / c1.
+                return f[0] * f[1].inverse().unwrap();
+            }
+            loop {
+                let a = Gf2_128::new(rng.random());
+                // Tr(a·x) mod q = Σ_i a^(2^i) · x^(2^i).
+                let mut tr: P = vec![];
+                let mut apow = a;
+                for xq in xpow.iter() {
+                    tr = add(&tr, &scale(xq, apow));
+                    apow = apow * apow;
+                }
+                let g = gcd(f.clone(), rem(&tr, q));
+                if deg(&g) >= 1 && deg(&g) < deg(f) {
+                    return split(&g, xpow, q, rng);
+                }
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(0x6420_1128);
+        let r = split(&q, &xpow, &q, &mut rng);
+
+        // Verify q(r) = 0.
+        let mut acc = Gf2_128::ZERO;
+        let mut rp = Gf2_128::ONE;
+        for &qi in &q {
+            if qi != Gf2_128::ZERO {
+                acc = acc + rp;
+            }
+            rp = rp * r;
+        }
+        assert_eq!(acc, Gf2_128::ZERO, "r must be a root of q");
+
+        // A monomial-basis second element θ ∉ subfield (θ^(2^64) ≠ θ).
+        let frob64 = |mut z: Gf2_128| {
+            for _ in 0..64 {
+                z = z * z;
+            }
+            z
+        };
+        let x = Gf2_128::new(2);
+        assert_ne!(frob64(x), x, "x must lie outside GF(2^64) for the basis");
+
+        println!("GF2_64 embedding root r = 0x{:032x}", r.to_inner());
+    }
+
+    /// The GF(2^64) ↪ GF(2^128) embedding is a ring homomorphism: it preserves
+    /// `1`, addition, and multiplication, so authenticating GF(2^64) values
+    /// with GF(2^128) MACs is consistent.
+    #[test]
+    fn gf2_64_embedding_is_homomorphism() {
+        use crate::gf2_64::Gf2_64;
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+
+        let mut rng = StdRng::seed_from_u64(0x6420_1129);
+        assert_eq!(
+            <Gf2_128 as ExtensionField<Gf2_64>>::embed(Gf2_64::ONE),
+            Gf2_128::ONE,
+        );
+        assert_eq!(
+            <Gf2_128 as ExtensionField<Gf2_64>>::embed(Gf2_64::ZERO),
+            Gf2_128::ZERO,
+        );
+        for _ in 0..512 {
+            let a = Gf2_64(rng.random());
+            let b = Gf2_64(rng.random());
+            let ea = <Gf2_128 as ExtensionField<Gf2_64>>::embed(a);
+            let eb = <Gf2_128 as ExtensionField<Gf2_64>>::embed(b);
+            assert_eq!(
+                <Gf2_128 as ExtensionField<Gf2_64>>::embed(a + b),
+                ea + eb,
+                "additive",
+            );
+            assert_eq!(
+                <Gf2_128 as ExtensionField<Gf2_64>>::embed(a * b),
+                ea * eb,
+                "multiplicative",
+            );
+            // `scale_by_subfield` agrees with embed-then-multiply.
+            let m = Gf2_128::new(rng.random());
+            assert_eq!(m.scale_by_subfield(a), m * ea);
+        }
+    }
+
     #[test]
     fn test_gf2_128_basic() {
         test_field_basic::<Gf2_128>();

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -8,7 +8,7 @@ use mpz_vm_core::{
 use mpz_vm_ir::{Function, Module};
 
 use mpz_vm_memory::{AuthState, Bit, Registers};
-use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, Proof, prover_wire, vope_receiver};
+use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, Proof, ProverOutput, prover_wire, vope_receiver};
 use rand_chacha::ChaCha12Rng;
 use rand_chacha::rand_core::SeedableRng;
 use rangeset::set::RangeSet;
@@ -332,7 +332,7 @@ where
                     last_out = Some(LastOut { auth, revealed });
                 }
 
-                let (u, v, assertions) = ctx
+                let ProverOutput { u, v, assertions, .. } = ctx
                     .finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
                 Ok((u, v, assertions, last_out))
@@ -698,6 +698,7 @@ where
                 assertions: out.assertions,
                 u: out.u + a_0,
                 v: out.v + a_1,
+                coefficients: Vec::new(),
             };
             io.io_mut()
                 .send(ProofMessage {
@@ -814,7 +815,7 @@ where
                 .ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
             revealed = reveal::reveal_prover(&mut ctx, &self.auth, memory, &reveal_ranges)?;
         }
-        let (u, v, assertions) = ctx
+        let ProverOutput { u, v, assertions, .. } = ctx
             .finish()
             .map_err(|e| ZkVmError::Internal(e.to_string()))?;
 
@@ -823,6 +824,7 @@ where
             assertions,
             u: u + a_0,
             v: v + a_1,
+            coefficients: Vec::new(),
         };
         io.io_mut()
             .send(ProofMessage {

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -15,7 +15,7 @@ use serio::{SinkExt, stream::IoStreamExt};
 use std::ops::Range;
 
 use mpz_vm_memory::{AuthState, Bit, Registers};
-use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, verifier_wire, vope_sender};
+use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, VerifierOutput, verifier_wire, vope_sender};
 
 use crate::{
     ChunkOutcome, ProofMessage, VOPE_BITS,
@@ -232,7 +232,7 @@ where
                     last_auth = Some(auth);
                 }
 
-                let (w, assertions) = ctx
+                let VerifierOutput { w, assertions, .. } = ctx
                     .finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
                 Ok((w, assertions, last_auth))
@@ -711,7 +711,7 @@ where
         if reveal_pending {
             reveal::reveal_verifier(&mut ctx, &self.auth, &reveal_ranges, &revealed)?;
         }
-        let (w, assertions) = ctx
+        let VerifierOutput { w, assertions, .. } = ctx
             .finish()
             .map_err(|e| ZkVmError::Internal(e.to_string()))?;
 

--- a/crates/zk-core/Cargo.toml
+++ b/crates/zk-core/Cargo.toml
@@ -13,10 +13,12 @@ mpz-circuits = { workspace = true }
 mpz-fields = { workspace = true }
 
 blake3 = { workspace = true }
+hybrid-array = { workspace = true }
 itybity = { workspace = true }
 rand_core = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+typenum = { workspace = true }
 zerocopy = { workspace = true }
 
 [dev-dependencies]
@@ -28,6 +30,14 @@ sha2 = { workspace = true, features = ["compress"] }
 
 [[bench]]
 name = "sha256"
+harness = false
+
+[[bench]]
+name = "poly"
+harness = false
+
+[[bench]]
+name = "product_gf64"
 harness = false
 
 [lints]

--- a/crates/zk-core/benches/poly.rs
+++ b/crates/zk-core/benches/poly.rs
@@ -1,0 +1,328 @@
+//! Polynomial-constraint prover/verifier benchmark.
+//!
+//! **`mux`**: a 1-of-16 multiplexer over 32-bit values. Each output bit is a
+//! depth-4 binary mux tree `a + sel·(a + b)` over the committed inputs and four
+//! committed selector bits, giving 32 degree-5 constraints per multiplexer.
+//!
+//! The workload uses only `lift` + `assert_zero` (no AND gates and no
+//! `materialize`), so the triple check is trivial and the measured cost is the
+//! polynomial path: building the degree-raising expressions and folding them
+//! into [`ProverPoly`]/[`VerifierPoly`].
+//!
+//! Run with: `cargo bench -p mpz-zk-core --bench poly`
+
+use std::time::Duration;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use mpz_core::Block;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
+use mpz_ot_core::ideal::rcot::IdealRCOT;
+use mpz_zk_core::{
+    Commit, DeltaPowers, Proof, Prover, ProverOutput, Verifier, VerifierOutput,
+    poly::{Expr, PolyContext},
+    vope_receiver, vope_sender,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand_chacha::ChaCha12Rng;
+use typenum::U1;
+
+const VOPE_COST: usize = 128;
+
+// ===========================================================================
+// Gadget
+// ===========================================================================
+
+/// One 1-of-16 multiplexer over 32-bit values: `sel` is 4 committed selector
+/// bits, `inputs` is 16 committed 32-bit values, `out` is the committed
+/// selected value. Each output bit is a depth-4 mux tree, a degree-5
+/// constraint.
+fn mux16_u32<C>(ctx: &mut C, sel: &[Gf2_128; 4], inputs: &[[Gf2_128; 32]; 16], out: &[Gf2_128; 32])
+where
+    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C::Error: std::fmt::Debug,
+{
+    let s: [Expr<C::Coeffs, U1>; 4] = core::array::from_fn(|i| ctx.lift(sel[i]));
+    for bit in 0..32 {
+        let leaf: [Expr<C::Coeffs, U1>; 16] = core::array::from_fn(|n| ctx.lift(inputs[n][bit]));
+        // Mux level: `a + sel·(a + b)`, raising the degree by one each time.
+        let l0: [Expr<C::Coeffs, _>; 8] =
+            core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
+        let l1: [Expr<C::Coeffs, _>; 4] =
+            core::array::from_fn(|j| l0[2 * j] + s[1] * (l0[2 * j] + l0[2 * j + 1]));
+        let l2: [Expr<C::Coeffs, _>; 2] =
+            core::array::from_fn(|j| l1[2 * j] + s[2] * (l1[2 * j] + l1[2 * j + 1]));
+        let top = l2[0] + s[3] * (l2[0] + l2[1]); // degree 5
+        let o = ctx.lift(out[bit]);
+        ctx.assert_zero(top - o).expect("mux output");
+    }
+}
+
+// ===========================================================================
+// Circuit: a satisfying witness plus a carrier-generic evaluation.
+// ===========================================================================
+
+/// A benchmark circuit: a fixed satisfying witness (committed bits) and a
+/// degree, evaluated by reading the flat committed-wire slice.
+trait PolyCircuit {
+    /// The satisfying witness, one bit per committed wire.
+    fn witness(&self) -> Vec<bool>;
+    /// The proof degree `d_max` (number of coefficients sent).
+    fn d_max(&self) -> usize;
+    /// Evaluates the circuit over the committed wires (same order as the
+    /// witness), emitting its constraints.
+    fn eval<C>(&self, ctx: &mut C, wires: &[Gf2_128])
+    where
+        C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+        C::Error: std::fmt::Debug;
+}
+
+/// `n` independent 1-of-16 multiplexers over 32-bit values; 548 committed bits
+/// each (4 selector + 16·32 inputs + 32 output).
+struct MuxCircuit {
+    n: usize,
+}
+
+const MUX_BITS: usize = 4 + 16 * 32 + 32;
+
+impl PolyCircuit for MuxCircuit {
+    fn witness(&self) -> Vec<bool> {
+        let mut rng = StdRng::seed_from_u64(0x111);
+        let mut bits = Vec::with_capacity(self.n * MUX_BITS);
+        for _ in 0..self.n {
+            let sel: [bool; 4] = core::array::from_fn(|_| rng.random());
+            let idx = (0..4).fold(0usize, |a, i| a | ((sel[i] as usize) << i));
+            let inputs: [[bool; 32]; 16] =
+                core::array::from_fn(|_| core::array::from_fn(|_| rng.random()));
+            let out = inputs[idx];
+
+            bits.extend(sel);
+            for value in &inputs {
+                bits.extend(value);
+            }
+            bits.extend(out);
+        }
+        bits
+    }
+
+    fn d_max(&self) -> usize {
+        5
+    }
+
+    fn eval<C>(&self, ctx: &mut C, wires: &[Gf2_128])
+    where
+        C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+        C::Error: std::fmt::Debug,
+    {
+        for m in 0..self.n {
+            let base = m * MUX_BITS;
+            let sel: [Gf2_128; 4] = core::array::from_fn(|i| wires[base + i]);
+            let inputs: [[Gf2_128; 32]; 16] =
+                core::array::from_fn(|n| core::array::from_fn(|b| wires[base + 4 + n * 32 + b]));
+            let out: [Gf2_128; 32] = core::array::from_fn(|b| wires[base + 4 + 512 + b]);
+            mux16_u32(ctx, &sel, &inputs, &out);
+        }
+    }
+}
+
+// ===========================================================================
+// Poly proof harness
+// ===========================================================================
+
+/// Samples `total` RCOT correlations as `(delta, raw_keys, choices, macs)`
+/// with `delta.lsb = 1`.
+fn sample_rcot<R: Rng>(
+    rng: &mut R,
+    total: usize,
+) -> (Gf2_128, Vec<Gf2_128>, Vec<bool>, Vec<Gf2_128>) {
+    let mut delta_block: Block = rng.random();
+    delta_block.set_lsb(true);
+    let seed: Block = rng.random();
+
+    let mut rcot = IdealRCOT::new(seed, delta_block);
+    rcot.alloc(total);
+    rcot.flush().expect("ideal rcot flush");
+    let (sender_out, receiver_out) = rcot.transfer(total).expect("ideal rcot transfer");
+
+    (
+        delta_block.into(),
+        sender_out.keys.into_iter().map(Into::into).collect(),
+        receiver_out.choices,
+        receiver_out.msgs.into_iter().map(Into::into).collect(),
+    )
+}
+
+/// Sets the LSB of `g` to `bit`.
+fn set_lsb(g: Gf2_128, bit: bool) -> Gf2_128 {
+    Gf2_128::new((g.to_inner() & !1) | u128::from(bit))
+}
+
+/// Everything needed to run the prover and verifier benchmarks for one
+/// circuit: pre-committed input wires and a precomputed (valid) proof.
+struct PolyInputs {
+    delta: Gf2_128,
+    d_max: usize,
+    /// Prover input wires (MACs, LSB = committed bit).
+    mac_wires: Vec<Gf2_128>,
+    /// Verifier input wires (keys, pre-adjusted off-band).
+    key_wires: Vec<Gf2_128>,
+    chi: [u8; 32],
+    vope_choices: [bool; VOPE_COST],
+    vope_ev: [Gf2_128; VOPE_COST],
+    vope_keys: [Gf2_128; VOPE_COST],
+    /// Powers of `delta` for the polynomial check.
+    powers: DeltaPowers,
+    /// Verifier's side of the polynomial-check VOPE correlation.
+    poly_vope_sum: Gf2_128,
+    /// The prover's masked polynomial coefficients (degrees `0 ..= d_max-1`).
+    coefficients: Vec<Gf2_128>,
+    /// The triple-check proof (trivial here — no AND gates).
+    proof: Proof,
+}
+
+fn setup<Circ: PolyCircuit>(circ: &Circ) -> PolyInputs {
+    let mut rng = StdRng::seed_from_u64(7);
+    let witness = circ.witness();
+    let input_count = witness.len();
+    let d_max = circ.d_max();
+
+    let total = input_count + VOPE_COST;
+    let (delta, raw_keys, choices, macs) = sample_rcot(&mut rng, total);
+
+    // Commit the input bits: adjust = bit ^ choice, MAC LSB = bit, key
+    // pre-adjusted.
+    let mac_wires: Vec<Gf2_128> = (0..input_count)
+        .map(|i| set_lsb(macs[i], witness[i]))
+        .collect();
+    let key_wires: Vec<Gf2_128> = (0..input_count)
+        .map(|i| {
+            let adjust = witness[i] ^ choices[i];
+            let k = raw_keys[i];
+            set_lsb(if adjust { k + delta } else { k }, false)
+        })
+        .collect();
+
+    let vope_choices: [bool; VOPE_COST] = core::array::from_fn(|i| choices[input_count + i]);
+    let vope_ev: [Gf2_128; VOPE_COST] = core::array::from_fn(|i| macs[input_count + i]);
+    let vope_keys: [Gf2_128; VOPE_COST] = core::array::from_fn(|i| raw_keys[input_count + i]);
+    let chi: [u8; 32] = rng.random();
+
+    // Mock degree-`d_max` polynomial-check VOPE: random mask coefficients on
+    // the prover side, their Δ-weighted sum on the verifier side.
+    let powers = DeltaPowers::new(delta);
+    let poly_masks: Vec<Gf2_128> = (0..d_max).map(|_| Gf2_128::new(rng.random())).collect();
+    let mut poly_vope_sum = Gf2_128::new(0);
+    let mut pw = Gf2_128::new(1);
+    for &m in &poly_masks {
+        poly_vope_sum = poly_vope_sum + m * pw;
+        pw = pw * delta;
+    }
+
+    // Run the prover once to produce the proof and the masked coefficients.
+    let mut commit = Commit::new(&mut []);
+    circ.eval(&mut commit, &ptr_wires(&witness));
+    commit.finish().expect("commit finish");
+
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    circ.eval(&mut prover, &mac_wires);
+    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
+
+    let coefficients: Vec<Gf2_128> = poly
+        .coefficients(d_max)
+        .expect("coefficients")
+        .into_iter()
+        .zip(&poly_masks)
+        .map(|(c, &m)| c + m)
+        .collect();
+
+    let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
+    let proof = Proof {
+        assertions,
+        u: u + a_0,
+        v: v + a_1,
+        coefficients: coefficients.clone(),
+    };
+
+    PolyInputs {
+        delta,
+        d_max,
+        mac_wires,
+        key_wires,
+        chi,
+        vope_choices,
+        vope_ev,
+        vope_keys,
+        powers,
+        poly_vope_sum,
+        coefficients,
+        proof,
+    }
+}
+
+/// Pointer-bit wires for the commit pass: each wire's LSB carries the bit.
+fn ptr_wires(witness: &[bool]) -> Vec<Gf2_128> {
+    witness.iter().map(|&b| Gf2_128::new(b as u128)).collect()
+}
+
+fn run_prover<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
+    let mut commit = Commit::new(&mut []);
+    circ.eval(&mut commit, &ptr_wires(&circ.witness()));
+    commit.finish().expect("commit finish");
+
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    circ.eval(&mut prover, &inputs.mac_wires);
+    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
+
+    let coefficients: Vec<Gf2_128> = poly.coefficients(inputs.d_max).expect("coefficients");
+    let (a_0, a_1) = vope_receiver(&inputs.vope_choices, &inputs.vope_ev);
+    let _proof = Proof {
+        assertions,
+        u: u + a_0,
+        v: v + a_1,
+        coefficients,
+    };
+}
+
+fn run_verifier<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
+    let verifier = Verifier::new(inputs.delta, &[], &[]).expect("new");
+    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    circ.eval(&mut verifier, &inputs.key_wires);
+    let VerifierOutput { w, poly, assertions } = verifier.finish().expect("finish");
+
+    poly.check(&inputs.powers, &inputs.coefficients, inputs.poly_vope_sum)
+        .expect("poly check");
+
+    let b = vope_sender(&inputs.vope_keys);
+    assert_eq!(assertions, inputs.proof.assertions);
+    assert_eq!(
+        w + b,
+        inputs.proof.u + inputs.delta * inputs.proof.v,
+        "triple check failed"
+    );
+}
+
+fn bench_circuit<Circ: PolyCircuit>(c: &mut Criterion, name: &str, circ: Circ, units: u64) {
+    let inputs = setup(&circ);
+
+    let mut pg = c.benchmark_group(format!("poly_prover_{name}"));
+    pg.sample_size(10);
+    pg.measurement_time(Duration::from_secs(10));
+    pg.throughput(Throughput::Elements(units));
+    pg.bench_function("run", |b| b.iter(|| run_prover(&circ, &inputs)));
+    pg.finish();
+
+    let mut vg = c.benchmark_group(format!("poly_verifier_{name}"));
+    vg.sample_size(10);
+    vg.measurement_time(Duration::from_secs(10));
+    vg.throughput(Throughput::Elements(units));
+    vg.bench_function("run", |b| b.iter(|| run_verifier(&circ, &inputs)));
+    vg.finish();
+}
+
+fn bench_poly(c: &mut Criterion) {
+    // 2k 1-of-16 multiplexers of 32-bit values.
+    const N_MUX: usize = 2_000;
+    bench_circuit(c, "mux", MuxCircuit { n: N_MUX }, N_MUX as u64);
+}
+
+criterion_group!(benches, bench_poly);
+criterion_main!(benches);

--- a/crates/zk-core/benches/poly.rs
+++ b/crates/zk-core/benches/poly.rs
@@ -1,8 +1,10 @@
 //! Polynomial-constraint prover/verifier benchmark.
 //!
-//! **`mux`**: a 1-of-16 multiplexer over 32-bit values. Each output bit is a
-//! depth-4 binary mux tree `a + sel·(a + b)` over the committed inputs and four
-//! committed selector bits, giving 32 degree-5 constraints per multiplexer.
+//! **`mux{2,4,8,16}`**: a 1-of-`w` multiplexer over 32-bit values. Each output
+//! bit is a depth-`log2(w)` binary mux tree `a + sel·(a + b)` over the committed
+//! inputs and `log2(w)` committed selector bits, giving 32 degree-`(log2(w)+1)`
+//! constraints per multiplexer. The variants sweep the mux degree: 1-of-2
+//! (degree 2) through 1-of-16 (degree 5).
 //!
 //! The workload uses only `lift` + `assert_zero` (no AND gates and no
 //! `materialize`), so the triple check is trivial and the measured cost is the
@@ -32,18 +34,75 @@ const VOPE_COST: usize = 128;
 // Gadget
 // ===========================================================================
 
-/// One 1-of-16 multiplexer over 32-bit values: `sel` is 4 committed selector
-/// bits, `inputs` is 16 committed 32-bit values, `out` is the committed
-/// selected value. Each output bit is a depth-4 mux tree, a degree-5
-/// constraint.
-fn mux16_u32<C>(ctx: &mut C, sel: &[Gf2_128; 4], inputs: &[[Gf2_128; 32]; 16], out: &[Gf2_128; 32])
+// Each gadget builds 32 output-bit constraints for one 1-of-`w` multiplexer.
+// The selectors (`sel`, `log2(w)` wires), inputs (`inputs`, `w·32` wires laid
+// out as `input·32 + bit`) and output (`out`, 32 wires) are flat committed-wire
+// slices. The mux level `a + sel·(a + b)` raises the expression degree by one
+// per tree level, so the top constraint is degree `log2(w)+1`. The degree is
+// part of the `Expr` *type*, so each width is spelled out statically rather than
+// folded over a runtime-sized tree.
+
+/// 1-of-2 mux, depth 1, degree-2 constraints.
+fn mux2_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+where
+    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C::Error: std::fmt::Debug,
+{
+    let s0 = ctx.lift(sel[0]);
+    for bit in 0..32 {
+        let leaf: [Expr<C::Coeffs, U1>; 2] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let top = leaf[0] + s0 * (leaf[0] + leaf[1]); // degree 2
+        let o = ctx.lift(out[bit]);
+        ctx.assert_zero(top - o).expect("mux output");
+    }
+}
+
+/// 1-of-4 mux, depth 2, degree-3 constraints.
+fn mux4_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+where
+    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C::Error: std::fmt::Debug,
+{
+    let s: [Expr<C::Coeffs, U1>; 2] = core::array::from_fn(|i| ctx.lift(sel[i]));
+    for bit in 0..32 {
+        let leaf: [Expr<C::Coeffs, U1>; 4] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let l0: [Expr<C::Coeffs, _>; 2] =
+            core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
+        let top = l0[0] + s[1] * (l0[0] + l0[1]); // degree 3
+        let o = ctx.lift(out[bit]);
+        ctx.assert_zero(top - o).expect("mux output");
+    }
+}
+
+/// 1-of-8 mux, depth 3, degree-4 constraints.
+fn mux8_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+where
+    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C::Error: std::fmt::Debug,
+{
+    let s: [Expr<C::Coeffs, U1>; 3] = core::array::from_fn(|i| ctx.lift(sel[i]));
+    for bit in 0..32 {
+        let leaf: [Expr<C::Coeffs, U1>; 8] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let l0: [Expr<C::Coeffs, _>; 4] =
+            core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
+        let l1: [Expr<C::Coeffs, _>; 2] =
+            core::array::from_fn(|j| l0[2 * j] + s[1] * (l0[2 * j] + l0[2 * j + 1]));
+        let top = l1[0] + s[2] * (l1[0] + l1[1]); // degree 4
+        let o = ctx.lift(out[bit]);
+        ctx.assert_zero(top - o).expect("mux output");
+    }
+}
+
+/// 1-of-16 mux, depth 4, degree-5 constraints.
+fn mux16_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
 where
     C: PolyContext<Field = Gf2, Wire = Gf2_128>,
     C::Error: std::fmt::Debug,
 {
     let s: [Expr<C::Coeffs, U1>; 4] = core::array::from_fn(|i| ctx.lift(sel[i]));
     for bit in 0..32 {
-        let leaf: [Expr<C::Coeffs, U1>; 16] = core::array::from_fn(|n| ctx.lift(inputs[n][bit]));
+        let leaf: [Expr<C::Coeffs, U1>; 16] =
+            core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
         // Mux level: `a + sel·(a + b)`, raising the degree by one each time.
         let l0: [Expr<C::Coeffs, _>; 8] =
             core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
@@ -76,23 +135,37 @@ trait PolyCircuit {
         C::Error: std::fmt::Debug;
 }
 
-/// `n` independent 1-of-16 multiplexers over 32-bit values; 548 committed bits
-/// each (4 selector + 16·32 inputs + 32 output).
+/// `n` independent 1-of-`width` multiplexers over 32-bit values. Each mux
+/// commits `log2(width)` selector + `width·32` input + 32 output bits.
 struct MuxCircuit {
+    /// Number of mux inputs (a power of two: 2, 4, 8 or 16).
+    width: usize,
     n: usize,
 }
 
-const MUX_BITS: usize = 4 + 16 * 32 + 32;
+impl MuxCircuit {
+    /// Number of selector bits / mux-tree depth.
+    fn depth(&self) -> usize {
+        self.width.trailing_zeros() as usize
+    }
+
+    /// Committed bits per multiplexer.
+    fn mux_bits(&self) -> usize {
+        self.depth() + self.width * 32 + 32
+    }
+}
 
 impl PolyCircuit for MuxCircuit {
     fn witness(&self) -> Vec<bool> {
+        let depth = self.depth();
         let mut rng = StdRng::seed_from_u64(0x111);
-        let mut bits = Vec::with_capacity(self.n * MUX_BITS);
+        let mut bits = Vec::with_capacity(self.n * self.mux_bits());
         for _ in 0..self.n {
-            let sel: [bool; 4] = core::array::from_fn(|_| rng.random());
-            let idx = (0..4).fold(0usize, |a, i| a | ((sel[i] as usize) << i));
-            let inputs: [[bool; 32]; 16] =
-                core::array::from_fn(|_| core::array::from_fn(|_| rng.random()));
+            let sel: Vec<bool> = (0..depth).map(|_| rng.random()).collect();
+            let idx = (0..depth).fold(0usize, |a, i| a | ((sel[i] as usize) << i));
+            let inputs: Vec<[bool; 32]> = (0..self.width)
+                .map(|_| core::array::from_fn(|_| rng.random()))
+                .collect();
             let out = inputs[idx];
 
             bits.extend(sel);
@@ -105,7 +178,7 @@ impl PolyCircuit for MuxCircuit {
     }
 
     fn d_max(&self) -> usize {
-        5
+        self.depth() + 1
     }
 
     fn eval<C>(&self, ctx: &mut C, wires: &[Gf2_128])
@@ -113,13 +186,20 @@ impl PolyCircuit for MuxCircuit {
         C: PolyContext<Field = Gf2, Wire = Gf2_128>,
         C::Error: std::fmt::Debug,
     {
+        let depth = self.depth();
+        let mux_bits = self.mux_bits();
         for m in 0..self.n {
-            let base = m * MUX_BITS;
-            let sel: [Gf2_128; 4] = core::array::from_fn(|i| wires[base + i]);
-            let inputs: [[Gf2_128; 32]; 16] =
-                core::array::from_fn(|n| core::array::from_fn(|b| wires[base + 4 + n * 32 + b]));
-            let out: [Gf2_128; 32] = core::array::from_fn(|b| wires[base + 4 + 512 + b]);
-            mux16_u32(ctx, &sel, &inputs, &out);
+            let base = m * mux_bits;
+            let sel = &wires[base..base + depth];
+            let inputs = &wires[base + depth..base + depth + self.width * 32];
+            let out = &wires[base + mux_bits - 32..base + mux_bits];
+            match self.width {
+                2 => mux2_u32(ctx, sel, inputs, out),
+                4 => mux4_u32(ctx, sel, inputs, out),
+                8 => mux8_u32(ctx, sel, inputs, out),
+                16 => mux16_u32(ctx, sel, inputs, out),
+                w => unreachable!("unsupported mux width {w}"),
+            }
         }
     }
 }
@@ -319,9 +399,17 @@ fn bench_circuit<Circ: PolyCircuit>(c: &mut Criterion, name: &str, circ: Circ, u
 }
 
 fn bench_poly(c: &mut Criterion) {
-    // 2k 1-of-16 multiplexers of 32-bit values.
+    // 2k multiplexers of 32-bit values each, swept over 1-of-{2,4,8,16}
+    // (mux degrees 2..=5).
     const N_MUX: usize = 2_000;
-    bench_circuit(c, "mux", MuxCircuit { n: N_MUX }, N_MUX as u64);
+    for width in [2usize, 4, 8, 16] {
+        bench_circuit(
+            c,
+            &format!("mux{width}"),
+            MuxCircuit { width, n: N_MUX },
+            N_MUX as u64,
+        );
+    }
 }
 
 criterion_group!(benches, bench_poly);

--- a/crates/zk-core/benches/product_gf64.rs
+++ b/crates/zk-core/benches/product_gf64.rs
@@ -1,0 +1,415 @@
+//! Accelerated permutation-product argument over `GF(2^64)`.
+//!
+//! Permutation/lookup arguments reduce to a grand product over the committed
+//! memory tuples `eᵢ` and a public challenge `r`:
+//!
+//! ```text
+//!   p(r) = ∏_{i=1}^{M} (eᵢ + r)
+//! ```
+//!
+//! The gate-by-gate evaluation commits every running product, costing one
+//! authenticated value per entry. The accelerated method (SpeakUp,
+//! "Accelerating permutation products") splits the entries into chunks of
+//! `d − 1` and verifies each chunk as a single **degree-`d` QuickSilver
+//! constraint**
+//!
+//! ```text
+//!   acc_k − acc_{k-1} · ∏_{i ∈ chunk k} (eᵢ + r) = 0
+//! ```
+//!
+//! committing only the chunk-boundary partial products `acc_k`. Amortized cost
+//! per entry drops from `κ` to `κ / (d − 1)` sVOLEs. This is exactly the
+//! `GF(2^64)` polynomial-constraint path ([`PolyContext`]): `eᵢ` and `acc_k`
+//! are committed wires, `r` is a public constant, and each chunk is one
+//! degree-`d` `assert_zero`.
+//!
+//! The benchmark runs chunk sizes `c ∈ {1, 3, 7, 15, 31}` (degrees 2, 4, 8,
+//! 16, 32) so the amortization is visible: larger chunks commit fewer partial
+//! products but fold higher-degree constraints.
+//!
+//! Run with: `cargo bench -p mpz-zk-core --bench product_gf64`
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use mpz_fields::{ExtensionField, gf2_64::Gf2_64, gf2_128::Gf2_128};
+use mpz_zk_core::{
+    DeltaPowers, PolyContext, Proof, ProverOutput, VerifierOutput,
+    gf64::{Auth64, Commit, Prover, Verifier},
+    poly::Expr,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand_chacha::ChaCha12Rng;
+use typenum::U0;
+
+/// Total number of entries. Chunks tile `⌊M / c⌋·c` entries; any short tail
+/// (at most `c − 1` entries) is committed but unconstrained.
+const M: usize = 32_768;
+
+/// Subfield injection `GF(2^64) ↪ GF(2^128)`.
+fn embed(v: Gf2_64) -> Gf2_128 {
+    <Gf2_128 as ExtensionField<Gf2_64>>::embed(v)
+}
+
+// ===========================================================================
+// Chunked product constraints
+// ===========================================================================
+
+/// One chunk size of the product argument: `C` entries per chunk, verified as
+/// a degree-`D = C + 1` constraint.
+trait Chunk {
+    /// Entries per chunk.
+    const C: usize;
+    /// Constraint degree `C + 1` (the proof's `d_max`).
+    const D: usize;
+
+    /// Emits `acc_out − acc_in · ∏(eᵢ + r) = 0` for one chunk.
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        entries: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug;
+}
+
+/// Gate-by-gate baseline: one factor per chunk, degree 2.
+struct Chunk1;
+impl Chunk for Chunk1 {
+    const C: usize = 1;
+    const D: usize = 2;
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        e: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug,
+    {
+        let p = ctx.lift(e[0]) + r;
+        let term = ctx.lift(acc_in) * p;
+        ctx.assert_zero(term - ctx.lift(acc_out)).expect("chunk");
+    }
+}
+
+/// Degree-4 chunk: three factors.
+struct Chunk3;
+impl Chunk for Chunk3 {
+    const C: usize = 3;
+    const D: usize = 4;
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        e: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug,
+    {
+        let p = (ctx.lift(e[0]) + r) * (ctx.lift(e[1]) + r) * (ctx.lift(e[2]) + r);
+        let term = ctx.lift(acc_in) * p;
+        ctx.assert_zero(term - ctx.lift(acc_out)).expect("chunk");
+    }
+}
+
+/// Degree-8 chunk: seven factors.
+struct Chunk7;
+impl Chunk for Chunk7 {
+    const C: usize = 7;
+    const D: usize = 8;
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        e: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug,
+    {
+        let p = (ctx.lift(e[0]) + r)
+            * (ctx.lift(e[1]) + r)
+            * (ctx.lift(e[2]) + r)
+            * (ctx.lift(e[3]) + r)
+            * (ctx.lift(e[4]) + r)
+            * (ctx.lift(e[5]) + r)
+            * (ctx.lift(e[6]) + r);
+        let term = ctx.lift(acc_in) * p;
+        ctx.assert_zero(term - ctx.lift(acc_out)).expect("chunk");
+    }
+}
+
+/// Degree-16 chunk: fifteen factors.
+struct Chunk15;
+impl Chunk for Chunk15 {
+    const C: usize = 15;
+    const D: usize = 16;
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        e: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug,
+    {
+        let p = (ctx.lift(e[0]) + r)
+            * (ctx.lift(e[1]) + r)
+            * (ctx.lift(e[2]) + r)
+            * (ctx.lift(e[3]) + r)
+            * (ctx.lift(e[4]) + r)
+            * (ctx.lift(e[5]) + r)
+            * (ctx.lift(e[6]) + r)
+            * (ctx.lift(e[7]) + r)
+            * (ctx.lift(e[8]) + r)
+            * (ctx.lift(e[9]) + r)
+            * (ctx.lift(e[10]) + r)
+            * (ctx.lift(e[11]) + r)
+            * (ctx.lift(e[12]) + r)
+            * (ctx.lift(e[13]) + r)
+            * (ctx.lift(e[14]) + r);
+        let term = ctx.lift(acc_in) * p;
+        ctx.assert_zero(term - ctx.lift(acc_out)).expect("chunk");
+    }
+}
+
+/// Degree-32 chunk: thirty-one factors.
+struct Chunk31;
+impl Chunk for Chunk31 {
+    const C: usize = 31;
+    const D: usize = 32;
+    fn constrain<Ctx>(
+        ctx: &mut Ctx,
+        acc_in: Ctx::Wire,
+        e: &[Ctx::Wire],
+        r: Expr<Ctx::Coeffs, U0>,
+        acc_out: Ctx::Wire,
+    ) where
+        Ctx: PolyContext<Field = Gf2_64>,
+        Ctx::Error: std::fmt::Debug,
+    {
+        // ∏_{i=0}^{30} (e_i + r), degree 31, then × acc_in for degree 32.
+        // Each `*` raises the degree by one, so the running type is
+        // `Expr<_, U_{j+1}>`; the rebindings let the compile-time degrees flow.
+        let p = ctx.lift(e[0]) + r;
+        let p = p * (ctx.lift(e[1]) + r);
+        let p = p * (ctx.lift(e[2]) + r);
+        let p = p * (ctx.lift(e[3]) + r);
+        let p = p * (ctx.lift(e[4]) + r);
+        let p = p * (ctx.lift(e[5]) + r);
+        let p = p * (ctx.lift(e[6]) + r);
+        let p = p * (ctx.lift(e[7]) + r);
+        let p = p * (ctx.lift(e[8]) + r);
+        let p = p * (ctx.lift(e[9]) + r);
+        let p = p * (ctx.lift(e[10]) + r);
+        let p = p * (ctx.lift(e[11]) + r);
+        let p = p * (ctx.lift(e[12]) + r);
+        let p = p * (ctx.lift(e[13]) + r);
+        let p = p * (ctx.lift(e[14]) + r);
+        let p = p * (ctx.lift(e[15]) + r);
+        let p = p * (ctx.lift(e[16]) + r);
+        let p = p * (ctx.lift(e[17]) + r);
+        let p = p * (ctx.lift(e[18]) + r);
+        let p = p * (ctx.lift(e[19]) + r);
+        let p = p * (ctx.lift(e[20]) + r);
+        let p = p * (ctx.lift(e[21]) + r);
+        let p = p * (ctx.lift(e[22]) + r);
+        let p = p * (ctx.lift(e[23]) + r);
+        let p = p * (ctx.lift(e[24]) + r);
+        let p = p * (ctx.lift(e[25]) + r);
+        let p = p * (ctx.lift(e[26]) + r);
+        let p = p * (ctx.lift(e[27]) + r);
+        let p = p * (ctx.lift(e[28]) + r);
+        let p = p * (ctx.lift(e[29]) + r);
+        let p = p * (ctx.lift(e[30]) + r);
+        let term = ctx.lift(acc_in) * p;
+        ctx.assert_zero(term - ctx.lift(acc_out)).expect("chunk");
+    }
+}
+
+/// Walks the whole product: wires are `[e_0..e_{M-1}, acc_0..acc_{n_chunks}]`
+/// with `acc_0 = 1`, and chunk `k` constrains `acc_{k+1}` against `acc_k`.
+fn eval<Ch, Ctx>(ctx: &mut Ctx, wires: &[Ctx::Wire], r: Gf2_64)
+where
+    Ch: Chunk,
+    Ctx: PolyContext<Field = Gf2_64>,
+    Ctx::Error: std::fmt::Debug,
+{
+    let r_expr = ctx.lift_const(r);
+    let n_chunks = M / Ch::C;
+    for k in 0..n_chunks {
+        let entries = &wires[k * Ch::C..k * Ch::C + Ch::C];
+        Ch::constrain(ctx, wires[M + k], entries, r_expr, wires[M + k + 1]);
+    }
+}
+
+// ===========================================================================
+// Harness
+// ===========================================================================
+
+/// The satisfying witness: `M` random entries followed by the `n_chunks + 1`
+/// partial products `acc_0 = 1, acc_k = acc_{k-1}·∏(eᵢ + r)`.
+fn witness<Ch: Chunk>(rng: &mut StdRng) -> (Vec<Gf2_64>, Gf2_64) {
+    let r = Gf2_64(rng.random());
+    let entries: Vec<Gf2_64> = (0..M).map(|_| Gf2_64(rng.random())).collect();
+
+    let n_chunks = M / Ch::C;
+    let mut acc = vec![Gf2_64::ONE; n_chunks + 1];
+    for k in 0..n_chunks {
+        let mut prod = Gf2_64::ONE;
+        for j in 0..Ch::C {
+            prod = prod * (entries[k * Ch::C + j] + r);
+        }
+        acc[k + 1] = acc[k] * prod;
+    }
+
+    let mut values = entries;
+    values.extend(acc);
+    (values, r)
+}
+
+struct Inputs {
+    delta: Gf2_128,
+    d_max: usize,
+    r: Gf2_64,
+    /// Cleartext committed values (for the commit pass).
+    values: Vec<Gf2_64>,
+    /// Prover input wires (value + raw MAC).
+    mac_wires: Vec<Auth64>,
+    /// Verifier input wires (adjusted keys).
+    key_wires: Vec<Gf2_128>,
+    chi: [u8; 32],
+    powers: DeltaPowers,
+    poly_vope_sum: Gf2_128,
+    coefficients: Vec<Gf2_128>,
+}
+
+fn setup<Ch: Chunk>() -> Inputs {
+    let mut rng = StdRng::seed_from_u64(0x9_0d);
+    let (values, r) = witness::<Ch>(&mut rng);
+    let n = values.len();
+    let delta = Gf2_128::new(rng.random());
+    let d_max = Ch::D;
+
+    // Subfield sVOLE: choice ∈ GF(2^64), key ∈ GF(2^128),
+    // mac = key + embed(choice)·Δ.
+    let choices: Vec<Gf2_64> = (0..n).map(|_| Gf2_64(rng.random())).collect();
+    let keys: Vec<Gf2_128> = (0..n).map(|_| Gf2_128::new(rng.random())).collect();
+    let mac_wires: Vec<Auth64> = (0..n)
+        .map(|i| Auth64 {
+            value: values[i],
+            mac: keys[i] + embed(choices[i]) * delta,
+        })
+        .collect();
+    let key_wires: Vec<Gf2_128> = (0..n)
+        .map(|i| keys[i] + embed(values[i] + choices[i]) * delta)
+        .collect();
+
+    // Mock degree-`d_max` polynomial-check VOPE.
+    let powers = DeltaPowers::new(delta);
+    let poly_masks: Vec<Gf2_128> = (0..d_max).map(|_| Gf2_128::new(rng.random())).collect();
+    let mut poly_vope_sum = Gf2_128::new(0);
+    let mut pw = Gf2_128::new(1);
+    for &m in &poly_masks {
+        poly_vope_sum = poly_vope_sum + m * pw;
+        pw = pw * delta;
+    }
+
+    // Fiat–Shamir challenge stream seed, shared by setup and the benched runs.
+    let chi: [u8; 32] = rng.random();
+
+    // One prover run to produce the masked coefficients.
+    let mut commit = Commit::new(&mut []);
+    eval::<Ch, _>(&mut commit, &values, r);
+    commit.finish().expect("commit finish");
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    eval::<Ch, _>(&mut prover, &mac_wires, r);
+    let ProverOutput { poly, .. } = prover.finish().expect("accumulate finish");
+    let coefficients: Vec<Gf2_128> = poly
+        .coefficients(d_max)
+        .expect("coefficients")
+        .into_iter()
+        .zip(&poly_masks)
+        .map(|(c, &m)| c + m)
+        .collect();
+
+    Inputs {
+        delta,
+        d_max,
+        r,
+        values,
+        mac_wires,
+        key_wires,
+        chi,
+        powers,
+        poly_vope_sum,
+        coefficients,
+    }
+}
+
+fn run_prover<Ch: Chunk>(inputs: &Inputs) {
+    let mut commit = Commit::new(&mut []);
+    eval::<Ch, _>(&mut commit, &inputs.values, inputs.r);
+    commit.finish().expect("commit finish");
+
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    eval::<Ch, _>(&mut prover, &inputs.mac_wires, inputs.r);
+    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
+
+    let coefficients: Vec<Gf2_128> = poly.coefficients(inputs.d_max).expect("coefficients");
+    let _proof = Proof {
+        assertions,
+        u,
+        v,
+        coefficients,
+    };
+}
+
+fn run_verifier<Ch: Chunk>(inputs: &Inputs) {
+    let verifier = Verifier::new(inputs.delta, &[], &[]).expect("new");
+    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    eval::<Ch, _>(&mut verifier, &inputs.key_wires, inputs.r);
+    let VerifierOutput { poly, .. } = verifier.finish().expect("finish");
+
+    poly.check(&inputs.powers, &inputs.coefficients, inputs.poly_vope_sum)
+        .expect("poly check");
+}
+
+fn bench_one<Ch: Chunk>(c: &mut Criterion, label: &str) {
+    let inputs = setup::<Ch>();
+
+    let mut pg = c.benchmark_group("product_prover");
+    pg.sample_size(10);
+    pg.measurement_time(Duration::from_secs(10));
+    pg.throughput(Throughput::Elements(M as u64));
+    pg.bench_function(BenchmarkId::new("chunk", label), |b| {
+        b.iter(|| run_prover::<Ch>(&inputs))
+    });
+    pg.finish();
+
+    let mut vg = c.benchmark_group("product_verifier");
+    vg.sample_size(10);
+    vg.measurement_time(Duration::from_secs(10));
+    vg.throughput(Throughput::Elements(M as u64));
+    vg.bench_function(BenchmarkId::new("chunk", label), |b| {
+        b.iter(|| run_verifier::<Ch>(&inputs))
+    });
+    vg.finish();
+}
+
+fn bench_product(c: &mut Criterion) {
+    bench_one::<Chunk1>(c, "1_deg2");
+    bench_one::<Chunk3>(c, "3_deg4");
+    bench_one::<Chunk7>(c, "7_deg8");
+    bench_one::<Chunk15>(c, "15_deg16");
+    bench_one::<Chunk31>(c, "31_deg32");
+}
+
+criterion_group!(benches, bench_product);
+criterion_main!(benches);

--- a/crates/zk-core/benches/sha256.rs
+++ b/crates/zk-core/benches/sha256.rs
@@ -14,7 +14,7 @@ use mpz_circuits::{
 use mpz_core::Block;
 use mpz_fields::gf2_128::Gf2_128;
 use mpz_ot_core::ideal::rcot::IdealRCOT;
-use mpz_zk_core::{Commit, Proof, Prover, Verifier, vope_receiver, vope_sender};
+use mpz_zk_core::{Commit, Proof, Prover, ProverOutput, Verifier, VerifierOutput, vope_receiver, vope_sender};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rand_chacha::ChaCha12Rng;
 
@@ -141,13 +141,14 @@ fn setup_inputs(num_blocks: usize) -> BenchInputs {
     commit.finish().expect("commit finish");
     let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
     let _ = sha256_chain(&mut prover, state_p, &msg_p);
-    let (u, v, assertions) = prover.finish().expect("accumulate finish");
+    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
 
     let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
     let proof = Proof {
         assertions,
         u: u + a_0,
         v: v + a_1,
+        coefficients: Vec::new(),
     };
 
     BenchInputs {
@@ -179,13 +180,14 @@ fn run_prover(inputs: &BenchInputs, num_blocks: usize) {
     let mut prover =
         Prover::committed(&inputs.gate_macs).accumulate(ChaCha12Rng::from_seed(inputs.chi));
     let _ = sha256_chain(&mut prover, state, &msg_blocks);
-    let (u, v, assertions) = prover.finish().expect("accumulate finish");
+    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
 
     let (a_0, a_1) = vope_receiver(&inputs.vope_choices, &inputs.vope_ev);
     let _proof = Proof {
         assertions,
         u: u + a_0,
         v: v + a_1,
+        coefficients: Vec::new(),
     };
 }
 
@@ -199,7 +201,7 @@ fn run_verifier(inputs: &BenchInputs, num_blocks: usize) {
         Verifier::new(inputs.delta, &inputs.gate_keys, &inputs.gate_adjust).expect("new");
     let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
     let _ = sha256_chain(&mut verifier, state, &msg_blocks);
-    let (w, assertions) = verifier.finish().expect("finish");
+    let VerifierOutput { w, assertions, .. } = verifier.finish().expect("finish");
 
     let b = vope_sender(&inputs.vope_keys);
     assert_eq!(assertions, inputs.proof.assertions);

--- a/crates/zk-core/src/gf64.rs
+++ b/crates/zk-core/src/gf64.rs
@@ -1,0 +1,564 @@
+//! Circuits over `GF(2^64)` with `GF(2^128)` MACs (a subfield IT-MAC).
+//!
+//! The boolean path ([`Prover`](crate::Prover)/[`Verifier`](crate::Verifier))
+//! packs the committed bit into the MAC's LSB (the pointer-bit trick); a 64-bit
+//! value cannot be packed that way, so this path carries the value explicitly.
+//!
+//! A committed value `x ∈ GF(2^64)` is authenticated by `M = K + embed(x)·Δ`,
+//! where `M` (prover MAC) and `K` (verifier key) live in `GF(2^128)`, `Δ` is
+//! the verifier's secret, and `embed` is the subfield injection
+//! [`ExtensionField<Gf2_64>`](mpz_fields::ExtensionField) of `GF(2^64)` into
+//! `GF(2^128)`. The prover wire is [`Auth64`] (value + MAC); the verifier wire
+//! is the key alone.
+//!
+//! The protocol matches the boolean path otherwise: a mask-only commit pass
+//! ([`Commit`]) records the per-wire adjustment `adjust = value − choice ∈
+//! GF(2^64)`, and the accumulate passes fold each multiplication into the
+//! QuickSilver triple check under a streamed challenge. The two specializations
+//! relative to the boolean path are (1) the value is tracked in [`Auth64`]
+//! rather than the MAC LSB, and (2) the verifier reconstructs keys with
+//! `key += embed(adjust)·Δ` (a subfield scaling) instead of a conditional `Δ`
+//! add.
+
+use blake3::Hasher;
+use mpz_circuits::Context;
+use mpz_fields::{
+    Accumulator, ExtensionField,
+    gf2_64::Gf2_64,
+    gf2_128::{Gf2_128, Gf2_128Accumulator},
+};
+use rand_core::RngCore;
+use typenum::{Max, Maximum, U0, U1, Unsigned};
+use zerocopy::IntoBytes;
+
+use crate::{
+    Error, ProverOutput, Result, VerifierOutput,
+    poly::{
+        Degree, Expr, PlainCoeffs, PolyContext, ProverCoeffs, ProverPoly, VerifierCoeffs,
+        VerifierPoly,
+    },
+    util::draw_chi,
+};
+
+/// `mac · embed(v)` — scale a MAC by a subfield value (`embed` is the subfield
+/// injection `GF(2^64) ↪ GF(2^128)`).
+#[inline]
+fn scale(mac: Gf2_128, v: Gf2_64) -> Gf2_128 {
+    <Gf2_128 as ExtensionField<Gf2_64>>::scale_by_subfield(mac, v)
+}
+
+/// A prover-side authenticated `GF(2^64)` wire: the cleartext `value` and its
+/// MAC `M = K + embed(value)·Δ`.
+#[derive(Debug, Clone, Copy)]
+pub struct Auth64 {
+    /// The cleartext value.
+    pub value: Gf2_64,
+    /// The MAC over [`value`](Self::value).
+    pub mac: Gf2_128,
+}
+
+// ===========================================================================
+// Commit pass
+// ===========================================================================
+
+/// The prover's commit-pass context over `GF(2^64)`.
+///
+/// Pure cleartext evaluation over the values. Each input and multiplication
+/// records its adjustment `value − choice` into the mask tape in place (the
+/// tape starts holding the sVOLE `choice` values); the resulting adjustments
+/// are sent to the verifier. Circuits must be re-walked with the same inputs in
+/// the accumulate pass.
+#[derive(Debug)]
+pub struct Commit<'a> {
+    masks: &'a mut [Gf2_64],
+    cursor: usize,
+}
+
+impl<'a> Commit<'a> {
+    /// Creates a commit-pass context over the mask tape.
+    pub fn new(masks: &'a mut [Gf2_64]) -> Self {
+        Self { masks, cursor: 0 }
+    }
+
+    /// Commits a private input `value`, recording its adjustment, and returns
+    /// the cleartext wire.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mask tape has been exhausted.
+    pub fn input(&mut self, value: Gf2_64) -> Gf2_64 {
+        let i = self.cursor;
+        let slot = self
+            .masks
+            .get_mut(i)
+            .expect("mask tape exhausted during input");
+        *slot = *slot + value;
+        self.cursor = i + 1;
+        value
+    }
+
+    /// Returns the wire for a public input `value` (consumes no tape entry).
+    pub fn input_public(&self, value: Gf2_64) -> Gf2_64 {
+        value
+    }
+
+    /// Completes the commit pass.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the number of consumed tape entries does not match
+    /// the tape length.
+    pub fn finish(self) -> Result<()> {
+        if self.cursor != self.masks.len() {
+            return Err(Error::tape_unconsumed(self.cursor, self.masks.len()));
+        }
+        Ok(())
+    }
+}
+
+impl Context for Commit<'_> {
+    type Error = Error;
+    type Wire = Gf2_64;
+    type Field = Gf2_64;
+
+    fn add(&mut self, a: Gf2_64, b: Gf2_64) -> Gf2_64 {
+        a + b
+    }
+
+    fn sub(&mut self, a: Gf2_64, b: Gf2_64) -> Gf2_64 {
+        a - b
+    }
+
+    fn mul(&mut self, a: Gf2_64, b: Gf2_64) -> Gf2_64 {
+        let i = self.cursor;
+        let slot = self
+            .masks
+            .get_mut(i)
+            .expect("mask tape exhausted: circuit has more multiplications than the tape");
+        let z = a * b;
+        *slot = *slot + z;
+        self.cursor = i + 1;
+        z
+    }
+
+    fn constant(&mut self, v: Gf2_64) -> Gf2_64 {
+        v
+    }
+
+    fn assert_const(&mut self, v: Gf2_64, expected: Gf2_64) -> Result<()> {
+        // The proof's assertion binding is built in the accumulate pass; here
+        // the check only surfaces witness bugs early.
+        if v != expected {
+            return Err(Error::assert());
+        }
+        Ok(())
+    }
+}
+
+impl PolyContext for Commit<'_> {
+    /// Plaintext evaluation: an expression is just its cleartext `GF(2^64)`
+    /// value, so polynomial gadgets compile down to field operations.
+    type Coeffs = PlainCoeffs<Gf2_64>;
+
+    fn lift(&self, wire: Gf2_64) -> Expr<PlainCoeffs<Gf2_64>, U1> {
+        Expr::new(wire)
+    }
+
+    fn lift_const(&self, value: Gf2_64) -> Expr<PlainCoeffs<Gf2_64>, U0> {
+        Expr::new(value)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<PlainCoeffs<Gf2_64>, N>) -> Gf2_64
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        self.input(expr.plain())
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<PlainCoeffs<Gf2_64>, N>) -> Result<()> {
+        if expr.plain() != Gf2_64::ZERO {
+            return Err(Error::assert());
+        }
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// Prover
+// ===========================================================================
+
+/// The prover side of the `GF(2^64)` protocol.
+///
+/// Mirrors [`Prover`](crate::Prover): a mask-only [`Commit`] pass, then an
+/// accumulate pass from [`Prover::committed`] that folds every multiplication
+/// into the running proof under the installed challenge stream.
+/// [`finish`](Prover::finish) yields a [`ProverOutput`], which the caller
+/// masks with the VOPE correlation.
+#[derive(Debug)]
+pub struct Prover<'a, S> {
+    macs: &'a [Gf2_128],
+    cursor: usize,
+    state: S,
+}
+
+/// Committed state for the [`Prover`].
+#[derive(Debug)]
+pub struct Committed;
+
+/// Accumulate-phase state for the [`Prover`].
+#[derive(Debug)]
+pub struct Accumulate<R> {
+    assertions: Hasher,
+    rng: R,
+    u: Gf2_128Accumulator,
+    v: Gf2_128Accumulator,
+    poly: ProverPoly,
+}
+
+impl<'a> Prover<'a, Committed> {
+    /// Creates a prover directly in the committed state over the MAC tape.
+    pub fn committed(macs: &'a [Gf2_128]) -> Self {
+        Self {
+            macs,
+            cursor: 0,
+            state: Committed,
+        }
+    }
+
+    /// Begins the accumulate pass, drawing challenge weights from `rng`.
+    ///
+    /// Each multiplication consumes 16 bytes of the stream, so `rng` must be
+    /// positioned to match the gates evaluated.
+    pub fn accumulate<R: RngCore>(self, rng: R) -> Prover<'a, Accumulate<R>> {
+        Prover {
+            macs: self.macs,
+            cursor: self.cursor,
+            state: Accumulate {
+                assertions: Hasher::default(),
+                rng,
+                u: Gf2_128Accumulator::zero(),
+                v: Gf2_128Accumulator::zero(),
+                poly: ProverPoly::default(),
+            },
+        }
+    }
+}
+
+impl<'a, R> Prover<'a, Accumulate<R>> {
+    /// Consumes the next tape entry for a private input `value`, returning its
+    /// authenticated wire (the raw sVOLE MAC; the verifier adjusts its key).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the MAC tape has been exhausted.
+    pub fn input(&mut self, value: Gf2_64) -> Auth64 {
+        let i = self.cursor;
+        let mac = *self.macs.get(i).expect("mac tape exhausted during input");
+        self.cursor = i + 1;
+        Auth64 { value, mac }
+    }
+
+    /// Returns the authenticated wire for a public input `value` (MAC `0`).
+    pub fn input_public(&self, value: Gf2_64) -> Auth64 {
+        Auth64 {
+            value,
+            mac: Gf2_128::ZERO,
+        }
+    }
+
+    /// Completes the accumulate phase, yielding a [`ProverOutput`].
+    ///
+    /// `poly` carries the polynomial-check coefficients (empty unless
+    /// [`PolyContext`] constraints were recorded); the caller masks them with
+    /// the degree-`d_max` VOPE before sending.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the consumed tape length does not match the tape.
+    pub fn finish(self) -> Result<ProverOutput> {
+        if self.cursor != self.macs.len() {
+            return Err(Error::tape_unconsumed(self.cursor, self.macs.len()));
+        }
+        Ok(ProverOutput {
+            u: self.state.u.reduce(),
+            v: self.state.v.reduce(),
+            poly: self.state.poly,
+            assertions: *self.state.assertions.finalize().as_bytes(),
+        })
+    }
+}
+
+impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
+    type Error = Error;
+    type Wire = Auth64;
+    type Field = Gf2_64;
+
+    fn add(&mut self, a: Auth64, b: Auth64) -> Auth64 {
+        Auth64 {
+            value: a.value + b.value,
+            mac: a.mac + b.mac,
+        }
+    }
+
+    fn sub(&mut self, a: Auth64, b: Auth64) -> Auth64 {
+        self.add(a, b)
+    }
+
+    fn mul(&mut self, a: Auth64, b: Auth64) -> Auth64 {
+        let i = self.cursor;
+        let mac = *self
+            .macs
+            .get(i)
+            .expect("mac tape exhausted: circuit has more multiplications than the tape");
+        self.cursor = i + 1;
+
+        let value = a.value * b.value;
+        let chi = draw_chi(&mut self.state.rng);
+
+        // QuickSilver triple check: u accumulates `M_x·M_y`, v accumulates
+        // `embed(x)·M_y + embed(y)·M_x + M_z` (the subfield-scaled body).
+        let body_v = scale(b.mac, a.value) + scale(a.mac, b.value) + mac;
+        self.state.u.add_product(a.mac * b.mac, chi);
+        self.state.v.add_product(body_v, chi);
+
+        Auth64 { value, mac }
+    }
+
+    fn constant(&mut self, v: Gf2_64) -> Auth64 {
+        self.input_public(v)
+    }
+
+    fn assert_const(&mut self, v: Auth64, expected: Gf2_64) -> Result<()> {
+        if v.value != expected {
+            return Err(Error::assert());
+        }
+        self.state.assertions.update(v.mac.as_bytes());
+        Ok(())
+    }
+}
+
+impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
+    type Coeffs = ProverCoeffs<Gf2_64>;
+
+    fn lift(&self, wire: Auth64) -> Expr<ProverCoeffs<Gf2_64>, U1> {
+        Expr::<ProverCoeffs<Gf2_64>, U1>::lift_wire(wire.mac, wire.value)
+    }
+
+    fn lift_const(&self, value: Gf2_64) -> Expr<ProverCoeffs<Gf2_64>, U0> {
+        Expr::<ProverCoeffs<Gf2_64>, U0>::constant(value)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<ProverCoeffs<Gf2_64>, N>) -> Auth64
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        let wire = self.input(expr.value());
+        // Pin the fresh wire to the expression: `expr - wire == 0`.
+        let constraint = expr - self.lift(wire);
+        let chi = draw_chi(&mut self.state.rng);
+        self.state.poly.fold_expr(&constraint, chi);
+        wire
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<ProverCoeffs<Gf2_64>, N>) -> Result<()> {
+        let Self { state, .. } = self;
+        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+    }
+}
+
+// ===========================================================================
+// Verifier
+// ===========================================================================
+
+/// The verifier side of the `GF(2^64)` protocol.
+///
+/// Mirrors [`Verifier`](crate::Verifier): constructed from the commitment
+/// (per-wire adjustments) and the key tape, it installs the challenge stream
+/// and folds every multiplication into the check state. [`finish`](Self::finish)
+/// yields a [`VerifierOutput`]; the caller accepts iff `w == u + Δ·v` (after
+/// VOPE masking) and the assertion hashes match.
+#[derive(Debug)]
+pub struct Verifier<'a, S> {
+    keys: &'a [Gf2_128],
+    adjust: &'a [Gf2_64],
+    delta: Gf2_128,
+    cursor: usize,
+    state: S,
+}
+
+/// Committed state for the [`Verifier`].
+#[derive(Debug)]
+pub struct VerifierCommitted;
+
+/// Accumulate-phase state for the [`Verifier`].
+#[derive(Debug)]
+pub struct VerifierAccumulate<R> {
+    assertions: Hasher,
+    rng: R,
+    xy: Gf2_128Accumulator,
+    z: Gf2_128Accumulator,
+    poly: VerifierPoly,
+}
+
+impl<'a> Verifier<'a, VerifierCommitted> {
+    /// Creates a verifier with the global MAC key `delta`, the key tape, and
+    /// the adjustment tape received as the commitment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if `keys` and `adjust` differ in length.
+    pub fn new(delta: Gf2_128, keys: &'a [Gf2_128], adjust: &'a [Gf2_64]) -> Result<Self> {
+        if keys.len() != adjust.len() {
+            return Err(Error::tape_len("adjust", keys.len(), adjust.len()));
+        }
+        Ok(Self {
+            keys,
+            adjust,
+            delta,
+            cursor: 0,
+            state: VerifierCommitted,
+        })
+    }
+
+    /// Begins the accumulate pass, drawing challenge weights from `rng`.
+    pub fn accumulate<R: RngCore>(self, rng: R) -> Verifier<'a, VerifierAccumulate<R>> {
+        Verifier {
+            keys: self.keys,
+            adjust: self.adjust,
+            delta: self.delta,
+            cursor: self.cursor,
+            state: VerifierAccumulate {
+                assertions: Hasher::default(),
+                rng,
+                xy: Gf2_128Accumulator::zero(),
+                z: Gf2_128Accumulator::zero(),
+                poly: VerifierPoly::default(),
+            },
+        }
+    }
+}
+
+impl<'a, R> Verifier<'a, VerifierAccumulate<R>> {
+    /// Consumes the next input from the tapes and returns its verifier key,
+    /// adjusted by `embed(adjust)·Δ`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a tape has been exhausted.
+    pub fn input(&mut self) -> Gf2_128 {
+        let i = self.cursor;
+        let raw = *self.keys.get(i).expect("key tape exhausted during input");
+        let adj = *self
+            .adjust
+            .get(i)
+            .expect("adjust tape exhausted during input");
+        self.cursor = i + 1;
+        raw + scale(self.delta, adj)
+    }
+
+    /// Returns the verifier key for a public input `value`: `embed(value)·Δ`.
+    pub fn input_public(&self, value: Gf2_64) -> Gf2_128 {
+        scale(self.delta, value)
+    }
+
+    /// Completes the accumulate phase, yielding a [`VerifierOutput`].
+    ///
+    /// `poly` carries the polynomial-check state ([`VerifierPoly::check`]);
+    /// empty unless [`PolyContext`] constraints were recorded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the consumed tape length does not match the tape.
+    pub fn finish(self) -> Result<VerifierOutput> {
+        if self.cursor != self.adjust.len() {
+            return Err(Error::tape_unconsumed(self.cursor, self.adjust.len()));
+        }
+        let w = self.state.xy.reduce() + self.delta * self.state.z.reduce();
+        Ok(VerifierOutput {
+            w,
+            poly: self.state.poly,
+            assertions: *self.state.assertions.finalize().as_bytes(),
+        })
+    }
+}
+
+impl<R: RngCore> Context for Verifier<'_, VerifierAccumulate<R>> {
+    type Error = Error;
+    type Wire = Gf2_128;
+    type Field = Gf2_64;
+
+    fn add(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+        a + b
+    }
+
+    fn sub(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+        a - b
+    }
+
+    fn mul(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+        let i = self.cursor;
+        let raw = *self
+            .keys
+            .get(i)
+            .expect("key tape exhausted: circuit has more multiplications than the tape");
+        let adj = *self
+            .adjust
+            .get(i)
+            .expect("adjust tape exhausted: circuit has more multiplications than the tape");
+        self.cursor = i + 1;
+
+        let key = raw + scale(self.delta, adj);
+        let chi = draw_chi(&mut self.state.rng);
+
+        self.state.xy.add_product(a * b, chi);
+        self.state.z.add_product(key, chi);
+
+        key
+    }
+
+    fn constant(&mut self, v: Gf2_64) -> Gf2_128 {
+        self.input_public(v)
+    }
+
+    fn assert_const(&mut self, v: Gf2_128, expected: Gf2_64) -> Result<()> {
+        // If the committed value is `expected`, the prover's MAC equals
+        // `v + embed(expected)·Δ`; hash that to match the prover.
+        let mac = v + scale(self.delta, expected);
+        self.state.assertions.update(mac.as_bytes());
+        Ok(())
+    }
+}
+
+impl<R: RngCore> PolyContext for Verifier<'_, VerifierAccumulate<R>> {
+    type Coeffs = VerifierCoeffs;
+
+    fn lift(&self, wire: Gf2_128) -> Expr<VerifierCoeffs, U1> {
+        Expr::<VerifierCoeffs, U1>::lift_key(wire, self.delta)
+    }
+
+    fn lift_const(&self, value: Gf2_64) -> Expr<VerifierCoeffs, U0> {
+        Expr::<VerifierCoeffs, U0>::constant(value, self.delta)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Gf2_128
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        let wire = self.input();
+        // Pin the fresh wire to the expression: `expr - wire == 0`.
+        let constraint = expr - self.lift(wire);
+        let chi = draw_chi(&mut self.state.rng);
+        self.state
+            .poly
+            .fold_expr(&constraint, Maximum::<N, U1>::USIZE, chi);
+        wire
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Result<()> {
+        let Self { state, .. } = self;
+        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+    }
+}

--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -10,13 +10,13 @@
 //! starts from [`prover::Prover::committed`], installs the challenge stream,
 //! and the accumulate pass
 //! ([`prover::Accumulate`]) folds every multiplication and assertion into the
-//! proof, yielding `(u, v, assertions)`, which the caller masks with the VOPE
+//! proof, yielding a [`ProverOutput`], which the caller masks with the VOPE
 //! correlation ([`vope_receiver`]) to form a [`Proof`].
 //!
 //! The verifier starts from the received commitment
 //! ([`verifier::Committed`]), installs the challenge stream it sampled, and
 //! performs a single accumulate pass ([`verifier::Accumulate`]) over the same
-//! circuits, yielding `(w, assertions)`. The caller masks `w` with the VOPE
+//! circuits, yielding a [`VerifierOutput`]. The caller masks `w` with the VOPE
 //! correlation ([`vope_sender`]) and accepts iff `w == u + delta * v` and the
 //! assertion hashes match.
 //!
@@ -25,20 +25,71 @@
 //! the challenge stream seeked to its gate offset — and the partial results
 //! combined by field addition. See [`prover::Prover::committed`].
 //!
+//! Two extensions reuse the same machinery:
+//!
+//! - [`PolyContext`] (composite QuickSilver) verifies higher-degree polynomial
+//!   constraints `f(w) = 0` directly, rather than committing every intermediate
+//!   product — the prover sends `d_max` masked coefficients per proof and the
+//!   verifier batches all constraints into one check.
+//! - [`gf64`] runs the whole protocol over `GF(2^64)` instead of bits, keeping
+//!   the `GF(2^128)` MACs (a subfield IT-MAC). The boolean path's pointer-bit
+//!   packing does not generalize, so the prover carries the value explicitly;
+//!   both the triple check and [`PolyContext`] are available there too.
+//!
 //! Errors surfaced by these operations are reported via [`Error`] and the
 //! crate-wide [`Result`] alias.
 
+pub mod gf64;
+pub mod poly;
 pub mod prover;
 mod util;
 pub mod verifier;
 mod vope;
 
+pub use poly::{DeltaPowers, MAX_DEGREE, PolyContext, ProverPoly, VerifierPoly};
 pub use prover::{Commit, Prover};
 pub use verifier::Verifier;
 pub use vope::{vope_receiver, vope_sender};
 
 use mpz_core::bitvec::BitVec;
 use mpz_fields::gf2_128::Gf2_128;
+
+/// The output of a prover accumulate pass ([`Prover::finish`] and its
+/// [`gf64`] counterpart).
+///
+/// The caller masks `(u, v)` with the VOPE correlation
+/// ([`vope_receiver`]) and the polynomial-check `poly` coefficients
+/// ([`ProverPoly::coefficients`]) with the degree-`d_max` VOPE coefficients
+/// before assembling a [`Proof`].
+#[derive(Debug)]
+pub struct ProverOutput {
+    /// The `u` proof accumulator (the `Σ χᵢ·MₓMᵧ` body), reduced.
+    pub u: Gf2_128,
+    /// The `v` proof accumulator (the subfield-scaled body), reduced.
+    pub v: Gf2_128,
+    /// The polynomial-check coefficients; empty unless [`PolyContext`]
+    /// constraints were recorded.
+    pub poly: ProverPoly,
+    /// Hash of the wires asserted during evaluation.
+    pub assertions: [u8; 32],
+}
+
+/// The output of a verifier accumulate pass ([`Verifier::finish`] and its
+/// [`gf64`] counterpart).
+///
+/// The caller masks `w` with the VOPE correlation ([`vope_sender`]) and
+/// accepts iff `w == u + delta·v`, the assertion hashes match, and the
+/// polynomial check passes ([`VerifierPoly::check`]).
+#[derive(Debug)]
+pub struct VerifierOutput {
+    /// The reduced check value `Σ χᵢ·xᵢyᵢ + Δ·Σ χᵢ·zᵢ`.
+    pub w: Gf2_128,
+    /// The polynomial-check state; empty unless [`PolyContext`] constraints
+    /// were recorded.
+    pub poly: VerifierPoly,
+    /// Hash of the wires asserted during evaluation.
+    pub assertions: [u8; 32],
+}
 
 /// Materializes the prover's authenticated wire for the tape entry `mac`
 /// committed to `bit`.
@@ -106,6 +157,11 @@ pub struct Proof {
     pub u: Gf2_128,
     /// The masked `v` proof accumulator.
     pub v: Gf2_128,
+    /// Masked coefficients of the polynomial check, degrees
+    /// `0 ..= d_max - 1` ([`ProverPoly::coefficients`] plus the degree-`d_max`
+    /// VOPE mask coefficients). Empty when no polynomial constraints were
+    /// recorded.
+    pub coefficients: Vec<Gf2_128>,
 }
 
 /// An error returned by the prover or verifier.
@@ -133,12 +189,24 @@ impl Error {
     pub(crate) fn tape_unconsumed(consumed: usize, total: usize) -> Self {
         Self(ErrorRepr::TapeUnconsumed { consumed, total })
     }
+
+    pub(crate) fn degree(max_seen: usize, d_max: usize) -> Self {
+        Self(ErrorRepr::Degree { max_seen, d_max })
+    }
+
+    pub(crate) fn check() -> Self {
+        Self(ErrorRepr::Check)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
 enum ErrorRepr {
     #[error("witness assertion failed")]
     Assert,
+    #[error("polynomial check failed")]
+    Check,
+    #[error("constraint degree {max_seen} exceeds d_max {d_max}")]
+    Degree { max_seen: usize, d_max: usize },
     #[error("tape `{name}` length mismatch: expected {expected}, got {actual}")]
     TapeLength {
         name: &'static str,
@@ -161,9 +229,10 @@ mod tests {
     use rand_chacha::ChaCha12Rng;
 
     use super::{
-        Commit, Error, ErrorRepr, Proof, Prover, Verifier, util::set_lsb, vope_receiver,
-        vope_sender,
+        Commit, DeltaPowers, Error, ErrorRepr, PolyContext, Proof, Prover, ProverOutput, Verifier,
+        VerifierOutput, util::set_lsb, vope_receiver, vope_sender,
     };
+    use mpz_fields::gf2::Gf2;
 
     fn random_delta(rng: &mut StdRng) -> Gf2_128 {
         let mut d = Gf2_128::new(rng.random());
@@ -256,13 +325,14 @@ mod tests {
         commit.finish().unwrap();
         let mut prover = Prover::committed(&i.gate_macs).accumulate(ChaCha12Rng::from_seed(i.chi));
         let _ = compress(&mut prover, i.msg_macs, i.state_macs);
-        let (u, v, assertions) = prover.finish().unwrap();
+        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&i.vope_choices, &i.vope_ev);
         Proof {
             assertions,
             u: u + a_0,
             v: v + a_1,
+            coefficients: Vec::new(),
         }
     }
 
@@ -272,7 +342,8 @@ mod tests {
         let verifier = Verifier::new(i.delta, gate_keys, masks).unwrap();
         let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(i.chi));
         let _ = compress(&mut verifier, i.msg_keys, i.state_keys);
-        verifier.finish().unwrap()
+        let VerifierOutput { w, assertions, .. } = verifier.finish().unwrap();
+        (w, assertions)
     }
 
     #[test]
@@ -380,7 +451,7 @@ mod tests {
             let mut prover =
                 Prover::committed(&i.gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
             let _ = compress(&mut prover, i.msg_macs, i.state_macs);
-            let (u, v, _) = prover.finish().unwrap();
+            let ProverOutput { u, v, .. } = prover.finish().unwrap();
             (u, v)
         };
 
@@ -432,7 +503,7 @@ mod tests {
             for (a, b, _, _) in wires {
                 let _ = p.mul(*a, *b);
             }
-            let (u, v, _) = p.finish().unwrap();
+            let ProverOutput { u, v, .. } = p.finish().unwrap();
             (u, v)
         };
 
@@ -442,11 +513,13 @@ mod tests {
                              gate_offset: usize| {
             let mut rng = ChaCha12Rng::from_seed(chi);
             rng.set_word_pos((gate_offset * 4) as u128);
-            let mut v = Verifier::new(delta, keys, adjust).unwrap().accumulate(rng);
+            let mut v = Verifier::new(delta, keys, adjust)
+                .unwrap()
+                .accumulate(rng);
             for (_, _, a, b) in wires {
                 let _ = v.mul(*a, *b);
             }
-            let (w, _) = v.finish().unwrap();
+            let VerifierOutput { w, .. } = v.finish().unwrap();
             w
         };
 
@@ -488,19 +561,20 @@ mod tests {
         commit.finish().unwrap();
         let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
         prover.assert_eq(mac_a, mac_b).unwrap();
-        let (u, v, assertions) = prover.finish().unwrap();
+        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
         let proof = Proof {
             assertions,
             u: u + a_0,
             v: v + a_1,
+            coefficients: Vec::new(),
         };
 
         let verifier = Verifier::new(delta, &gate_keys, &gate_masks).unwrap();
         let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
         verifier.assert_eq(key_a, key_b).unwrap();
-        let (w, v_assertions) = verifier.finish().unwrap();
+        let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().unwrap();
         let b = vope_sender(&vope_keys);
 
         assert_eq!(v_assertions, proof.assertions);
@@ -552,25 +626,263 @@ mod tests {
         // Prover skips the assertion (simulating a malicious party).
         Commit::new(&mut gate_masks).finish().unwrap();
         let prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
-        let (u, v, assertions) = prover.finish().unwrap();
+        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
         let proof = Proof {
             assertions,
             u: u + a_0,
             v: v + a_1,
+            coefficients: Vec::new(),
         };
 
         // Verifier honestly performs the assertion.
         let verifier = Verifier::new(delta, &gate_keys, &gate_masks).unwrap();
         let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
         verifier.assert_eq(key_a, key_b).unwrap();
-        let (w, v_assertions) = verifier.finish().unwrap();
+        let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().unwrap();
         let b = vope_sender(&vope_keys);
 
         assert_ne!(v_assertions, proof.assertions);
         // The check equation itself still holds — rejection comes from
         // the assertion hash mismatch.
         assert_eq!(w + b, proof.u + delta * proof.v);
+    }
+
+    /// A trace mixing the triple check and the polynomial check: a committed
+    /// multiplication, a degree-3 `acc_mux`-shaped constraint, a materialized
+    /// degree-2 mux whose output feeds another committed multiplication.
+    ///
+    /// Consumes 3 tape entries and 4 challenge weights.
+    fn poly_trace<C>(ctx: &mut C, w: [C::Wire; 6]) -> Result<C::Wire, C::Error>
+    where
+        C: PolyContext<Field = Gf2>,
+    {
+        let m = ctx.mul(w[0], w[1]);
+
+        let [y, a, ww, s, u0, u1] = w.map(|x| ctx.lift(x));
+        let r = u0 * (ww + a);
+        let t = u1 * (s + a + r);
+        ctx.assert_zero(y + a + r + t)?;
+
+        let mux = a + u0 * (a + s);
+        let out = ctx.materialize(mux);
+
+        Ok(ctx.mul(out, m))
+    }
+
+    /// Satisfying witness for [`poly_trace`]: bits `[y, a, w, s, u0, u1]`
+    /// with `y` solved so the degree-3 constraint holds.
+    fn poly_witness(rng: &mut StdRng) -> [bool; 6] {
+        let mut b: [bool; 6] = core::array::from_fn(|_| rng.random());
+        let r = b[4] & (b[2] ^ b[1]);
+        b[0] = b[1] ^ r ^ (b[5] & (b[3] ^ b[1] ^ r));
+        b
+    }
+
+    /// Mocked degree-`d_max` VOPE correlation: random mask coefficients on
+    /// the prover side, their `Δ`-weighted sum on the verifier side.
+    fn mock_poly_vope(
+        rng: &mut StdRng,
+        powers: &DeltaPowers,
+        d_max: usize,
+    ) -> (Vec<Gf2_128>, Gf2_128) {
+        let coeffs: Vec<Gf2_128> = (0..d_max).map(|_| Gf2_128::new(rng.random())).collect();
+        let mut sum = Gf2_128::new(0);
+        let mut pw = Gf2_128::new(1);
+        for &c in &coeffs {
+            sum = sum + c * pw;
+            pw = pw * powers.delta();
+        }
+        (coeffs, sum)
+    }
+
+    #[test]
+    fn poly_round_trip() {
+        let mut rng = StdRng::seed_from_u64(20);
+        let delta = random_delta(&mut rng);
+        let powers = DeltaPowers::new(delta);
+        let chi: [u8; 32] = rng.random();
+        const D_MAX: usize = 3;
+
+        let bits = poly_witness(&mut rng);
+        let pairs: Vec<(Gf2_128, Gf2_128)> =
+            bits.iter().map(|&b| input(&mut rng, b, delta)).collect();
+        let macs_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
+        let keys_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+
+        let gates: Vec<_> = (0..3).map(|_| corr(&mut rng, delta)).collect();
+        let mut masks: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
+        let gate_macs: Vec<Gf2_128> = gates.iter().map(|(_, m, _)| *m).collect();
+        let gate_keys: Vec<Gf2_128> = gates.iter().map(|(_, _, k)| *k).collect();
+
+        let vope: [(bool, Gf2_128, Gf2_128); 128] = core::array::from_fn(|_| corr(&mut rng, delta));
+        let vope_choices: [bool; 128] = core::array::from_fn(|i| vope[i].0);
+        let vope_ev: [Gf2_128; 128] = core::array::from_fn(|i| vope[i].1);
+        let vope_keys: [Gf2_128; 128] = core::array::from_fn(|i| vope[i].2);
+        let (poly_masks, poly_vope_sum) = mock_poly_vope(&mut rng, &powers, D_MAX);
+
+        // Prover: commit pass, then accumulate pass.
+        let mut commit = Commit::new(&mut masks);
+        poly_trace(&mut commit, macs_in).unwrap();
+        commit.finish().unwrap();
+
+        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        poly_trace(&mut prover, macs_in).unwrap();
+        let ProverOutput { u, v, poly, assertions } = prover.finish().unwrap();
+
+        let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
+        let coefficients: Vec<Gf2_128> = poly
+            .coefficients(D_MAX)
+            .unwrap()
+            .iter()
+            .zip(&poly_masks)
+            .map(|(&c, &m)| c + m)
+            .collect();
+        let proof = Proof {
+            assertions,
+            u: u + a_0,
+            v: v + a_1,
+            coefficients,
+        };
+
+        // Verifier: single accumulate pass over the same trace.
+        let verifier = Verifier::new(delta, &gate_keys, &masks).unwrap();
+        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        poly_trace(&mut verifier, keys_in).unwrap();
+        let VerifierOutput { w, poly: v_poly, assertions: v_assertions } = verifier.finish().unwrap();
+        let b = vope_sender(&vope_keys);
+
+        assert_eq!(v_assertions, proof.assertions);
+        assert_eq!(w + b, proof.u + delta * proof.v);
+        v_poly
+            .check(&powers, &proof.coefficients, poly_vope_sum)
+            .unwrap();
+    }
+
+    #[test]
+    fn poly_dishonest_adjust_rejected() {
+        // An honest run, then the verifier consumes a flipped adjust bit for
+        // the materialized wire: the triple or poly check must reject.
+        let mut rng = StdRng::seed_from_u64(21);
+        let delta = random_delta(&mut rng);
+        let powers = DeltaPowers::new(delta);
+        let chi: [u8; 32] = rng.random();
+        const D_MAX: usize = 3;
+
+        let bits = poly_witness(&mut rng);
+        let pairs: Vec<(Gf2_128, Gf2_128)> =
+            bits.iter().map(|&b| input(&mut rng, b, delta)).collect();
+        let macs_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
+        let keys_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+
+        let gates: Vec<_> = (0..3).map(|_| corr(&mut rng, delta)).collect();
+        let mut masks: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
+        let gate_macs: Vec<Gf2_128> = gates.iter().map(|(_, m, _)| *m).collect();
+        let gate_keys: Vec<Gf2_128> = gates.iter().map(|(_, _, k)| *k).collect();
+        let (poly_masks, poly_vope_sum) = mock_poly_vope(&mut rng, &powers, D_MAX);
+
+        let mut commit = Commit::new(&mut masks);
+        poly_trace(&mut commit, macs_in).unwrap();
+        commit.finish().unwrap();
+
+        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        poly_trace(&mut prover, macs_in).unwrap();
+        let ProverOutput { poly, .. } = prover.finish().unwrap();
+        let coefficients: Vec<Gf2_128> = poly
+            .coefficients(D_MAX)
+            .unwrap()
+            .iter()
+            .zip(&poly_masks)
+            .map(|(&c, &m)| c + m)
+            .collect();
+
+        // Flip the adjust bit of the materialized wire (tape entry 1).
+        masks[1] = !masks[1];
+
+        let verifier = Verifier::new(delta, &gate_keys, &masks).unwrap();
+        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        poly_trace(&mut verifier, keys_in).unwrap();
+        let VerifierOutput { poly: v_poly, .. } = verifier.finish().unwrap();
+
+        assert!(
+            v_poly
+                .check(&powers, &coefficients, poly_vope_sum)
+                .is_err(),
+            "flipped materialize commitment must break the poly check"
+        );
+    }
+
+    #[test]
+    fn poly_subrange_folding_matches_full() {
+        // Two disjoint batches of poly constraints folded with seeked
+        // challenge streams and merged must match the full fold. Each
+        // constraint consumes one 16-byte challenge (4 ChaCha words).
+        let mut rng = StdRng::seed_from_u64(22);
+        let delta = random_delta(&mut rng);
+        let powers = DeltaPowers::new(delta);
+        let chi: [u8; 32] = rng.random();
+        const N: usize = 10;
+        const MID: usize = 4;
+        const D_MAX: usize = 3;
+
+        let wires: Vec<[(Gf2_128, Gf2_128); 6]> = (0..N)
+            .map(|_| {
+                let bits = poly_witness(&mut rng);
+                core::array::from_fn(|i| input(&mut rng, bits[i], delta))
+            })
+            .collect();
+
+        let fold_prover = |range: core::ops::Range<usize>, offset: usize| {
+            let mut rng = ChaCha12Rng::from_seed(chi);
+            rng.set_word_pos((offset * 4) as u128);
+            let mut p = Prover::committed(&[]).accumulate(rng);
+            for w in &wires[range] {
+                let [y, a, ww, s, u0, u1] =
+                    core::array::from_fn(|i| p.lift(w[i].0));
+                let r = u0 * (ww + a);
+                let t = u1 * (s + a + r);
+                p.assert_zero(y + a + r + t).unwrap();
+            }
+            let ProverOutput { poly, .. } = p.finish().unwrap();
+            poly
+        };
+
+        let full = fold_prover(0..N, 0);
+        let mut lo = fold_prover(0..MID, 0);
+        let hi = fold_prover(MID..N, MID);
+        lo.merge(&hi);
+        assert_eq!(
+            full.coefficients(D_MAX).unwrap(),
+            lo.coefficients(D_MAX).unwrap()
+        );
+
+        // Verifier partials must satisfy the check against the full prover
+        // coefficients.
+        let fold_verifier = |range: core::ops::Range<usize>, offset: usize| {
+            let mut rng = ChaCha12Rng::from_seed(chi);
+            rng.set_word_pos((offset * 4) as u128);
+            let v = Verifier::new(delta, &[], &[]).unwrap();
+            let mut v = v.accumulate(rng);
+            for w in &wires[range] {
+                let [y, a, ww, s, u0, u1] =
+                    core::array::from_fn(|i| v.lift(w[i].1));
+                let r = u0 * (ww + a);
+                let t = u1 * (s + a + r);
+                v.assert_zero(y + a + r + t).unwrap();
+            }
+            let VerifierOutput { poly, .. } = v.finish().unwrap();
+            poly
+        };
+
+        let mut v_lo = fold_verifier(0..MID, 0);
+        let v_hi = fold_verifier(MID..N, MID);
+        v_lo.merge(&v_hi);
+        v_lo.check(
+            &powers,
+            &full.coefficients(D_MAX).unwrap(),
+            Gf2_128::new(0),
+        )
+        .unwrap();
     }
 }

--- a/crates/zk-core/src/poly.rs
+++ b/crates/zk-core/src/poly.rs
@@ -1,0 +1,1102 @@
+//! Polynomial-constraint expressions for the composite QuickSilver check
+//! (eprint 2021/076, §5).
+//!
+//! A constraint is a polynomial `f` over committed wire values with
+//! `f(w) = 0`. Instead of committing every intermediate product (circuit
+//! mode), a degree-`d` constraint is evaluated *symbolically* into a
+//! polynomial in `Δ`:
+//!
+//! - The prover holds, per wire, the linear form `mac + value·X`; building `f`
+//!   over these forms yields the coefficient vector of
+//!   `g(X) = Σ_h f_h(mac + value·X)·X^{d-h}` ([`ProverCoeffs<V>`]). The top
+//!   coefficient (`X^d`) is `f(w)`, dropped by the protocol.
+//! - The verifier holds, per wire, the key `k = mac + value·Δ`; building `f`
+//!   over the keys yields `g(Δ)` directly ([`VerifierCoeffs`]).
+//!
+//! Both build the *same* expression with the `+`/`-`/`*` operators; at `Δ` the
+//! prover's coefficient vector and the verifier's value agree. Addition
+//! top-aligns operands (multiplying the lower-degree one by `X^shift` /
+//! `Δ^shift`) so each (sub)expression stays top-aligned to its own degree,
+//! matching the `X^{d-h}` weighting. All arithmetic is over characteristic-2
+//! fields, so negation is the identity and subtraction equals addition.
+//!
+//! # Compile-time degree
+//!
+//! An expression's degree is part of its *type*: [`Expr<C, N>`] carries a
+//! [`typenum`] degree `N`, and the operators raise it at the type level —
+//! `Add` takes the max ([`Maximum`]), `Mul` the sum ([`Sum`]). This sizes the
+//! prover's coefficient storage to the *actual* degree of each expression
+//! (a degree-2 product stores two coefficients, not [`MAX_DEGREE`]), and lets
+//! the compiler unroll the convolution and alignment loops. Gadgets stay
+//! generic over the carrier `C` (so one definition runs on both prover and
+//! verifier); the concrete degrees flow through inference without any
+//! per-gadget bounds.
+//!
+//! The carrier `C` is what differs between the two sides ([`ProverCoeffs<V>`]
+//! keeps a coefficient vector, [`VerifierCoeffs`] keeps the single value
+//! `g(Δ)`); [`PlainCoeffs<V>`] collapses an expression to its cleartext value
+//! for the prover's commit pass.
+//!
+//! # Representation
+//!
+//! The carriers are generic over the subfield `V` (the wire-value field): the
+//! boolean path uses `V = Gf2`, the [`gf64`](crate::gf64) path `V = Gf2_64`,
+//! and both embed into the `GF(2^128)` MAC field as
+//! [`ExtensionField<V>`](ExtensionField). The expression algebra preserves a
+//! stronger invariant: the *top* coefficient of every expression lies in the
+//! subfield `V`. A lifted wire is `mac + value·X` (top = `value`), a constant
+//! is a bare subfield element, top-aligned addition sums tops in `V`, and
+//! multiplication multiplies them. [`ProverCoeffs<V>`] therefore stores the top
+//! coefficient as a `V` `value` — which doubles as the cleartext evaluation
+//! `f(w)` — and only the `N` lower coefficients as MAC-field elements. The
+//! cross-terms between tops and lower coefficients are subfield scalings
+//! ([`ExtensionField::scale_by_subfield`]) rather than full MAC
+//! multiplications, so a degree `a × b` product costs `a·b` MAC multiplications
+//! rather than `(a+1)·(b+1)`. For `V = Gf2` the scaling is a branchless masked
+//! XOR (no carry-less multiply at all); for `V = Gf2_64` it is a full MAC
+//! multiply — a property of each subfield's `scale_by_subfield` impl.
+//!
+//! # Accumulation
+//!
+//! The challenge streams during the accumulate pass, so a constraint is folded
+//! into the running check state the moment it is asserted — expressions are
+//! never buffered. The prover folds its χ-weighted coefficients top-aligned to
+//! [`MAX_DEGREE`] into [`ProverPoly`]; the verifier buckets `χ·g(Δ)` by
+//! constraint degree in [`VerifierPoly`], deferring the `Δ^{d_max-d}`
+//! alignment factor to a single multiplication per bucket. Both are additive,
+//! so disjoint sub-ranges of a trace fold independently and
+//! [`merge`](ProverPoly::merge).
+
+use core::{
+    marker::PhantomData,
+    ops::{Add, Mul, Sub},
+};
+
+use hybrid_array::{Array, ArraySize};
+use mpz_circuits::Context;
+use mpz_fields::{
+    Accumulator, ExtensionField, Field,
+    gf2_128::{Gf2_128, Gf2_128Accumulator},
+};
+use typenum::{Max, Maximum, Sum, U0, U1};
+
+use crate::{Error, Result};
+
+/// Degree bound for an [`Expr`]: a [`typenum`] size whose coefficient array is
+/// `Copy`.
+///
+/// [`hybrid_array::Array<T, N>`] is only `Copy` when `N::ArrayType<T>: Copy`, a
+/// fact [`ArraySize`] does not promise for a *generic* `N`. Bundling that
+/// guarantee here keeps every [`Expr`] unconditionally `Copy` — so gadgets
+/// reuse expressions freely — without threading per-degree `Copy` bounds
+/// through gadget signatures. Blanket-implemented for every supported size.
+pub trait Degree: ArraySize<ArrayType<Gf2_128>: Copy> {}
+
+impl<N: ArraySize<ArrayType<Gf2_128>: Copy>> Degree for N {}
+
+/// Polynomial-constraint extension of [`Context`].
+///
+/// Build a degree-`d` constraint symbolically over committed wires with the
+/// `+`/`-`/`*` operators on [`Expr`] (free, degree-raising, uncommitted), then
+/// either [`materialize`](Self::materialize) its output as a fresh committed
+/// wire pinned by a degree-`d` constraint, or [`assert_zero`](Self::assert_zero)
+/// it as a pure check. Implemented by the same contexts that implement
+/// [`Context`].
+pub trait PolyContext: Context {
+    /// The coefficient carrier for this context's side of the protocol.
+    type Coeffs: Coeffs;
+
+    /// Lifts a committed wire into a degree-1 expression.
+    fn lift(&self, wire: Self::Wire) -> Expr<Self::Coeffs, U1>;
+
+    /// A degree-0 public constant.
+    fn lift_const(&self, value: Self::Field) -> Expr<Self::Coeffs, U0>;
+
+    /// Commits the expression's value as a fresh wire and records the
+    /// degree-`d` constraint pinning it to the expression. Returns the
+    /// committed wire.
+    ///
+    /// Consumes one tape entry and 16 bytes of the challenge stream.
+    fn materialize<N>(&mut self, expr: Expr<Self::Coeffs, N>) -> Self::Wire
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree;
+
+    /// Records a degree-`d` constraint that `expr == 0` (no commitment).
+    ///
+    /// Consumes 16 bytes of the challenge stream when `d ≥ 1`; a degree-0
+    /// expression is a public assertion checked locally.
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<Self::Coeffs, N>)
+    -> Result<(), Self::Error>;
+}
+
+/// Maximum supported constraint degree.
+///
+/// The proof's `d_max` (the number of coefficients sent) is at most this; the
+/// per-proof accumulators in [`ProverPoly`]/[`VerifierPoly`] are sized to it.
+/// Individual expressions are *not* sized to this — their storage tracks their
+/// own degree (see [`Expr`]).
+pub const MAX_DEGREE: usize = 32;
+
+/// A symbolic polynomial-in-`Δ` of compile-time degree `N` over committed
+/// wires, carried by side `C`.
+///
+/// `Copy` and stack-allocated; composed with the `+`/`-`/`*` operators, which
+/// raise the degree at the type level. The storage lives in `C::At<N>` and is
+/// sized to `N`, not to [`MAX_DEGREE`].
+#[must_use]
+pub struct Expr<C: Coeffs, N: Degree> {
+    pub(crate) store: C::At<N>,
+}
+
+impl<C: Coeffs, N: Degree> Expr<C, N> {
+    #[inline]
+    pub(crate) fn new(store: C::At<N>) -> Self {
+        Self { store }
+    }
+}
+
+impl<C: Coeffs, N: Degree> Clone for Expr<C, N> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C: Coeffs, N: Degree> Copy for Expr<C, N> {}
+
+impl<C, A, B> Add<Expr<C, B>> for Expr<C, A>
+where
+    C: Coeffs,
+    A: Degree + Max<B>,
+    B: Degree,
+    Maximum<A, B>: Degree,
+{
+    type Output = Expr<C, Maximum<A, B>>;
+
+    #[inline]
+    fn add(self, other: Expr<C, B>) -> Self::Output {
+        Expr::new(C::add::<A, B>(self.store, other.store))
+    }
+}
+
+impl<C, A, B> Sub<Expr<C, B>> for Expr<C, A>
+where
+    C: Coeffs,
+    A: Degree + Max<B>,
+    B: Degree,
+    Maximum<A, B>: Degree,
+{
+    type Output = Expr<C, Maximum<A, B>>;
+
+    /// Subtracts. Characteristic 2, so identical to [`Add`].
+    #[inline]
+    fn sub(self, other: Expr<C, B>) -> Self::Output {
+        self.add(other)
+    }
+}
+
+impl<C, A, B> Mul<Expr<C, B>> for Expr<C, A>
+where
+    C: Coeffs,
+    A: Degree + Add<B>,
+    B: Degree,
+    Sum<A, B>: Degree,
+{
+    type Output = Expr<C, Sum<A, B>>;
+
+    #[inline]
+    fn mul(self, other: Expr<C, B>) -> Self::Output {
+        Expr::new(C::mul::<A, B>(self.store, other.store))
+    }
+}
+
+/// A per-side coefficient carrier: the storage and primitive arithmetic for
+/// one protocol role.
+///
+/// `At<N>` is the storage for a degree-`N` expression. The two non-trivial
+/// operations — top-aligned [`add`](Self::add) and degree-raising
+/// [`mul`](Self::mul) — are degree-generic so [`Expr`]'s operators can delegate
+/// to them. Implemented by [`PlainCoeffs<V>`] (commit pass), [`ProverCoeffs<V>`],
+/// and [`VerifierCoeffs`].
+pub trait Coeffs: Copy {
+    /// Storage for a degree-`N` expression.
+    type At<N: Degree>: Copy;
+
+    /// Top-aligned sum of a degree-`A` and a degree-`B` expression, at the
+    /// larger degree.
+    fn add<A, B>(a: Self::At<A>, b: Self::At<B>) -> Self::At<Maximum<A, B>>
+    where
+        A: Degree + Max<B>,
+        B: Degree,
+        Maximum<A, B>: Degree;
+
+    /// Product of a degree-`A` and a degree-`B` expression, at degree `A + B`.
+    fn mul<A, B>(a: Self::At<A>, b: Self::At<B>) -> Self::At<Sum<A, B>>
+    where
+        A: Degree + Add<B>,
+        B: Degree,
+        Sum<A, B>: Degree;
+}
+
+// --- commit-pass carrier ----------------------------------------------------
+
+/// Plaintext carrier for the prover's commit pass over the subfield `V`: an
+/// expression is just its cleartext value, so polynomial gadgets compile down
+/// to subfield operations.
+pub struct PlainCoeffs<V>(PhantomData<V>);
+
+impl<V> Clone for PlainCoeffs<V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<V> Copy for PlainCoeffs<V> {}
+
+impl<V: Field> Coeffs for PlainCoeffs<V> {
+    type At<N: Degree> = V;
+
+    #[inline]
+    fn add<A, B>(a: V, b: V) -> V
+    where
+        A: Degree + Max<B>,
+        B: Degree,
+        Maximum<A, B>: Degree,
+    {
+        a + b
+    }
+
+    #[inline]
+    fn mul<A, B>(a: V, b: V) -> V
+    where
+        A: Degree + Add<B>,
+        B: Degree,
+        Sum<A, B>: Degree,
+    {
+        a * b
+    }
+}
+
+impl<V: Field, N: Degree> Expr<PlainCoeffs<V>, N> {
+    /// The cleartext subfield value this expression evaluates to.
+    #[inline]
+    pub(crate) fn plain(self) -> V {
+        self.store
+    }
+}
+
+// --- prover carrier ---------------------------------------------------------
+
+/// Prover-side coefficient carrier over the subfield `V`: keeps the
+/// `Δ`-polynomial's lower coefficients and its subfield top.
+pub struct ProverCoeffs<V>(PhantomData<V>);
+
+impl<V> Clone for ProverCoeffs<V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<V> Copy for ProverCoeffs<V> {}
+
+/// Storage for a degree-`N` prover expression: the `N` lower coefficients
+/// (`coeffs[h]` is the coefficient of `Δ^h`) and the subfield top coefficient
+/// `value` (of `Δ^N`), which is the cleartext evaluation `f(w)`.
+pub struct ProverStore<V, N: Degree> {
+    pub(crate) coeffs: Array<Gf2_128, N>,
+    pub(crate) value: V,
+}
+
+impl<V: Field, N: Degree> Clone for ProverStore<V, N> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<V: Field, N: Degree> Copy for ProverStore<V, N> {}
+
+impl<V: Field> Coeffs for ProverCoeffs<V>
+where
+    Gf2_128: ExtensionField<V>,
+{
+    type At<N: Degree> = ProverStore<V, N>;
+
+    #[inline]
+    fn add<A, B>(a: ProverStore<V, A>, b: ProverStore<V, B>) -> ProverStore<V, Maximum<A, B>>
+    where
+        A: Degree + Max<B>,
+        B: Degree,
+        Maximum<A, B>: Degree,
+    {
+        let (da, db) = (A::USIZE, B::USIZE);
+        let dmax = da.max(db);
+        let mut coeffs = Array::<Gf2_128, Maximum<A, B>>::from_fn(|_| Gf2_128::ZERO);
+        // Each operand top-aligns: coeff of degree `d` lands at `dmax - own + d`.
+        for h in 0..da {
+            coeffs[(dmax - da) + h] = coeffs[(dmax - da) + h] + a.coeffs[h];
+        }
+        for h in 0..db {
+            coeffs[(dmax - db) + h] = coeffs[(dmax - db) + h] + b.coeffs[h];
+        }
+        ProverStore {
+            coeffs,
+            value: a.value + b.value,
+        }
+    }
+
+    #[inline]
+    fn mul<A, B>(a: ProverStore<V, A>, b: ProverStore<V, B>) -> ProverStore<V, Sum<A, B>>
+    where
+        A: Degree + Add<B>,
+        B: Degree,
+        Sum<A, B>: Degree,
+    {
+        let (da, db) = (A::USIZE, B::USIZE);
+        let mut coeffs = Array::<Gf2_128, Sum<A, B>>::from_fn(|_| Gf2_128::ZERO);
+        // Convolution of the lower coefficients.
+        for i in 0..da {
+            for j in 0..db {
+                coeffs[i + j] = coeffs[i + j] + a.coeffs[i] * b.coeffs[j];
+            }
+        }
+        // Cross-terms against the subfield tops: subfield scalings
+        // (a branchless masked XOR for `V = Gf2`, a full MAC multiply for
+        // `V = Gf2_64` — see `ExtensionField::scale_by_subfield`).
+        for i in 0..da {
+            coeffs[i + db] = coeffs[i + db] + a.coeffs[i].scale_by_subfield(b.value);
+        }
+        for j in 0..db {
+            coeffs[j + da] = coeffs[j + da] + b.coeffs[j].scale_by_subfield(a.value);
+        }
+        ProverStore {
+            coeffs,
+            value: a.value * b.value,
+        }
+    }
+}
+
+impl<V: Field> Expr<ProverCoeffs<V>, U1>
+where
+    Gf2_128: ExtensionField<V>,
+{
+    /// Degree-1 form `mac + value·X` for a committed wire.
+    ///
+    /// The caller supplies the cleartext `value` (the top coefficient): in the
+    /// boolean path it is read off the MAC's LSB, in the
+    /// [`gf64`](crate::gf64) path it is carried explicitly.
+    #[inline]
+    pub(crate) fn lift_wire(mac: Gf2_128, value: V) -> Self {
+        let mut coeffs = Array::<Gf2_128, U1>::from_fn(|_| Gf2_128::ZERO);
+        coeffs[0] = mac;
+        Expr::new(ProverStore { coeffs, value })
+    }
+}
+
+impl<V: Field> Expr<ProverCoeffs<V>, U0>
+where
+    Gf2_128: ExtensionField<V>,
+{
+    /// Degree-0 public constant.
+    #[inline]
+    pub(crate) fn constant(value: V) -> Self {
+        Expr::new(ProverStore {
+            coeffs: Array::<Gf2_128, U0>::from_fn(|_| Gf2_128::ZERO),
+            value,
+        })
+    }
+}
+
+impl<V: Field, N: Degree> Expr<ProverCoeffs<V>, N>
+where
+    Gf2_128: ExtensionField<V>,
+{
+    /// The witness value computed by this expression: its top coefficient.
+    #[inline]
+    pub(crate) fn value(self) -> V {
+        self.store.value
+    }
+}
+
+// --- verifier carrier -------------------------------------------------------
+
+/// Verifier-side coefficient carrier: keeps the single value `g(Δ)` at the
+/// expression's own degree, plus `Δ` for top-alignment in `add`.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifierCoeffs;
+
+/// Storage for a verifier expression: its value `g(Δ)` and `Δ` (carried so
+/// [`add`](Coeffs::add) can compute the `Δ^shift` top-alignment factor without
+/// borrowing a powers table — the degree gap is small and known at compile
+/// time, so the power fully unrolls).
+#[derive(Clone, Copy, Debug)]
+pub struct VerifierStore {
+    val: Gf2_128,
+    delta: Gf2_128,
+}
+
+/// `base^exp` by repeated multiplication; `exp` is the (small) degree gap.
+#[inline]
+fn pow(base: Gf2_128, exp: usize) -> Gf2_128 {
+    let mut acc = Gf2_128::ONE;
+    for _ in 0..exp {
+        acc = acc * base;
+    }
+    acc
+}
+
+impl Coeffs for VerifierCoeffs {
+    type At<N: Degree> = VerifierStore;
+
+    #[inline]
+    fn add<A, B>(a: VerifierStore, b: VerifierStore) -> VerifierStore
+    where
+        A: Degree + Max<B>,
+        B: Degree,
+        Maximum<A, B>: Degree,
+    {
+        let (da, db) = (A::USIZE, B::USIZE);
+        let dmax = da.max(db);
+        let val = a.val * pow(a.delta, dmax - da) + b.val * pow(b.delta, dmax - db);
+        VerifierStore {
+            val,
+            delta: a.delta,
+        }
+    }
+
+    #[inline]
+    fn mul<A, B>(a: VerifierStore, b: VerifierStore) -> VerifierStore
+    where
+        A: Degree + Add<B>,
+        B: Degree,
+        Sum<A, B>: Degree,
+    {
+        VerifierStore {
+            val: a.val * b.val,
+            delta: a.delta,
+        }
+    }
+}
+
+impl Expr<VerifierCoeffs, U1> {
+    /// Degree-1 form for a committed wire: its key `k = mac + value·Δ`.
+    #[inline]
+    pub(crate) fn lift_key(key: Gf2_128, delta: Gf2_128) -> Self {
+        Expr::new(VerifierStore { val: key, delta })
+    }
+}
+
+impl Expr<VerifierCoeffs, U0> {
+    /// Degree-0 public constant over the subfield `V`: `g(Δ) = embed(value)`.
+    #[inline]
+    pub(crate) fn constant<V: Field>(value: V, delta: Gf2_128) -> Self
+    where
+        Gf2_128: ExtensionField<V>,
+    {
+        Expr::new(VerifierStore {
+            val: <Gf2_128 as ExtensionField<V>>::embed(value),
+            delta,
+        })
+    }
+}
+
+impl<N: Degree> Expr<VerifierCoeffs, N> {
+    /// The expression's value `g(Δ)`.
+    #[inline]
+    pub(crate) fn value(self) -> Gf2_128 {
+        self.store.val
+    }
+}
+
+// --- accumulation -----------------------------------------------------------
+
+/// The prover's running polynomial-check state.
+///
+/// Constraint coefficients are folded in χ-weighted and top-aligned to
+/// [`MAX_DEGREE`] with deferred reduction; positions below
+/// `MAX_DEGREE - d_max` stay untouched, so [`coefficients`](Self::coefficients)
+/// can slice out any `d_max ≥` the maximum degree seen. Partial states from
+/// disjoint sub-ranges combine with [`merge`](Self::merge).
+#[derive(Debug, Clone)]
+pub struct ProverPoly {
+    acc: [Gf2_128Accumulator; MAX_DEGREE],
+    max_degree: usize,
+}
+
+impl Default for ProverPoly {
+    fn default() -> Self {
+        Self {
+            acc: [Gf2_128Accumulator::zero(); MAX_DEGREE],
+            max_degree: 0,
+        }
+    }
+}
+
+impl ProverPoly {
+    /// Folds a constraint's χ-weighted lower coefficients, dropping the top
+    /// (`= f(w)`, zero when satisfied).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `coeffs.len()` exceeds [`MAX_DEGREE`].
+    #[inline]
+    pub(crate) fn fold(&mut self, coeffs: &[Gf2_128], chi: Gf2_128) {
+        let d = coeffs.len();
+        assert!(d <= MAX_DEGREE, "constraint degree exceeds MAX_DEGREE");
+        let off = MAX_DEGREE - d;
+        for (acc, &c) in self.acc[off..].iter_mut().zip(coeffs) {
+            acc.add_product(c, chi);
+        }
+        self.max_degree = self.max_degree.max(d);
+    }
+
+    /// Folds an expression's χ-weighted lower coefficients into the running
+    /// state.
+    ///
+    /// The shared body of [`PolyContext::materialize`] and
+    /// [`PolyContext::assert_zero`] on the prover side: both reduce to folding
+    /// the coefficient vector of some [`Expr<ProverCoeffs<V>, N>`] (a pinned
+    /// `expr - wire` constraint, or the bare assertion).
+    #[inline]
+    pub(crate) fn fold_expr<V: Field, N: Degree>(
+        &mut self,
+        expr: &Expr<ProverCoeffs<V>, N>,
+        chi: Gf2_128,
+    ) where
+        Gf2_128: ExtensionField<V>,
+    {
+        self.fold(&expr.store.coeffs, chi);
+    }
+
+    /// Records a degree-`d` constraint that `expr == 0`.
+    ///
+    /// Surfaces a witness bug early via the top coefficient `f(w) = expr.value`,
+    /// short-circuits the degree-0 public case (no fold, no challenge drawn),
+    /// and otherwise folds the lower coefficients under a freshly drawn `chi`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the witness value is non-zero.
+    #[inline]
+    pub(crate) fn assert_expr<V: Field, N: Degree>(
+        &mut self,
+        expr: &Expr<ProverCoeffs<V>, N>,
+        draw_chi: impl FnOnce() -> Gf2_128,
+    ) -> Result<()>
+    where
+        Gf2_128: ExtensionField<V>,
+    {
+        if expr.value() != V::zero() {
+            return Err(Error::assert());
+        }
+        // A degree-0 expression is a public assertion; nothing to fold.
+        if N::USIZE == 0 {
+            return Ok(());
+        }
+        self.fold(&expr.store.coeffs, draw_chi());
+        Ok(())
+    }
+
+    /// The maximum constraint degree folded in so far.
+    pub fn max_degree(&self) -> usize {
+        self.max_degree
+    }
+
+    /// `true` if no constraint has been folded in.
+    pub fn is_empty(&self) -> bool {
+        self.max_degree == 0
+    }
+
+    /// Adds another partial state into `self`.
+    ///
+    /// Used to combine sub-ranges of a trace folded independently.
+    pub fn merge(&mut self, other: &Self) {
+        for (a, b) in self.acc.iter_mut().zip(&other.acc) {
+            a.merge(b);
+        }
+        self.max_degree = self.max_degree.max(other.max_degree);
+    }
+
+    /// Reduces to the proof coefficients `U_0 ..= U_{d_max - 1}`.
+    ///
+    /// The caller masks them with the degree-`d_max` VOPE coefficients before
+    /// sending (see [`Proof::coefficients`](crate::Proof::coefficients)).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if `d_max` exceeds [`MAX_DEGREE`] or is smaller than
+    /// the maximum constraint degree folded in.
+    pub fn coefficients(&self, d_max: usize) -> Result<Vec<Gf2_128>> {
+        if d_max > MAX_DEGREE || self.max_degree > d_max {
+            return Err(Error::degree(self.max_degree, d_max));
+        }
+        Ok((0..d_max)
+            .map(|h| self.acc[MAX_DEGREE - d_max + h].reduce())
+            .collect())
+    }
+}
+
+/// Precomputed powers `Δ^0 ..= Δ^MAX_DEGREE` of the verifier's MAC key, used by
+/// [`VerifierPoly::check`].
+#[derive(Debug, Clone)]
+pub struct DeltaPowers {
+    pow: [Gf2_128; MAX_DEGREE + 1],
+}
+
+impl DeltaPowers {
+    /// Precomputes the powers of `delta`.
+    pub fn new(delta: Gf2_128) -> Self {
+        let mut pow = [Gf2_128::ONE; MAX_DEGREE + 1];
+        for i in 1..=MAX_DEGREE {
+            pow[i] = pow[i - 1] * delta;
+        }
+        Self { pow }
+    }
+
+    /// The MAC key `Δ` itself.
+    pub fn delta(&self) -> Gf2_128 {
+        self.pow[1]
+    }
+}
+
+/// The verifier's running polynomial-check state.
+///
+/// Each constraint contributes `χ·g(Δ)` into the bucket of its degree with
+/// deferred reduction; the `Δ^{d_max - d}` top-alignment factor is applied
+/// once per bucket in [`check`](Self::check). Partial states from disjoint
+/// sub-ranges combine with [`merge`](Self::merge).
+#[derive(Debug, Clone)]
+pub struct VerifierPoly {
+    /// `buckets[d]` accumulates `Σ χ_i·g_i(Δ)` over degree-`d` constraints;
+    /// index 0 is unused (degree-0 assertions are public, checked locally).
+    buckets: [Gf2_128Accumulator; MAX_DEGREE + 1],
+    max_degree: usize,
+}
+
+impl Default for VerifierPoly {
+    fn default() -> Self {
+        Self {
+            buckets: [Gf2_128Accumulator::zero(); MAX_DEGREE + 1],
+            max_degree: 0,
+        }
+    }
+}
+
+impl VerifierPoly {
+    /// Folds a constraint's χ-weighted value into its degree bucket.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `degree` exceeds [`MAX_DEGREE`].
+    #[inline]
+    pub(crate) fn fold(&mut self, val: Gf2_128, degree: usize, chi: Gf2_128) {
+        assert!(degree <= MAX_DEGREE, "constraint degree exceeds MAX_DEGREE");
+        self.buckets[degree].add_product(val, chi);
+        self.max_degree = self.max_degree.max(degree);
+    }
+
+    /// Folds an expression's χ-weighted value `g(Δ)` into its degree bucket.
+    ///
+    /// The shared body of [`PolyContext::materialize`] (which folds the pinned
+    /// `expr - wire` constraint at degree `Maximum::<N, U1>::USIZE`) on the
+    /// verifier side; the caller supplies the bucket `degree`.
+    #[inline]
+    pub(crate) fn fold_expr<N: Degree>(
+        &mut self,
+        expr: &Expr<VerifierCoeffs, N>,
+        degree: usize,
+        chi: Gf2_128,
+    ) {
+        self.fold(expr.value(), degree, chi);
+    }
+
+    /// Records a degree-`d` constraint that `expr == 0`.
+    ///
+    /// Short-circuits the degree-0 public case (checked locally, no fold and no
+    /// challenge drawn), and otherwise folds `g(Δ)` into bucket `N::USIZE`
+    /// under a freshly drawn `chi`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if a degree-0 expression's value is non-zero.
+    #[inline]
+    pub(crate) fn assert_expr<N: Degree>(
+        &mut self,
+        expr: &Expr<VerifierCoeffs, N>,
+        draw_chi: impl FnOnce() -> Gf2_128,
+    ) -> Result<()> {
+        // A degree-0 expression is a public assertion, checked locally.
+        if N::USIZE == 0 {
+            if expr.value() != Gf2_128::ZERO {
+                return Err(Error::assert());
+            }
+            return Ok(());
+        }
+        self.fold(expr.value(), N::USIZE, draw_chi());
+        Ok(())
+    }
+
+    /// The maximum constraint degree folded in so far.
+    pub fn max_degree(&self) -> usize {
+        self.max_degree
+    }
+
+    /// `true` if no constraint has been folded in.
+    pub fn is_empty(&self) -> bool {
+        self.max_degree == 0
+    }
+
+    /// Adds another partial state into `self`.
+    ///
+    /// Used to combine sub-ranges of a trace folded independently.
+    pub fn merge(&mut self, other: &Self) {
+        for (a, b) in self.buckets.iter_mut().zip(&other.buckets) {
+            a.merge(b);
+        }
+        self.max_degree = self.max_degree.max(other.max_degree);
+    }
+
+    /// Checks the prover's masked coefficients against the accumulated state:
+    /// `Σ_i χ_i·B_i + B* = Σ_h U_h·Δ^h`, with `d_max = coefficients.len()`,
+    /// `B_i = g_i(Δ)·Δ^{d_max - d_i}` and `B* = vope_sum` the verifier's side
+    /// of the degree-`d_max` VOPE correlation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if `d_max` exceeds [`MAX_DEGREE`], is smaller than
+    /// the maximum constraint degree folded in, or the check equation does not
+    /// hold.
+    pub fn check(
+        &self,
+        powers: &DeltaPowers,
+        coefficients: &[Gf2_128],
+        vope_sum: Gf2_128,
+    ) -> Result<()> {
+        let d_max = coefficients.len();
+        if d_max > MAX_DEGREE || self.max_degree > d_max {
+            return Err(Error::degree(self.max_degree, d_max));
+        }
+
+        let mut b = vope_sum;
+        for d in 1..=d_max {
+            b = b + self.buckets[d].reduce() * powers.pow[d_max - d];
+        }
+
+        let rhs = coefficients
+            .iter()
+            .zip(&powers.pow)
+            .map(|(&u, &p)| u * p)
+            .fold(Gf2_128::ZERO, |a, x| a + x);
+
+        if b != rhs {
+            return Err(Error::check());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::lsb;
+    use mpz_fields::gf2::Gf2;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+    use typenum::{U2, U3, U4};
+
+    /// Embeds a witness bit into the MAC field.
+    fn embed(v: Gf2) -> Gf2_128 {
+        <Gf2_128 as ExtensionField<Gf2>>::embed(v)
+    }
+
+    /// A wire pair: prover MAC (LSB = value) and verifier key
+    /// (`key = mac + value·Δ`, LSB of key = 0).
+    fn wire(rng: &mut StdRng, value: bool, delta: Gf2_128) -> (Gf2_128, Gf2_128) {
+        let key = Gf2_128::new(rng.random::<u128>() & !1);
+        let mac = if value { key + delta } else { key };
+        (mac, key)
+    }
+
+    fn random_delta(rng: &mut StdRng) -> Gf2_128 {
+        Gf2_128::new(rng.random::<u128>() | 1)
+    }
+
+    /// Degree-3 constraint `Y + a + r + u1·(s + a + r)` with `r = u0·(w + a)`,
+    /// exercising mul, add, and reuse (an `acc_mux`-shaped polynomial).
+    /// Generic over the carrier so it runs on both sides.
+    fn gadget<C: Coeffs>(v: [Expr<C, U1>; 6]) -> Expr<C, U3> {
+        let [y, a, w, s, u0, u1] = v;
+        let r = u0 * (w + a);
+        let inner = s + a + r;
+        let u1_term = u1 * inner;
+        y + a + r + u1_term
+    }
+
+    /// Lifts six prover wires into degree-1 expressions.
+    fn prover_lift(macs: [Gf2_128; 6]) -> [Expr<ProverCoeffs<Gf2>, U1>; 6] {
+        core::array::from_fn(|i| Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(macs[i], lsb(macs[i])))
+    }
+
+    /// Lifts six verifier keys into degree-1 expressions.
+    fn verifier_lift(keys: [Gf2_128; 6], delta: Gf2_128) -> [Expr<VerifierCoeffs, U1>; 6] {
+        core::array::from_fn(|i| Expr::<VerifierCoeffs, U1>::lift_key(keys[i], delta))
+    }
+
+    /// Evaluates a prover expression at `Δ`, including the subfield top.
+    fn eval_prover<N: Degree>(e: Expr<ProverCoeffs<Gf2>, N>, delta: Gf2_128) -> Gf2_128 {
+        let mut acc = embed(e.store.value) * pow(delta, N::USIZE);
+        for h in 0..N::USIZE {
+            acc = acc + e.store.coeffs[h] * pow(delta, h);
+        }
+        acc
+    }
+
+    /// Differential: the prover's coefficient vector evaluated at `Δ` must
+    /// equal the verifier's value, and the top coefficient must be `f(w)`.
+    #[test]
+    fn prover_verifier_agree_at_delta() {
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+        for _ in 0..256 {
+            let delta = random_delta(&mut rng);
+
+            let bits: [bool; 6] = core::array::from_fn(|_| rng.random());
+            let pairs: [(Gf2_128, Gf2_128); 6] =
+                core::array::from_fn(|i| wire(&mut rng, bits[i], delta));
+            let macs: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
+            let keys: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+
+            let pe = gadget(prover_lift(macs));
+            let ve = gadget(verifier_lift(keys, delta));
+
+            assert_eq!(
+                eval_prover(pe, delta),
+                ve.value(),
+                "prover poly at Δ disagrees with verifier value"
+            );
+
+            let expected = {
+                let w: [Gf2; 6] = core::array::from_fn(|i| Gf2(bits[i]));
+                let r = w[4] * (w[2] + w[1]);
+                w[0] + w[1] + r + w[5] * (w[3] + w[1] + r)
+            };
+            assert_eq!(pe.value(), expected, "top coefficient must be f(w)");
+        }
+    }
+
+    /// Folds the lower coefficients of a degree-`N` prover expression.
+    fn fold_prover<N: Degree>(poly: &mut ProverPoly, e: Expr<ProverCoeffs<Gf2>, N>, chi: Gf2_128) {
+        poly.fold(&e.store.coeffs, chi);
+    }
+
+    /// `ProverPoly::fold` and `VerifierPoly::check` satisfy the batch check
+    /// for satisfied constraints of mixed degrees.
+    #[test]
+    fn accumulate_matches_batch_value() {
+        let mut rng = StdRng::seed_from_u64(0x5EED);
+        let delta = random_delta(&mut rng);
+        let powers = DeltaPowers::new(delta);
+        let d_max = 4usize;
+
+        let mut prover = ProverPoly::default();
+        let mut verifier = VerifierPoly::default();
+
+        // Degree-2 instances of `w0·w1 + w2 = 0` (w2 = w0·w1).
+        for _ in 0..4 {
+            let w0: bool = rng.random();
+            let w1: bool = rng.random();
+            let pairs: [(Gf2_128, Gf2_128); 3] = [
+                wire(&mut rng, w0, delta),
+                wire(&mut rng, w1, delta),
+                wire(&mut rng, w0 & w1, delta),
+            ];
+            let chi = Gf2_128::new(rng.random());
+
+            let pe = {
+                let [a, b, c] =
+                    core::array::from_fn(|i| {
+                        Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(pairs[i].0, lsb(pairs[i].0))
+                    });
+                a * b + c
+            };
+            assert_eq!(pe.value(), Gf2::ZERO, "constraint must be satisfied");
+            fold_prover(&mut prover, pe, chi);
+
+            let ve = {
+                let [a, b, c] = core::array::from_fn(|i| {
+                    Expr::<VerifierCoeffs, U1>::lift_key(pairs[i].1, delta)
+                });
+                a * b + c
+            };
+            verifier.fold(ve.value(), 2, chi);
+        }
+        // Degree-3 gadget instances with Y solved so the gadget is zero.
+        for _ in 0..4 {
+            let mut w: [Gf2; 6] = core::array::from_fn(|_| Gf2(rng.random()));
+            w[0] = Gf2::ZERO;
+            let r = w[4] * (w[2] + w[1]);
+            w[0] = w[1] + r + w[5] * (w[3] + w[1] + r);
+            let pairs: [(Gf2_128, Gf2_128); 6] =
+                core::array::from_fn(|i| wire(&mut rng, w[i].0, delta));
+            let macs: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
+            let keys: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+            let chi = Gf2_128::new(rng.random());
+
+            let pe = gadget(prover_lift(macs));
+            assert_eq!(pe.value(), Gf2::ZERO);
+            fold_prover(&mut prover, pe, chi);
+
+            let ve = gadget(verifier_lift(keys, delta));
+            verifier.fold(ve.value(), 3, chi);
+        }
+
+        let coefficients = prover.coefficients(d_max).unwrap();
+        verifier
+            .check(&powers, &coefficients, Gf2_128::ZERO)
+            .unwrap();
+
+        // Corrupting a coefficient breaks the check.
+        let mut bad = coefficients.clone();
+        bad[1] = bad[1] + Gf2_128::ONE;
+        assert!(verifier.check(&powers, &bad, Gf2_128::ZERO).is_err());
+    }
+
+    /// Merged sub-range partials equal the full fold.
+    #[test]
+    fn merge_matches_full() {
+        let mut rng = StdRng::seed_from_u64(0xFAB);
+        let delta = random_delta(&mut rng);
+
+        struct Item {
+            macs: [Gf2_128; 6],
+            keys: [Gf2_128; 6],
+            chi: Gf2_128,
+        }
+        let items: Vec<Item> = (0..10)
+            .map(|_| {
+                let bits: [bool; 6] = core::array::from_fn(|_| rng.random());
+                let pairs: [(Gf2_128, Gf2_128); 6] =
+                    core::array::from_fn(|i| wire(&mut rng, bits[i], delta));
+                Item {
+                    macs: core::array::from_fn(|i| pairs[i].0),
+                    keys: core::array::from_fn(|i| pairs[i].1),
+                    chi: Gf2_128::new(rng.random()),
+                }
+            })
+            .collect();
+
+        let mut full = ProverPoly::default();
+        let mut lo = ProverPoly::default();
+        let mut hi = ProverPoly::default();
+        for (i, it) in items.iter().enumerate() {
+            let pe = gadget(prover_lift(it.macs));
+            fold_prover(&mut full, pe, it.chi);
+            fold_prover(if i < 5 { &mut lo } else { &mut hi }, pe, it.chi);
+        }
+        lo.merge(&hi);
+        assert_eq!(full.coefficients(4).unwrap(), lo.coefficients(4).unwrap());
+
+        let mut v_full = VerifierPoly::default();
+        let mut v_lo = VerifierPoly::default();
+        let mut v_hi = VerifierPoly::default();
+        for (i, it) in items.iter().enumerate() {
+            let ve = gadget(verifier_lift(it.keys, delta));
+            v_full.fold(ve.value(), 3, it.chi);
+            (if i < 5 { &mut v_lo } else { &mut v_hi }).fold(ve.value(), 3, it.chi);
+        }
+        v_lo.merge(&v_hi);
+        for d in 0..=MAX_DEGREE {
+            assert_eq!(
+                v_full.buckets[d].reduce(),
+                v_lo.buckets[d].reduce(),
+                "bucket {d}"
+            );
+        }
+    }
+
+    /// `d_max` smaller than the maximum folded degree is rejected.
+    #[test]
+    fn d_max_too_small_rejected() {
+        let mut rng = StdRng::seed_from_u64(0xD0D0);
+        let delta = random_delta(&mut rng);
+        let powers = DeltaPowers::new(delta);
+
+        let pairs: [(Gf2_128, Gf2_128); 6] =
+            core::array::from_fn(|_| wire(&mut rng, false, delta));
+        let macs: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
+        let keys: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+
+        let mut prover = ProverPoly::default();
+        fold_prover(&mut prover, gadget(prover_lift(macs)), Gf2_128::ONE);
+        assert!(prover.coefficients(2).is_err());
+        assert!(prover.coefficients(MAX_DEGREE + 1).is_err());
+
+        let mut verifier = VerifierPoly::default();
+        verifier.fold(gadget(verifier_lift(keys, delta)).value(), 3, Gf2_128::ONE);
+        assert!(
+            verifier
+                .check(&powers, &[Gf2_128::ZERO; 2], Gf2_128::ZERO)
+                .is_err()
+        );
+    }
+
+    /// The plaintext carrier collapses a gadget to its cleartext bit, matching
+    /// the prover expression's top.
+    #[test]
+    fn plain_matches_top() {
+        let mut rng = StdRng::seed_from_u64(0x9);
+        let delta = random_delta(&mut rng);
+        for _ in 0..64 {
+            let bits: [bool; 6] = core::array::from_fn(|_| rng.random());
+            let macs: [Gf2_128; 6] = core::array::from_fn(|i| {
+                let (m, _) = wire(&mut rng, bits[i], delta);
+                m
+            });
+            let plain: [Expr<PlainCoeffs<Gf2>, U1>; 6] =
+                core::array::from_fn(|i| Expr::new(Gf2(bits[i])));
+            let pe = gadget(prover_lift(macs));
+            let ce: Expr<PlainCoeffs<Gf2>, U3> = gadget(plain);
+            assert_eq!(ce.plain(), pe.value());
+        }
+    }
+
+    /// Reduction tree over 3 selectors and 8 leaves: each level is a 2-to-1
+    /// mux `a + sel·(a + b)` that raises the degree by one (degree 2 → 3 → 4),
+    /// exercising mixed-degree adds and muls. The degrees are concrete at each
+    /// level, so the gadget stays generic over the carrier with no extra
+    /// bounds.
+    fn mux_tree<C: Coeffs>(s: [Expr<C, U1>; 3], x: [Expr<C, U1>; 8]) -> Expr<C, U4> {
+        let m0: [Expr<C, U2>; 4] = core::array::from_fn(|j| x[2 * j] + s[0] * (x[2 * j] + x[2 * j + 1]));
+        let m1: [Expr<C, U3>; 2] = core::array::from_fn(|j| m0[2 * j] + s[1] * (m0[2 * j] + m0[2 * j + 1]));
+        m1[0] + s[2] * (m1[0] + m1[1])
+    }
+
+    /// The degree-4 reduction tree round-trips: prover coefficients at `Δ`
+    /// equal the verifier value, on the same carrier-generic gadget.
+    #[test]
+    fn high_degree_round_trip() {
+        let mut rng = StdRng::seed_from_u64(0x600);
+        let delta = random_delta(&mut rng);
+
+        for _ in 0..64 {
+            let sbits: [bool; 3] = core::array::from_fn(|_| rng.random());
+            let xbits: [bool; 8] = core::array::from_fn(|_| rng.random());
+            let sw: [(Gf2_128, Gf2_128); 3] =
+                core::array::from_fn(|i| wire(&mut rng, sbits[i], delta));
+            let xw: [(Gf2_128, Gf2_128); 8] =
+                core::array::from_fn(|i| wire(&mut rng, xbits[i], delta));
+
+            let pe = mux_tree(
+                core::array::from_fn(|i| {
+                    Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(sw[i].0, lsb(sw[i].0))
+                }),
+                core::array::from_fn(|i| {
+                    Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(xw[i].0, lsb(xw[i].0))
+                }),
+            );
+            let ve = mux_tree(
+                core::array::from_fn(|i| Expr::<VerifierCoeffs, U1>::lift_key(sw[i].1, delta)),
+                core::array::from_fn(|i| Expr::<VerifierCoeffs, U1>::lift_key(xw[i].1, delta)),
+            );
+
+            assert_eq!(eval_prover(pe, delta), ve.value());
+        }
+    }
+}

--- a/crates/zk-core/src/poly.rs
+++ b/crates/zk-core/src/poly.rs
@@ -444,6 +444,24 @@ fn pow(base: Gf2_128, exp: usize) -> Gf2_128 {
     acc
 }
 
+/// Top-aligns `val` by `Δ^gap`, where `gap` is an operand's degree shortfall
+/// against the sum's degree.
+///
+/// In balanced expression trees `gap` is almost always 0 or 1, so those cases
+/// are handled without the `pow` loop — and `gap == 0` skips the multiply
+/// entirely. That spurious `val · Δ^0 = val · 1` is otherwise paid on *every*
+/// equal-degree addition and dominates the verifier's cost in addition-heavy
+/// gadgets (mux trees, etc.). The `Δ^1 = Δ` case is the precomputed shift the
+/// store already carries. Larger gaps (rare) fall back to `pow`.
+#[inline]
+fn align(val: Gf2_128, delta: Gf2_128, gap: usize) -> Gf2_128 {
+    match gap {
+        0 => val,
+        1 => val * delta,
+        n => val * pow(delta, n),
+    }
+}
+
 impl Coeffs for VerifierCoeffs {
     type At<N: Degree> = VerifierStore;
 
@@ -456,7 +474,7 @@ impl Coeffs for VerifierCoeffs {
     {
         let (da, db) = (A::USIZE, B::USIZE);
         let dmax = da.max(db);
-        let val = a.val * pow(a.delta, dmax - da) + b.val * pow(b.delta, dmax - db);
+        let val = align(a.val, a.delta, dmax - da) + align(b.val, b.delta, dmax - db);
         VerifierStore {
             val,
             delta: a.delta,

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -7,9 +7,14 @@ use mpz_fields::{
     gf2_128::{Gf2_128, Gf2_128Accumulator},
 };
 use rand_core::RngCore;
-use zerocopy::IntoBytes;
 
-use crate::{Error, MAC_ONE, MAC_ZERO, Result, util::set_lsb};
+use typenum::{Max, Maximum, U0, U1};
+
+use crate::{
+    Error, MAC_ONE, MAC_ZERO, ProverOutput, Result,
+    poly::{Degree, Expr, PlainCoeffs, PolyContext, ProverCoeffs, ProverPoly},
+    util::{draw_chi, lsb, set_lsb},
+};
 
 /// The prover side of the zero-knowledge protocol.
 ///
@@ -19,7 +24,7 @@ use crate::{Error, MAC_ONE, MAC_ZERO, Result, util::set_lsb};
 /// installs the challenge stream via [`accumulate`](Self::accumulate) and
 /// re-evaluates the same circuits in the same order, folding every
 /// multiplication and assertion directly into the running proof state.
-/// [`finish`](Self::finish) yields `(u, v, assertions)`.
+/// [`finish`](Self::finish) yields a [`ProverOutput`].
 ///
 /// The caller masks `(u, v)` with the VOPE correlation
 /// ([`vope_receiver`](crate::vope_receiver)) before sending the proof.
@@ -101,6 +106,37 @@ impl<'a> Commit<'a> {
     }
 }
 
+impl PolyContext for Commit<'_> {
+    /// Plaintext evaluation: an expression is just its cleartext bit, so the
+    /// commit pass compiles polynomial gadgets down to bit operations.
+    type Coeffs = PlainCoeffs<Gf2>;
+
+    fn lift(&self, wire: Gf2_128) -> Expr<PlainCoeffs<Gf2>, U1> {
+        Expr::new(lsb(wire))
+    }
+
+    fn lift_const(&self, value: Gf2) -> Expr<PlainCoeffs<Gf2>, U0> {
+        Expr::new(value)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<PlainCoeffs<Gf2>, N>) -> Gf2_128
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        self.input(expr.plain().0)
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<PlainCoeffs<Gf2>, N>) -> Result<()> {
+        // The check binding constraints into the proof is built during the
+        // accumulate pass; here the check only surfaces witness bugs early.
+        if expr.plain() != Gf2::ZERO {
+            return Err(Error::assert());
+        }
+        Ok(())
+    }
+}
+
 impl Context for Commit<'_> {
     type Error = Error;
     type Wire = Gf2_128;
@@ -159,6 +195,7 @@ pub struct Accumulate<R> {
     rng: R,
     u: Gf2_128Accumulator,
     v: Gf2_128Accumulator,
+    poly: ProverPoly,
 }
 
 impl<'a> Prover<'a, Committed> {
@@ -180,9 +217,12 @@ impl<'a> Prover<'a, Committed> {
 
     /// Begins the accumulate pass, drawing challenge weights from `rng`.
     ///
-    /// Each multiplication consumes 16 bytes of the stream, so `rng` must be
-    /// positioned to match the gates evaluated: the caller derives it from the
-    /// agreed challenge and seeks it when folding a sub-range of the trace.
+    /// Each multiplication and each polynomial constraint
+    /// ([`PolyContext::assert_zero`] of degree ≥ 1, or
+    /// [`PolyContext::materialize`]) consumes 16 bytes of the stream, so `rng`
+    /// must be positioned to match the trace evaluated: the caller derives it
+    /// from the agreed challenge and seeks it when folding a sub-range of the
+    /// trace.
     pub fn accumulate<R: RngCore>(self, rng: R) -> Prover<'a, Accumulate<R>> {
         Prover {
             macs: self.macs,
@@ -192,6 +232,7 @@ impl<'a> Prover<'a, Committed> {
                 rng,
                 u: Gf2_128Accumulator::zero(),
                 v: Gf2_128Accumulator::zero(),
+                poly: ProverPoly::default(),
             },
         }
     }
@@ -222,25 +263,28 @@ impl<'a, R> Prover<'a, Accumulate<R>> {
         if bit { MAC_ONE } else { MAC_ZERO }
     }
 
-    /// Completes the accumulate phase, yielding `(u, v, assertions)`.
+    /// Completes the accumulate phase, yielding a [`ProverOutput`].
     ///
     /// The caller masks `(u, v)` with the VOPE correlation
-    /// ([`vope_receiver`](crate::vope_receiver)) before sending the proof.
+    /// ([`vope_receiver`](crate::vope_receiver)) and the polynomial check
+    /// coefficients ([`ProverPoly::coefficients`]) with the degree-`d_max`
+    /// VOPE coefficients before sending the proof.
     ///
     /// # Errors
     ///
     /// Returns [`Error`] if the number of consumed tape entries does not match
     /// the tape length, indicating the circuits drew fewer inputs and AND
     /// gates than the tape provides.
-    pub fn finish(self) -> Result<(Gf2_128, Gf2_128, [u8; 32])> {
+    pub fn finish(self) -> Result<ProverOutput> {
         if self.cursor != self.macs.len() {
             return Err(Error::tape_unconsumed(self.cursor, self.macs.len()));
         }
-        Ok((
-            self.state.u.reduce(),
-            self.state.v.reduce(),
-            *self.state.assertions.finalize().as_bytes(),
-        ))
+        Ok(ProverOutput {
+            u: self.state.u.reduce(),
+            v: self.state.v.reduce(),
+            poly: self.state.poly,
+            assertions: *self.state.assertions.finalize().as_bytes(),
+        })
     }
 }
 
@@ -268,8 +312,7 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
         set_lsb(&mut mac, x & y);
         self.cursor = i + 1;
 
-        let mut chi = Gf2_128::new(0);
-        self.state.rng.fill_bytes(chi.as_mut_bytes());
+        let chi = draw_chi(&mut self.state.rng);
 
         // `a_10 = b if lsb(a) else 0`, `a_11 = a if lsb(b) else 0`,
         // expressed as `a · mask` with `mask ∈ {0, u128::MAX}` so there
@@ -298,5 +341,38 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
         self.state.assertions.update(&v.to_inner().to_le_bytes());
 
         Ok(())
+    }
+}
+
+impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
+    type Coeffs = ProverCoeffs<Gf2>;
+
+    fn lift(&self, wire: Gf2_128) -> Expr<ProverCoeffs<Gf2>, U1> {
+        // The wire's LSB carries its committed bit, so the top is read off it.
+        Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(wire, lsb(wire))
+    }
+
+    fn lift_const(&self, value: Gf2) -> Expr<ProverCoeffs<Gf2>, U0> {
+        Expr::<ProverCoeffs<Gf2>, U0>::constant(value)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<ProverCoeffs<Gf2>, N>) -> Gf2_128
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        let wire = self.input(expr.value().0);
+        // Pin the fresh wire to the expression: `expr - wire == 0`. The
+        // constraint's top coefficient is `expr.value + lsb(wire) = 0` by
+        // construction, so it folds without a witness check.
+        let constraint = expr - self.lift(wire);
+        let chi = draw_chi(&mut self.state.rng);
+        self.state.poly.fold_expr(&constraint, chi);
+        wire
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<ProverCoeffs<Gf2>, N>) -> Result<()> {
+        let Self { state, .. } = self;
+        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
     }
 }

--- a/crates/zk-core/src/util.rs
+++ b/crates/zk-core/src/util.rs
@@ -1,6 +1,25 @@
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
+use rand_core::RngCore;
+use zerocopy::IntoBytes;
 
 #[inline]
 pub(crate) fn set_lsb(g: &mut Gf2_128, bit: bool) {
     *g = Gf2_128::new((g.to_inner() & !1) | u128::from(bit));
+}
+
+/// Least-significant bit of a wire: the pointer-bit witness value.
+#[inline]
+pub(crate) fn lsb(g: Gf2_128) -> Gf2 {
+    Gf2(g.to_inner() & 1 == 1)
+}
+
+/// Draws the next 16-byte challenge weight from a streamed challenge.
+///
+/// Each multiplication and each polynomial constraint consumes one such weight,
+/// so callers must keep `rng` positioned to match the gates evaluated.
+#[inline]
+pub(crate) fn draw_chi(rng: &mut impl RngCore) -> Gf2_128 {
+    let mut chi = Gf2_128::new(0);
+    rng.fill_bytes(chi.as_mut_bytes());
+    chi
 }

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -6,9 +6,14 @@ use mpz_fields::{
     gf2_128::{Gf2_128, Gf2_128Accumulator},
 };
 use rand_core::RngCore;
-use zerocopy::IntoBytes;
 
-use crate::{Error, MAC_ONE, MAC_ZERO, Result, util::set_lsb};
+use typenum::{Max, Maximum, U0, U1, Unsigned};
+
+use crate::{
+    Error, MAC_ONE, MAC_ZERO, Result, VerifierOutput,
+    poly::{Degree, Expr, PolyContext, VerifierCoeffs, VerifierPoly},
+    util::{draw_chi, set_lsb},
+};
 
 /// The verifier side of the zero-knowledge protocol.
 ///
@@ -21,8 +26,8 @@ use crate::{Error, MAC_ONE, MAC_ZERO, Result, util::set_lsb};
 ///    by the caller.
 /// 2. [`Verifier<Accumulate>`](Accumulate) implements [`Context`] directly,
 ///    folding every multiplication and assertion into the running check state
-///    as the circuits are evaluated. [`finish`](Self::finish) yields
-///    `(w, assertions)`.
+///    as the circuits are evaluated. [`finish`](Self::finish) yields a
+///    [`VerifierOutput`].
 ///
 /// The caller masks `w` with the VOPE correlation
 /// ([`vope_sender`](crate::vope_sender)) and accepts the prover's proof iff
@@ -56,6 +61,7 @@ pub struct Accumulate<R> {
     rng: R,
     xy: Gf2_128Accumulator,
     z: Gf2_128Accumulator,
+    poly: VerifierPoly,
 }
 
 impl<'a> Verifier<'a, Committed> {
@@ -69,6 +75,11 @@ impl<'a> Verifier<'a, Committed> {
     /// When folding a sub-range of a trace, pass the sub-range's tape slices
     /// and seek the challenge stream to the sub-range's gate offset: the `w`
     /// outputs of the sub-ranges sum to the full trace's `w`.
+    ///
+    /// The polynomial check ([`VerifierPoly::check`]) needs the powers of
+    /// `delta` ([`DeltaPowers`](crate::poly::DeltaPowers)); the accumulate pass
+    /// itself does not, so the caller precomputes them once and supplies them
+    /// at check time.
     ///
     /// # Errors
     ///
@@ -89,10 +100,12 @@ impl<'a> Verifier<'a, Committed> {
 
     /// Begins the accumulate pass, drawing challenge weights from `rng`.
     ///
-    /// Each multiplication consumes 16 bytes of the stream, so `rng` must be
-    /// positioned to match the gates evaluated: the caller derives it from the
-    /// challenge it sampled and seeks it when folding a sub-range of the
-    /// trace.
+    /// Each multiplication and each polynomial constraint
+    /// ([`PolyContext::assert_zero`] of degree ≥ 1, or
+    /// [`PolyContext::materialize`]) consumes 16 bytes of the stream, so `rng`
+    /// must be positioned to match the trace evaluated: the caller derives it
+    /// from the challenge it sampled and seeks it when folding a sub-range of
+    /// the trace.
     pub fn accumulate<R: RngCore>(self, rng: R) -> Verifier<'a, Accumulate<R>> {
         Verifier {
             keys: self.keys,
@@ -105,6 +118,7 @@ impl<'a> Verifier<'a, Committed> {
                 rng,
                 xy: Gf2_128Accumulator::zero(),
                 z: Gf2_128Accumulator::zero(),
+                poly: VerifierPoly::default(),
             },
         }
     }
@@ -140,23 +154,28 @@ impl<'a, R> Verifier<'a, Accumulate<R>> {
         if bit { self.key_one } else { MAC_ZERO }
     }
 
-    /// Completes the accumulate phase, yielding `(w, assertions)`.
+    /// Completes the accumulate phase, yielding a [`VerifierOutput`].
     ///
     /// The caller masks `w` with the VOPE correlation
     /// ([`vope_sender`](crate::vope_sender)) and accepts the prover's proof
-    /// iff `w == u + delta * v` and the assertion hashes match.
+    /// iff `w == u + delta * v`, the assertion hashes match, and the
+    /// polynomial check passes ([`VerifierPoly::check`]).
     ///
     /// # Errors
     ///
     /// Returns [`Error`] if the number of consumed tape entries does not match
     /// the tape length, indicating the circuits drew fewer inputs and AND
     /// gates than the tape provides.
-    pub fn finish(self) -> Result<(Gf2_128, [u8; 32])> {
+    pub fn finish(self) -> Result<VerifierOutput> {
         if self.cursor != self.adjust.len() {
             return Err(Error::tape_unconsumed(self.cursor, self.adjust.len()));
         }
         let w = self.state.xy.reduce() + self.delta * self.state.z.reduce();
-        Ok((w, *self.state.assertions.finalize().as_bytes()))
+        Ok(VerifierOutput {
+            w,
+            poly: self.state.poly,
+            assertions: *self.state.assertions.finalize().as_bytes(),
+        })
     }
 }
 
@@ -190,8 +209,7 @@ impl<R: RngCore> Context for Verifier<'_, Accumulate<R>> {
         set_lsb(&mut key, false);
         self.cursor = i + 1;
 
-        let mut chi = Gf2_128::new(0);
-        self.state.rng.fill_bytes(chi.as_mut_bytes());
+        let chi = draw_chi(&mut self.state.rng);
 
         self.state.xy.add_product(a * b, chi);
         self.state.z.add_product(key, chi);
@@ -208,5 +226,37 @@ impl<R: RngCore> Context for Verifier<'_, Accumulate<R>> {
         self.state.assertions.update(&mac.to_inner().to_le_bytes());
 
         Ok(())
+    }
+}
+
+impl<R: RngCore> PolyContext for Verifier<'_, Accumulate<R>> {
+    type Coeffs = VerifierCoeffs;
+
+    fn lift(&self, wire: Gf2_128) -> Expr<VerifierCoeffs, U1> {
+        Expr::<VerifierCoeffs, U1>::lift_key(wire, self.delta)
+    }
+
+    fn lift_const(&self, value: Gf2) -> Expr<VerifierCoeffs, U0> {
+        Expr::<VerifierCoeffs, U0>::constant(value, self.delta)
+    }
+
+    fn materialize<N>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Gf2_128
+    where
+        N: Degree + Max<U1>,
+        Maximum<N, U1>: Degree,
+    {
+        let wire = self.input();
+        // Pin the fresh wire to the expression: `expr - wire == 0`.
+        let constraint = expr - self.lift(wire);
+        let chi = draw_chi(&mut self.state.rng);
+        self.state
+            .poly
+            .fold_expr(&constraint, Maximum::<N, U1>::USIZE, chi);
+        wire
+    }
+
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Result<()> {
+        let Self { state, .. } = self;
+        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
     }
 }

--- a/crates/zk-core/tests/gf64.rs
+++ b/crates/zk-core/tests/gf64.rs
@@ -1,0 +1,337 @@
+//! End-to-end tests for the `GF(2^64)` circuit path: build a small arithmetic
+//! circuit over `Gf2_64`, drive it through the [`Commit`]/[`Prover`]/[`Verifier`]
+//! triple against a simulated subfield sVOLE tape, and check that the
+//! QuickSilver consistency check accepts a correct execution and rejects a
+//! corrupted one.
+
+use mpz_circuits::Context;
+use mpz_fields::{ExtensionField, gf2_64::Gf2_64, gf2_128::Gf2_128};
+use mpz_zk_core::{
+    DeltaPowers, PolyContext, ProverOutput, VerifierOutput,
+    gf64::{Auth64, Commit, Prover, Verifier},
+    vope_receiver, vope_sender,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand_chacha::ChaCha12Rng;
+
+const VOPE_COST: usize = 128;
+
+/// Subfield injection `GF(2^64) ↪ GF(2^128)`.
+fn embed(v: Gf2_64) -> Gf2_128 {
+    <Gf2_128 as ExtensionField<Gf2_64>>::embed(v)
+}
+
+/// The benchmark circuit: `out = ((i0·i1) + i2)·i1 + 5`, asserted to equal the
+/// public `expected`. Two multiplications consume the gate tape.
+fn circuit<C>(ctx: &mut C, inputs: &[C::Wire], expected: Gf2_64) -> Result<(), C::Error>
+where
+    C: Context<Field = Gf2_64>,
+{
+    let a = ctx.mul(inputs[0], inputs[1]);
+    let b = ctx.add(a, inputs[2]);
+    let c = ctx.mul(b, inputs[1]);
+    let five = ctx.constant(Gf2_64(5));
+    let out = ctx.add(c, five);
+    ctx.assert_const(out, expected)
+}
+
+/// Cleartext evaluation of [`circuit`] for the expected output.
+fn eval(i: &[Gf2_64; 3]) -> Gf2_64 {
+    let a = i[0] * i[1];
+    let b = a + i[2];
+    let c = b * i[1];
+    c + Gf2_64(5)
+}
+
+const N_IN: usize = 3;
+const N_GATE: usize = 2;
+
+struct Setup {
+    delta: Gf2_128,
+    /// Prover input wires (value + raw MAC).
+    input_auth: Vec<Auth64>,
+    /// Verifier input wires (adjusted keys).
+    input_keys: Vec<Gf2_128>,
+    /// Cleartext input values (for the commit pass).
+    input_values: [Gf2_64; N_IN],
+    gate_masks: Vec<Gf2_64>,
+    gate_macs: Vec<Gf2_128>,
+    gate_keys: Vec<Gf2_128>,
+    expected: Gf2_64,
+    vope_choices: [bool; VOPE_COST],
+    vope_ev: [Gf2_128; VOPE_COST],
+    vope_keys: [Gf2_128; VOPE_COST],
+    chi: [u8; 32],
+}
+
+/// Samples a subfield sVOLE tape and commits the inputs, returning everything
+/// the prover and verifier need.
+fn setup(seed: u64) -> Setup {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let delta = Gf2_128::new(rng.random());
+
+    let input_values: [Gf2_64; N_IN] = core::array::from_fn(|_| Gf2_64(rng.random()));
+    let expected = eval(&input_values);
+
+    // Subfield sVOLE: per entry, choice ∈ GF(2^64), key ∈ GF(2^128),
+    // mac = key + embed(choice)·Δ.
+    let total = N_IN + N_GATE;
+    let choices: Vec<Gf2_64> = (0..total).map(|_| Gf2_64(rng.random())).collect();
+    let keys: Vec<Gf2_128> = (0..total).map(|_| Gf2_128::new(rng.random())).collect();
+    let macs: Vec<Gf2_128> = (0..total)
+        .map(|i| keys[i] + embed(choices[i]) * delta)
+        .collect();
+
+    // Commit the inputs: adjust = value + choice, key adjusted, mac raw.
+    let input_auth: Vec<Auth64> = (0..N_IN)
+        .map(|i| Auth64 {
+            value: input_values[i],
+            mac: macs[i],
+        })
+        .collect();
+    let input_keys: Vec<Gf2_128> = (0..N_IN)
+        .map(|i| {
+            let adjust = input_values[i] + choices[i];
+            keys[i] + embed(adjust) * delta
+        })
+        .collect();
+
+    // Gate tape: masks start at the sVOLE choices; the commit pass overwrites
+    // them with adjustments.
+    let gate_masks: Vec<Gf2_64> = choices[N_IN..].to_vec();
+    let gate_macs: Vec<Gf2_128> = macs[N_IN..].to_vec();
+    let gate_keys: Vec<Gf2_128> = keys[N_IN..].to_vec();
+
+    // VOPE correlation (single GF(2^128) line over 128 bit-choices).
+    let vope: Vec<(bool, Gf2_128, Gf2_128)> = (0..VOPE_COST)
+        .map(|_| {
+            let choice: bool = rng.random();
+            let key = Gf2_128::new(rng.random());
+            let mac = if choice { key + delta } else { key };
+            (choice, mac, key)
+        })
+        .collect();
+    let vope_choices: [bool; VOPE_COST] = core::array::from_fn(|i| vope[i].0);
+    let vope_ev: [Gf2_128; VOPE_COST] = core::array::from_fn(|i| vope[i].1);
+    let vope_keys: [Gf2_128; VOPE_COST] = core::array::from_fn(|i| vope[i].2);
+    let chi: [u8; 32] = rng.random();
+
+    Setup {
+        delta,
+        input_auth,
+        input_keys,
+        input_values,
+        gate_masks,
+        gate_macs,
+        gate_keys,
+        expected,
+        vope_choices,
+        vope_ev,
+        vope_keys,
+        chi,
+    }
+}
+
+/// Runs the prover's two passes and returns the masked `(u, v, assertions)`
+/// and the gate adjust tape for the verifier.
+fn prove(s: &Setup) -> (Gf2_128, Gf2_128, [u8; 32], Vec<Gf2_64>) {
+    let mut gate_adjust = s.gate_masks.clone();
+    let mut commit = Commit::new(&mut gate_adjust);
+    circuit(&mut commit, &s.input_values, s.expected).unwrap();
+    commit.finish().unwrap();
+
+    let mut prover = Prover::committed(&s.gate_macs).accumulate(ChaCha12Rng::from_seed(s.chi));
+    circuit(&mut prover, &s.input_auth, s.expected).unwrap();
+    let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
+
+    let (a_0, a_1) = vope_receiver(&s.vope_choices, &s.vope_ev);
+    (u + a_0, v + a_1, assertions, gate_adjust)
+}
+
+/// Runs the verifier's accumulate pass and returns `(w + b, assertions)`.
+fn verify(s: &Setup, gate_adjust: &[Gf2_64]) -> (Gf2_128, [u8; 32]) {
+    let verifier = Verifier::new(s.delta, &s.gate_keys, gate_adjust).unwrap();
+    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(s.chi));
+    circuit(&mut verifier, &s.input_keys, s.expected).unwrap();
+    let VerifierOutput { w, assertions, .. } = verifier.finish().unwrap();
+    (w + vope_sender(&s.vope_keys), assertions)
+}
+
+#[test]
+fn happy_path() {
+    let s = setup(1);
+    let (u, v, p_assertions, gate_adjust) = prove(&s);
+    let (wb, v_assertions) = verify(&s, &gate_adjust);
+
+    assert_eq!(p_assertions, v_assertions, "assertion hashes must match");
+    assert_eq!(wb, u + s.delta * v, "consistency check must accept");
+}
+
+#[test]
+fn corrupted_gate_rejected() {
+    // Honest prover, then corrupt a verifier gate key before its pass: the
+    // triple's z no longer matches, so the check equation fails.
+    let mut s = setup(2);
+    let (u, v, _p_assertions, gate_adjust) = prove(&s);
+
+    s.gate_keys[0] = s.gate_keys[0] + Gf2_128::new(0xdead_beef);
+
+    let (wb, _v_assertions) = verify(&s, &gate_adjust);
+    assert_ne!(wb, u + s.delta * v, "corrupted gate must be rejected");
+}
+
+#[test]
+fn wrong_expected_breaks_assertion() {
+    // The assertion binds the claimed public output: a verifier checking a
+    // different output reconstructs a different MAC, so the hashes diverge.
+    let s = setup(3);
+    let (_u, _v, p_assertions, gate_adjust) = prove(&s);
+
+    let verifier = Verifier::new(s.delta, &s.gate_keys, &gate_adjust).unwrap();
+    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(s.chi));
+    let wrong = s.expected + Gf2_64(1);
+    circuit(&mut verifier, &s.input_keys, wrong).unwrap();
+    let VerifierOutput { assertions: v_assertions, .. } = verifier.finish().unwrap();
+
+    assert_ne!(
+        p_assertions, v_assertions,
+        "a wrong claimed output must break the assertion hash"
+    );
+}
+
+#[test]
+fn unsatisfying_witness_fails_commit() {
+    // The commit pass evaluates in cleartext and catches a witness that does
+    // not satisfy the asserted output early.
+    let s = setup(5);
+    let mut masks = s.gate_masks.clone();
+    let mut commit = Commit::new(&mut masks);
+    let wrong = s.expected + Gf2_64(1);
+    assert!(circuit(&mut commit, &s.input_values, wrong).is_err());
+}
+
+#[test]
+fn tape_length_mismatch_rejected() {
+    let s = setup(4);
+    let bad_adjust = vec![Gf2_64(0); s.gate_keys.len() + 1];
+    assert!(Verifier::new(s.delta, &s.gate_keys, &bad_adjust).is_err());
+}
+
+// --- polynomial-constraint path --------------------------------------------
+
+/// A degree-2 polynomial constraint `x·y − z = 0` over committed `GF(2^64)`
+/// wires, plus a degree-3 `x·y·u − w = 0`, exercising the `PolyContext`.
+fn poly_gadget<C>(ctx: &mut C, w: &[C::Wire]) -> Result<(), C::Error>
+where
+    C: PolyContext<Field = Gf2_64>,
+    C::Error: core::fmt::Debug,
+{
+    let x = ctx.lift(w[0]);
+    let y = ctx.lift(w[1]);
+    let z = ctx.lift(w[2]);
+    let u = ctx.lift(w[3]);
+    let ww = ctx.lift(w[4]);
+    ctx.assert_zero(x * y - z)?; // degree 2
+    ctx.assert_zero(x * y * u - ww)?; // degree 3
+    Ok(())
+}
+
+const POLY_DMAX: usize = 3;
+
+#[test]
+fn poly_round_trip() {
+    let mut rng = StdRng::seed_from_u64(20);
+    let delta = Gf2_128::new(rng.random());
+    let powers = DeltaPowers::new(delta);
+    let chi: [u8; 32] = rng.random();
+
+    // Witness: x, y, z = x·y, u, w = x·y·u — five committed values.
+    let x = Gf2_64(rng.random());
+    let y = Gf2_64(rng.random());
+    let u = Gf2_64(rng.random());
+    let z = x * y;
+    let w = z * u;
+    let values = [x, y, z, u, w];
+    let n = values.len();
+
+    // Subfield sVOLE for the five input wires.
+    let choices: Vec<Gf2_64> = (0..n).map(|_| Gf2_64(rng.random())).collect();
+    let keys: Vec<Gf2_128> = (0..n).map(|_| Gf2_128::new(rng.random())).collect();
+    let macs: Vec<Gf2_128> = (0..n).map(|i| keys[i] + embed(choices[i]) * delta).collect();
+    let input_auth: Vec<Auth64> = (0..n)
+        .map(|i| Auth64 {
+            value: values[i],
+            mac: macs[i],
+        })
+        .collect();
+    let input_keys: Vec<Gf2_128> = (0..n)
+        .map(|i| keys[i] + embed(values[i] + choices[i]) * delta)
+        .collect();
+
+    // Mock degree-`d_max` polynomial-check VOPE.
+    let poly_masks: Vec<Gf2_128> = (0..POLY_DMAX).map(|_| Gf2_128::new(rng.random())).collect();
+    let mut vope_sum = Gf2_128::new(0);
+    let mut pw = Gf2_128::new(1);
+    for &m in &poly_masks {
+        vope_sum = vope_sum + m * pw;
+        pw = pw * delta;
+    }
+
+    // Commit pass validates the witness in cleartext.
+    let mut commit = Commit::new(&mut []);
+    poly_gadget(&mut commit, &values).unwrap();
+    commit.finish().unwrap();
+
+    // Prover accumulate.
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    poly_gadget(&mut prover, &input_auth).unwrap();
+    let ProverOutput { poly, .. } = prover.finish().unwrap();
+    let coefficients: Vec<Gf2_128> = poly
+        .coefficients(POLY_DMAX)
+        .unwrap()
+        .into_iter()
+        .zip(&poly_masks)
+        .map(|(c, &m)| c + m)
+        .collect();
+
+    // Verifier accumulate + check.
+    let verifier = Verifier::new(delta, &[], &[]).unwrap();
+    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+    poly_gadget(&mut verifier, &input_keys).unwrap();
+    let VerifierOutput { poly: vpoly, .. } = verifier.finish().unwrap();
+
+    vpoly.check(&powers, &coefficients, vope_sum).unwrap();
+
+    // A corrupted coefficient must fail the check.
+    let mut bad = coefficients.clone();
+    bad[0] = bad[0] + Gf2_128::ONE;
+    assert!(vpoly.check(&powers, &bad, vope_sum).is_err());
+}
+
+#[test]
+fn poly_unsatisfied_rejected() {
+    // An unsatisfying witness (z ≠ x·y) is caught by the prover's local
+    // assert_zero during the accumulate pass.
+    let mut rng = StdRng::seed_from_u64(21);
+    let delta = Gf2_128::new(rng.random());
+    let chi: [u8; 32] = rng.random();
+
+    let x = Gf2_64(rng.random());
+    let y = Gf2_64(rng.random());
+    let u = Gf2_64(rng.random());
+    let values = [x, y, x * y + Gf2_64(1), u, x * y * u]; // z is wrong
+
+    let n = values.len();
+    let choices: Vec<Gf2_64> = (0..n).map(|_| Gf2_64(rng.random())).collect();
+    let keys: Vec<Gf2_128> = (0..n).map(|_| Gf2_128::new(rng.random())).collect();
+    let macs: Vec<Gf2_128> = (0..n).map(|i| keys[i] + embed(choices[i]) * delta).collect();
+    let input_auth: Vec<Auth64> = (0..n)
+        .map(|i| Auth64 {
+            value: values[i],
+            mac: macs[i],
+        })
+        .collect();
+
+    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    assert!(poly_gadget(&mut prover, &input_auth).is_err());
+}

--- a/crates/zk-core/tests/sha256.rs
+++ b/crates/zk-core/tests/sha256.rs
@@ -16,7 +16,7 @@ use mpz_ot_core::ideal::rcot::IdealRCOT;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rand_chacha::ChaCha12Rng;
 
-use mpz_zk_core::{Commit, Proof, Prover, Verifier, vope_receiver, vope_sender};
+use mpz_zk_core::{Commit, Proof, Prover, ProverOutput, Verifier, VerifierOutput, vope_receiver, vope_sender};
 
 const VOPE_COST: usize = 128;
 
@@ -151,13 +151,14 @@ fn sha256_quicksilver_batch_check_accepts() {
     // Accumulate pass: re-evaluates the circuit, folding the proof.
     let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
     let prover_out = sha256_compress(&mut prover, msg_p, state_p);
-    let (u, v, assertions) = prover.finish().expect("accumulate finish");
+    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
 
     let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
     let proof = Proof {
         assertions,
         u: u + a_0,
         v: v + a_1,
+        coefficients: Vec::new(),
     };
 
     // ---- VERIFIER side ----
@@ -177,7 +178,7 @@ fn sha256_quicksilver_batch_check_accepts() {
     let msg_v: [Gf2_128; 512] = core::array::from_fn(|i| input_key_wires[i]);
     let state_v: [Gf2_128; 256] = core::array::from_fn(|i| input_key_wires[512 + i]);
     let verifier_out = sha256_compress(&mut verifier, msg_v, state_v);
-    let (w, v_assertions) = verifier.finish().expect("finish");
+    let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().expect("finish");
 
     // Output IT-MAC sanity: MAC == key + b·delta for each output bit.
     let expected_bits = sha2_compress_out_bits(msg, H0);


### PR DESCRIPTION
## Summary

Adds the composite QuickSilver polynomial-constraint proof to `mpz-zk-core` and a GF(2^64) circuit path that reuses the existing GF(2^128) MACs.

**PolyContext (composite QuickSilver)**
- Degree-typed `Expr<C, N>`: per-expression coefficient storage sized to the constraint's actual degree via typenum + hybrid-array, not `MAX_DEGREE`.
- Prover/Verifier fold constraints during the accumulate pass into `ProverPoly`/`VerifierPoly` under a streamed challenge; the verifier expression carries `delta` so it stays lifetime-free.

**GF(2^64) circuits** (boolean path left untouched)
- `ExtensionField<Gf2_64>` for `Gf2_128`: a subfield embedding (a root of GF(2^64)'s modulus in GF(2^128)), proven to be a ring homomorphism.
- `gf64` module: Commit/Prover/Verifier carrying explicit-value `Auth64` wires with a subfield-scaled triple check, plus `PolyContext` over GF(2^64).

**Benchmarks**
- `mux` (Gf2 poly) and the accelerated permutation-product argument over GF(2^64) (chunked degree-d grand product, per SpeakUp).

## Test plan
- [ ] `cargo test -p mpz-zk-core`
- [ ] `cargo test -p mpz-fields`
