### PR TITLE
perf(fields): Karatsuba GF(2^128) multiply on WASM + soft backends

### DIFF
--- a/crates/fields/src/bmul.rs
+++ b/crates/fields/src/bmul.rs
@@ -69,13 +69,14 @@ pub(crate) fn bmul128_full(a: u128, b: u128) -> (u128, u128) {
     let b_lo = b as u64;
     let b_hi = (b >> 64) as u64;
 
+    // Karatsuba: the middle partial p01^p10 = p_mid ^ p00 ^ p11, where
+    // p_mid = (a_lo+a_hi)(b_lo+b_hi) — three bmul64_full instead of four.
     let (p00_lo, p00_hi) = bmul64_full(a_lo, b_lo);
     let (p11_lo, p11_hi) = bmul64_full(a_hi, b_hi);
-    let (p01_lo, p01_hi) = bmul64_full(a_lo, b_hi);
-    let (p10_lo, p10_hi) = bmul64_full(a_hi, b_lo);
+    let (pm_lo, pm_hi) = bmul64_full(a_lo ^ a_hi, b_lo ^ b_hi);
 
-    let mid_lo = p01_lo ^ p10_lo;
-    let mid_hi = p01_hi ^ p10_hi;
+    let mid_lo = pm_lo ^ p00_lo ^ p11_lo;
+    let mid_hi = pm_hi ^ p00_hi ^ p11_hi;
 
     // Lay out the 256-bit result:
     //   p00 → bits [0..128]

--- a/crates/fields/src/bmul_simd.rs
+++ b/crates/fields/src/bmul_simd.rs
@@ -128,13 +128,14 @@ pub(crate) fn bmul128_full(a: u128, b: u128) -> (u128, u128) {
     let b_lo = b as u64;
     let b_hi = (b >> 64) as u64;
 
+    // Karatsuba: the middle partial p01^p10 = p_mid ^ p00 ^ p11, where
+    // p_mid = (a_lo+a_hi)(b_lo+b_hi) — three bmul64_full instead of four.
     let (p00_lo, p00_hi) = bmul64_full(a_lo, b_lo);
     let (p11_lo, p11_hi) = bmul64_full(a_hi, b_hi);
-    let (p01_lo, p01_hi) = bmul64_full(a_lo, b_hi);
-    let (p10_lo, p10_hi) = bmul64_full(a_hi, b_lo);
+    let (pm_lo, pm_hi) = bmul64_full(a_lo ^ a_hi, b_lo ^ b_hi);
 
-    let mid_lo = p01_lo ^ p10_lo;
-    let mid_hi = p01_hi ^ p10_hi;
+    let mid_lo = pm_lo ^ p00_lo ^ p11_lo;
+    let mid_hi = pm_hi ^ p00_hi ^ p11_hi;
 
     let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
     let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);

--- a/crates/fields/src/gf2_128/soft.rs
+++ b/crates/fields/src/gf2_128/soft.rs
@@ -1,6 +1,6 @@
 //! Portable software backend for GF(2¹²⁸) — uses BearSSL-style
-//! constant-time `bmul128_full` (four `bmul64_full` calls) to avoid
-//! schoolbook's per-bit u128 loop, and amortises reduction across the
+//! constant-time `bmul128_full` (Karatsuba: three `bmul64_full` calls) to
+//! avoid schoolbook's per-bit u128 loop, and amortises reduction across the
 //! inner-product accumulator.
 
 use crate::{bmul::bmul128_full, spread::bit_spread_u32};

--- a/crates/fields/src/gf2_128/wasm.rs
+++ b/crates/fields/src/gf2_128/wasm.rs
@@ -1,9 +1,9 @@
 //! WASM `simd128` backend for GF(2¹²⁸).
 //!
-//! Uses `bmul_simd::bmul128_full` (four `bmul64_full`s, each of which
-//! runs its forward and reversed halves in v128 parallel), then reduces
-//! mod p(x) = x¹²⁸+x⁷+x²+x+1 with the same shift/XOR chain as the soft
-//! backend.
+//! Uses `bmul_simd::bmul128_full` (Karatsuba: three `bmul64_full`s, each
+//! of which runs its forward and reversed halves in v128 parallel), then
+//! reduces mod p(x) = x¹²⁸+x⁷+x²+x+1 with the same shift/XOR chain as the
+//! soft backend.
 
 use std::arch::wasm32::*;
 
@@ -68,20 +68,24 @@ pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
         let b_lo = y.0 as u64;
         let b_hi = (y.0 >> 64) as u64;
 
+        // Karatsuba: three products instead of four. The middle partial
+        // p01^p10 = p_mid ^ p00 ^ p11 is recovered after the loop — both the
+        // recovery and the XOR merge are linear over GF(2), so they defer.
         let p00 = bmul64_raw(a_lo, b_lo);
         let p11 = bmul64_raw(a_hi, b_hi);
-        let p01 = bmul64_raw(a_lo, b_hi);
-        let p10 = bmul64_raw(a_hi, b_lo);
+        let p_mid = bmul64_raw(a_lo ^ a_hi, b_lo ^ b_hi);
 
         acc00 = v128_xor(acc00, p00);
         acc11 = v128_xor(acc11, p11);
-        acc_mid = v128_xor(acc_mid, v128_xor(p01, p10));
+        acc_mid = v128_xor(acc_mid, p_mid);
     }
 
-    // One-time recovery + Karatsuba merge.
+    // One-time recovery, then the Karatsuba merge mid = p_mid ^ p00 ^ p11.
     let (p00_lo, p00_hi) = recover_raw(acc00);
     let (p11_lo, p11_hi) = recover_raw(acc11);
     let (mid_lo, mid_hi) = recover_raw(acc_mid);
+    let mid_lo = mid_lo ^ p00_lo ^ p11_lo;
+    let mid_hi = mid_hi ^ p00_hi ^ p11_hi;
 
     let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
     let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);
@@ -111,19 +115,21 @@ pub(super) fn double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) 
         let b_lo = z.0 as u64;
         let b_hi = (z.0 >> 64) as u64;
 
+        // Karatsuba: three products; middle recovered after the loop.
         let p00 = bmul64_raw(a_lo, b_lo);
         let p11 = bmul64_raw(a_hi, b_hi);
-        let p01 = bmul64_raw(a_lo, b_hi);
-        let p10 = bmul64_raw(a_hi, b_lo);
+        let p_mid = bmul64_raw(a_lo ^ a_hi, b_lo ^ b_hi);
 
         acc00 = v128_xor(acc00, p00);
         acc11 = v128_xor(acc11, p11);
-        acc_mid = v128_xor(acc_mid, v128_xor(p01, p10));
+        acc_mid = v128_xor(acc_mid, p_mid);
     }
 
     let (p00_lo, p00_hi) = recover_raw(acc00);
     let (p11_lo, p11_hi) = recover_raw(acc11);
     let (mid_lo, mid_hi) = recover_raw(acc_mid);
+    let mid_lo = mid_lo ^ p00_lo ^ p11_lo;
+    let mid_hi = mid_hi ^ p00_hi ^ p11_hi;
 
     let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
     let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);


### PR DESCRIPTION
## Summary
Replaces schoolbook (4 sub-products) with **Karatsuba (3 sub-products)** in the carry-less 128×128 multiply on the backends that emulate it in software — WASM `simd128` and the portable `soft` fallback — where each GF(2⁶⁴) sub-multiply is expensive (no `PCLMULQDQ`).

Karatsuba middle partial: `p01^p10 = p_mid ^ p00 ^ p11`, with `p_mid = (a_lo+a_hi)(b_lo+b_hi)`. In the deferred-reduction inner-product kernels the merge is recovered **once after the loop** — valid because recovery (`rev64`+shift) and the XOR merge are linear over GF(2).

## Scope
- `bmul::bmul128_full` — soft backend (covers `mul`/`mul_full`/`inner_product`/`double_inner_product`, which all route through it)
- `bmul_simd::bmul128_full` — WASM `mul`/`mul_full`
- WASM `inner_product` / `double_inner_product` deferred kernels (4→3 `bmul64_raw`/term)

The **x86 PCLMUL** path is intentionally left on schoolbook — `pclmulqdq` throughput is high, so trading a multiply for several XORs isn't a clear win there.

## Impact
Measured **~10%** on the `pack` bench under `wasm32-wasip1` (the BearSSL emulation spends a large fraction on masking/recover XORs, so the multiply-third reduction nets ~10%, not 25%). Applies to **every** GF(2¹²⁸) multiply on these backends, so the proving-pipeline benefit is broader than the single bench.

## Tests
- `cargo test -p mpz-fields --lib` (native): 42 passed — includes `bmul128_known_vectors`.
- `cargo test -p mpz-fields --target wasm32-wasip1`: 35 passed.