### PR TITLE
feat(vm-zk): default chunk cap sized to one Ferret extension

### DIFF
--- a/crates/vm-zk/src/lib.rs
+++ b/crates/vm-zk/src/lib.rs
@@ -39,6 +39,15 @@ pub use verifier::Verifier;
 
 pub(crate) const VOPE_BITS: usize = 128;
 
+/// Default per-chunk op-cost cap, sized to sit within the net correlations one
+/// Ferret extension can deliver. A single round of the largest regular-LPN
+/// params ([`mpz_ot_core::ferret::REGULAR_PARAMS`]) yields `n` correlations but
+/// must reserve `t·log2(n/t) + k + CSP` of them as seed for the next iteration,
+/// so the usable yield is `n - iteration_cost = 15_015_684`. Capping below that
+/// keeps a chunk's sVOLE demand serviceable by one extension round, with margin
+/// left for the per-chunk commit and VOPE overhead.
+pub const DEFAULT_CHUNK_CAP: usize = 15_000_000;
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ProofMessage {
     pub(crate) output: Option<Value>,
@@ -54,4 +63,33 @@ pub(crate) struct ChunkOutcome {
     /// verifier merges these before capturing so it can resolve the reveals in
     /// lockstep; replay then opens each against its committed wires.
     pub(crate) revealed: BTreeMap<u32, RevealPayload>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DEFAULT_CHUNK_CAP;
+
+    /// `DEFAULT_CHUNK_CAP` must stay within the net correlations one Ferret
+    /// extension delivers — its output `n` less the `t·log2(n/t) + k + CSP`
+    /// seed it reserves for the next iteration — so a chunk's sVOLE demand fits
+    /// a single extension round. Guards against a future params change that
+    /// would shrink the net yield below the cap.
+    #[test]
+    fn default_chunk_cap_fits_ferret_iteration() {
+        // Ferret's computational security parameter (`config::CSP`), inlined
+        // since it is private to `mpz_ot_core`.
+        const CSP: usize = 128;
+        let net = mpz_ot_core::ferret::REGULAR_PARAMS
+            .iter()
+            .map(|p| {
+                let iteration_cost = p.t * (p.n / p.t).ilog2() as usize + p.k + CSP;
+                p.n - iteration_cost
+            })
+            .max()
+            .expect("Ferret defines at least one LPN parameter set");
+        assert!(
+            DEFAULT_CHUNK_CAP <= net,
+            "DEFAULT_CHUNK_CAP {DEFAULT_CHUNK_CAP} exceeds Ferret net yield {net}"
+        );
+    }
 }

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -17,7 +17,7 @@ use serio::{SinkExt, stream::IoStreamExt};
 use std::ops::Range;
 
 use crate::{
-    ChunkOutcome, ProofMessage, VOPE_BITS,
+    ChunkOutcome, DEFAULT_CHUNK_CAP, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
     commit::{self, PendingIo, ProverTape, prepare_params},
     error::ZkVmError,
@@ -68,7 +68,7 @@ impl<T> Prover<T> {
             pending_reveal: RangeSet::default(),
             reveal_state: host::RevealState::default(),
             auth,
-            chunk_cap: None,
+            chunk_cap: Some(DEFAULT_CHUNK_CAP),
             segment_cost: None,
         })
     }
@@ -78,7 +78,8 @@ impl<T> Prover<T> {
     ///
     /// A value of `Some(cap)` bounds each chunk to at most `cap` operations,
     /// trading proof granularity against memory use. `None` places no bound and
-    /// lets a chunk run until the program completes or traps.
+    /// lets a chunk run until the program completes or traps. Defaults to
+    /// [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP).
     pub fn with_chunk_cap(mut self, cap: Option<usize>) -> Self {
         self.chunk_cap = cap;
         self

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -18,7 +18,7 @@ use mpz_vm_memory::{AuthState, Bit, Registers};
 use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, verifier_wire, vope_sender};
 
 use crate::{
-    ChunkOutcome, ProofMessage, VOPE_BITS,
+    ChunkOutcome, DEFAULT_CHUNK_CAP, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
     commit::{self, PendingIo, VerifierTape, prepare_params},
     error::ZkVmError,
@@ -79,7 +79,7 @@ where
             reveal_state: host::RevealState::default(),
             auth,
             delta,
-            chunk_cap: None,
+            chunk_cap: Some(DEFAULT_CHUNK_CAP),
             segment_cost: None,
         })
     }
@@ -89,7 +89,8 @@ where
     ///
     /// A value of `Some(cap)` bounds each chunk to at most `cap` operations,
     /// trading proof granularity against memory use; `None` places no bound.
-    /// This must match the prover's setting for the two sides to agree.
+    /// Defaults to [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP). This
+    /// must match the prover's setting for the two sides to agree.
     pub fn with_chunk_cap(mut self, cap: Option<usize>) -> Self {
         self.chunk_cap = cap;
         self


### PR DESCRIPTION
## Summary
- `Prover`/`Verifier` defaulted `chunk_cap` to `None`, so the whole program ran as a single chunk and the streaming memory bound was opt-in only. They now default to `DEFAULT_CHUNK_CAP`.
- Sizes the cap (`15_000_000`) below the net correlations one Ferret extension can deliver.

## Why this size
The largest regular-LPN params (`mpz_ot_core::ferret::REGULAR_PARAMS`) yield `n` correlations per extension, but must reserve `t·log2(n/t) + k + CSP` of them to seed the next iteration:

```
n              = 15_564_800
iteration_cost = 1900·log2(8192) + 524288 + 128 = 549_116
net            = 15_564_800 - 549_116           = 15_015_684
```

Capping below `net` keeps a chunk's sVOLE demand serviceable by a single extension round, leaving margin for the per-chunk commit and VOPE overhead (`commit_bits + tape_len + VOPE_BITS`). Capping at the raw `n` would overshoot the deliverable by ~3.5% and force a second extension round per chunk.

## Notes
- `with_chunk_cap(None)` still opts out of capping.
- A unit test guards the cap against a future params change that would shrink the net yield below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)