### PR TITLE
feat(ot-core,ot): skip Ferret for small cold demands

### DIFF
--- a/crates/ot-core/benches/ot.rs
+++ b/crates/ot-core/benches/ot.rs
@@ -102,6 +102,8 @@ fn ferret(c: &mut Criterion) {
             receiver.alloc_bootstrap().unwrap();
             sender.acquire_cot().flush().unwrap();
             receiver.acquire_cot().flush().unwrap();
+            sender.bootstrap().unwrap();
+            receiver.bootstrap().unwrap();
             sender.alloc(n).unwrap();
             receiver.alloc(n).unwrap();
 

--- a/crates/ot-core/src/ferret.rs
+++ b/crates/ot-core/src/ferret.rs
@@ -92,6 +92,8 @@ mod tests {
 
         let mut builder = FerretConfig::builder();
 
+        // Disable passthrough so a small count still exercises the protocol.
+        builder.direct_passthrough(false);
         builder.param_selector(|_, _| TEST_PARAMS);
 
         let config = builder.build().unwrap();
@@ -108,6 +110,9 @@ mod tests {
 
         sender.acquire_cot().flush().unwrap();
         receiver.acquire_cot().flush().unwrap();
+
+        sender.bootstrap().unwrap();
+        receiver.bootstrap().unwrap();
 
         sender.alloc(count).unwrap();
         receiver.alloc(count).unwrap();
@@ -129,5 +134,94 @@ mod tests {
         let RCOTReceiverOutput { choices, msgs, .. } = receiver.try_recv_rcot(count).unwrap();
 
         assert_cot(delta, &choices, &keys, &msgs);
+    }
+
+    #[test]
+    fn test_ferret_direct() {
+        use rand::Rng;
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = rng.random();
+        let cot = IdealRCOT::new(rng.random(), delta);
+
+        let config = FerretConfig::default();
+
+        // A small demand is served straight from the base COT, skipping Ferret.
+        let count = 1_000;
+        assert!(count < config.bootstrap_cost());
+
+        let mut sender = Sender::new(rng.random(), config.clone(), cot.clone());
+        let mut receiver = Receiver::new(rng.random(), config, cot);
+
+        sender.alloc(count).unwrap();
+        receiver.alloc(count).unwrap();
+
+        assert!(sender.wants_bootstrap());
+        assert!(receiver.wants_bootstrap());
+
+        sender.alloc_bootstrap().unwrap();
+        receiver.alloc_bootstrap().unwrap();
+
+        sender.acquire_cot().flush().unwrap();
+        receiver.acquire_cot().flush().unwrap();
+
+        sender.bootstrap().unwrap();
+        receiver.bootstrap().unwrap();
+
+        // The demand is satisfied directly, so no extension is needed.
+        assert!(!sender.wants_extend());
+        assert!(!receiver.wants_extend());
+
+        let RCOTSenderOutput { keys, .. } = sender.try_send_rcot(count).unwrap();
+        let RCOTReceiverOutput { choices, msgs, .. } = receiver.try_recv_rcot(count).unwrap();
+
+        assert_cot(delta, &choices, &keys, &msgs);
+    }
+
+    #[test]
+    fn test_ferret_direct_multi_round() {
+        use rand::Rng;
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = rng.random();
+        let cot = IdealRCOT::new(rng.random(), delta);
+
+        let config = FerretConfig::default();
+        let count = 1_000;
+        assert!(count < config.bootstrap_cost());
+
+        let mut sender = Sender::new(rng.random(), config.clone(), cot.clone());
+        let mut receiver = Receiver::new(rng.random(), config, cot);
+
+        // alloc -> consume, repeated. Each round is served directly and drains
+        // the buffer back to empty, so the next round starts cold.
+        for _ in 0..3 {
+            sender.alloc(count).unwrap();
+            receiver.alloc(count).unwrap();
+
+            assert!(sender.wants_bootstrap());
+            assert!(receiver.wants_bootstrap());
+
+            sender.alloc_bootstrap().unwrap();
+            receiver.alloc_bootstrap().unwrap();
+
+            sender.acquire_cot().flush().unwrap();
+            receiver.acquire_cot().flush().unwrap();
+
+            sender.bootstrap().unwrap();
+            receiver.bootstrap().unwrap();
+
+            assert!(!sender.wants_extend());
+            assert!(!receiver.wants_extend());
+
+            let RCOTSenderOutput { keys, .. } = sender.try_send_rcot(count).unwrap();
+            let RCOTReceiverOutput { choices, msgs, .. } = receiver.try_recv_rcot(count).unwrap();
+
+            assert_cot(delta, &choices, &keys, &msgs);
+
+            // Drained back to empty: still cold, never warmed into Ferret.
+            assert_eq!(sender.available(), 0);
+            assert_eq!(receiver.available(), 0);
+        }
     }
 }

--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -21,6 +21,10 @@ pub struct FerretConfig {
     /// Whether to reserve bootstrap COTs.
     #[builder(default = "true")]
     reserve_bootstrap: bool,
+    /// Whether to serve small demands directly from the base COT instead of
+    /// running a full Ferret iteration. See [`FerretConfig::direct_passthrough`].
+    #[builder(default = "true")]
+    direct_passthrough: bool,
     #[builder(setter(custom), default = "Arc::new(default_parameter_selector)")]
     param_selector: Arc<dyn Fn(usize, usize) -> LpnParameters + Send + Sync + 'static>,
 }
@@ -29,6 +33,7 @@ impl Debug for FerretConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FerretConfig")
             .field("reserve_bootstrap", &self.reserve_bootstrap)
+            .field("direct_passthrough", &self.direct_passthrough)
             .finish_non_exhaustive()
     }
 }
@@ -37,6 +42,7 @@ impl Default for FerretConfig {
     fn default() -> Self {
         Self {
             reserve_bootstrap: true,
+            direct_passthrough: true,
             param_selector: Arc::new(default_parameter_selector),
         }
     }
@@ -69,6 +75,16 @@ impl FerretConfig {
     /// Returns `true` if bootstrap COTs should be reserved.
     pub fn reserve_bootstrap(&self) -> bool {
         self.reserve_bootstrap
+    }
+
+    /// Returns `true` if small demands should be served directly from the base
+    /// COT.
+    ///
+    /// While Ferret is cold, a demand below the bootstrap cost is cheaper to
+    /// satisfy from the base COT than by running a full Ferret iteration, which
+    /// has a large fixed cost and produces a correspondingly large surplus.
+    pub fn direct_passthrough(&self) -> bool {
+        self.direct_passthrough
     }
 
     /// Returns the cost of a bootstrap iteration.

--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -91,16 +91,60 @@ where
         self.available() < self.alloc
     }
 
-    /// Allocates COTs for bootstrapping.
+    /// Allocates base COTs for the next bootstrap.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let missing = self.config.bootstrap_cost().saturating_sub(self.macs.len());
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?
-            .alloc(missing)
+            .alloc(self.bootstrap_count())
             .map_err(Error::bootstrap)?;
 
         Ok(())
+    }
+
+    /// Pulls the allocated base COTs into the buffer.
+    ///
+    /// When the demand is small enough that a full Ferret iteration would be
+    /// wasteful, this serves it directly from the base COT (see
+    /// [`FerretConfig::direct_passthrough`]); otherwise it seeds the next
+    /// extension.
+    pub fn bootstrap(&mut self) -> Result<()> {
+        let count = self.bootstrap_count();
+        let RCOTReceiverOutput {
+            msgs: macs,
+            choices,
+            ..
+        } = self
+            .cot
+            .try_lock()
+            .map_err(|_| ErrorRepr::MutexLocked)?
+            .try_recv_rcot(count)
+            .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
+
+        self.macs.extend(macs.iter().map(|&mac| Gf2_128::from(mac)));
+        self.choices.extend_from_slice(&choices);
+
+        // If the buffer now satisfies the demand, the base COTs are the output
+        // and no extension is needed.
+        if self.alloc.saturating_sub(self.available()) == 0 {
+            self.alloc = 0;
+            self.process_queue();
+        }
+
+        Ok(())
+    }
+
+    /// Returns the number of base COTs to pull on the next bootstrap: just the
+    /// outstanding demand when it is below the bootstrap cost (served directly),
+    /// otherwise a full bootstrap batch.
+    fn bootstrap_count(&self) -> usize {
+        let missing = self.alloc.saturating_sub(self.available());
+        if self.config.direct_passthrough() && missing > 0 && missing < self.config.bootstrap_cost()
+        {
+            missing
+        } else {
+            self.config.bootstrap_cost().saturating_sub(self.macs.len())
+        }
     }
 
     /// Starts extension.
@@ -108,24 +152,6 @@ where
         let State::Extend = self.state.take() else {
             return Err(ErrorRepr::State("not in extend state".to_string()).into());
         };
-
-        // If available COTs are insufficient, we bootstrap from the inner COT instance.
-        if self.wants_bootstrap() {
-            let missing = self.config.bootstrap_cost() - self.macs.len();
-            let RCOTReceiverOutput {
-                msgs: macs,
-                choices,
-                ..
-            } = self
-                .cot
-                .try_lock()
-                .map_err(|_| ErrorRepr::MutexLocked)?
-                .try_recv_rcot(missing)
-                .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
-
-            self.macs.extend(macs.iter().map(|&mac| Gf2_128::from(mac)));
-            self.choices.extend_from_slice(&choices);
-        }
 
         let missing = self.alloc.saturating_sub(self.available());
         let params = self.config.select_params(self.macs.len(), missing);
@@ -342,8 +368,10 @@ where
 
     fn available(&self) -> usize {
         let len = self.macs.len() - self.pending;
-        if self.config.reserve_bootstrap() {
-            len.saturating_sub(self.config.bootstrap_cost())
+        // Reserve a bootstrap batch only once we hold at least that many, so
+        // that directly-served base COTs (a smaller buffer) stay available.
+        if self.config.reserve_bootstrap() && len >= self.config.bootstrap_cost() {
+            len - self.config.bootstrap_cost()
         } else {
             len
         }

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -94,16 +94,55 @@ where
         self.available() < self.alloc
     }
 
-    /// Allocates COTs for bootstrapping.
+    /// Allocates base COTs for the next bootstrap.
     pub fn alloc_bootstrap(&self) -> Result<()> {
-        let missing = self.config.bootstrap_cost().saturating_sub(self.keys.len());
         self.cot
             .try_lock()
             .map_err(|_| ErrorRepr::MutexLocked)?
-            .alloc(missing)
+            .alloc(self.bootstrap_count())
             .map_err(Error::bootstrap)?;
 
         Ok(())
+    }
+
+    /// Pulls the allocated base COTs into the buffer.
+    ///
+    /// When the demand is small enough that a full Ferret iteration would be
+    /// wasteful, this serves it directly from the base COT (see
+    /// [`FerretConfig::direct_passthrough`]); otherwise it seeds the next
+    /// extension.
+    pub fn bootstrap(&mut self) -> Result<()> {
+        let count = self.bootstrap_count();
+        let RCOTSenderOutput { keys, .. } = self
+            .cot
+            .try_lock()
+            .map_err(|_| ErrorRepr::MutexLocked)?
+            .try_send_rcot(count)
+            .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
+
+        self.keys.extend(keys.iter().map(|&key| Gf2_128::from(key)));
+
+        // If the buffer now satisfies the demand, the base COTs are the output
+        // and no extension is needed.
+        if self.alloc.saturating_sub(self.available()) == 0 {
+            self.alloc = 0;
+            self.process_queue();
+        }
+
+        Ok(())
+    }
+
+    /// Returns the number of base COTs to pull on the next bootstrap: just the
+    /// outstanding demand when it is below the bootstrap cost (served directly),
+    /// otherwise a full bootstrap batch.
+    fn bootstrap_count(&self) -> usize {
+        let missing = self.alloc.saturating_sub(self.available());
+        if self.config.direct_passthrough() && missing > 0 && missing < self.config.bootstrap_cost()
+        {
+            missing
+        } else {
+            self.config.bootstrap_cost().saturating_sub(self.keys.len())
+        }
     }
 
     /// Starts extension.
@@ -112,18 +151,6 @@ where
             return Err(ErrorRepr::State("not in extend state".to_string()).into());
         };
 
-        // If available COTs are insufficient, we bootstrap from the inner COT instance.
-        if self.wants_bootstrap() {
-            let missing = self.config.bootstrap_cost() - self.keys.len();
-            let RCOTSenderOutput { keys, .. } = self
-                .cot
-                .try_lock()
-                .map_err(|_| ErrorRepr::MutexLocked)?
-                .try_send_rcot(missing)
-                .map_err(|e| ErrorRepr::Bootstrap(Box::new(e)))?;
-
-            self.keys.extend(keys.iter().map(|&key| Gf2_128::from(key)));
-        }
         let missing = self.alloc.saturating_sub(self.available());
         let params = self.config.select_params(self.keys.len(), missing);
 
@@ -307,8 +334,10 @@ where
 
     fn available(&self) -> usize {
         let len = self.keys.len() - self.pending;
-        if self.config.reserve_bootstrap() {
-            len.saturating_sub(self.config.bootstrap_cost())
+        // Reserve a bootstrap batch only once we hold at least that many, so
+        // that directly-served base COTs (a smaller buffer) stay available.
+        if self.config.reserve_bootstrap() && len >= self.config.bootstrap_cost() {
+            len - self.config.bootstrap_cost()
         } else {
             len
         }

--- a/crates/ot/src/ferret.rs
+++ b/crates/ot/src/ferret.rs
@@ -26,6 +26,8 @@ mod tests {
 
         let mut builder = FerretConfig::builder();
 
+        // Disable passthrough so a small count still exercises the protocol.
+        builder.direct_passthrough(false);
         builder.param_selector(|_, _| LpnParameters {
             n: 9600,
             k: 1024,
@@ -38,5 +40,25 @@ mod tests {
         let receiver = Receiver::new(config, rng.random(), cot_receiver);
 
         test_rcot(sender, receiver, 20_000, 2).await;
+    }
+
+    #[tokio::test]
+    async fn test_ferret_direct_passthrough() {
+        use crate::test::test_rcot;
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let delta = rng.random();
+
+        let (cot_sender, cot_receiver) = ideal_rcot(rng.random(), delta);
+
+        // Default config: a small demand is served straight from the base COT.
+        let config = FerretConfig::default();
+
+        let sender = Sender::new(config.clone(), rng.random(), cot_sender);
+        let receiver = Receiver::new(config, rng.random(), cot_receiver);
+
+        // Multiple alloc -> consume rounds, each served directly from the base
+        // COT (count stays below the bootstrap cost).
+        test_rcot(sender, receiver, 1_000, 5).await;
     }
 }

--- a/crates/ot/src/ferret/receiver.rs
+++ b/crates/ot/src/ferret/receiver.rs
@@ -80,6 +80,7 @@ where
                 .flush(ctx)
                 .await
                 .map_err(Error::bootstrap)?;
+            self.core.bootstrap()?;
         }
 
         while self.core.wants_extend() {

--- a/crates/ot/src/ferret/sender.rs
+++ b/crates/ot/src/ferret/sender.rs
@@ -80,6 +80,7 @@ where
                 .flush(ctx)
                 .await
                 .map_err(Error::bootstrap)?;
+            self.core.bootstrap()?;
         }
 
         while self.core.wants_extend() {


### PR DESCRIPTION
## Summary

Serve a cold RCOT demand directly from the base COT (KOS) when it is below the Ferret bootstrap cost (~74k), instead of running a full LPN iteration. Below that threshold KOS is cheaper on both bandwidth and CPU, and a Ferret iteration would overproduce ~870k COTs for a tiny request.

## Design

Folds into the existing bootstrap driver — no parallel `*_direct` public API; consumers only ever touch the RCOT interface.

- `bootstrap_count()`: pulls just the outstanding demand when it is `< bootstrap_cost` (direct), otherwise a full seed batch.
- `bootstrap()`: the base-COT pull moved here from `start_extend`; when the buffer already covers the demand it serves it and resets, so the extend loop never runs.
- `available()`: reserves a bootstrap batch only once the buffer holds at least one, so directly-served COTs (a smaller buffer) stay reachable. The cold/warm boundary is purely buffer size (`keys < bootstrap_cost`), so no extra state is needed.
- `FerretConfig::direct_passthrough` (default `true`) gates the behavior.

## Multi-round

`alloc` resets to 0 whenever demand is met (in `bootstrap()` or `finish_extend()`), so it never leaks across rounds; a drained round returns to a cold start. Leftover that crosses `bootstrap_cost` transitions cleanly to the Ferret path, reusing the base COTs as valid seed.

## Tests

- `test_ferret_direct` / `test_ferret_direct_multi_round` (ot-core): direct path + 3-round drain with state assertions (stays cold, never warms).
- `test_ferret_direct_passthrough` (ot): 5 alloc→flush→consume cycles through the async path.
- `test_ferret` pinned with `direct_passthrough(false)` to keep exercising the protocol; ot-core bench updated for the moved pull.

All ot-core (25) and ot (12) tests pass.