### PR TITLE
feat(vm-zk): tracing instrumentation for proving pipeline + Config

### DIFF
--- a/crates/ot/Cargo.toml
+++ b/crates/ot/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true, optional = true }
 serio.workspace = true
 cfg-if.workspace = true
 tokio = { workspace = true, features = ["sync"] }
+tracing.workspace = true
 
 [dev-dependencies]
 mpz-common = { workspace = true, features = [

--- a/crates/ot/src/chou_orlandi/receiver.rs
+++ b/crates/ot/src/chou_orlandi/receiver.rs
@@ -91,6 +91,7 @@ impl Flush for Receiver {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "base_ot.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         let mut receiver = match self.state.take() {
             State::Initialized(receiver) => {

--- a/crates/ot/src/chou_orlandi/sender.rs
+++ b/crates/ot/src/chou_orlandi/sender.rs
@@ -87,6 +87,7 @@ impl Flush for Sender {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "base_ot.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         let mut sender = match self.state.take() {
             State::Initialized(sender) => {

--- a/crates/ot/src/ferret/receiver.rs
+++ b/crates/ot/src/ferret/receiver.rs
@@ -72,6 +72,7 @@ where
         self.core.wants_extend()
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "ferret.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         if self.core.wants_bootstrap() {
             self.core.alloc_bootstrap()?;

--- a/crates/ot/src/ferret/sender.rs
+++ b/crates/ot/src/ferret/sender.rs
@@ -72,6 +72,7 @@ where
         self.core.wants_extend()
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "ferret.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         if self.core.wants_bootstrap() {
             self.core.alloc_bootstrap()?;

--- a/crates/ot/src/softspoken/receiver.rs
+++ b/crates/ot/src/softspoken/receiver.rs
@@ -104,6 +104,7 @@ where
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "softspoken.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         let mut receiver = match self.state.take() {
             State::Initialized {

--- a/crates/ot/src/softspoken/sender.rs
+++ b/crates/ot/src/softspoken/sender.rs
@@ -106,6 +106,7 @@ where
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, name = "softspoken.flush")]
     async fn flush(&mut self, ctx: &mut Context) -> Result<(), Self::Error> {
         let mut sender = match self.state.take() {
             State::Initialized {

--- a/crates/vm-ir/src/lib.rs
+++ b/crates/vm-ir/src/lib.rs
@@ -261,6 +261,22 @@ impl Module {
         &self.function_names
     }
 
+    /// Returns a human-readable name for the function at `func_idx`, if known.
+    ///
+    /// Prefers the WASM name section
+    /// ([`function_names`](Self::function_names)), falling back to the
+    /// function's export name. Returns `None` for a function that is neither
+    /// named nor exported.
+    pub fn func_name(&self, func_idx: u32) -> Option<&str> {
+        if let Some(name) = self.function_names.get(&func_idx) {
+            return Some(name.as_str());
+        }
+        self.exports.iter().find_map(|e| match e.kind {
+            ExportKind::Func(idx) if idx == func_idx => Some(e.name.as_str()),
+            _ => None,
+        })
+    }
+
     /// Returns the start function index if defined.
     pub fn start(&self) -> Option<u32> {
         self.start

--- a/crates/vm-zk/benches/vm.rs
+++ b/crates/vm-zk/benches/vm.rs
@@ -194,6 +194,33 @@ fn prove_sha256(module: &Module, msg: &[u8], session: &mut Session) -> Vec<u8> {
     verifier.read(digest_ptr, DIGEST_LEN).unwrap().to_vec()
 }
 
+/// Installs a tracing subscriber when `RUST_LOG` is set that prints, on each
+/// span's close, its `time.busy`/`time.idle` wall-clock alongside the full
+/// span scope (`chunk:allocate:ferret.flush`, etc.) and recorded fields — the
+/// per-stage proving profile. A no-op (no subscriber, zero span cost) when
+/// `RUST_LOG` is unset, so a plain `cargo bench` measures undisturbed
+/// throughput.
+///
+/// For a profile run:
+/// `RUST_LOG=mpz_vm_zk=debug,mpz_ot=debug cargo bench -p mpz-vm-zk --bench vm`.
+/// The prover and verifier run on separate threads into one subscriber; their
+/// close lines carry the `role`/target so the two sides stay distinguishable,
+/// or narrow to one with a target filter (e.g. `mpz_vm_zk::prover=debug`).
+/// Absolute throughput numbers should be read from a run with `RUST_LOG` unset.
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
+
+    let Ok(filter) = EnvFilter::try_from_default_env() else {
+        return;
+    };
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
 /// Message sizes (bytes) to benchmark SHA-256 over. The headline is 4 KiB.
 const SHA256_SIZES: &[usize] = &[4096, 16384];
 
@@ -201,6 +228,7 @@ const SHA256_SIZES: &[usize] = &[4096, 16384];
 /// against a reference SHA-256 (proving the guest + VM + reveal are correct)
 /// before being timed.
 fn bench_sha256(c: &mut Criterion) {
+    init_tracing();
     let wasm = include_bytes!("guests/sha256.wasm");
     let module = Module::parse(wasm).unwrap();
 

--- a/crates/vm-zk/src/capture.rs
+++ b/crates/vm-zk/src/capture.rs
@@ -111,7 +111,7 @@ pub(crate) struct ChunkCapture {
     pub(crate) marks: Vec<SegmentMark>,
 }
 
-#[tracing::instrument(level = "trace", skip_all, fields(?limits, ?role, announced_trap))]
+#[tracing::instrument(level = "debug", name = "capture", skip_all, fields(?role))]
 pub(crate) fn capture_chunk(
     module: &Module,
     global: &mut Global,

--- a/crates/vm-zk/src/config.rs
+++ b/crates/vm-zk/src/config.rs
@@ -1,0 +1,138 @@
+//! Configuration for the [`Prover`](crate::Prover) and
+//! [`Verifier`](crate::Verifier).
+
+use crate::DEFAULT_CHUNK_CAP;
+
+/// Configuration shared by a [`Prover`](crate::Prover) and a
+/// [`Verifier`](crate::Verifier).
+///
+/// `chunk_cap` and `segment_cost` shape proving and MUST match on both sides
+/// for the parties to agree. `id` is a purely local logging label — it is
+/// attached to the party's tracing spans so concurrent instances can be told
+/// apart, and need not match (or be set on) the peer.
+///
+/// Build one with [`Config::builder`], or use [`Config::default`] for the
+/// standard settings.
+#[derive(Debug, Clone)]
+pub struct Config {
+    id: Option<u64>,
+    chunk_cap: Option<usize>,
+    segment_cost: Option<usize>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            id: None,
+            chunk_cap: Some(DEFAULT_CHUNK_CAP),
+            segment_cost: None,
+        }
+    }
+}
+
+impl Config {
+    /// Returns a [`ConfigBuilder`] initialized to the defaults.
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+
+    /// The instance identifier attached to this party's tracing spans, if set.
+    ///
+    /// A logging label only: it lets one prover/verifier instance's spans be
+    /// distinguished from another's when several run concurrently in a process.
+    /// It does not affect the protocol.
+    pub fn id(&self) -> Option<u64> {
+        self.id
+    }
+
+    /// The maximum number of operations executed per chunk. See
+    /// [`ConfigBuilder::chunk_cap`].
+    pub fn chunk_cap(&self) -> Option<usize> {
+        self.chunk_cap
+    }
+
+    /// The gate-cost target per proving segment. See
+    /// [`ConfigBuilder::segment_cost`].
+    pub fn segment_cost(&self) -> Option<usize> {
+        self.segment_cost
+    }
+}
+
+/// Builder for a [`Config`].
+///
+/// Created by [`Config::builder`]; starts from [`Config::default`] and overrides
+/// only the fields that are set.
+#[derive(Debug, Clone)]
+pub struct ConfigBuilder {
+    config: Config,
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self {
+            config: Config::default(),
+        }
+    }
+}
+
+impl ConfigBuilder {
+    /// Sets the instance identifier attached to this party's tracing spans.
+    ///
+    /// Purely a logging label to disambiguate concurrent instances; it has no
+    /// effect on the protocol and need not match the peer's.
+    pub fn id(mut self, id: u64) -> Self {
+        self.config.id = Some(id);
+        self
+    }
+
+    /// Sets the maximum number of operations executed per chunk.
+    ///
+    /// `Some(cap)` bounds each chunk to at most `cap` operations, trading proof
+    /// granularity against memory use; `None` places no bound and lets a chunk
+    /// run until the program completes or traps. Defaults to
+    /// [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP). Must match the
+    /// peer's setting for the two sides to agree.
+    pub fn chunk_cap(mut self, cap: Option<usize>) -> Self {
+        self.config.chunk_cap = cap;
+        self
+    }
+
+    /// Sets the gate-cost target per proving segment.
+    ///
+    /// `Some(cost)` splits each chunk's trace into segments of roughly `cost`
+    /// gate bits, committed and folded by parallel workers; `None` (the default)
+    /// auto-derives the target from the chunk cap so a full chunk splits into
+    /// about [`TARGET_SEGMENTS`](crate::TARGET_SEGMENTS) segments. Must match the
+    /// peer's setting for the two sides to agree.
+    pub fn segment_cost(mut self, cost: Option<usize>) -> Self {
+        self.config.segment_cost = cost;
+        self
+    }
+
+    /// Consumes the builder, returning the configured [`Config`].
+    pub fn build(self) -> Config {
+        self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_carries_standard_settings() {
+        let config = Config::default();
+        assert_eq!(config.id(), None);
+        assert_eq!(config.chunk_cap(), Some(DEFAULT_CHUNK_CAP));
+        assert_eq!(config.segment_cost(), None);
+    }
+
+    #[test]
+    fn builder_overrides_only_set_fields() {
+        let config = Config::builder().id(7).segment_cost(Some(5_000)).build();
+        assert_eq!(config.id(), Some(7));
+        // Untouched: still the default.
+        assert_eq!(config.chunk_cap(), Some(DEFAULT_CHUNK_CAP));
+        assert_eq!(config.segment_cost(), Some(5_000));
+    }
+}

--- a/crates/vm-zk/src/lib.rs
+++ b/crates/vm-zk/src/lib.rs
@@ -20,6 +20,7 @@ use mpz_zk_core::Proof;
 
 pub(crate) mod capture;
 pub(crate) mod commit;
+pub(crate) mod config;
 pub(crate) mod cost;
 pub(crate) mod error;
 pub(crate) mod finalize;
@@ -33,6 +34,7 @@ mod verifier;
 
 use host::RevealPayload;
 
+pub use config::{Config, ConfigBuilder};
 pub use error::ZkVmError;
 pub use prover::Prover;
 pub use verifier::Verifier;
@@ -62,7 +64,7 @@ pub const DEFAULT_CHUNK_CAP: usize = 15_000_000;
 pub(crate) const TARGET_SEGMENTS: usize = 64;
 
 /// Floor on the auto-derived per-segment gate-bit cost, so a small
-/// [`chunk_cap`](Prover::with_chunk_cap) never produces segments too tiny to
+/// [`chunk_cap`](ConfigBuilder::chunk_cap) never produces segments too tiny to
 /// amortize their boundary commitment ("a segment for every gate").
 pub(crate) const MIN_SEGMENT_COST: usize = 50_000;
 
@@ -70,7 +72,7 @@ pub(crate) const MIN_SEGMENT_COST: usize = 50_000;
 /// place segment marks.
 ///
 /// `Some(cost)` is honored verbatim — an explicit
-/// [`with_segment_cost`](Prover::with_segment_cost) override. `None`
+/// [`segment_cost`](ConfigBuilder::segment_cost) override. `None`
 /// auto-derives a target from the shared `chunk_cap` so a full chunk splits
 /// into about [`TARGET_SEGMENTS`] segments: workload-proportional, and
 /// identical on both sides because it depends only on protocol-shared values,
@@ -85,6 +87,29 @@ pub(crate) fn effective_segment_cost(
         Some(cost) => Some(cost),
         None => chunk_cap.map(|cap| (cap / TARGET_SEGMENTS).max(MIN_SEGMENT_COST)),
     }
+}
+
+/// Records the parallel-pass timing profile of `times` (one busy-duration per
+/// segment worker) onto the current span's `segments`, `worker_max_us`, and
+/// `worker_sum_us` fields.
+///
+/// `worker_max_us` is the critical path (the slowest worker bounds the pass);
+/// `worker_sum_us` is the total work across all workers. Their ratio over
+/// `segments` reports achieved core utilization. A no-op when no subscriber
+/// records those fields.
+pub(crate) fn record_worker_times(times: &[std::time::Duration]) {
+    use std::time::Duration;
+
+    let span = tracing::Span::current();
+    span.record("segments", times.len());
+    span.record(
+        "worker_max_us",
+        times.iter().max().copied().unwrap_or_default().as_micros() as u64,
+    );
+    span.record(
+        "worker_sum_us",
+        times.iter().sum::<Duration>().as_micros() as u64,
+    );
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -15,9 +15,11 @@ use rangeset::set::RangeSet;
 use rayon::prelude::*;
 use serio::{SinkExt, stream::IoStreamExt};
 use std::ops::Range;
+use std::time::Instant;
+use tracing::Instrument;
 
 use crate::{
-    ChunkOutcome, DEFAULT_CHUNK_CAP, ProofMessage, VOPE_BITS,
+    ChunkOutcome, Config, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
     commit::{self, PendingIo, ProverTape, prepare_params},
     error::ZkVmError,
@@ -46,18 +48,27 @@ pub struct Prover<T> {
     pending_reveal: RangeSet<u32>,
     reveal_state: host::RevealState,
     auth: AuthState,
-    chunk_cap: Option<usize>,
-    segment_cost: Option<usize>,
+    config: Config,
 }
 
 impl<T> Prover<T> {
     /// Creates a new prover for `module`, drawing its correlated randomness
-    /// from `svole`.
+    /// from `svole`, with the default [`Config`].
     ///
     /// # Errors
     ///
     /// Returns a [`ZkVmError`] if state for `module` cannot be initialized.
     pub fn new(module: Module, svole: T) -> Result<Self, ZkVmError> {
+        Self::new_with_config(module, svole, Config::default())
+    }
+
+    /// Creates a new prover for `module`, drawing its correlated randomness
+    /// from `svole` and configured by `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ZkVmError`] if state for `module` cannot be initialized.
+    pub fn new_with_config(module: Module, svole: T, config: Config) -> Result<Self, ZkVmError> {
         let global = Global::new(&module)?;
         let auth = AuthState::new(Bit(MAC_ZERO), Bit(MAC_ONE));
         Ok(Self {
@@ -68,37 +79,8 @@ impl<T> Prover<T> {
             pending_reveal: RangeSet::default(),
             reveal_state: host::RevealState::default(),
             auth,
-            chunk_cap: Some(DEFAULT_CHUNK_CAP),
-            segment_cost: None,
+            config,
         })
-    }
-
-    /// Sets the maximum number of operations executed per chunk, returning the
-    /// updated prover.
-    ///
-    /// A value of `Some(cap)` bounds each chunk to at most `cap` operations,
-    /// trading proof granularity against memory use. `None` places no bound and
-    /// lets a chunk run until the program completes or traps. Defaults to
-    /// [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP).
-    pub fn with_chunk_cap(mut self, cap: Option<usize>) -> Self {
-        self.chunk_cap = cap;
-        self
-    }
-
-    /// Sets the gate-cost target per proving segment, returning the updated
-    /// prover.
-    ///
-    /// A value of `Some(cost)` splits each chunk's trace into segments of
-    /// roughly `cost` gate bits, which are committed and folded by parallel
-    /// workers and stitched together with boundary commitments. `None` (the
-    /// default) auto-derives the target from the chunk cap so a full chunk
-    /// splits into about [`TARGET_SEGMENTS`](crate::TARGET_SEGMENTS) segments,
-    /// scaling the parallelism to the workload; an unbounded chunk cap proves
-    /// each chunk as a single segment. This must match the verifier's setting
-    /// for the two sides to agree.
-    pub fn with_segment_cost(mut self, cost: Option<usize>) -> Self {
-        self.segment_cost = cost;
-        self
     }
 }
 
@@ -138,6 +120,16 @@ where
     ///
     /// `commit_bits` is the input-commit prefix length; the segment region
     /// (gates, advice, and boundary commitments) follows it.
+    #[tracing::instrument(
+        level = "debug",
+        name = "commit",
+        skip_all,
+        fields(
+            segments = tracing::field::Empty,
+            worker_max_us = tracing::field::Empty,
+            worker_sum_us = tracing::field::Empty
+        )
+    )]
     #[allow(clippy::too_many_arguments)]
     fn commit_pass(
         &mut self,
@@ -203,11 +195,13 @@ where
         let gate_masks = gate_mask_slices(seg_masks, &plan.segments);
         let module = &self.module;
         let auth_base = &self.auth;
-        plan.segments
+        let times = plan
+            .segments
             .par_iter()
             .zip(gate_masks)
             .enumerate()
-            .try_for_each(|(j, (seg, gmasks))| -> Result<(), ZkVmError> {
+            .map(|(j, (seg, gmasks))| -> Result<std::time::Duration, ZkVmError> {
+                let start = Instant::now();
                 let mut auth = auth_base.clone();
                 for (prev_seg, prev_wires) in plan.segments.iter().zip(&ptr_wires).take(j) {
                     let prev = prev_seg
@@ -229,8 +223,10 @@ where
                 )?;
                 ctx.finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
-                Ok(())
-            })?;
+                Ok(start.elapsed())
+            })
+            .collect::<Result<Vec<_>, ZkVmError>>()?;
+        crate::record_worker_times(&times);
 
         Ok(boundary_bits)
     }
@@ -238,6 +234,16 @@ where
     /// The parallel per-segment accumulate pass. Returns the combined
     /// `(u, v, assertions)`, the opened reveal cleartext, and the chunk-final
     /// authenticated state to persist.
+    #[tracing::instrument(
+        level = "debug",
+        name = "accumulate",
+        skip_all,
+        fields(
+            segments = tracing::field::Empty,
+            worker_max_us = tracing::field::Empty,
+            worker_sum_us = tracing::field::Empty
+        )
+    )]
     #[allow(clippy::too_many_arguments)]
     fn accumulate_pass(
         &self,
@@ -270,11 +276,12 @@ where
         let memory = self.global.memory();
         let last = plan.segments.len() - 1;
 
-        let results: Vec<(Gf2_128, Gf2_128, [u8; 32], Option<LastOut>)> = plan
+        let results: Vec<(Gf2_128, Gf2_128, [u8; 32], Option<LastOut>, std::time::Duration)> = plan
             .segments
             .par_iter()
             .enumerate()
             .map(|(j, seg)| -> Result<_, ZkVmError> {
+                let start = Instant::now();
                 let mut auth = auth_base.clone();
                 for (prev_seg, prev_wires) in plan.segments.iter().zip(&boundary_wires).take(j) {
                     let prev = prev_seg
@@ -339,15 +346,18 @@ where
                 let (u, v, assertions) = ctx
                     .finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
-                Ok((u, v, assertions, last_out))
+                Ok((u, v, assertions, last_out, start.elapsed()))
             })
             .collect::<Result<_, _>>()?;
+
+        let times: Vec<_> = results.iter().map(|r| r.4).collect();
+        crate::record_worker_times(&times);
 
         let mut u = Gf2_128::new(0);
         let mut v = Gf2_128::new(0);
         let mut hasher = blake3::Hasher::new();
         let mut final_out = None;
-        for (u_j, v_j, h_j, last_out) in results {
+        for (u_j, v_j, h_j, last_out, _) in results {
             u = u + u_j;
             v = v + v_j;
             hasher.update(&h_j);
@@ -500,7 +510,7 @@ where
     /// local function. Returns a [`ZkVmError`] if proving fails or
     /// communication over `io` fails, and [`ZkVmError::Trap`] if execution
     /// is proven to trap.
-    #[tracing::instrument(level = "info", skip(self, io, params), fields(func_idx, num_params = params.len(), chunk_cap = ?self.chunk_cap))]
+    #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "prover", func = self.module.func_name(func_idx).unwrap_or("?")))]
     async fn call(
         &mut self,
         io: &mut Context,
@@ -557,8 +567,11 @@ where
                 &mut self.global,
                 &mut thread,
                 capture::Limits {
-                    chunk_cap: self.chunk_cap,
-                    segment_cost: crate::effective_segment_cost(self.segment_cost, self.chunk_cap),
+                    chunk_cap: self.config.chunk_cap(),
+                    segment_cost: crate::effective_segment_cost(
+                        self.config.segment_cost(),
+                        self.config.chunk_cap(),
+                    ),
                 },
                 Role::Prover,
                 None,
@@ -655,22 +668,24 @@ where
 
             // The whole execute tape's adjust witness (commit prefix, gates,
             // and boundary commitments) ships in one Commitment message, sent
-            // before the prover learns the verifier's challenge.
+            // before the prover learns the verifier's challenge. The verifier
+            // samples its challenge only after holding the commitment, so the
+            // prover cannot tailor its witness to it.
             let commitment = Commitment {
                 adjust: exec_masks.iter().copied().collect(),
             };
-            io.io_mut()
-                .send(commitment)
-                .await
-                .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
-
-            // The verifier samples its challenge only after holding the
-            // commitment, so the prover cannot tailor its witness to it.
-            let chi: [u8; 32] = io
-                .io_mut()
-                .expect_next()
-                .await
-                .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
+            let chi: [u8; 32] = async {
+                io.io_mut()
+                    .send(commitment)
+                    .await
+                    .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+                io.io_mut()
+                    .expect_next()
+                    .await
+                    .map_err(|e| ZkVmError::IoRecv(e.to_string()))
+            }
+            .instrument(tracing::debug_span!("exchange"))
+            .await?;
 
             // ---- Accumulate pass: parallel proof folding ----
             let seg_macs = &exec_macs[exec_macs.len() - plan.tape_len..];
@@ -758,7 +773,7 @@ where
     ///
     /// Returns a [`ZkVmError`] if proving fails or communication over `io`
     /// fails.
-    #[tracing::instrument(level = "info", skip(self, io))]
+    #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "prover"))]
     async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
         let commit_bits = self.pending_io.cost_bits();
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();

--- a/crates/vm-zk/src/replay.rs
+++ b/crates/vm-zk/src/replay.rs
@@ -120,7 +120,7 @@ impl ReplayState {
     }
 }
 
-#[tracing::instrument(level = "debug", skip_all, fields(events = trace.len()))]
+#[tracing::instrument(level = "trace", skip_all, fields(events = trace.len()))]
 pub(crate) fn replay<C>(
     trace: &[Directive],
     reveal_actions: &[RevealEvent],

--- a/crates/vm-zk/src/segment.rs
+++ b/crates/vm-zk/src/segment.rs
@@ -232,6 +232,11 @@ impl Scan {
 /// A trace the scan cannot mirror (e.g. one that replay will reject anyway)
 /// also degrades to a single sequential segment, so the proving pass surfaces
 /// the same error at the same protocol point on both sides.
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(segments = tracing::field::Empty, tape_len = tracing::field::Empty)
+)]
 pub(crate) fn plan(
     chunk: &ChunkCapture,
     module: &Module,
@@ -239,16 +244,21 @@ pub(crate) fn plan(
     params: &[Param],
     root_reg_base: Reg,
 ) -> Plan {
-    if chunk.marks.is_empty() {
-        return single_segment(chunk);
-    }
-    match scan_plan(chunk, module, auth, params, root_reg_base) {
-        Ok(plan) => plan,
-        Err(e) => {
-            tracing::warn!(error = %e, "segment scan failed; falling back to one segment");
-            single_segment(chunk)
+    let plan = if chunk.marks.is_empty() {
+        single_segment(chunk)
+    } else {
+        match scan_plan(chunk, module, auth, params, root_reg_base) {
+            Ok(plan) => plan,
+            Err(e) => {
+                tracing::warn!(error = %e, "segment scan failed; falling back to one segment");
+                single_segment(chunk)
+            }
         }
-    }
+    };
+    let span = tracing::Span::current();
+    span.record("segments", plan.segments.len());
+    span.record("tape_len", plan.tape_len);
+    plan
 }
 
 fn single_segment(chunk: &ChunkCapture) -> Plan {

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -13,12 +13,14 @@ use rangeset::set::RangeSet;
 use rayon::prelude::*;
 use serio::{SinkExt, stream::IoStreamExt};
 use std::ops::Range;
+use std::time::Instant;
+use tracing::Instrument;
 
 use mpz_vm_memory::{AuthState, Bit, Registers};
 use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, verifier_wire, vope_sender};
 
 use crate::{
-    ChunkOutcome, DEFAULT_CHUNK_CAP, ProofMessage, VOPE_BITS,
+    ChunkOutcome, Config, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
     commit::{self, PendingIo, VerifierTape, prepare_params},
     error::ZkVmError,
@@ -47,21 +49,32 @@ pub struct Verifier<T> {
     reveal_state: host::RevealState,
     auth: AuthState,
     delta: Gf2_128,
-    chunk_cap: Option<usize>,
-    segment_cost: Option<usize>,
+    config: Config,
 }
 
 impl<T> Verifier<T>
 where
     T: RCOTSender<Block>,
 {
-    /// Creates a verifier for `module` backed by `svole`.
+    /// Creates a verifier for `module` backed by `svole`, with the default
+    /// [`Config`].
     ///
     /// # Errors
     ///
     /// Returns [`ZkVmError`] if state for `module` cannot be initialized, or if
     /// `svole` provides a correlation that the protocol cannot use.
     pub fn new(module: Module, svole: T) -> Result<Self, ZkVmError> {
+        Self::new_with_config(module, svole, Config::default())
+    }
+
+    /// Creates a verifier for `module` backed by `svole` and configured by
+    /// `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZkVmError`] if state for `module` cannot be initialized, or if
+    /// `svole` provides a correlation that the protocol cannot use.
+    pub fn new_with_config(module: Module, svole: T, config: Config) -> Result<Self, ZkVmError> {
         let global = Global::new(&module)?;
         let delta: Gf2_128 = zerocopy::transmute!(svole.delta());
         // Pointer-bit convention: delta.lsb must be 1 so the per-wire
@@ -79,33 +92,8 @@ where
             reveal_state: host::RevealState::default(),
             auth,
             delta,
-            chunk_cap: Some(DEFAULT_CHUNK_CAP),
-            segment_cost: None,
+            config,
         })
-    }
-
-    /// Sets the maximum number of operations executed per chunk, returning the
-    /// updated verifier.
-    ///
-    /// A value of `Some(cap)` bounds each chunk to at most `cap` operations,
-    /// trading proof granularity against memory use; `None` places no bound.
-    /// Defaults to [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP). This
-    /// must match the prover's setting for the two sides to agree.
-    pub fn with_chunk_cap(mut self, cap: Option<usize>) -> Self {
-        self.chunk_cap = cap;
-        self
-    }
-
-    /// Sets the gate-cost target per proving segment, returning the updated
-    /// verifier.
-    ///
-    /// Splits each chunk into segments folded by parallel workers; `None` (the
-    /// default) auto-derives the target from the chunk cap. See
-    /// [`Prover::with_segment_cost`](crate::Prover::with_segment_cost). This
-    /// must match the prover's setting for the two sides to agree.
-    pub fn with_segment_cost(mut self, cost: Option<usize>) -> Self {
-        self.segment_cost = cost;
-        self
     }
 }
 
@@ -136,6 +124,16 @@ where
     /// The parallel per-segment accumulate pass: checks the prover's
     /// commitment by folding every segment with the sampled challenge.
     /// Returns the combined `(w, assertions)` and the chunk-final state.
+    #[tracing::instrument(
+        level = "debug",
+        name = "accumulate",
+        skip_all,
+        fields(
+            segments = tracing::field::Empty,
+            worker_max_us = tracing::field::Empty,
+            worker_sum_us = tracing::field::Empty
+        )
+    )]
     #[allow(clippy::too_many_arguments)]
     fn accumulate_pass(
         &self,
@@ -169,11 +167,12 @@ where
         let last = plan.segments.len() - 1;
         let pub_bit = move |b: bool| if b { MAC_ONE + delta } else { MAC_ZERO };
 
-        let results: Vec<(Gf2_128, [u8; 32], Option<AuthState>)> = plan
+        let results: Vec<(Gf2_128, [u8; 32], Option<AuthState>, std::time::Duration)> = plan
             .segments
             .par_iter()
             .enumerate()
             .map(|(j, seg)| -> Result<_, ZkVmError> {
+                let start = Instant::now();
                 let mut auth = auth_base.clone();
                 for (prev_seg, prev_wires) in plan.segments.iter().zip(&boundary_wires).take(j) {
                     let prev = prev_seg
@@ -237,14 +236,17 @@ where
                 let (w, assertions) = ctx
                     .finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
-                Ok((w, assertions, last_auth))
+                Ok((w, assertions, last_auth, start.elapsed()))
             })
             .collect::<Result<_, _>>()?;
+
+        let times: Vec<_> = results.iter().map(|r| r.3).collect();
+        crate::record_worker_times(&times);
 
         let mut w = Gf2_128::new(0);
         let mut hasher = blake3::Hasher::new();
         let mut final_auth = None;
-        for (w_j, h_j, last_auth) in results {
+        for (w_j, h_j, last_auth, _) in results {
             w = w + w_j;
             hasher.update(&h_j);
             if let Some(auth) = last_auth {
@@ -356,7 +358,7 @@ where
     /// function. Returns [`ZkVmError::Trap`] if the proven computation traps
     /// (e.g. divide by zero). Returns a [`ZkVmError`] if verification fails or
     /// communication over `io` fails.
-    #[tracing::instrument(level = "info", skip(self, io, params), fields(func_idx, num_params = params.len(), chunk_cap = ?self.chunk_cap))]
+    #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "verifier", func = self.module.func_name(func_idx).unwrap_or("?")))]
     async fn call(
         &mut self,
         io: &mut Context,
@@ -434,8 +436,11 @@ where
                 &mut self.global,
                 &mut thread,
                 capture::Limits {
-                    chunk_cap: self.chunk_cap,
-                    segment_cost: crate::effective_segment_cost(self.segment_cost, self.chunk_cap),
+                    chunk_cap: self.config.chunk_cap(),
+                    segment_cost: crate::effective_segment_cost(
+                        self.config.segment_cost(),
+                        self.config.chunk_cap(),
+                    ),
                 },
                 Role::Verifier,
                 outcome.trap_at.zip(outcome.trap.clone()),
@@ -499,24 +504,29 @@ where
             // Receive the prover's commitment to the whole execute tape
             // (commit prefix, gates, and boundary commitments), then sample
             // and send the challenge.
-            let commitment: Commitment = io
-                .io_mut()
-                .expect_next()
-                .await
-                .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
-            let adjust: Vec<bool> = commitment.adjust.iter().by_vals().collect();
-            if adjust.len() != execute_bits {
-                return Err(ZkVmError::Internal(format!(
-                    "commit adjust short: got {} want {}",
-                    adjust.len(),
-                    execute_bits
-                )));
+            let (adjust, chi): (Vec<bool>, [u8; 32]) = async {
+                let commitment: Commitment = io
+                    .io_mut()
+                    .expect_next()
+                    .await
+                    .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
+                let adjust: Vec<bool> = commitment.adjust.iter().by_vals().collect();
+                if adjust.len() != execute_bits {
+                    return Err(ZkVmError::Internal(format!(
+                        "commit adjust short: got {} want {}",
+                        adjust.len(),
+                        execute_bits
+                    )));
+                }
+                let chi: [u8; 32] = rand::rng().random();
+                io.io_mut()
+                    .send(chi)
+                    .await
+                    .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+                Ok((adjust, chi))
             }
-            let chi: [u8; 32] = rand::rng().random();
-            io.io_mut()
-                .send(chi)
-                .await
-                .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+            .instrument(tracing::debug_span!("exchange"))
+            .await?;
 
             let ProofMessage {
                 output,
@@ -648,7 +658,7 @@ where
     ///
     /// Returns a [`ZkVmError`] if verification fails or communication over `io`
     /// fails.
-    #[tracing::instrument(level = "info", skip(self, io))]
+    #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "verifier"))]
     async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
         let commit_bits = self.pending_io.cost_bits();
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();

--- a/crates/vm-zk/tests/reveal.rs
+++ b/crates/vm-zk/tests/reveal.rs
@@ -12,7 +12,7 @@ use mpz_common::context::test_st_context;
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
 use mpz_vm_ir::{ExportKind, Module, ValType};
-use mpz_vm_zk::{Prover, Verifier};
+use mpz_vm_zk::{Config, Prover, Verifier};
 use rand::{SeedableRng, rngs::StdRng};
 
 fn func_idx(module: &Module, name: &str) -> u32 {
@@ -49,12 +49,10 @@ fn run(wat: &str, func: &str, inputs: &[Value], expected: Value, chunk_cap: Opti
     delta.set_lsb(true);
     let (svole_sender, svole_receiver) = ideal_rcot(rand::Rng::random(&mut rng), delta);
 
-    let mut prover = Prover::new(module.clone(), svole_receiver)
-        .unwrap()
-        .with_chunk_cap(chunk_cap);
-    let mut verifier = Verifier::new(module, svole_sender)
-        .unwrap()
-        .with_chunk_cap(chunk_cap);
+    let config = Config::builder().chunk_cap(chunk_cap).build();
+    let mut prover =
+        Prover::new_with_config(module.clone(), svole_receiver, config.clone()).unwrap();
+    let mut verifier = Verifier::new_with_config(module, svole_sender, config).unwrap();
 
     let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
 

--- a/crates/vm-zk/tests/sha256_seg.rs
+++ b/crates/vm-zk/tests/sha256_seg.rs
@@ -8,7 +8,7 @@ use mpz_core::Block;
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, Write, value::Value};
 use mpz_vm_ir::{ExportKind, Module};
-use mpz_vm_zk::{Prover, Verifier};
+use mpz_vm_zk::{Config, Prover, Verifier};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use sha2::{Digest, Sha256};
 
@@ -36,12 +36,10 @@ fn sha256_segmented() {
     let mut delta: Block = rng.random();
     delta.set_lsb(true);
     let (svole_sender, svole_receiver) = ideal_rcot(rng.random(), delta);
-    let mut prover = Prover::new(module.clone(), svole_receiver)
-        .unwrap()
-        .with_segment_cost(Some(5_000));
-    let mut verifier = Verifier::new(module.clone(), svole_sender)
-        .unwrap()
-        .with_segment_cost(Some(5_000));
+    let config = Config::builder().segment_cost(Some(5_000)).build();
+    let mut prover =
+        Prover::new_with_config(module.clone(), svole_receiver, config.clone()).unwrap();
+    let mut verifier = Verifier::new_with_config(module.clone(), svole_sender, config).unwrap();
 
     // Allocate the input buffer in-guest, mirroring the bench.
     let realloc = func_idx(&module, "cabi_realloc");

--- a/crates/vm-zk/tests/spec.rs
+++ b/crates/vm-zk/tests/spec.rs
@@ -13,7 +13,7 @@ use mpz_ot::ideal::rcot::{IdealRCOTReceiver, IdealRCOTSender, ideal_rcot};
 use mpz_vm_core::{Param, Vm, value::Value};
 use mpz_vm_ir::Module;
 use mpz_vm_test_harness::{SpecConfig, SpecVm, run_suite, suites};
-use mpz_vm_zk::{Prover, Verifier, ZkVmError};
+use mpz_vm_zk::{Config, Prover, Verifier, ZkVmError};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 /// A prover/verifier pair wired over ideal sVOLE.
@@ -52,14 +52,14 @@ impl SpecVm for ZkPair {
         let mut delta: Block = rng.random();
         delta.set_lsb(true);
         let (svole_sender, svole_receiver) = ideal_rcot(rng.random(), delta);
-        let prover = Prover::new(module.clone(), svole_receiver)
-            .map_err(|e| format!("{:?}", e))?
-            .with_chunk_cap(cap)
-            .with_segment_cost(segment_cost);
-        let verifier = Verifier::new(module.clone(), svole_sender)
-            .map_err(|e| format!("{:?}", e))?
-            .with_chunk_cap(cap)
-            .with_segment_cost(segment_cost);
+        let config = Config::builder()
+            .chunk_cap(cap)
+            .segment_cost(segment_cost)
+            .build();
+        let prover = Prover::new_with_config(module.clone(), svole_receiver, config.clone())
+            .map_err(|e| format!("{:?}", e))?;
+        let verifier = Verifier::new_with_config(module.clone(), svole_sender, config)
+            .map_err(|e| format!("{:?}", e))?;
         Ok(Self { prover, verifier })
     }
 

--- a/crates/vm-zk/tests/streaming_dense.rs
+++ b/crates/vm-zk/tests/streaming_dense.rs
@@ -9,7 +9,7 @@ use mpz_common::context::test_st_context;
 use mpz_ot::ideal::rcot::ideal_rcot;
 use mpz_vm_core::{Param, Vm, value::Value};
 use mpz_vm_ir::{ExportKind, Module, ValType};
-use mpz_vm_zk::{Prover, Verifier};
+use mpz_vm_zk::{Config, Prover, Verifier};
 use rand::{SeedableRng, rngs::StdRng};
 
 fn func_idx(module: &Module, name: &str) -> u32 {
@@ -54,12 +54,10 @@ fn chunk_per_gate() {
     delta.set_lsb(true);
     let (svole_sender, svole_receiver) = ideal_rcot(rand::Rng::random(&mut rng), delta);
 
-    let mut prover = Prover::new(module.clone(), svole_receiver)
-        .unwrap()
-        .with_chunk_cap(Some(1));
-    let mut verifier = Verifier::new(module, svole_sender)
-        .unwrap()
-        .with_chunk_cap(Some(1));
+    let config = Config::builder().chunk_cap(Some(1)).build();
+    let mut prover =
+        Prover::new_with_config(module.clone(), svole_receiver, config.clone()).unwrap();
+    let mut verifier = Verifier::new_with_config(module, svole_sender, config).unwrap();
 
     let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
 


### PR DESCRIPTION
Instruments the zk-VM proving pipeline so it can be profiled and debugged, and gives each party a logging identity.

## vm-zk
- **Stage spans** across the prover/verifier `call` loop: `capture`, `plan`, `allocate`, `commit`, `exchange`, `accumulate` — entered on the main thread so they nest under the per-chunk span. The parallel `commit`/`accumulate` passes record `worker_max_us`/`worker_sum_us` (per-worker busy time) so core utilization is visible without per-segment span noise. `replay` demoted to TRACE; `capture` promoted to DEBUG.
- **`Config` type + builder** carrying `chunk_cap`, `segment_cost`, and an optional `id` used only to label this party's tracing spans (so concurrent instances are distinguishable). New `new_with_config` constructors; `new()` delegates to `Config::default()`. The old `with_chunk_cap`/`with_segment_cost` methods are replaced by the builder.
- `call`/`commit` spans carry `id`, `role`, and the function **name**; `skip_all` with explicit opt-in fields.

## mpz-ot
- Spans on the Ferret / SoftSpoken / base-OT `flush` methods so the `allocate` stage's OT cost decomposes by layer (they nest via the bootstrap/setup call-chain).

## mpz-vm-ir
- `Module::func_name(func_idx)` — prefers the WASM name section, falls back to the export name.

## bench
- Opt-in subscriber (`fmt` + `FmtSpan::CLOSE`) gated on `RUST_LOG`, printing per-span `time.busy`/`time.idle`; a no-op (zero overhead) when `RUST_LOG` is unset.

## Profiling
```
RUST_LOG=mpz_vm_zk=debug,mpz_ot=debug cargo bench -p mpz-vm-zk --bench vm
```
yields per-stage `time.busy`/`time.idle` with the OT layers nested under `allocate` and parallelism stats on the passes.

## Verification
- `mpz-ot`, `mpz-vm-ir`, `mpz-vm-zk` build (incl. all targets).
- Full `mpz-vm-zk` test suite passes (25 tests); the 4 tests that used `with_*` now build a `Config`.
- Default (`RUST_LOG` unset) bench run emits no spans.