### PR TITLE
refactor: streaming witness capture + two-pass QuickSilver rewrite

### DIFF
--- a/crates/core/benches/aes.rs
+++ b/crates/core/benches/aes.rs
@@ -43,17 +43,21 @@ fn criterion_benchmark(c: &mut Criterion) {
         let n = 8192;
         let mut src = vec![[0u8; 16]; n];
         for (i, b) in src.iter_mut().enumerate() {
-            *b = (i as u128).wrapping_mul(0x9E37_79B9_7F4A_7C15).to_le_bytes();
+            *b = (i as u128)
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                .to_le_bytes();
         }
         let mut dst = vec![[0u8; 16]; n];
 
         let mut group = c.benchmark_group("ccr");
         group.throughput(Throughput::Bytes((n * 16) as u64));
         group.bench_function("blocks_to", |bench| {
-            bench.iter(|| FIXED_KEY_AES.ccr_blocks_to(black_box(&src[..]), black_box(&mut dst[..])));
+            bench
+                .iter(|| FIXED_KEY_AES.ccr_blocks_to(black_box(&src[..]), black_box(&mut dst[..])));
         });
         group.bench_function("mmo_blocks_to", |bench| {
-            bench.iter(|| FIXED_KEY_AES.mmo_blocks_to(black_box(&src[..]), black_box(&mut dst[..])));
+            bench
+                .iter(|| FIXED_KEY_AES.mmo_blocks_to(black_box(&src[..]), black_box(&mut dst[..])));
         });
         group.finish();
     }

--- a/crates/ot-core/src/ferret/cggm.rs
+++ b/crates/ot-core/src/ferret/cggm.rs
@@ -188,7 +188,13 @@ mod tests {
                 let punctured_sums: Vec<Gf2_128> = sums
                     .iter()
                     .enumerate()
-                    .map(|(i, &sum)| if (idx >> i) & 1 == 1 { sum } else { sum + delta })
+                    .map(|(i, &sum)| {
+                        if (idx >> i) & 1 == 1 {
+                            sum
+                        } else {
+                            sum + delta
+                        }
+                    })
                     .collect();
 
                 // Pre-fill with garbage: the expansion must not rely on a

--- a/crates/ot-core/src/ferret/config.rs
+++ b/crates/ot-core/src/ferret/config.rs
@@ -22,7 +22,8 @@ pub struct FerretConfig {
     #[builder(default = "true")]
     reserve_bootstrap: bool,
     /// Whether to serve small demands directly from the base COT instead of
-    /// running a full Ferret iteration. See [`FerretConfig::direct_passthrough`].
+    /// running a full Ferret iteration. See
+    /// [`FerretConfig::direct_passthrough`].
     #[builder(default = "true")]
     direct_passthrough: bool,
     #[builder(setter(custom), default = "Arc::new(default_parameter_selector)")]

--- a/crates/ot-core/src/ferret/receiver.rs
+++ b/crates/ot-core/src/ferret/receiver.rs
@@ -141,8 +141,8 @@ where
     }
 
     /// Returns the number of base COTs to pull on the next bootstrap: just the
-    /// outstanding demand when it is below the bootstrap cost (served directly),
-    /// otherwise a full bootstrap batch.
+    /// outstanding demand when it is below the bootstrap cost (served
+    /// directly), otherwise a full bootstrap batch.
     fn bootstrap_count(&self) -> usize {
         let missing = self.alloc.saturating_sub(self.available());
         if self.config.direct_passthrough() && missing > 0 && missing < self.config.bootstrap_cost()
@@ -254,8 +254,13 @@ where
         self.macs.resize(start + params.n, Gf2_128::ZERO);
         self.pending = params.n;
 
-        self.spcot
-            .expand(&spcot_lengths, &spcot_idxs, sums, &cs, &mut self.macs[start..])?;
+        self.spcot.expand(
+            &spcot_lengths,
+            &spcot_idxs,
+            sums,
+            &cs,
+            &mut self.macs[start..],
+        )?;
 
         // The check MACs follow the LPN input in the scratch buffer; the check
         // masks are the tail of the choices buffer.

--- a/crates/ot-core/src/ferret/sender.rs
+++ b/crates/ot-core/src/ferret/sender.rs
@@ -140,8 +140,8 @@ where
     }
 
     /// Returns the number of base COTs to pull on the next bootstrap: just the
-    /// outstanding demand when it is below the bootstrap cost (served directly),
-    /// otherwise a full bootstrap batch.
+    /// outstanding demand when it is below the bootstrap cost (served
+    /// directly), otherwise a full bootstrap batch.
     fn bootstrap_count(&self) -> usize {
         let missing = self.alloc.saturating_sub(self.available());
         if self.config.direct_passthrough() && missing > 0 && missing < self.config.bootstrap_cost()
@@ -210,9 +210,11 @@ where
 
         // Derandomize the SPCOT keys in place: this is their only read, so we
         // avoid copying them out and reuse their buffer space for the output.
-        let cs = self
-            .spcot
-            .derandomize(&spcot_lengths, &self.keys[len - spcot_count..], &derandomize.flip)?;
+        let cs = self.spcot.derandomize(
+            &spcot_lengths,
+            &self.keys[len - spcot_count..],
+            &derandomize.flip,
+        )?;
 
         // The LPN input and check keys must survive into `check`/`finish`,
         // where the SPCOT output overwrites their old location, so copy them

--- a/crates/ot-core/src/ferret/spcot.rs
+++ b/crates/ot-core/src/ferret/spcot.rs
@@ -219,7 +219,9 @@ mod tests {
         let keys: Vec<Gf2_128> = keys.iter().map(|&key| key.into()).collect();
         let macs: Vec<Gf2_128> = macs.iter().map(|&mac| mac.into()).collect();
 
-        let cs = sender.derandomize(lengths, &keys, &derandomize.flip).unwrap();
+        let cs = sender
+            .derandomize(lengths, &keys, &derandomize.flip)
+            .unwrap();
         let cs = sender
             .expand(rng, lengths, cs, &derandomize.flip, &mut vs)
             .unwrap();

--- a/crates/ot-core/src/lib.rs
+++ b/crates/ot-core/src/lib.rs
@@ -28,10 +28,10 @@ pub mod chou_orlandi;
 pub mod cot;
 pub mod ferret;
 pub mod ideal;
-pub mod softspoken;
 pub mod ot;
 pub mod rcot;
 pub mod rot;
+pub mod softspoken;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test;
 

--- a/crates/ot-core/src/softspoken.rs
+++ b/crates/ot-core/src/softspoken.rs
@@ -275,8 +275,16 @@ mod tests {
         receiver_seeds: [[Block; 2]; CSP],
     ) {
         // Small batch so the larger `count` cases span multiple extends.
-        let sender_config = SenderConfig::builder().k(k).batch_size(2048).build().unwrap();
-        let receiver_config = ReceiverConfig::builder().k(k).batch_size(2048).build().unwrap();
+        let sender_config = SenderConfig::builder()
+            .k(k)
+            .batch_size(2048)
+            .build()
+            .unwrap();
+        let receiver_config = ReceiverConfig::builder()
+            .k(k)
+            .batch_size(2048)
+            .build()
+            .unwrap();
 
         let sender = Sender::new(sender_config, delta);
         let receiver = Receiver::new(receiver_config);

--- a/crates/ot-core/src/softspoken/check.rs
+++ b/crates/ot-core/src/softspoken/check.rs
@@ -125,9 +125,9 @@ mod tests {
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
     /// Independent reference: `t_r = (Σ_{j<m} χ_j · row_r[j]) + row_r[m]` with
-    /// `χ_j = AES_seed(j)`. Uses direct field multiplies — no deferred-reduction
-    /// accumulator and no column chunking — so it genuinely cross-checks the
-    /// optimized fold rather than restating it.
+    /// `χ_j = AES_seed(j)`. Uses direct field multiplies — no
+    /// deferred-reduction accumulator and no column chunking — so it
+    /// genuinely cross-checks the optimized fold rather than restating it.
     fn naive_check_fold(
         seed: Block,
         mac: &[u8],

--- a/crates/ot-core/src/softspoken/config.rs
+++ b/crates/ot-core/src/softspoken/config.rs
@@ -3,7 +3,8 @@ use derive_builder::Builder;
 use crate::softspoken::{CSP, SUPPORTED_K};
 
 // Large by default for throughput; trade down for lower first-flush latency.
-// Small allocations are unaffected (each batch is `min(batch_size, remaining)`).
+// Small allocations are unaffected (each batch is `min(batch_size,
+// remaining)`).
 const DEFAULT_BATCH_SIZE: usize = 1 << 18;
 const DEFAULT_K: usize = 4;
 
@@ -19,8 +20,8 @@ fn validate_k(k: usize) -> Result<(), String> {
     Ok(())
 }
 
-/// Defines a SoftSpoken config type. The sender and receiver configs differ only
-/// in their name and docs; the fields, builder validation, defaults, and
+/// Defines a SoftSpoken config type. The sender and receiver configs differ
+/// only in their name and docs; the fields, builder validation, defaults, and
 /// accessors are identical, so they share this definition.
 macro_rules! softspoken_config {
     (
@@ -108,7 +109,10 @@ mod tests {
     #[test]
     fn builder_validates_k_for_both_configs() {
         for k in [0usize, 1, 3, 5, 16] {
-            assert!(SenderConfig::builder().k(k).build().is_err(), "sender k={k}");
+            assert!(
+                SenderConfig::builder().k(k).build().is_err(),
+                "sender k={k}"
+            );
             assert!(
                 ReceiverConfig::builder().k(k).build().is_err(),
                 "receiver k={k}"

--- a/crates/ot-core/src/softspoken/fold.rs
+++ b/crates/ot-core/src/softspoken/fold.rs
@@ -39,8 +39,8 @@ pub(crate) fn xor_into(dst: &mut [u8], src: &[u8]) {
     }
 }
 
-/// Branchless conditional XOR: `dst ^= src & mask` over 16-byte lanes. `mask` is
-/// all-ones to apply `src`, zero for a no-op.
+/// Branchless conditional XOR: `dst ^= src & mask` over 16-byte lanes. `mask`
+/// is all-ones to apply `src`, zero for a no-op.
 pub(crate) fn xor_masked_into(dst: &mut [u8], src: &[u8], mask: [u8; 16]) {
     debug_assert_eq!(dst.len(), src.len());
     debug_assert_eq!(dst.len() % 16, 0);
@@ -136,7 +136,10 @@ mod tests {
                     xor_into(&mut u_ref, &rows[x * tb..(x + 1) * tb]);
                     for i in 0..k {
                         if (x >> i) & 1 == 1 {
-                            xor_into(&mut v_ref[i * tb..(i + 1) * tb], &rows[x * tb..(x + 1) * tb]);
+                            xor_into(
+                                &mut v_ref[i * tb..(i + 1) * tb],
+                                &rows[x * tb..(x + 1) * tb],
+                            );
                         }
                     }
                 }

--- a/crates/ot-core/src/softspoken/receiver.rs
+++ b/crates/ot-core/src/softspoken/receiver.rs
@@ -2,11 +2,11 @@ use std::{collections::VecDeque, mem};
 
 use crate::{
     TransferId,
+    rcot::{RCOTReceiver, RCOTReceiverOutput},
     softspoken::{
         CSP, Check, Corrections, Extend, ReceiverConfig, ReceiverError, SSP, check, fold,
         fold::TILE_TARGET_BLOCKS, ggm,
     },
-    rcot::{RCOTReceiver, RCOTReceiverOutput},
 };
 
 use mpz_common::future::{MaybeDone, Sender, new_output};
@@ -198,7 +198,11 @@ impl Receiver<state::Extension> {
         let q = self.config.leaves();
 
         // Round up to a multiple of SSP (the rows sacrificed to the check).
-        let count = self.config.batch_size().min(self.alloc).next_multiple_of(SSP);
+        let count = self
+            .config
+            .batch_size()
+            .min(self.alloc)
+            .next_multiple_of(SSP);
         let rb = count / 8;
         let m = count / CSP; // blocks per row this batch
 
@@ -276,8 +280,12 @@ impl Receiver<state::Extension> {
 
         let total_rb = self.state.total_rb;
 
-        let (check_t, check_x) =
-            check::check_fold(chi_seed, &self.state.mac, total_rb, Some(&self.state.choices));
+        let (check_t, check_x) = check::check_fold(
+            chi_seed,
+            &self.state.mac,
+            total_rb,
+            Some(&self.state.choices),
+        );
         let check_x = check_x.expect("choices were provided");
 
         // Transpose the matrix in place: it becomes the per-OT MACs. The last

--- a/crates/ot-core/src/softspoken/sender.rs
+++ b/crates/ot-core/src/softspoken/sender.rs
@@ -2,11 +2,11 @@ use std::{collections::VecDeque, mem};
 
 use crate::{
     TransferId,
+    rcot::{RCOTSender, RCOTSenderOutput},
     softspoken::{
         CSP, Check, Corrections, Extend, SSP, SenderConfig, SenderError, check, fold,
         fold::TILE_TARGET_BLOCKS, ggm,
     },
-    rcot::{RCOTSender, RCOTSenderOutput},
 };
 
 use itybity::ToBits;
@@ -223,7 +223,11 @@ impl Sender<state::Extension> {
         let q = self.config.leaves();
 
         // Round up to a multiple of SSP (the rows sacrificed to the check).
-        let expected_count = self.config.batch_size().min(self.alloc).next_multiple_of(SSP);
+        let expected_count = self
+            .config
+            .batch_size()
+            .min(self.alloc)
+            .next_multiple_of(SSP);
         if count != expected_count {
             return Err(SenderError::CountMismatch {
                 expected: expected_count,

--- a/crates/ot/benches/ferret_receiver.rs
+++ b/crates/ot/benches/ferret_receiver.rs
@@ -44,7 +44,8 @@ struct RecordedData {
     cot_recv_seed: u64,
     /// Seed for Ferret receiver.
     receiver_seed: Block,
-    /// Correlations actually produced (OT_COUNT rounded up to whole iterations).
+    /// Correlations actually produced (OT_COUNT rounded up to whole
+    /// iterations).
     actual_count: usize,
 }
 
@@ -144,7 +145,8 @@ struct RecordedDataMt {
     cot_recv_seed: u64,
     /// Seed for Ferret receiver.
     receiver_seed: Block,
-    /// Correlations actually produced (OT_COUNT rounded up to whole iterations).
+    /// Correlations actually produced (OT_COUNT rounded up to whole
+    /// iterations).
     actual_count: usize,
 }
 

--- a/crates/ot/benches/ferret_sender.rs
+++ b/crates/ot/benches/ferret_sender.rs
@@ -46,7 +46,8 @@ struct RecordedData {
     cot_seed: Block,
     /// Seed for Ferret sender.
     sender_seed: Block,
-    /// Correlations actually produced (OT_COUNT rounded up to whole iterations).
+    /// Correlations actually produced (OT_COUNT rounded up to whole
+    /// iterations).
     actual_count: usize,
 }
 
@@ -149,7 +150,8 @@ struct RecordedDataMt {
     cot_seed: Block,
     /// Seed for Ferret sender.
     sender_seed: Block,
-    /// Correlations actually produced (OT_COUNT rounded up to whole iterations).
+    /// Correlations actually produced (OT_COUNT rounded up to whole
+    /// iterations).
     actual_count: usize,
 }
 

--- a/crates/ot/src/lib.rs
+++ b/crates/ot/src/lib.rs
@@ -14,10 +14,10 @@ pub mod cot;
 pub mod ferret;
 #[cfg(any(test, feature = "ideal"))]
 pub mod ideal;
-pub mod softspoken;
 pub mod ot;
 pub mod rcot;
 pub mod rot;
+pub mod softspoken;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test;
 

--- a/crates/ot/src/softspoken/receiver.rs
+++ b/crates/ot/src/softspoken/receiver.rs
@@ -5,9 +5,11 @@ use serio::{SinkExt as _, stream::IoStreamExt};
 use mpz_common::{Context, ContextError, Flush, future::MaybeDone};
 use mpz_core::Block;
 use mpz_ot_core::{
-    softspoken::{Receiver as Core, ReceiverConfig, ReceiverError as CoreError, receiver_state as state},
     ot::OTSender,
     rcot::{RCOTReceiver, RCOTReceiverOutput},
+    softspoken::{
+        Receiver as Core, ReceiverConfig, ReceiverError as CoreError, receiver_state as state,
+    },
 };
 
 type Error = ReceiverError;

--- a/crates/ot/src/softspoken/sender.rs
+++ b/crates/ot/src/softspoken/sender.rs
@@ -3,9 +3,9 @@ use itybity::IntoBits;
 use mpz_common::{Context, ContextError, Flush, future::MaybeDone};
 use mpz_core::Block;
 use mpz_ot_core::{
-    softspoken::{Sender as Core, SenderConfig, SenderError as CoreError, sender_state as state},
     ot::{OTReceiver, OTReceiverOutput},
     rcot::{RCOTSender, RCOTSenderOutput},
+    softspoken::{Sender as Core, SenderConfig, SenderError as CoreError, sender_state as state},
 };
 use serio::{SinkExt, stream::IoStreamExt as _};
 

--- a/crates/vm-circuits/src/insn.rs
+++ b/crates/vm-circuits/src/insn.rs
@@ -3,12 +3,12 @@ use mpz_circuits::Context;
 use mpz_circuits::MaybeConst;
 #[cfg(test)]
 use mpz_fields::Field;
-use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
+use mpz_fields::gf2::Gf2;
 use mpz_vm_memory::{I32, I64};
 
-pub trait CircuitContext: Context<Wire = Gf2_128, Field = Gf2> {}
+pub trait CircuitContext: Context<Field = Gf2> {}
 
-impl<C: Context<Wire = Gf2_128, Field = Gf2>> CircuitContext for C {}
+impl<C: Context<Field = Gf2>> CircuitContext for C {}
 
 #[cfg(test)]
 macro_rules! assert_cost {
@@ -41,37 +41,31 @@ pub use count::*;
 pub use divrem::*;
 pub use shift::*;
 
-pub(crate) fn zero_extend_bit<C: CircuitContext>(ctx: &mut C, bit: Gf2_128) -> I32 {
+pub(crate) fn zero_extend_bit<C: CircuitContext>(ctx: &mut C, bit: C::Wire) -> I32<C::Wire> {
     let zero = ctx.constant(Gf2(false));
     let mut wires = [zero; 32];
     wires[0] = bit;
     I32::from(wires)
 }
 
-pub(crate) fn const_i32<C: CircuitContext>(ctx: &mut C, v: i32) -> I32 {
-    let mut wires = [Gf2_128::ZERO; 32];
-    for (i, w) in wires.iter_mut().enumerate() {
-        *w = ctx.constant(Gf2((v >> i) & 1 != 0));
-    }
+pub(crate) fn const_i32<C: CircuitContext>(ctx: &mut C, v: i32) -> I32<C::Wire> {
+    let wires: [C::Wire; 32] = core::array::from_fn(|i| ctx.constant(Gf2((v >> i) & 1 != 0)));
     I32::from(wires)
 }
 
-pub(crate) fn const_i64<C: CircuitContext>(ctx: &mut C, v: i64) -> I64 {
-    let mut wires = [Gf2_128::ZERO; 64];
-    for (i, w) in wires.iter_mut().enumerate() {
-        *w = ctx.constant(Gf2((v >> i) & 1 != 0));
-    }
+pub(crate) fn const_i64<C: CircuitContext>(ctx: &mut C, v: i64) -> I64<C::Wire> {
+    let wires: [C::Wire; 64] = core::array::from_fn(|i| ctx.constant(Gf2((v >> i) & 1 != 0)));
     I64::from(wires)
 }
 
 #[cfg(test)]
-pub(crate) fn dummy_i32() -> I32 {
-    I32::from([Gf2_128::ZERO; 32])
+pub(crate) fn dummy_i32() -> I32<Gf2> {
+    I32::from([Gf2::ZERO; 32])
 }
 
 #[cfg(test)]
-pub(crate) fn dummy_i64() -> I64 {
-    I64::from([Gf2_128::ZERO; 64])
+pub(crate) fn dummy_i64() -> I64<Gf2> {
+    I64::from([Gf2::ZERO; 64])
 }
 
 #[cfg(test)]
@@ -92,23 +86,23 @@ impl GateCount {
 #[cfg(test)]
 impl Context for GateCount {
     type Error = ();
-    type Wire = Gf2_128;
+    type Wire = Gf2;
     type Field = Gf2;
 
-    fn add(&mut self, _a: Gf2_128, _b: Gf2_128) -> Gf2_128 {
-        Gf2_128::ZERO
+    fn add(&mut self, _a: Gf2, _b: Gf2) -> Gf2 {
+        Gf2::ZERO
     }
 
-    fn sub(&mut self, _a: Gf2_128, _b: Gf2_128) -> Gf2_128 {
-        Gf2_128::ZERO
+    fn sub(&mut self, _a: Gf2, _b: Gf2) -> Gf2 {
+        Gf2::ZERO
     }
 
-    fn mul(&mut self, _a: Gf2_128, _b: Gf2_128) -> Gf2_128 {
+    fn mul(&mut self, _a: Gf2, _b: Gf2) -> Gf2 {
         self.ands += 1;
-        Gf2_128::ZERO
+        Gf2::ZERO
     }
 
-    fn mul_const(&mut self, a: Gf2_128, b: Gf2) -> MaybeConst<Gf2_128, Gf2> {
+    fn mul_const(&mut self, a: Gf2, b: Gf2) -> MaybeConst<Gf2, Gf2> {
         if b == Gf2::zero() {
             MaybeConst::Const(Gf2::zero())
         } else if b == Gf2::one() {
@@ -118,11 +112,11 @@ impl Context for GateCount {
         }
     }
 
-    fn constant(&mut self, _v: Gf2) -> Gf2_128 {
-        Gf2_128::ZERO
+    fn constant(&mut self, _v: Gf2) -> Gf2 {
+        Gf2::ZERO
     }
 
-    fn assert_const(&mut self, _v: Gf2_128, _expected: Gf2) -> Result<(), ()> {
+    fn assert_const(&mut self, _v: Gf2, _expected: Gf2) -> Result<(), ()> {
         Ok(())
     }
 }

--- a/crates/vm-circuits/src/insn/arith.rs
+++ b/crates/vm-circuits/src/insn/arith.rs
@@ -9,7 +9,7 @@ pub struct I32Add;
 impl I32Add {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::add_n::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 }
@@ -19,7 +19,7 @@ pub struct I32Sub;
 impl I32Sub {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::sub_n::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 }
@@ -30,11 +30,11 @@ impl I32Mul {
     pub const COST: usize = 2358;
     pub const COST_CONST: usize = 2358;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::mul_n::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32, konst: i32) -> I32 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, konst: i32) -> I32<C::Wire> {
         let k = const_i32(ctx, konst);
         I32::from(crate::mul_n::<C, 32>(ctx, a.to_wires(), k.to_wires()))
     }
@@ -45,7 +45,7 @@ pub struct I64Add;
 impl I64Add {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::add_n::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 }
@@ -55,7 +55,7 @@ pub struct I64Sub;
 impl I64Sub {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::sub_n::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 }
@@ -66,11 +66,11 @@ impl I64Mul {
     pub const COST: usize = 7669;
     pub const COST_CONST: usize = 7669;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::mul_n::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64, konst: i64) -> I64 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, konst: i64) -> I64<C::Wire> {
         let k = const_i64(ctx, konst);
         I64::from(crate::mul_n::<C, 64>(ctx, a.to_wires(), k.to_wires()))
     }

--- a/crates/vm-circuits/src/insn/bitwise.rs
+++ b/crates/vm-circuits/src/insn/bitwise.rs
@@ -10,11 +10,11 @@ impl I32And {
     pub const COST: usize = 32;
     pub const COST_CONST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::and_arr::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32, konst: i32) -> I32 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, konst: i32) -> I32<C::Wire> {
         let k = const_i32(ctx, konst);
         I32::from(crate::and_arr::<C, 32>(ctx, a.to_wires(), k.to_wires()))
     }
@@ -26,11 +26,11 @@ impl I32Or {
     pub const COST: usize = 32;
     pub const COST_CONST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::or_arr::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32, konst: i32) -> I32 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, konst: i32) -> I32<C::Wire> {
         let k = const_i32(ctx, konst);
         I32::from(crate::or_arr::<C, 32>(ctx, a.to_wires(), k.to_wires()))
     }
@@ -41,7 +41,7 @@ pub struct I32Xor;
 impl I32Xor {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::xor_arr::<C, 32>(ctx, a.to_wires(), b.to_wires()))
     }
 }
@@ -52,11 +52,11 @@ impl I64And {
     pub const COST: usize = 64;
     pub const COST_CONST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::and_arr::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64, konst: i64) -> I64 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, konst: i64) -> I64<C::Wire> {
         let k = const_i64(ctx, konst);
         I64::from(crate::and_arr::<C, 64>(ctx, a.to_wires(), k.to_wires()))
     }
@@ -68,11 +68,11 @@ impl I64Or {
     pub const COST: usize = 64;
     pub const COST_CONST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::or_arr::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 
-    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64, konst: i64) -> I64 {
+    pub fn eval_const<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, konst: i64) -> I64<C::Wire> {
         let k = const_i64(ctx, konst);
         I64::from(crate::or_arr::<C, 64>(ctx, a.to_wires(), k.to_wires()))
     }
@@ -83,7 +83,7 @@ pub struct I64Xor;
 impl I64Xor {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::xor_arr::<C, 64>(ctx, a.to_wires(), b.to_wires()))
     }
 }

--- a/crates/vm-circuits/src/insn/compare.rs
+++ b/crates/vm-circuits/src/insn/compare.rs
@@ -7,7 +7,7 @@ pub struct I32Eq;
 impl I32Eq {
     pub const COST: usize = 31;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         let bit = crate::eq_n::<C, 32>(ctx, a.to_wires(), b.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -18,7 +18,7 @@ pub struct I32Ne;
 impl I32Ne {
     pub const COST: usize = 31;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32, b: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>, b: I32<C::Wire>) -> I32<C::Wire> {
         let bit = crate::ne_n::<C, 32>(ctx, a.to_wires(), b.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -29,7 +29,11 @@ pub struct I32LtS;
 impl I32LtS {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_s_n::<C, 32>(ctx, left.to_wires(), right.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -40,7 +44,11 @@ pub struct I32LtU;
 impl I32LtU {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_u_n::<C, 32>(ctx, left.to_wires(), right.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -51,7 +59,11 @@ pub struct I32GtS;
 impl I32GtS {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_s_n::<C, 32>(ctx, right.to_wires(), left.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -62,7 +74,11 @@ pub struct I32GtU;
 impl I32GtU {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_u_n::<C, 32>(ctx, right.to_wires(), left.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -73,7 +89,11 @@ pub struct I32LeS;
 impl I32LeS {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let gt = crate::lt_s_n::<C, 32>(ctx, right.to_wires(), left.to_wires());
         let bit = crate::not(ctx, gt);
         super::zero_extend_bit(ctx, bit)
@@ -85,7 +105,11 @@ pub struct I32LeU;
 impl I32LeU {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let gt = crate::lt_u_n::<C, 32>(ctx, right.to_wires(), left.to_wires());
         let bit = crate::not(ctx, gt);
         super::zero_extend_bit(ctx, bit)
@@ -97,7 +121,11 @@ pub struct I32GeS;
 impl I32GeS {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let lt = crate::lt_s_n::<C, 32>(ctx, left.to_wires(), right.to_wires());
         let bit = crate::not(ctx, lt);
         super::zero_extend_bit(ctx, bit)
@@ -109,7 +137,11 @@ pub struct I32GeU;
 impl I32GeU {
     pub const COST: usize = 32;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I32, right: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I32<C::Wire>,
+        right: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let lt = crate::lt_u_n::<C, 32>(ctx, left.to_wires(), right.to_wires());
         let bit = crate::not(ctx, lt);
         super::zero_extend_bit(ctx, bit)
@@ -121,7 +153,7 @@ pub struct I32Eqz;
 impl I32Eqz {
     pub const COST: usize = 31;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         let bit = crate::eqz_n::<C, 32>(ctx, a.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -132,7 +164,7 @@ pub struct I64Eq;
 impl I64Eq {
     pub const COST: usize = 63;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I32<C::Wire> {
         let bit = crate::eq_n::<C, 64>(ctx, a.to_wires(), b.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -143,7 +175,7 @@ pub struct I64Ne;
 impl I64Ne {
     pub const COST: usize = 63;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64, b: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>, b: I64<C::Wire>) -> I32<C::Wire> {
         let bit = crate::ne_n::<C, 64>(ctx, a.to_wires(), b.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -154,7 +186,11 @@ pub struct I64LtS;
 impl I64LtS {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_s_n::<C, 64>(ctx, left.to_wires(), right.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -165,7 +201,11 @@ pub struct I64LtU;
 impl I64LtU {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_u_n::<C, 64>(ctx, left.to_wires(), right.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -176,7 +216,11 @@ pub struct I64GtS;
 impl I64GtS {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_s_n::<C, 64>(ctx, right.to_wires(), left.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -187,7 +231,11 @@ pub struct I64GtU;
 impl I64GtU {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let bit = crate::lt_u_n::<C, 64>(ctx, right.to_wires(), left.to_wires());
         super::zero_extend_bit(ctx, bit)
     }
@@ -198,7 +246,11 @@ pub struct I64LeS;
 impl I64LeS {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let gt = crate::lt_s_n::<C, 64>(ctx, right.to_wires(), left.to_wires());
         let bit = crate::not(ctx, gt);
         super::zero_extend_bit(ctx, bit)
@@ -210,7 +262,11 @@ pub struct I64LeU;
 impl I64LeU {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let gt = crate::lt_u_n::<C, 64>(ctx, right.to_wires(), left.to_wires());
         let bit = crate::not(ctx, gt);
         super::zero_extend_bit(ctx, bit)
@@ -222,7 +278,11 @@ pub struct I64GeS;
 impl I64GeS {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let lt = crate::lt_s_n::<C, 64>(ctx, left.to_wires(), right.to_wires());
         let bit = crate::not(ctx, lt);
         super::zero_extend_bit(ctx, bit)
@@ -234,7 +294,11 @@ pub struct I64GeU;
 impl I64GeU {
     pub const COST: usize = 64;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, left: I64, right: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        left: I64<C::Wire>,
+        right: I64<C::Wire>,
+    ) -> I32<C::Wire> {
         let lt = crate::lt_u_n::<C, 64>(ctx, left.to_wires(), right.to_wires());
         let bit = crate::not(ctx, lt);
         super::zero_extend_bit(ctx, bit)
@@ -246,7 +310,7 @@ pub struct I64Eqz;
 impl I64Eqz {
     pub const COST: usize = 63;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>) -> I32<C::Wire> {
         let bit = crate::eqz_n::<C, 64>(ctx, a.to_wires());
         super::zero_extend_bit(ctx, bit)
     }

--- a/crates/vm-circuits/src/insn/convert.rs
+++ b/crates/vm-circuits/src/insn/convert.rs
@@ -8,7 +8,7 @@ pub struct I32Extend8S;
 impl I32Extend8S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::sign_extend_low_in_place::<C, 32>(a.to_wires(), 8))
     }
 }
@@ -18,7 +18,7 @@ pub struct I32Extend16S;
 impl I32Extend16S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::sign_extend_low_in_place::<C, 32>(a.to_wires(), 16))
     }
 }
@@ -28,7 +28,7 @@ pub struct I64Extend8S;
 impl I64Extend8S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::sign_extend_low_in_place::<C, 64>(a.to_wires(), 8))
     }
 }
@@ -38,7 +38,7 @@ pub struct I64Extend16S;
 impl I64Extend16S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::sign_extend_low_in_place::<C, 64>(a.to_wires(), 16))
     }
 }
@@ -48,7 +48,7 @@ pub struct I64Extend32S;
 impl I64Extend32S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::sign_extend_low_in_place::<C, 64>(a.to_wires(), 32))
     }
 }
@@ -58,7 +58,7 @@ pub struct I32WrapI64;
 impl I32WrapI64 {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64) -> I32 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I64<C::Wire>) -> I32<C::Wire> {
         let wires = a.to_wires();
         let mut out = [wires[0]; 32];
         out.copy_from_slice(&wires[..32]);
@@ -71,7 +71,7 @@ pub struct I64ExtendI32S;
 impl I64ExtendI32S {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32) -> I64 {
+    pub fn eval<C: CircuitContext>(_ctx: &mut C, a: I32<C::Wire>) -> I64<C::Wire> {
         let wires = a.to_wires();
         let sign = wires[31];
         let mut out = [sign; 64];
@@ -85,7 +85,7 @@ pub struct I64ExtendI32U;
 impl I64ExtendI32U {
     pub const COST: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>) -> I64<C::Wire> {
         let wires = a.to_wires();
         let zero = ctx.constant(Gf2(false));
         let mut out = [zero; 64];

--- a/crates/vm-circuits/src/insn/count.rs
+++ b/crates/vm-circuits/src/insn/count.rs
@@ -15,15 +15,15 @@ impl I32Clz {
         crate::clz_advice_values(a as u64, 32) as u32
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::clz_n::<C, 32>(ctx, a.to_wires()))
     }
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        a: I32,
-        advice: I32,
-    ) -> Result<I32, C::Error> {
+        a: I32<C::Wire>,
+        advice: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let out = crate::clz_advice_n::<C, 32>(ctx, a.to_wires(), advice.to_wires())?;
         Ok(I32::from(out))
     }
@@ -42,15 +42,15 @@ impl I32Ctz {
         crate::ctz_advice_values(a as u64, 32) as u32
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::ctz_n::<C, 32>(ctx, a.to_wires()))
     }
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        a: I32,
-        advice: I32,
-    ) -> Result<I32, C::Error> {
+        a: I32<C::Wire>,
+        advice: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let out = crate::ctz_advice_n::<C, 32>(ctx, a.to_wires(), advice.to_wires())?;
         Ok(I32::from(out))
     }
@@ -61,7 +61,7 @@ pub struct I32Popcnt;
 impl I32Popcnt {
     pub const COST: usize = 88;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I32<C::Wire>) -> I32<C::Wire> {
         I32::from(crate::popcnt_tree_n::<C, 32>(ctx, a.to_wires()))
     }
 }
@@ -79,15 +79,15 @@ impl I64Clz {
         crate::clz_advice_values(a, 64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::clz_n::<C, 64>(ctx, a.to_wires()))
     }
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        a: I64,
-        advice: I64,
-    ) -> Result<I64, C::Error> {
+        a: I64<C::Wire>,
+        advice: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let out = crate::clz_advice_n::<C, 64>(ctx, a.to_wires(), advice.to_wires())?;
         Ok(I64::from(out))
     }
@@ -106,15 +106,15 @@ impl I64Ctz {
         crate::ctz_advice_values(a, 64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::ctz_n::<C, 64>(ctx, a.to_wires()))
     }
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        a: I64,
-        advice: I64,
-    ) -> Result<I64, C::Error> {
+        a: I64<C::Wire>,
+        advice: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let out = crate::ctz_advice_n::<C, 64>(ctx, a.to_wires(), advice.to_wires())?;
         Ok(I64::from(out))
     }
@@ -125,7 +125,7 @@ pub struct I64Popcnt;
 impl I64Popcnt {
     pub const COST: usize = 183;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(ctx: &mut C, a: I64<C::Wire>) -> I64<C::Wire> {
         I64::from(crate::popcnt_tree_n::<C, 64>(ctx, a.to_wires()))
     }
 }

--- a/crates/vm-circuits/src/insn/divrem.rs
+++ b/crates/vm-circuits/src/insn/divrem.rs
@@ -20,12 +20,20 @@ impl I32DivS {
         (q as u32 as i32, r as u32 as i32)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let (q, _r) = crate::divrem_s_n::<C, 32>(ctx, dividend.to_wires(), divisor.to_wires());
         I32::from(q)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: i32) -> I32 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: i32,
+    ) -> I32<C::Wire> {
         let d = const_i32(ctx, divisor);
         let (q, _r) = crate::divrem_s_n::<C, 32>(ctx, dividend.to_wires(), d.to_wires());
         I32::from(q)
@@ -33,11 +41,11 @@ impl I32DivS {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I32,
-        divisor: I32,
-        q: I32,
-        r: I32,
-    ) -> Result<I32, C::Error> {
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+        q: I32<C::Wire>,
+        r: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let (quot, _rem) = crate::divrem_s_advice_n::<C, 32>(
             ctx,
             dividend.to_wires(),
@@ -64,12 +72,20 @@ impl I32DivU {
         (q as u32, r as u32)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let (q, _r) = crate::divrem_u_n::<C, 32>(ctx, dividend.to_wires(), divisor.to_wires());
         I32::from(q)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: i32) -> I32 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: i32,
+    ) -> I32<C::Wire> {
         let d = const_i32(ctx, divisor);
         let (q, _r) = crate::divrem_u_n::<C, 32>(ctx, dividend.to_wires(), d.to_wires());
         I32::from(q)
@@ -77,11 +93,11 @@ impl I32DivU {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I32,
-        divisor: I32,
-        q: I32,
-        r: I32,
-    ) -> Result<I32, C::Error> {
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+        q: I32<C::Wire>,
+        r: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let (quot, _rem) = crate::divrem_u_advice_n::<C, 32>(
             ctx,
             dividend.to_wires(),
@@ -109,12 +125,20 @@ impl I32RemS {
         (q as u32 as i32, r as u32 as i32)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let (_q, r) = crate::divrem_s_n::<C, 32>(ctx, dividend.to_wires(), divisor.to_wires());
         I32::from(r)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: i32) -> I32 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: i32,
+    ) -> I32<C::Wire> {
         let d = const_i32(ctx, divisor);
         let (_q, r) = crate::divrem_s_n::<C, 32>(ctx, dividend.to_wires(), d.to_wires());
         I32::from(r)
@@ -122,11 +146,11 @@ impl I32RemS {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I32,
-        divisor: I32,
-        q: I32,
-        r: I32,
-    ) -> Result<I32, C::Error> {
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+        q: I32<C::Wire>,
+        r: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let (_quot, rem) = crate::divrem_s_advice_n::<C, 32>(
             ctx,
             dividend.to_wires(),
@@ -153,12 +177,20 @@ impl I32RemU {
         (q as u32, r as u32)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         let (_q, r) = crate::divrem_u_n::<C, 32>(ctx, dividend.to_wires(), divisor.to_wires());
         I32::from(r)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I32, divisor: i32) -> I32 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I32<C::Wire>,
+        divisor: i32,
+    ) -> I32<C::Wire> {
         let d = const_i32(ctx, divisor);
         let (_q, r) = crate::divrem_u_n::<C, 32>(ctx, dividend.to_wires(), d.to_wires());
         I32::from(r)
@@ -166,11 +198,11 @@ impl I32RemU {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I32,
-        divisor: I32,
-        q: I32,
-        r: I32,
-    ) -> Result<I32, C::Error> {
+        dividend: I32<C::Wire>,
+        divisor: I32<C::Wire>,
+        q: I32<C::Wire>,
+        r: I32<C::Wire>,
+    ) -> Result<I32<C::Wire>, C::Error> {
         let (_quot, rem) = crate::divrem_u_advice_n::<C, 32>(
             ctx,
             dividend.to_wires(),
@@ -197,12 +229,20 @@ impl I64DivS {
         (q as i64, r as i64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         let (q, _r) = crate::divrem_s_n::<C, 64>(ctx, dividend.to_wires(), divisor.to_wires());
         I64::from(q)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: i64) -> I64 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: i64,
+    ) -> I64<C::Wire> {
         let d = const_i64(ctx, divisor);
         let (q, _r) = crate::divrem_s_n::<C, 64>(ctx, dividend.to_wires(), d.to_wires());
         I64::from(q)
@@ -210,11 +250,11 @@ impl I64DivS {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I64,
-        divisor: I64,
-        q: I64,
-        r: I64,
-    ) -> Result<I64, C::Error> {
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+        q: I64<C::Wire>,
+        r: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let (quot, _rem) = crate::divrem_s_advice_n::<C, 64>(
             ctx,
             dividend.to_wires(),
@@ -240,12 +280,20 @@ impl I64DivU {
         crate::divrem_u_advice_values(dividend, divisor, 64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         let (q, _r) = crate::divrem_u_n::<C, 64>(ctx, dividend.to_wires(), divisor.to_wires());
         I64::from(q)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: i64) -> I64 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: i64,
+    ) -> I64<C::Wire> {
         let d = const_i64(ctx, divisor);
         let (q, _r) = crate::divrem_u_n::<C, 64>(ctx, dividend.to_wires(), d.to_wires());
         I64::from(q)
@@ -253,11 +301,11 @@ impl I64DivU {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I64,
-        divisor: I64,
-        q: I64,
-        r: I64,
-    ) -> Result<I64, C::Error> {
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+        q: I64<C::Wire>,
+        r: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let (quot, _rem) = crate::divrem_u_advice_n::<C, 64>(
             ctx,
             dividend.to_wires(),
@@ -284,12 +332,20 @@ impl I64RemS {
         (q as i64, r as i64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         let (_q, r) = crate::divrem_s_n::<C, 64>(ctx, dividend.to_wires(), divisor.to_wires());
         I64::from(r)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: i64) -> I64 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: i64,
+    ) -> I64<C::Wire> {
         let d = const_i64(ctx, divisor);
         let (_q, r) = crate::divrem_s_n::<C, 64>(ctx, dividend.to_wires(), d.to_wires());
         I64::from(r)
@@ -297,11 +353,11 @@ impl I64RemS {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I64,
-        divisor: I64,
-        q: I64,
-        r: I64,
-    ) -> Result<I64, C::Error> {
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+        q: I64<C::Wire>,
+        r: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let (_quot, rem) = crate::divrem_s_advice_n::<C, 64>(
             ctx,
             dividend.to_wires(),
@@ -327,12 +383,20 @@ impl I64RemU {
         crate::divrem_u_advice_values(dividend, divisor, 64)
     }
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         let (_q, r) = crate::divrem_u_n::<C, 64>(ctx, dividend.to_wires(), divisor.to_wires());
         I64::from(r)
     }
 
-    pub fn eval_const_divisor<C: CircuitContext>(ctx: &mut C, dividend: I64, divisor: i64) -> I64 {
+    pub fn eval_const_divisor<C: CircuitContext>(
+        ctx: &mut C,
+        dividend: I64<C::Wire>,
+        divisor: i64,
+    ) -> I64<C::Wire> {
         let d = const_i64(ctx, divisor);
         let (_q, r) = crate::divrem_u_n::<C, 64>(ctx, dividend.to_wires(), d.to_wires());
         I64::from(r)
@@ -340,11 +404,11 @@ impl I64RemU {
 
     pub fn eval_with_advice<C: CircuitContext>(
         ctx: &mut C,
-        dividend: I64,
-        divisor: I64,
-        q: I64,
-        r: I64,
-    ) -> Result<I64, C::Error> {
+        dividend: I64<C::Wire>,
+        divisor: I64<C::Wire>,
+        q: I64<C::Wire>,
+        r: I64<C::Wire>,
+    ) -> Result<I64<C::Wire>, C::Error> {
         let (_quot, rem) = crate::divrem_u_advice_n::<C, 64>(
             ctx,
             dividend.to_wires(),

--- a/crates/vm-circuits/src/insn/shift.rs
+++ b/crates/vm-circuits/src/insn/shift.rs
@@ -8,7 +8,11 @@ impl I32Shl {
     pub const COST: usize = 160;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I32, amount: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         I32::from(crate::shl_n::<C, 32>(
             ctx,
             value.to_wires(),
@@ -16,7 +20,11 @@ impl I32Shl {
         ))
     }
 
-    pub fn eval_const_amount<C: CircuitContext>(ctx: &mut C, value: I32, amount: i32) -> I32 {
+    pub fn eval_const_amount<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: i32,
+    ) -> I32<C::Wire> {
         let z = crate::zero(ctx);
         I32::from(crate::shift_left_const(
             value.to_wires(),
@@ -32,7 +40,11 @@ impl I32ShrS {
     pub const COST: usize = 160;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I32, amount: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         I32::from(crate::shr_s_n::<C, 32>(
             ctx,
             value.to_wires(),
@@ -40,7 +52,7 @@ impl I32ShrS {
         ))
     }
 
-    pub fn eval_const_amount(value: I32, amount: i32) -> I32 {
+    pub fn eval_const_amount<W: Copy>(value: I32<W>, amount: i32) -> I32<W> {
         let w = value.to_wires();
         let sign = w[31];
         I32::from(crate::shift_right_const(
@@ -57,7 +69,11 @@ impl I32ShrU {
     pub const COST: usize = 160;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I32, amount: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         I32::from(crate::shr_u_n::<C, 32>(
             ctx,
             value.to_wires(),
@@ -65,7 +81,11 @@ impl I32ShrU {
         ))
     }
 
-    pub fn eval_const_amount<C: CircuitContext>(ctx: &mut C, value: I32, amount: i32) -> I32 {
+    pub fn eval_const_amount<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: i32,
+    ) -> I32<C::Wire> {
         let z = crate::zero(ctx);
         I32::from(crate::shift_right_const(
             value.to_wires(),
@@ -81,7 +101,11 @@ impl I32Rotl {
     pub const COST: usize = 160;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I32, amount: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         I32::from(crate::rotl_n::<C, 32>(
             ctx,
             value.to_wires(),
@@ -89,7 +113,7 @@ impl I32Rotl {
         ))
     }
 
-    pub fn eval_const_amount(value: I32, amount: i32) -> I32 {
+    pub fn eval_const_amount<W: Copy>(value: I32<W>, amount: i32) -> I32<W> {
         I32::from(crate::rotate_left_const(
             value.to_wires(),
             (amount as u32 % 32) as usize,
@@ -103,7 +127,11 @@ impl I32Rotr {
     pub const COST: usize = 160;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I32, amount: I32) -> I32 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I32<C::Wire>,
+        amount: I32<C::Wire>,
+    ) -> I32<C::Wire> {
         I32::from(crate::rotr_n::<C, 32>(
             ctx,
             value.to_wires(),
@@ -111,7 +139,7 @@ impl I32Rotr {
         ))
     }
 
-    pub fn eval_const_amount(value: I32, amount: i32) -> I32 {
+    pub fn eval_const_amount<W: Copy>(value: I32<W>, amount: i32) -> I32<W> {
         I32::from(crate::rotate_right_const(
             value.to_wires(),
             (amount as u32 % 32) as usize,
@@ -125,7 +153,11 @@ impl I64Shl {
     pub const COST: usize = 384;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I64, amount: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         I64::from(crate::shl_n::<C, 64>(
             ctx,
             value.to_wires(),
@@ -133,7 +165,11 @@ impl I64Shl {
         ))
     }
 
-    pub fn eval_const_amount<C: CircuitContext>(ctx: &mut C, value: I64, amount: i64) -> I64 {
+    pub fn eval_const_amount<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: i64,
+    ) -> I64<C::Wire> {
         let z = crate::zero(ctx);
         I64::from(crate::shift_left_const(
             value.to_wires(),
@@ -149,7 +185,11 @@ impl I64ShrS {
     pub const COST: usize = 384;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I64, amount: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         I64::from(crate::shr_s_n::<C, 64>(
             ctx,
             value.to_wires(),
@@ -157,7 +197,7 @@ impl I64ShrS {
         ))
     }
 
-    pub fn eval_const_amount(value: I64, amount: i64) -> I64 {
+    pub fn eval_const_amount<W: Copy>(value: I64<W>, amount: i64) -> I64<W> {
         let w = value.to_wires();
         let sign = w[63];
         I64::from(crate::shift_right_const(
@@ -174,7 +214,11 @@ impl I64ShrU {
     pub const COST: usize = 384;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I64, amount: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         I64::from(crate::shr_u_n::<C, 64>(
             ctx,
             value.to_wires(),
@@ -182,7 +226,11 @@ impl I64ShrU {
         ))
     }
 
-    pub fn eval_const_amount<C: CircuitContext>(ctx: &mut C, value: I64, amount: i64) -> I64 {
+    pub fn eval_const_amount<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: i64,
+    ) -> I64<C::Wire> {
         let z = crate::zero(ctx);
         I64::from(crate::shift_right_const(
             value.to_wires(),
@@ -198,7 +246,11 @@ impl I64Rotl {
     pub const COST: usize = 384;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I64, amount: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         I64::from(crate::rotl_n::<C, 64>(
             ctx,
             value.to_wires(),
@@ -206,7 +258,7 @@ impl I64Rotl {
         ))
     }
 
-    pub fn eval_const_amount(value: I64, amount: i64) -> I64 {
+    pub fn eval_const_amount<W: Copy>(value: I64<W>, amount: i64) -> I64<W> {
         I64::from(crate::rotate_left_const(
             value.to_wires(),
             (amount as u32 % 64) as usize,
@@ -220,7 +272,11 @@ impl I64Rotr {
     pub const COST: usize = 384;
     pub const COST_CONST_AMOUNT: usize = 0;
 
-    pub fn eval<C: CircuitContext>(ctx: &mut C, value: I64, amount: I64) -> I64 {
+    pub fn eval<C: CircuitContext>(
+        ctx: &mut C,
+        value: I64<C::Wire>,
+        amount: I64<C::Wire>,
+    ) -> I64<C::Wire> {
         I64::from(crate::rotr_n::<C, 64>(
             ctx,
             value.to_wires(),
@@ -228,7 +284,7 @@ impl I64Rotr {
         ))
     }
 
-    pub fn eval_const_amount(value: I64, amount: i64) -> I64 {
+    pub fn eval_const_amount<W: Copy>(value: I64<W>, amount: i64) -> I64<W> {
         I64::from(crate::rotate_right_const(
             value.to_wires(),
             (amount as u32 % 64) as usize,

--- a/crates/vm-circuits/src/insn/value_tests.rs
+++ b/crates/vm-circuits/src/insn/value_tests.rs
@@ -1,74 +1,63 @@
 use super::*;
 use mpz_circuits::Context;
-use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
+use mpz_fields::gf2::Gf2;
 use mpz_vm_memory::{I32, I64};
 
 struct EvalCtx;
 
 impl Context for EvalCtx {
     type Error = ();
-    type Wire = Gf2_128;
+    type Wire = Gf2;
     type Field = Gf2;
 
-    fn add(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+    fn add(&mut self, a: Gf2, b: Gf2) -> Gf2 {
         a + b
     }
 
-    fn sub(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
-        a + b
+    fn sub(&mut self, a: Gf2, b: Gf2) -> Gf2 {
+        a - b
     }
 
-    fn mul(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+    fn mul(&mut self, a: Gf2, b: Gf2) -> Gf2 {
         a * b
     }
 
-    fn constant(&mut self, v: Gf2) -> Gf2_128 {
-        if v.0 { Gf2_128::ONE } else { Gf2_128::ZERO }
+    fn constant(&mut self, v: Gf2) -> Gf2 {
+        v
     }
 
-    fn assert_const(&mut self, v: Gf2_128, expected: Gf2) -> Result<(), ()> {
-        let exp = if expected.0 {
-            Gf2_128::ONE
-        } else {
-            Gf2_128::ZERO
-        };
-        if v == exp { Ok(()) } else { Err(()) }
+    fn assert_const(&mut self, v: Gf2, expected: Gf2) -> Result<(), ()> {
+        if v == expected { Ok(()) } else { Err(()) }
     }
 }
 
-fn wires<const N: usize>(v: u64) -> [Gf2_128; N] {
-    let mut w = [Gf2_128::ZERO; N];
-    for (i, wi) in w.iter_mut().enumerate() {
-        if (v >> i) & 1 == 1 {
-            *wi = Gf2_128::ONE;
-        }
-    }
-    w
+fn wires<const N: usize>(v: u64) -> [Gf2; N] {
+    core::array::from_fn(|i| Gf2((v >> i) & 1 == 1))
 }
 
-fn read<const N: usize>(w: [Gf2_128; N]) -> u64 {
+fn read<const N: usize>(w: [Gf2; N]) -> u64 {
     let mut v = 0u64;
     for (i, wi) in w.iter().enumerate() {
-        if *wi == Gf2_128::ONE {
+        if wi.0 {
             v |= 1u64 << i;
         }
     }
     v
 }
 
-fn i32_in(v: u32) -> I32 {
+fn i32_in(v: u32) -> I32<Gf2> {
     I32::from(wires::<32>(v as u64))
 }
 
-fn i64_in(v: u64) -> I64 {
+fn i64_in(v: u64) -> I64<Gf2> {
     I64::from(wires::<64>(v))
 }
 
-fn i32_out(x: I32) -> u32 {
+fn i32_out(x: I32<Gf2>) -> u32 {
     read(x.to_wires()) as u32
 }
 
-fn i64_out(x: I64) -> u64 {
+fn i64_out(x: I64<Gf2>) -> u64 {
     read(x.to_wires())
 }
 

--- a/crates/vm-core/benches/witness.rs
+++ b/crates/vm-core/benches/witness.rs
@@ -74,9 +74,6 @@ fn bench_witness_sha256(c: &mut Criterion) {
 
     let msg: Vec<u8> = (0..MSG_LEN).map(|i| i as u8).collect();
 
-    // Allocate the message buffer inside the running module via its canonical
-    // `cabi_realloc` export, exactly as the zk harness does, so the staged
-    // region is in bounds and memory is grown by the guest's own allocator.
     let mut global = Global::new(&module).unwrap();
     let ptr = {
         let mut thread = Thread::new();
@@ -101,8 +98,6 @@ fn bench_witness_sha256(c: &mut Criterion) {
         }
     };
 
-    // Stage the message privately: its loads become symbolic, so the whole hash
-    // executes symbolically and emits the full directive trace (the witness).
     let stage = |global: &mut Global| {
         global.memory_mut().unwrap().write_bytes(ptr, &msg).unwrap();
         global.set_memory_visibility(ptr, MSG_LEN, Visibility::Private);
@@ -114,9 +109,6 @@ fn bench_witness_sha256(c: &mut Criterion) {
         Param::Public(Value::I32(MSG_LEN as i32)),
     ];
 
-    // Validate once: the witnessed run must produce a correct SHA-256 digest
-    // (the prover evaluates the private computation concretely). `hash` returns
-    // the address of the digest it wrote to its own freshly allocated buffer.
     {
         let mut thread = Thread::new();
         thread

--- a/crates/vm-core/src/access_log.rs
+++ b/crates/vm-core/src/access_log.rs
@@ -1,0 +1,117 @@
+//! An append-only log of memory accesses with a call-global clock.
+//!
+//! When enabled on the [`Global`](crate::Global), a [`Thread`](crate::Thread)
+//! records one [`Access`] per completed memory access — including the public
+//! stores that take the silent fast path and never surface as a
+//! [`Directive`](crate::Directive). Threads record their own memory ops;
+//! embedders record host-call writes they perform outside any op (e.g. a
+//! precompile's in-place output) via
+//! [`Global::log_host_write`](crate::Global::log_host_write). The log is shared
+//! public structure: it is identical on every party, so it never carries a
+//! symbolic address even on the party that locally holds it. An embedder (e.g.
+//! a future RAM argument) drains the resident prefix once it has consumed it.
+//!
+//! The clock is implicit by position: there is no per-entry clock field. The
+//! log tracks a [`base`](AccessLog::base) clock; the `i`-th resident entry has
+//! clock `base + i`, and [`clock`](AccessLog::clock) is the clock the next
+//! access will receive.
+
+/// The effective address of a memory access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessAddr {
+    /// A concrete effective byte address, known to all parties.
+    Public(u32),
+    /// A symbolic address: the address register is symbolic, so the effective
+    /// address is deliberately kept out of the shared log — on both parties,
+    /// including the one that locally holds it.
+    Symbolic,
+}
+
+/// Whether a memory access reads from or writes to linear memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessKind {
+    /// A load from memory.
+    Read,
+    /// A store to memory.
+    Write,
+}
+
+/// A single recorded memory access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Access {
+    /// Whether the access reads or writes.
+    pub kind: AccessKind,
+    /// The effective address, or [`AccessAddr::Symbolic`] when the address
+    /// register is symbolic.
+    pub addr: AccessAddr,
+    /// The number of bytes accessed (1, 2, 4, or 8).
+    pub width: u8,
+    /// The per-byte symbolic mask: bit `i` is set iff byte `i` of the access is
+    /// symbolic. Zero when the address is symbolic.
+    pub symbolic_mask: u8,
+    /// The written bytes assembled as a little-endian `u64` for a
+    /// concrete-value write; `None` for reads and symbolic-value writes.
+    pub value: Option<u64>,
+    /// Whether this access also surfaced as a [`Directive`](crate::Directive):
+    /// `false` on the silent fast paths, `true` on the directive paths.
+    pub emitted: bool,
+    /// Whether this is an embedder-initiated (host-call) write recorded via
+    /// [`Global::log_host_write`](crate::Global::log_host_write), as opposed
+    /// to an access performed by a thread memory op.
+    pub host: bool,
+}
+
+/// An append-only log of memory accesses with a call-global clock.
+///
+/// Entries are appended in access order and drained from the front by the
+/// embedder. See the [module documentation](self) for the clock model.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccessLog {
+    base: u64,
+    entries: Vec<Access>,
+}
+
+impl AccessLog {
+    /// Creates an empty log whose clock starts at zero.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the clock the next appended access will receive: `base +
+    /// entries.len()`.
+    pub fn clock(&self) -> u64 {
+        self.base + self.entries.len() as u64
+    }
+
+    /// Returns the clock of the first resident entry, equal to
+    /// [`clock`](Self::clock) when the log is empty.
+    pub fn base(&self) -> u64 {
+        self.base
+    }
+
+    /// Returns the resident suffix of entries; entry `i` has clock `base() +
+    /// i`.
+    pub fn entries(&self) -> &[Access] {
+        &self.entries
+    }
+
+    /// Appends `access`, assigning it the current [`clock`](Self::clock).
+    pub(crate) fn push(&mut self, access: Access) {
+        self.entries.push(access);
+    }
+
+    /// Drops every resident entry whose clock is `< clock`, advancing
+    /// [`base`](Self::base) accordingly.
+    ///
+    /// [`clock`](Self::clock) is unchanged: dropping entries never invents or
+    /// forgets future clocks. A `clock` at or before [`base`](Self::base) drops
+    /// nothing; a `clock` at or beyond the end drops every resident entry and
+    /// leaves the log empty with `base == clock()`.
+    pub fn drain_upto(&mut self, clock: u64) {
+        let drop = clock
+            .saturating_sub(self.base)
+            .min(self.entries.len() as u64) as usize;
+        self.entries.drain(..drop);
+        self.base += drop as u64;
+    }
+}

--- a/crates/vm-core/src/arithmetic.rs
+++ b/crates/vm-core/src/arithmetic.rs
@@ -478,7 +478,6 @@ fn i64_extend32_s(v: i64) -> i64 {
     (v as i32) as i64
 }
 
-// WebAssembly `nearest` rounds halfway cases to the nearest even integer.
 fn f32_nearest(v: f32) -> f32 {
     v.round_ties_even()
 }
@@ -487,8 +486,6 @@ fn f64_nearest(v: f64) -> f64 {
     v.round_ties_even()
 }
 
-// WebAssembly min/max propagate NaN and have defined behavior for signed
-// zeros, neither of which is guaranteed by the std f32/f64 min/max methods.
 fn f32_min(a: f32, b: f32) -> f32 {
     if a.is_nan() || b.is_nan() {
         f32::NAN

--- a/crates/vm-core/src/lib.rs
+++ b/crates/vm-core/src/lib.rs
@@ -23,6 +23,7 @@
 //!   [`StepResult::Blocked`] carrying a [`Pending`] request, which the embedder
 //!   satisfies with the matching `Thread::resolve_*` method.
 
+mod access_log;
 pub(crate) mod analysis;
 pub(crate) mod arithmetic;
 pub(crate) mod bitset;
@@ -35,6 +36,7 @@ pub mod thread;
 pub mod trap;
 pub mod value;
 
+pub use access_log::{Access, AccessAddr, AccessKind, AccessLog};
 pub use call::{Call, Param};
 pub use error::Error;
 pub use memory::Memory;

--- a/crates/vm-core/src/memory.rs
+++ b/crates/vm-core/src/memory.rs
@@ -72,7 +72,6 @@ impl Memory {
         let current_pages = (self.data.len() / 65536) as u32;
         let new_size = self.data.len() + (delta_pages as usize * 65536);
 
-        // WebAssembly spec: memory can grow up to 2^16 pages (4 GiB)
         if new_size as u64 > (1u64 << 16) * 65536 {
             return Err(Trap::MemoryOutOfBounds);
         }
@@ -202,7 +201,7 @@ mod tests {
     #[test]
     fn test_memory_creation() {
         let mem = Memory::new(1, None).unwrap();
-        assert_eq!(mem.len(), 65536); // 1 page = 64 KiB
+        assert_eq!(mem.len(), 65536);
         assert_eq!(mem.size_pages(), 1);
     }
 
@@ -228,7 +227,6 @@ mod tests {
 
     #[test]
     fn test_memory_too_large() {
-        // Trying to create memory larger than 4 GiB should fail
         assert!(Memory::new(65537, None).is_err());
     }
 
@@ -267,9 +265,7 @@ mod tests {
     fn test_read_i32_partial_8bit() {
         let mut mem = Memory::new(1, None).unwrap();
         mem.write_bytes(0, &[0xFF]).unwrap();
-        // Signed: 0xFF as i8 = -1, extended to i32
         assert_eq!(mem.read_i32_partial(0, 1, true).unwrap(), -1);
-        // Unsigned: 0xFF as u8 = 255
         assert_eq!(mem.read_i32_partial(0, 1, false).unwrap(), 255);
     }
 
@@ -277,9 +273,7 @@ mod tests {
     fn test_read_i32_partial_16bit() {
         let mut mem = Memory::new(1, None).unwrap();
         mem.write_bytes(0, &[0xFF, 0xFF]).unwrap();
-        // Signed: 0xFFFF as i16 = -1
         assert_eq!(mem.read_i32_partial(0, 2, true).unwrap(), -1);
-        // Unsigned: 0xFFFF as u16 = 65535
         assert_eq!(mem.read_i32_partial(0, 2, false).unwrap(), 65535);
     }
 
@@ -287,17 +281,14 @@ mod tests {
     fn test_read_i64_partial() {
         let mut mem = Memory::new(1, None).unwrap();
         mem.write_bytes(0, &[0xFF, 0xFF, 0xFF, 0xFF]).unwrap();
-        // Signed: 0xFFFFFFFF as i32 = -1, extended to i64
         assert_eq!(mem.read_i64_partial(0, 4, true).unwrap(), -1);
-        // Unsigned: 0xFFFFFFFF as u32 = 4294967295
         assert_eq!(mem.read_i64_partial(0, 4, false).unwrap(), 4294967295);
     }
 
     #[test]
     fn test_read_out_of_bounds() {
-        let mem = Memory::new(1, None).unwrap(); // 64KB
+        let mem = Memory::new(1, None).unwrap();
 
-        // Reading past end should fail
         assert!(mem.read_i32(65536).is_err());
         assert!(mem.read_i64(65536).is_err());
     }

--- a/crates/vm-core/src/state.rs
+++ b/crates/vm-core/src/state.rs
@@ -1,6 +1,11 @@
 use mpz_vm_ir::{ConstExpr, ElementItems, ElementKind, Instruction, Module};
 
-use crate::{Error, Memory, Trap, Visibility, taint::Taints, value::Value};
+use crate::{
+    Error, Memory, Trap, Visibility,
+    access_log::{Access, AccessAddr, AccessKind, AccessLog},
+    taint::Taints,
+    value::Value,
+};
 
 /// State shared across all calls executing against a single [`Module`].
 ///
@@ -14,6 +19,7 @@ pub struct Global {
     globals: Vec<Value>,
     global_taints: Taints,
     table: Vec<Option<u32>>,
+    access_log: Option<AccessLog>,
 }
 
 impl Global {
@@ -75,6 +81,49 @@ impl Global {
     pub fn set_memory_visibility(&mut self, addr: u32, len: usize, visibility: Visibility) {
         self.memory_taints.set_range(addr, len, visibility.into());
     }
+
+    /// Enables the [`AccessLog`], causing every subsequent memory access to be
+    /// recorded.
+    ///
+    /// Must be called before execution begins so the log captures the whole
+    /// run. Idempotent: calling it again leaves an already-enabled log (and its
+    /// entries) intact. Recording is off by default, so a disabled log costs
+    /// nothing beyond an `Option` check per access.
+    pub fn enable_access_log(&mut self) {
+        self.access_log.get_or_insert_with(AccessLog::new);
+    }
+
+    /// Returns the [`AccessLog`], or `None` if recording is disabled.
+    pub fn access_log(&self) -> Option<&AccessLog> {
+        self.access_log.as_ref()
+    }
+
+    /// Returns a mutable reference to the [`AccessLog`], or `None` if recording
+    /// is disabled. The embedder's hook for draining consumed entries.
+    pub fn access_log_mut(&mut self) -> Option<&mut AccessLog> {
+        self.access_log.as_mut()
+    }
+
+    /// Records an embedder-initiated (host-call) write into the access log.
+    ///
+    /// Thread memory ops record their own accesses; this is the channel for
+    /// writes the embedder performs outside them (e.g. a precompile writing
+    /// its output in place). No-op when the log is disabled. The entry is
+    /// never `emitted`: host writes do not surface as memory-op directives, so
+    /// the emitted-entries ↔ memory-op-directives zip is preserved.
+    pub fn log_host_write(&mut self, addr: u32, width: u8, symbolic_mask: u8, value: Option<u64>) {
+        if let Some(log) = self.access_log.as_mut() {
+            log.push(Access {
+                kind: AccessKind::Write,
+                addr: AccessAddr::Public(addr),
+                width,
+                symbolic_mask,
+                value,
+                emitted: false,
+                host: true,
+            });
+        }
+    }
 }
 
 impl Global {
@@ -128,9 +177,6 @@ impl Global {
             }
         }
 
-        // Size the vector before evaluating initializers so that an
-        // initializer referencing an earlier global resolves against a
-        // populated slot.
         globals.resize(module.globals().len(), Value::I32(0));
 
         for (i, global) in module.globals().iter().enumerate() {
@@ -187,6 +233,7 @@ impl Global {
             globals,
             global_taints: Taints::new(),
             table,
+            access_log: None,
         })
     }
 }
@@ -215,4 +262,48 @@ fn eval_elem_expr(expr: &[Instruction]) -> Result<Option<u32>, Error> {
         }
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn global_with_memory() -> Global {
+        let module = Module::parse(&wat::parse_str("(module (memory 1))").unwrap()).unwrap();
+        Global::new(&module).unwrap()
+    }
+
+    #[test]
+    fn log_host_write_is_noop_when_disabled() {
+        let mut global = global_with_memory();
+        global.log_host_write(0x100, 8, 0, Some(0xdead_beef));
+        assert!(
+            global.access_log().is_none(),
+            "log_host_write must not enable the log"
+        );
+    }
+
+    #[test]
+    fn log_host_write_appends_entry_and_advances_clock() {
+        let mut global = global_with_memory();
+        global.enable_access_log();
+        let before = global.access_log().expect("log enabled").clock();
+        global.log_host_write(0x100, 8, 0, Some(0xdead_beef));
+
+        let log = global.access_log().expect("log enabled");
+        assert_eq!(log.clock(), before + 1, "the host write advances the clock");
+        assert_eq!(
+            log.entries(),
+            &[Access {
+                kind: AccessKind::Write,
+                addr: AccessAddr::Public(0x100),
+                width: 8,
+                symbolic_mask: 0,
+                value: Some(0xdead_beef),
+                emitted: false,
+                host: true,
+            }],
+            "the host write appends the expected unemitted entry"
+        );
+    }
 }

--- a/crates/vm-core/src/thread.rs
+++ b/crates/vm-core/src/thread.rs
@@ -35,6 +35,7 @@ use mpz_vm_ir::Module;
 
 use crate::{
     Directive, Global, MaybeTrap, Op, Operand, Trap, Visibility,
+    access_log::{Access, AccessAddr, AccessKind},
     analysis::{BranchRegion, FunctionAnalysis},
     arithmetic,
     call::{Call, Param},
@@ -310,8 +311,6 @@ impl Thread {
             Some(Pending::Branch) => {
                 self.pending = None;
                 if unreachable {
-                    // A trap is a terminal outcome, not an error: surface it
-                    // as `StepResult::Trapped` on the next `step`.
                     self.deferred_trap = Some(Trap::Unreachable);
                 } else {
                     self.op_counter += 1;
@@ -348,14 +347,11 @@ impl Thread {
             match value {
                 Some(v) => {
                     self.registers[reg.index()] = v;
-                    // The result's visibility is determined by the specific call
-                    // and supplied by the embedder.
                     self.reg_taints.set(reg.as_u32(), Class::from(visibility));
                 }
                 None => return Err(Error::MissingHostCallValue),
             }
         }
-        // The call op_counter was advanced when the directive was emitted.
         self.pending = None;
         Ok(())
     }
@@ -455,12 +451,8 @@ impl Thread {
         for (i, param) in params.into_iter().enumerate() {
             let abs_reg = (reg_base + i) as u32;
             let (value, class) = match param {
-                // This party holds the bits: taints but held.
                 Param::Private(value) => (value, Class::Private),
-                // Public: concrete and held by both parties.
                 Param::Public(value) => (value, Class::Public),
-                // The remote party holds the bits: taints and unheld here
-                // (the register value is a placeholder, never read).
                 Param::Blind(ty) => (Value::zero(ty), Class::Blind),
             };
             self.registers[reg_base + i] = value;
@@ -498,9 +490,6 @@ impl Thread {
     /// [`Error::Unimplemented`] when the operation being executed cannot be
     /// interpreted.
     pub fn step(&mut self, module: &Module, global: &mut Global) -> Result<StepResult, Error> {
-        // An imported call is emitted as a directive and only then marked
-        // pending. If the embedder steps again without resolving it, re-surface
-        // it as blocked rather than erroring.
         if let Some(pending @ Pending::HostCall { .. }) = &self.pending {
             return Ok(StepResult::Blocked(pending.clone()));
         }
@@ -533,7 +522,6 @@ impl Thread {
             _ => return Err(Error::InvalidFunction(func_idx)),
         };
 
-        // Compute (or fetch) the cached branch analysis for this function.
         let analysis = match self.analysis.get(&func_idx) {
             Some(analysis) => Arc::clone(analysis),
             None => {
@@ -574,8 +562,6 @@ impl Thread {
                         bail_out,
                         ..
                     } => {
-                        // Bail-out branches are publicly deducible — don't
-                        // enter private CF, but still require trap resolution.
                         if !bail_out && self.private_cf.is_none() {
                             self.private_cf = Some(match exit {
                                 Some(block) => PrivateCfExit::Join {
@@ -587,10 +573,6 @@ impl Thread {
                                 },
                             });
                         }
-                        // The condition is taints. If this party doesn't hold
-                        // its bits it can't pick a path — block for the embedder
-                        // to resolve. (The operand carries `Some` value iff it
-                        // is available to this party.)
                         if cond_value.is_none() {
                             if exit.is_none() {
                                 self.exit_frame()?;
@@ -600,9 +582,6 @@ impl Thread {
                             return Ok(StepResult::Blocked(Pending::Branch));
                         }
                     }
-                    // Emit the imported call as a directive, but mark it pending
-                    // so a later step blocks until the embedder resolves it with
-                    // `resolve_host_call`.
                     Directive::Call {
                         dst,
                         func_idx,
@@ -622,11 +601,6 @@ impl Thread {
                 Ok(StepResult::Directive(event))
             }
             FrameStepResult::Trapped { directive, trap } => {
-                // An op trapped while executing concretely (e.g. the embedder
-                // evaluated an `i32.div_u` trap condition itself, or a memory
-                // access went out of bounds). Terminal: mark done. The index it
-                // occupies is the current op_counter; no bump (the op is not a
-                // normal emission).
                 let index = self.op_counter;
                 self.done = true;
                 Ok(StepResult::Trapped {
@@ -651,8 +625,6 @@ impl Thread {
                         _ => unreachable!("local call args should be taints"),
                     })
                     .collect();
-                // The callee's frame begins at the current end of the register
-                // file; capture it before `enter_frame` grows it.
                 let param_base = Reg(self.registers.len() as u32);
                 self.enter_frame(cx, func_idx, func, reg_args, dst)?;
                 self.op_counter += 1;
@@ -668,10 +640,6 @@ impl Thread {
                 self.check_private_cf_exit();
                 let src = return_reg.map(|r| popped.reg_base + r);
                 let (dst, reclaim) = if self.call_stack.is_empty() {
-                    // Outermost return: the result lives in the popped frame's
-                    // registers (read by `complete`), so it is neither copied
-                    // into a caller nor reclaimed. Defer `Done` until the next
-                    // step so observers see this `Return` first.
                     self.deferred_complete = true;
                     (None, None)
                 } else {
@@ -694,8 +662,6 @@ impl Thread {
     fn check_private_cf_exit(&mut self) {
         let exited = match self.private_cf {
             Some(PrivateCfExit::Join { block, depth }) => {
-                // Exit when we reach the join block at the right depth,
-                // OR when the call depth drops (function returned/trapped).
                 self.call_stack.len() < depth
                     || (self.call_stack.len() == depth
                         && self
@@ -733,14 +699,12 @@ impl Thread {
             self.registers.resize(target_len, Value::I32(0));
         }
 
-        // Copy args (preserving their class)
         for (i, arg) in args.iter().enumerate() {
             let abs_dst = (reg_base + i) as u32;
             self.registers[reg_base + i] = self.registers[arg.index()];
             self.reg_taints.copy(arg.as_u32(), abs_dst, 1);
         }
 
-        // Zero declared locals (concrete and held)
         let num_params = func_type.params.len();
         let mut local_idx = num_params;
         for local in func.locals() {
@@ -770,10 +734,6 @@ impl Thread {
             .call_stack
             .pop()
             .ok_or_else(|| Error::Internal("no frame to exit".into()))?;
-        // Reclaim the popped frame's register slots: clear their taints and
-        // shrink the register file back to this frame's base so a later call at
-        // the same depth reuses them. This bounds the register file by the live
-        // call stack rather than by total calls made.
         self.reg_taints.set_range(
             frame.reg_base.as_u32(),
             frame.num_regs as usize,
@@ -786,8 +746,6 @@ impl Thread {
     fn complete(&mut self) -> Result<StepResult, Error> {
         self.done = true;
         let (result, symbolic) = if self.has_result {
-            // The return value occupies register 0; its taint there is
-            // authoritative for whether the result is symbolic.
             (Some(self.registers[0]), self.reg_taints.is_symbolic(0))
         } else {
             (None, false)
@@ -868,14 +826,11 @@ impl Frame {
 
     fn operand(&self, registers: &[Value], taints: &Taints, reg: Reg) -> Operand {
         if self.is_symbolic(taints, reg) {
-            // The directive carries the concrete value only if this party
-            // holds it.
             let value = if self.is_available(taints, reg) {
                 Some(self.get(registers, reg))
             } else {
                 None
             };
-            // Directives speak in absolute registers.
             Operand::Symbol {
                 reg: self.abs(reg),
                 value,
@@ -1028,8 +983,6 @@ impl Frame {
                 let false_sym = self.is_symbolic(taints, *if_false);
 
                 if !cond_sym {
-                    // Concrete condition: the result takes the taint and
-                    // availability of the *selected* operand only.
                     let condition = self.get(registers, *cond).as_i32()?;
                     let (result, sel_reg, sel_sym) = if condition != 0 {
                         (self.get(registers, *if_true), *if_true, true_sym)
@@ -1052,10 +1005,6 @@ impl Frame {
                     self.set_clear(registers, taints, *dst, result);
                     self.advance_ip();
                 } else {
-                    // Symbolic condition: the result is taints. This party
-                    // can compute it only if it holds the condition (to pick
-                    // the operand) and that operand; otherwise it is
-                    // taints.
                     let d = Directive::Op(Op::Select {
                         dst: self.abs(*dst),
                         cond: self.operand(registers, taints, *cond),
@@ -1073,7 +1022,6 @@ impl Frame {
                         self.set(registers, *dst, result);
                         self.set_symbolic(taints, *dst, avail);
                     } else {
-                        // Can't pick the operand: placeholder, taints.
                         let placeholder = self.get(registers, *if_true);
                         self.set(registers, *dst, placeholder);
                         self.set_symbolic(taints, *dst, false);
@@ -1125,11 +1073,6 @@ impl Frame {
             }
 
             Instruction::MemoryGrow { dst, pages } => {
-                // The growth mutates shared memory by `pages`, which both parties
-                // must apply identically. If the count is symbolic and not held
-                // here, this party cannot pick it: block for the embedder to
-                // supply it. A held value (concrete, or symbolic but available)
-                // is used directly.
                 let delta = match resolved {
                     Some(v) => v,
                     None if self.is_symbolic(taints, *pages)
@@ -1151,8 +1094,6 @@ impl Frame {
             }
 
             Instruction::MemoryFill { dest, val, len } => {
-                // Destination unknown to this party: surface the op as a
-                // directive, mark memory conservatively, and do not write.
                 if self.addr_unlocatable(taints, *dest) {
                     let d = Directive::Op(Op::MemoryFill {
                         dest: self.operand(registers, taints, *dest),
@@ -1168,7 +1109,6 @@ impl Frame {
                 let dest_addr = self.get(registers, *dest).as_i32()? as usize;
                 let memory = cx.global.memory_mut().ok_or(Error::MemoryNotDefined)?;
                 mem_try!(memory.fill(dest_addr, byte_val, size));
-                // Concrete fill clears taints state at destination.
                 if !in_private_cf {
                     cx.global
                         .memory_taints_mut()
@@ -1254,11 +1194,6 @@ impl Frame {
                 table_idx,
                 args,
             } => {
-                // The call target is selected by the index. If the index is
-                // symbolic and not held here, this party cannot pick the target:
-                // block for the embedder to supply the concrete index. A held
-                // value (concrete, or symbolic but available) dispatches
-                // directly.
                 let idx = match resolved {
                     Some(v) => v,
                     None if self.is_symbolic(taints, *table_idx)
@@ -1344,7 +1279,6 @@ impl Frame {
                         src: self.abs(unary.src),
                     });
                     if self.is_available(taints, unary.src) {
-                        // We hold the operand: compute the real result.
                         let (dst, val) = match arithmetic::execute(instr, |reg| {
                             Ok(registers[reg_base + reg.index()])
                         })? {
@@ -1359,7 +1293,7 @@ impl Frame {
                         registers[reg_base + dst.index()] = val;
                         self.set_symbolic(taints, unary.dst, true);
                     } else {
-                        // We don't: result is taints and taints.
+                        self.set(registers, unary.dst, Value::zero(unary.op.return_ty()));
                         self.set_symbolic(taints, unary.dst, false);
                     }
                     self.advance_ip();
@@ -1382,11 +1316,6 @@ impl Frame {
             InstructionArith::Binary(binary) => {
                 let lhs_sym = self.is_symbolic(taints, binary.lhs);
                 let rhs_sym = self.is_symbolic(taints, binary.rhs);
-                // Ops that may trap based on operand values: the integer
-                // div/rem ops. `DivideByZero` is decided by the divisor
-                // (`rhs`) alone; the signed divides additionally decide
-                // `IntegerOverflow` from the dividend (`lhs`), so they need
-                // both operands available to resolve locally.
                 let could_trap = binary_could_trap(binary.op);
                 let needs_lhs = binary_trap_needs_lhs(binary.op);
                 if lhs_sym || rhs_sym {
@@ -1401,7 +1330,6 @@ impl Frame {
                     self.advance_ip();
 
                     if could_trap && rhs_avail && (!needs_lhs || lhs_avail) {
-                        // Trap-determining operands available: decide locally.
                         let lhs = registers[reg_base + binary.lhs.index()];
                         let rhs = registers[reg_base + binary.rhs.index()];
                         if let Some(trap) = binary_trap(binary.op, lhs, rhs) {
@@ -1413,8 +1341,6 @@ impl Frame {
                     }
 
                     if lhs_avail && rhs_avail {
-                        // All operands held: compute the real result (and
-                        // surface any other trap it raises).
                         match arithmetic::execute(instr, |reg| {
                             Ok(registers[reg_base + reg.index()])
                         })? {
@@ -1430,13 +1356,11 @@ impl Frame {
                             }
                         }
                     } else {
+                        self.set(registers, binary.dst, Value::zero(binary.op.return_ty()));
                         self.set_symbolic(taints, binary.dst, false);
                     }
                     return Ok(FrameStepResult::Directive(d));
                 }
-                // Both operands concrete: compute. A trap surfaces with no
-                // directive (the op is fully public) and is turned into
-                // `StepResult::Trapped` by the caller.
                 match arithmetic::execute(instr, |reg| Ok(registers[reg_base + reg.index()]))? {
                     Ok((dst, val)) => {
                         self.set_clear(registers, taints, dst, val);
@@ -1487,15 +1411,20 @@ impl Frame {
             };
             self.set_clear(registers, taints, dst, value);
             self.advance_ip();
+            if let Some(log) = cx.global.access_log_mut() {
+                log.push(Access {
+                    kind: AccessKind::Read,
+                    addr: AccessAddr::Public(eff_addr),
+                    width: byte_size as u8,
+                    symbolic_mask: 0,
+                    value: None,
+                    emitted: false,
+                    host: false,
+                });
+            }
             return Ok(FrameStepResult::Continue);
         }
 
-        // Build the directive. The address operand carries its concrete value
-        // (or marks it symbolic — the embedder decides what to do with a
-        // symbolic address). For a concrete address, also carry the concrete
-        // bytes in range (symbolic bytes zeroed) and the per-byte symbolic mask,
-        // so an embedder can authenticate the symbolic bytes and materialize the
-        // concrete ones.
         let addr_op = self.operand(registers, taints, addr);
         let (concrete, symbolic_mask) = if addr_sym {
             (0, 0)
@@ -1525,8 +1454,6 @@ impl Frame {
             concrete,
             symbolic_mask,
         });
-        // The loaded value is available iff this party holds the address (to
-        // know which bytes) and holds every byte in range.
         let result_avail = self.is_available(taints, addr)
             && !cx
                 .global
@@ -1545,9 +1472,25 @@ impl Frame {
             self.set(registers, dst, value);
             self.set_symbolic(taints, dst, true);
         } else {
+            self.set(registers, dst, Value::zero(kind.result_ty()));
             self.set_symbolic(taints, dst, false);
         }
         self.advance_ip();
+        if let Some(log) = cx.global.access_log_mut() {
+            log.push(Access {
+                kind: AccessKind::Read,
+                addr: if addr_sym {
+                    AccessAddr::Symbolic
+                } else {
+                    AccessAddr::Public(eff_addr)
+                },
+                width: byte_size as u8,
+                symbolic_mask,
+                value: None,
+                emitted: true,
+                host: false,
+            });
+        }
         Ok(FrameStepResult::Directive(d))
     }
 
@@ -1565,26 +1508,37 @@ impl Frame {
         store_op: Directive,
     ) -> Result<FrameStepResult, Error> {
         let byte_size = kind.byte_size();
-        let mark_all_sym_on_sym_addr = kind.is_narrowing();
+        let full_mask = ((1u16 << byte_size) - 1) as u8;
         if self.is_symbolic(taints, addr) {
             if !self.is_available(taints, addr) {
-                // The destination is unknown to this party: conservatively mark
-                // the whole memory taints and taints, emit, don't write.
-                if mark_all_sym_on_sym_addr && let Some(memory) = cx.global.memory() {
+                if let Some(memory) = cx.global.memory() {
                     let len = memory.len();
                     cx.global
                         .memory_taints_mut()
                         .set_range(0, len, Class::Blind);
                 }
                 self.advance_ip();
+                if let Some(log) = cx.global.access_log_mut() {
+                    log.push(Access {
+                        kind: AccessKind::Write,
+                        addr: AccessAddr::Symbolic,
+                        width: byte_size as u8,
+                        symbolic_mask: full_mask,
+                        value: None,
+                        emitted: true,
+                        host: false,
+                    });
+                }
                 return Ok(FrameStepResult::Directive(store_op));
             }
-            // Address held: write at the (taints) location; the stored bytes
-            // take the value's availability.
             let addr_val = self.get(registers, addr).as_i32()?;
             let eff_addr = (addr_val as u64 + memarg.offset as u64) as u32;
             let val_avail = self.is_available(taints, val);
             let bytes = self.get(registers, val).to_le_bytes();
+            if let Some(memory) = cx.global.memory() {
+                let len = memory.len();
+                cx.global.memory_taints_mut().mark_symbolic_range(0, len);
+            }
             let memory = cx.global.memory_mut().ok_or(Error::MemoryNotDefined)?;
             mem_try!(memory.write_bytes(eff_addr, &bytes[..byte_size]));
             cx.global.memory_taints_mut().set_range(
@@ -1593,6 +1547,17 @@ impl Frame {
                 Class::symbolic(val_avail),
             );
             self.advance_ip();
+            if let Some(log) = cx.global.access_log_mut() {
+                log.push(Access {
+                    kind: AccessKind::Write,
+                    addr: AccessAddr::Symbolic,
+                    width: byte_size as u8,
+                    symbolic_mask: full_mask,
+                    value: None,
+                    emitted: true,
+                    host: false,
+                });
+            }
             return Ok(FrameStepResult::Directive(store_op));
         }
         let addr_val = self.get(registers, addr).as_i32()?;
@@ -1600,7 +1565,6 @@ impl Frame {
         let val_sym = self.is_symbolic(taints, val);
 
         if !val_sym {
-            // Concrete value: bytes become concrete (and available).
             let bytes = self.get(registers, val).to_le_bytes();
             let memory = cx.global.memory_mut().ok_or(Error::MemoryNotDefined)?;
             mem_try!(memory.write_bytes(eff_addr, &bytes[..byte_size]));
@@ -1609,9 +1573,22 @@ impl Frame {
                     .memory_taints_mut()
                     .set_range(eff_addr, byte_size, Class::Public);
             }
+            if let Some(log) = cx.global.access_log_mut() {
+                let mut value = 0u64;
+                for (i, &b) in bytes[..byte_size].iter().enumerate() {
+                    value |= (b as u64) << (i * 8);
+                }
+                log.push(Access {
+                    kind: AccessKind::Write,
+                    addr: AccessAddr::Public(eff_addr),
+                    width: byte_size as u8,
+                    symbolic_mask: 0,
+                    value: Some(value),
+                    emitted: false,
+                    host: false,
+                });
+            }
         } else {
-            // Symbolic value at a concrete address: bytes inherit the value's
-            // taint and availability.
             let val_avail = self.is_available(taints, val);
             if val_avail {
                 let bytes = self.get(registers, val).to_le_bytes();
@@ -1624,6 +1601,17 @@ impl Frame {
                 Class::symbolic(val_avail),
             );
             self.advance_ip();
+            if let Some(log) = cx.global.access_log_mut() {
+                log.push(Access {
+                    kind: AccessKind::Write,
+                    addr: AccessAddr::Public(eff_addr),
+                    width: byte_size as u8,
+                    symbolic_mask: full_mask,
+                    value: None,
+                    emitted: true,
+                    host: false,
+                });
+            }
             return Ok(FrameStepResult::Directive(store_op));
         }
         self.advance_ip();
@@ -1645,9 +1633,6 @@ impl Frame {
             .ok_or(Error::UndefinedFunction(func_idx))?;
 
         match func {
-            // The interpreter does not own host/import semantics. Surface every
-            // imported call as a `Directive::Call` (which `step` turns into a
-            // `Pending::HostCall`) for the embedder to service or reject.
             Function::Import(_) => {
                 let args: Vec<Operand> = args
                     .iter()
@@ -1658,8 +1643,6 @@ impl Frame {
                     dst: dst.map(|r| self.abs(r)),
                     func_idx,
                     args,
-                    // A host/imported call enters no frame, so there is no
-                    // callee parameter base.
                     param_base: Reg(0),
                 }))
             }
@@ -1722,9 +1705,6 @@ impl Frame {
                 if self.is_symbolic(taints, *cond) {
                     let region = analysis.region(self.current_block);
                     if !self.is_available(taints, *cond) {
-                        // We don't hold the condition: emit the taints branch
-                        // directive; `Thread::step` blocks (the cond operand
-                        // carries no value) for the embedder to resolve.
                         return self.handle_symbolic_branch(
                             cx,
                             registers,
@@ -1735,8 +1715,6 @@ impl Frame {
                             in_private_cf,
                         );
                     }
-                    // We hold the condition: emit the directive (and taint),
-                    // then follow the path we know.
                     let result = self.handle_symbolic_branch(
                         cx,
                         registers,
@@ -1797,7 +1775,6 @@ impl Frame {
                         region,
                         in_private_cf,
                     )?;
-                    // We hold the index: follow the real target.
                     let index = self.get(registers, *idx).as_i32()?;
                     let target = if (index as usize) < targets.len() {
                         targets[index as usize]
@@ -1854,14 +1831,12 @@ impl Frame {
         region: &BranchRegion,
         _in_private_cf: bool,
     ) -> Result<FrameStepResult, Error> {
-        // Taint globals written in the branch region.
         for &global_idx in &region.globals_written {
             cx.global
                 .global_taints_mut()
                 .mark_symbolic_range(global_idx, 1);
         }
 
-        // Taint all memory if any store exists in the branch region.
         if region.has_memory_store
             && let Some(memory) = cx.global.memory()
         {
@@ -1869,12 +1844,10 @@ impl Frame {
             cx.global.memory_taints_mut().mark_symbolic_range(0, len);
         }
 
-        // Mark registers written in the branch region as symbolic.
         for &reg in &region.registers_written {
             taints.mark_symbolic_range(self.abs(reg).as_u32(), 1);
         }
 
-        // Also taint the absolute result register (outside the frame).
         if let Some(idx) = self.reg_result {
             taints.mark_symbolic_range(idx.as_u32(), 1);
         }
@@ -1890,8 +1863,6 @@ impl Frame {
         let bail_out = region.bail_out;
 
         if self.is_available(taints, cond_reg) {
-            // We hold the condition: emit it with its value; the caller follows
-            // the path.
             return Ok(FrameStepResult::Directive(Directive::Branch {
                 func_idx: self.func_idx,
                 block: branch_block,
@@ -1965,9 +1936,6 @@ mod tests {
 
     #[test]
     fn memory_grow_blind_pages_blocks_then_resolves() {
-        // The page count is blind (symbolic and unheld), so `memory.grow` must
-        // block rather than error; resolving it re-runs the op with the
-        // supplied count.
         let wat = r#"
             (module
               (memory 1)
@@ -1998,7 +1966,6 @@ mod tests {
                     thread.resolve_memory_grow(1).unwrap();
                 }
                 StepResult::Done { result, .. } => {
-                    // Growing from the initial 1 page returns the prior size.
                     assert_eq!(result, Some(Value::I32(1)));
                     break;
                 }
@@ -2063,10 +2030,6 @@ mod tests {
 
     #[test]
     fn blind_divisor_div_u_emits_directive_and_continues() {
-        // A blind divisor means this party can't decide whether the div_u traps.
-        // The op no longer blocks: it emits as an ordinary directive and
-        // execution continues as if it did not trap. A peer detects any trap by
-        // correlating the op index.
         let module = div_module();
         let (mut thread, mut global) = setup_div_params(
             &module,
@@ -2078,7 +2041,6 @@ mod tests {
             let pre_counter = thread.op_counter();
             match thread.step(&module, &mut global).expect("step") {
                 StepResult::Directive(d) if is_div_u_directive(&d) => {
-                    // The div_u emits at its slot and op_counter bumps once.
                     assert_eq!(thread.op_counter(), pre_counter + 1);
                     assert!(!thread.is_done());
                     div_index = Some(pre_counter);
@@ -2130,9 +2092,6 @@ mod tests {
     fn op_counter_matches_for_div_u() {
         let module = div_module();
 
-        // Drive a thread until it emits the div_u, recording its op index. The
-        // op emits as a Directive at the same slot whether the divisor is held
-        // or blind — the could-trap case no longer blocks.
         let run = |blind_divisor: bool| -> u64 {
             let divisor = if blind_divisor {
                 Param::Blind(ValType::I32)
@@ -2234,5 +2193,424 @@ mod tests {
             }
             assert!(trapped, "public div-by-zero should trap");
         }
+    }
+
+    /// Steps `thread` to completion, collecting every emitted [`Directive`].
+    fn run_collect(module: &Module, global: &mut Global, thread: &mut Thread) -> Vec<Directive> {
+        let mut directives = Vec::new();
+        loop {
+            match thread.step(module, global).expect("step") {
+                StepResult::Directive(d) => directives.push(d),
+                StepResult::Continue => {}
+                StepResult::Done { .. } => break,
+                StepResult::Trapped { trap, .. } => panic!("unexpected trap: {trap:?}"),
+                StepResult::Blocked(p) => panic!("unexpected block: {p:?}"),
+            }
+        }
+        directives
+    }
+
+    /// The per-byte symbolic axis of linear memory, LSB-address first.
+    fn memory_symbolic_axis(global: &Global) -> Vec<bool> {
+        let len = global.memory().expect("memory should be defined").len();
+        (0..len as u32)
+            .map(|i| global.memory_tainted(i, 1))
+            .collect()
+    }
+
+    #[test]
+    fn symbolic_address_store_smears_symbolic_axis_identically() {
+        let wat = r#"
+            (module
+              (memory 1)
+              (func (export "s") (param i32 i32)
+                local.get 0
+                local.get 1
+                i32.store))
+        "#;
+        let module = Module::parse(&wat::parse_str(wat).unwrap()).unwrap();
+        let func_idx = export_func_idx(&module, "s");
+
+        let mut prover_global = Global::new(&module).unwrap();
+        let mut prover = Thread::new();
+        prover
+            .call(
+                &module,
+                &mut prover_global,
+                Call {
+                    func_idx,
+                    params: vec![
+                        Param::Private(Value::I32(8)),
+                        Param::Private(Value::I32(0x1122_3344)),
+                    ],
+                },
+            )
+            .unwrap();
+        run_collect(&module, &mut prover_global, &mut prover);
+
+        let mut verifier_global = Global::new(&module).unwrap();
+        let mut verifier = Thread::new();
+        verifier
+            .call(
+                &module,
+                &mut verifier_global,
+                Call {
+                    func_idx,
+                    params: vec![Param::Blind(ValType::I32), Param::Blind(ValType::I32)],
+                },
+            )
+            .unwrap();
+        run_collect(&module, &mut verifier_global, &mut verifier);
+
+        let prover_axis = memory_symbolic_axis(&prover_global);
+        let verifier_axis = memory_symbolic_axis(&verifier_global);
+        assert_eq!(
+            prover_axis, verifier_axis,
+            "symbolic axes must match after a symbolic-address store"
+        );
+        assert!(
+            prover_axis.iter().all(|&b| b),
+            "the whole memory must be smeared symbolic"
+        );
+    }
+
+    #[test]
+    fn symbolic_address_load_leaves_memory_taint_untouched() {
+        let wat = r#"
+            (module
+              (memory 1)
+              (func (export "l") (param i32) (result i32)
+                local.get 0
+                i32.load))
+        "#;
+        let module = Module::parse(&wat::parse_str(wat).unwrap()).unwrap();
+        let func_idx = export_func_idx(&module, "l");
+
+        let mut prover_global = Global::new(&module).unwrap();
+        let mut prover = Thread::new();
+        prover
+            .call(
+                &module,
+                &mut prover_global,
+                Call {
+                    func_idx,
+                    params: vec![Param::Private(Value::I32(8))],
+                },
+            )
+            .unwrap();
+        let before = memory_symbolic_axis(&prover_global);
+        let directives = run_collect(&module, &mut prover_global, &mut prover);
+
+        let mut verifier_global = Global::new(&module).unwrap();
+        let mut verifier = Thread::new();
+        verifier
+            .call(
+                &module,
+                &mut verifier_global,
+                Call {
+                    func_idx,
+                    params: vec![Param::Blind(ValType::I32)],
+                },
+            )
+            .unwrap();
+        run_collect(&module, &mut verifier_global, &mut verifier);
+
+        assert!(
+            directives
+                .iter()
+                .any(|d| matches!(d, Directive::Op(Op::Load { .. }))),
+            "a symbolic-address load must emit its directive"
+        );
+        assert_eq!(
+            memory_symbolic_axis(&prover_global),
+            before,
+            "a symbolic-address load must not touch memory taint"
+        );
+        assert!(
+            memory_symbolic_axis(&verifier_global).iter().all(|&b| !b),
+            "a symbolic-address load must not touch memory taint on the verifier"
+        );
+    }
+
+    #[test]
+    fn concrete_store_stays_silent_and_logs() {
+        let overwrite_wat = r#"
+            (module
+              (memory 1)
+              (func (export "f") (param i32)
+                i32.const 0
+                local.get 0
+                i32.store
+                i32.const 0
+                i32.const 42
+                i32.store))
+        "#;
+        let module = Module::parse(&wat::parse_str(overwrite_wat).unwrap()).unwrap();
+        let func_idx = export_func_idx(&module, "f");
+        let mut global = Global::new(&module).unwrap();
+        global.enable_access_log();
+        let mut thread = Thread::new();
+        thread
+            .call(
+                &module,
+                &mut global,
+                Call {
+                    func_idx,
+                    params: vec![Param::Private(Value::I32(7))],
+                },
+            )
+            .unwrap();
+        let directives = run_collect(&module, &mut global, &mut thread);
+        let concrete_stores = directives
+            .iter()
+            .filter(|d| {
+                matches!(
+                    d,
+                    Directive::Op(Op::Store {
+                        val: Operand::Concrete(_),
+                        ..
+                    })
+                )
+            })
+            .count();
+        assert_eq!(
+            concrete_stores, 0,
+            "a concrete store must stay silent even when overwriting symbolic bytes"
+        );
+        let log = global.access_log().expect("access log should be enabled");
+        let overwrite = log
+            .entries()
+            .iter()
+            .find(|a| matches!(a.kind, AccessKind::Write) && a.value == Some(42))
+            .expect("the concrete overwrite should be logged");
+        assert!(
+            !overwrite.emitted,
+            "the logged overwrite must be marked unemitted"
+        );
+
+        let public_wat = r#"
+            (module
+              (memory 1)
+              (func (export "g")
+                i32.const 0
+                i32.const 42
+                i32.store))
+        "#;
+        let module = Module::parse(&wat::parse_str(public_wat).unwrap()).unwrap();
+        let func_idx = export_func_idx(&module, "g");
+        let mut global = Global::new(&module).unwrap();
+        let mut thread = Thread::new();
+        thread
+            .call(
+                &module,
+                &mut global,
+                Call {
+                    func_idx,
+                    params: vec![],
+                },
+            )
+            .unwrap();
+        let directives = run_collect(&module, &mut global, &mut thread);
+        let stores = directives
+            .iter()
+            .filter(|d| matches!(d, Directive::Op(Op::Store { .. })))
+            .count();
+        assert_eq!(
+            stores, 0,
+            "a concrete store over public bytes must stay silent"
+        );
+    }
+
+    const MIXED_WAT: &str = r#"
+        (module
+          (memory 1)
+          (func (export "mixed") (param i32 i32)
+            ;; silent public store at address 0
+            i32.const 0
+            i32.const 42
+            i32.store
+            ;; fast-path public load at address 0
+            i32.const 0
+            i32.load
+            drop
+            ;; symbolic-value store at public address 8
+            i32.const 8
+            local.get 0
+            i32.store
+            ;; concrete store overwriting the symbolic bytes at address 8
+            i32.const 8
+            i32.const 99
+            i32.store
+            ;; symbolic-address store
+            local.get 1
+            i32.const 7
+            i32.store))
+    "#;
+
+    fn mixed_module() -> Module {
+        Module::parse(&wat::parse_str(MIXED_WAT).expect("wat should compile"))
+            .expect("module should parse")
+    }
+
+    fn prover_mixed_params() -> Vec<Param> {
+        vec![
+            Param::Private(Value::I32(0x1122_3344)),
+            Param::Private(Value::I32(16)),
+        ]
+    }
+
+    fn verifier_mixed_params() -> Vec<Param> {
+        vec![Param::Blind(ValType::I32), Param::Blind(ValType::I32)]
+    }
+
+    fn run_mixed(params: Vec<Param>, enable_log: bool) -> (Global, Vec<Directive>) {
+        let module = mixed_module();
+        let func_idx = export_func_idx(&module, "mixed");
+        let mut global = Global::new(&module).unwrap();
+        if enable_log {
+            global.enable_access_log();
+        }
+        let mut thread = Thread::new();
+        thread
+            .call(&module, &mut global, Call { func_idx, params })
+            .unwrap();
+        let directives = run_collect(&module, &mut global, &mut thread);
+        (global, directives)
+    }
+
+    /// Collapses a directive to its shape, ignoring operand values, so two runs
+    /// can be compared for a matching directive skeleton.
+    fn directive_skeleton(d: &Directive) -> &'static str {
+        match d {
+            Directive::Call { .. } => "call",
+            Directive::Return { .. } => "return",
+            Directive::Branch { .. } => "branch",
+            Directive::Op(Op::Load { .. }) => "load",
+            Directive::Op(Op::Store { .. }) => "store",
+            Directive::Op(_) => "op",
+        }
+    }
+
+    #[test]
+    fn access_log_disabled_by_default() {
+        let (global, _directives) = run_mixed(prover_mixed_params(), false);
+        assert!(
+            global.access_log().is_none(),
+            "the access log must be off by default"
+        );
+    }
+
+    #[test]
+    fn access_log_does_not_change_behavior() {
+        let (off_global, off_dirs) = run_mixed(prover_mixed_params(), false);
+        let (on_global, on_dirs) = run_mixed(prover_mixed_params(), true);
+
+        let off_skeleton: Vec<_> = off_dirs.iter().map(directive_skeleton).collect();
+        let on_skeleton: Vec<_> = on_dirs.iter().map(directive_skeleton).collect();
+        assert_eq!(
+            off_skeleton, on_skeleton,
+            "enabling the log must not change the directive stream"
+        );
+        assert_eq!(
+            memory_symbolic_axis(&off_global),
+            memory_symbolic_axis(&on_global),
+            "enabling the log must not change memory taint"
+        );
+    }
+
+    #[test]
+    fn prover_verifier_access_logs_match() {
+        let (prover_global, _) = run_mixed(prover_mixed_params(), true);
+        let (verifier_global, _) = run_mixed(verifier_mixed_params(), true);
+
+        let prover = prover_global.access_log().expect("log enabled");
+        let verifier = verifier_global.access_log().expect("log enabled");
+        assert_eq!(
+            prover.entries(),
+            verifier.entries(),
+            "the access log must match field-for-field on both parties"
+        );
+
+        let prover_sym = prover
+            .entries()
+            .last()
+            .expect("the symbolic-address store is the last access");
+        let verifier_sym = verifier
+            .entries()
+            .last()
+            .expect("the symbolic-address store is the last access");
+        assert!(
+            matches!(prover_sym.addr, AccessAddr::Symbolic),
+            "the symbolic-address store must have a symbolic addr on the prover"
+        );
+        assert!(
+            matches!(verifier_sym.addr, AccessAddr::Symbolic),
+            "the symbolic-address store must have a symbolic addr on the verifier"
+        );
+    }
+
+    #[test]
+    fn emitted_entries_zip_memory_directives() {
+        let (global, directives) = run_mixed(prover_mixed_params(), true);
+        let log = global.access_log().expect("log enabled");
+
+        let emitted: Vec<&Access> = log.entries().iter().filter(|a| a.emitted).collect();
+        let mem_dirs: Vec<&Directive> = directives
+            .iter()
+            .filter(|d| {
+                matches!(
+                    d,
+                    Directive::Op(Op::Load { .. }) | Directive::Op(Op::Store { .. })
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            emitted.len(),
+            mem_dirs.len(),
+            "each emitted entry corresponds to one memory directive"
+        );
+        for (access, directive) in emitted.iter().zip(mem_dirs.iter()) {
+            match (access.kind, directive) {
+                (AccessKind::Read, Directive::Op(Op::Load { .. })) => {}
+                (AccessKind::Write, Directive::Op(Op::Store { .. })) => {}
+                _ => panic!("emitted entry {access:?} does not match directive {directive:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn drain_upto_advances_base_and_preserves_clock() {
+        let (mut global, _) = run_mixed(prover_mixed_params(), true);
+        let all: Vec<Access> = global.access_log().expect("log enabled").entries().to_vec();
+        let clock = global.access_log().expect("log enabled").clock();
+        assert_eq!(clock, all.len() as u64);
+
+        let log = global.access_log_mut().expect("log enabled");
+        log.drain_upto(2);
+        assert_eq!(log.base(), 2, "draining two entries advances base to 2");
+        assert_eq!(
+            log.clock(),
+            clock,
+            "draining must not change the next clock"
+        );
+        assert_eq!(
+            log.entries(),
+            &all[2..],
+            "the resident suffix must start at clock 2"
+        );
+
+        let end = log.clock();
+        log.drain_upto(end);
+        assert!(
+            log.entries().is_empty(),
+            "draining up to the clock empties the log"
+        );
+        assert_eq!(
+            log.base(),
+            clock,
+            "the emptied log keeps the full clock as its base"
+        );
+        assert_eq!(log.clock(), clock);
     }
 }

--- a/crates/vm-memory/src/auth.rs
+++ b/crates/vm-memory/src/auth.rs
@@ -6,9 +6,7 @@
 //! the LSB-of-MAC pointer-bit convention (the LSB of the inner
 //! `Gf2_128` carries the authenticated bit value).
 //!
-//! The wire type only has to satisfy [`Wire`] — a purely structural
-//! bound (copy, addition, and the zerocopy traits needed to view a
-//! `[Bit<W>]` as a raw `[W]`). Everything protocol-specific — the
+//! The wire type only has to be `Copy`. Everything protocol-specific — the
 //! [`MAC_ZERO`]/[`MAC_ONE`] constants, the pointer-bit accessor, the
 //! `u128` constructor, and the `Default` encoding of a public-zero wire
 //! — lives only on the concrete `Bit<Gf2_128>` instantiation.
@@ -24,18 +22,9 @@
 //! values. Callers that need those supply them explicitly (see
 //! [`LinearMemory::new`](crate::LinearMemory::new)).
 
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_vm_ir::ValType;
 use thiserror::Error;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
-
-/// Structural requirements on a wire type: it must be `Copy` and
-/// zerocopy-castable so a `[Bit<W>]` can be viewed as a raw `[W]` at the
-/// boundary with crates that work in raw wires. Blanket-implemented for
-/// every conforming type.
-pub trait Wire: Copy + FromBytes + IntoBytes + Immutable + KnownLayout {}
-
-impl<W> Wire for W where W: Copy + FromBytes + IntoBytes + Immutable + KnownLayout {}
 
 /// Per-bit authenticated value over wire type `W`. `repr(transparent)`
 /// over `W` with the matching zerocopy derives, so an array of `Bit<W>`s
@@ -53,21 +42,6 @@ impl<W> Wire for W where W: Copy + FromBytes + IntoBytes + Immutable + KnownLayo
     zerocopy::KnownLayout,
 )]
 pub struct Bit<W = Gf2_128>(pub W);
-
-impl<W: Wire> Bit<W> {
-    /// View a slice of `Bit<W>` as raw `W` without copying, for handing
-    /// wires to crates that operate on raw `W` directly. `Bit<W>` is
-    /// `repr(transparent)` over `W`, so the cast is layout-preserving and
-    /// infallible.
-    pub(crate) fn cast_slice(bits: &[Bit<W>]) -> &[W] {
-        <[W]>::ref_from_bytes(bits.as_bytes()).expect("Bit is repr(transparent) over W")
-    }
-
-    /// Inverse of [`Bit::cast_slice`]: view raw `W` wires as `Bit<W>`s.
-    pub(crate) fn wrap_slice(raw: &[W]) -> &[Bit<W>] {
-        <[Bit<W>]>::ref_from_bytes(raw.as_bytes()).expect("Bit is repr(transparent) over W")
-    }
-}
 
 impl<W> From<W> for Bit<W> {
     fn from(w: W) -> Self {
@@ -145,7 +119,7 @@ macro_rules! wasm_value {
         )]
         pub struct $name<W = Gf2_128>(pub [Bit<W>; $bits]);
 
-        impl<W: Wire> $name<W> {
+        impl<W: Copy> $name<W> {
             /// Bit-width of this value type.
             pub const WIDTH: usize = $bits;
             /// Byte-width of this value type.
@@ -179,21 +153,19 @@ macro_rules! wasm_value {
             /// to a `Context` that operates on raw `W`. The inverse is
             /// `From<[W; WIDTH]>`.
             pub fn to_wires(&self) -> [W; $bits] {
-                Bit::cast_slice(&self.0)
-                    .try_into()
-                    .expect("slice is WIDTH wide")
+                self.0.map(|bit| bit.0)
             }
         }
 
-        impl<W: Wire> From<$name<W>> for AuthValue<W> {
+        impl<W: Copy> From<$name<W>> for AuthValue<W> {
             fn from(v: $name<W>) -> Self {
                 AuthValue::$name(v)
             }
         }
 
-        impl<W: Wire> From<[W; $bits]> for $name<W> {
+        impl<W: Copy> From<[W; $bits]> for $name<W> {
             fn from(wires: [W; $bits]) -> Self {
-                Self(Bit::wrap_slice(&wires).try_into().expect("slice is WIDTH wide"))
+                Self(wires.map(Bit))
             }
         }
     };
@@ -203,6 +175,44 @@ wasm_value!(I32, 32, 4, ValType::I32);
 wasm_value!(I64, 64, 8, ValType::I64);
 wasm_value!(F32, 32, 4, ValType::F32);
 wasm_value!(F64, 64, 8, ValType::F64);
+
+/// Spreads a native `i32` into a cleartext-bit [`I32`], LSB first.
+impl From<i32> for I32<Gf2> {
+    fn from(value: i32) -> Self {
+        I32(core::array::from_fn(|i| Bit(Gf2((value >> i) & 1 != 0))))
+    }
+}
+
+/// Reads a cleartext-bit [`I32`] back into a native `i32`, LSB first.
+impl From<I32<Gf2>> for i32 {
+    fn from(value: I32<Gf2>) -> Self {
+        value
+            .0
+            .iter()
+            .enumerate()
+            .filter(|(_, bit)| bit.0.0)
+            .fold(0, |acc, (i, _)| acc | (1 << i))
+    }
+}
+
+/// Spreads a native `i64` into a cleartext-bit [`I64`], LSB first.
+impl From<i64> for I64<Gf2> {
+    fn from(value: i64) -> Self {
+        I64(core::array::from_fn(|i| Bit(Gf2((value >> i) & 1 != 0))))
+    }
+}
+
+/// Reads a cleartext-bit [`I64`] back into a native `i64`, LSB first.
+impl From<I64<Gf2>> for i64 {
+    fn from(value: I64<Gf2>) -> Self {
+        value
+            .0
+            .iter()
+            .enumerate()
+            .filter(|(_, bit)| bit.0.0)
+            .fold(0, |acc, (i, _)| acc | (1 << i))
+    }
+}
 
 /// Authenticated register value: a typed bundle of [`Bit`]s mirroring
 /// [`mpz_vm_core::value::Value`]. The variant pins both the bit-width
@@ -232,7 +242,7 @@ pub struct AuthValueType {
     pub got: ValType,
 }
 
-impl<W: Wire> AuthValue<W> {
+impl<W: Copy> AuthValue<W> {
     /// WASM type of the underlying value.
     pub fn ty(&self) -> ValType {
         match self {
@@ -378,17 +388,6 @@ mod tests {
             assert_eq!(av.width(), w);
             assert_eq!(av.bits().len(), w);
         }
-    }
-
-    #[test]
-    fn cast_slice_round_trips() {
-        let bits: Vec<Bit> = (0..8).map(|i| bit(i as u128)).collect();
-        let raw = Bit::cast_slice(&bits);
-        assert_eq!(raw.len(), bits.len());
-        for (b, g) in bits.iter().zip(raw) {
-            assert_eq!(&b.0, g);
-        }
-        assert_eq!(Bit::wrap_slice(raw), bits.as_slice());
     }
 
     // -------- newtype tests --------

--- a/crates/vm-memory/src/lib.rs
+++ b/crates/vm-memory/src/lib.rs
@@ -19,8 +19,8 @@ mod memory;
 mod registers;
 mod state;
 
-pub use auth::{AuthValue, AuthValueType, AuthValueWidth, Bit, Byte, F32, F64, I32, I64, Wire};
-pub use memory::LinearMemory;
+pub use auth::{AuthValue, AuthValueType, AuthValueWidth, Bit, Byte, F32, F64, I32, I64};
+pub use memory::{LinearMemory, SharedMemory};
 pub use mpz_vm_ir::ValType;
-pub use registers::Registers;
+pub use registers::{RegDelta, Registers, SharedRegs};
 pub use state::AuthState;

--- a/crates/vm-memory/src/memory.rs
+++ b/crates/vm-memory/src/memory.rs
@@ -19,47 +19,128 @@
 //! - `store_i32_8`, `store_i32_16`
 //! - `store_i64_8`, `store_i64_16`, `store_i64_32`
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use mpz_fields::gf2_128::Gf2_128;
 
-use crate::auth::{Bit, Byte, F32, F64, I32, I64, Wire};
+use crate::auth::{Bit, Byte, F32, F64, I32, I64};
+
+/// Read-only memory layers shared by every worker in a pass: the chunk-initial
+/// base bytes plus each segment boundary's committed memory delta, oldest
+/// first. Memory has no reclaim semantics, so a later write simply shadows an
+/// earlier one.
+#[derive(Debug, Clone)]
+pub struct SharedMemory<W = Gf2_128> {
+    base: Arc<HashMap<u32, Byte<W>>>,
+    deltas: Vec<HashMap<u32, Byte<W>>>,
+}
+
+impl<W: Copy> SharedMemory<W> {
+    /// Begin a shared layer set from `base`'s bytes, shared (not copied).
+    pub fn new(base: &LinearMemory<W>) -> Self {
+        Self {
+            base: Arc::clone(&base.own),
+            deltas: Vec::new(),
+        }
+    }
+
+    /// Append the next boundary's memory delta.
+    pub fn push(&mut self, delta: HashMap<u32, Byte<W>>) {
+        self.deltas.push(delta);
+    }
+
+    /// Read `addr` across `deltas[..upto]` (newest first) then the base.
+    fn get(&self, addr: u32, upto: usize) -> Option<&Byte<W>> {
+        self.deltas[..upto]
+            .iter()
+            .rev()
+            .find_map(|d| d.get(&addr))
+            .or_else(|| self.base.get(&addr))
+    }
+}
 
 /// Sparse byte-addressed linear memory keyed by absolute byte address,
-/// storing one [`Byte<W>`] per tainted address. Carries the public-0 and
-/// public-1 [`Bit<W>`]s used to fill extensions and encode public bytes.
+/// storing one [`Byte<W>`] per tainted address. Either a *plain* store (the
+/// carried chunk memory, whose `own` map holds every byte) or a *layered*
+/// worker seed: an empty `own` overlay above a shared [`SharedMemory`]. Reads
+/// fall through `own` → newest visible delta → … → base; writes land in `own`.
+/// Carries the public-0 and public-1 [`Bit<W>`]s used to fill extensions and
+/// encode public bytes.
 #[derive(Debug, Clone)]
 pub struct LinearMemory<W = Gf2_128> {
-    inner: HashMap<u32, Byte<W>>,
+    own: Arc<HashMap<u32, Byte<W>>>,
+    shared: Option<(Arc<SharedMemory<W>>, usize)>,
     zero: Bit<W>,
     one: Bit<W>,
 }
 
-impl<W: Wire> LinearMemory<W> {
+impl<W: Copy> LinearMemory<W> {
     /// Create an empty memory whose public-0 and public-1 wires are
     /// `zero` and `one`.
     pub fn new(zero: Bit<W>, one: Bit<W>) -> Self {
         Self {
-            inner: HashMap::new(),
+            own: Arc::new(HashMap::new()),
+            shared: None,
             zero,
             one,
         }
     }
 
-    /// Set (or overwrite) the byte at the absolute address `addr`.
-    pub fn set_byte(&mut self, addr: u32, byte: Byte<W>) {
-        self.inner.insert(addr, byte);
+    /// A layered worker memory: an empty overlay above `shared`, seeing its
+    /// first `upto` deltas, reusing this memory's public-0/1 wires.
+    pub fn layered(&self, shared: Arc<SharedMemory<W>>, upto: usize) -> Self {
+        Self {
+            own: Arc::new(HashMap::new()),
+            shared: Some((shared, upto)),
+            zero: self.zero,
+            one: self.one,
+        }
     }
 
-    /// Borrow the byte at `addr`, if any.
+    /// Flatten a layered memory into a plain one, materialising base + visible
+    /// deltas + own overlay into a single map. A no-op for a plain store.
+    pub fn flatten(self) -> Self {
+        let Some((shared, upto)) = self.shared else {
+            return self;
+        };
+        let mut map: HashMap<u32, Byte<W>> = (*shared.base).clone();
+        for delta in &shared.deltas[..upto] {
+            for (a, b) in delta.iter() {
+                map.insert(*a, *b);
+            }
+        }
+        for (a, b) in self.own.iter() {
+            map.insert(*a, *b);
+        }
+        Self {
+            own: Arc::new(map),
+            shared: None,
+            zero: self.zero,
+            one: self.one,
+        }
+    }
+
+    /// Set (or overwrite) the byte at the absolute address `addr`.
+    pub fn set_byte(&mut self, addr: u32, byte: Byte<W>) {
+        Arc::make_mut(&mut self.own).insert(addr, byte);
+    }
+
+    /// Borrow the byte at `addr`, falling through to the shared layers.
     pub fn get_byte(&self, addr: u32) -> Option<&Byte<W>> {
-        self.inner.get(&addr)
+        if let Some(b) = self.own.get(&addr) {
+            return Some(b);
+        }
+        match &self.shared {
+            Some((shared, upto)) => shared.get(addr, *upto),
+            None => None,
+        }
     }
 
     /// Store `val` as a public byte at `addr`, encoding each bit with the
     /// memory's public-0/public-1 wires (LSB first).
     pub fn set_public_byte(&mut self, addr: u32, val: u8) {
-        self.inner.insert(addr, self.public_byte(val));
+        let byte = self.public_byte(val);
+        Arc::make_mut(&mut self.own).insert(addr, byte);
     }
 
     /// Build (without storing) a public byte holding `val`, encoding each bit
@@ -83,7 +164,7 @@ impl<W: Wire> LinearMemory<W> {
 // needed, no nonlinear gates are emitted. Loads return `None` if
 // any required byte is absent.
 
-impl<W: Wire> LinearMemory<W> {
+impl<W: Copy> LinearMemory<W> {
     /// `i32.load`: 4 little-endian bytes → [`I32`].
     pub fn load_i32(&self, addr: u32) -> Option<I32<W>> {
         self.load_i32_mixed(addr, 0, !0)
@@ -369,7 +450,7 @@ impl<W: Wire> LinearMemory<W> {
     /// committed byte.
     fn mixed_byte(&self, addr: u32, i: usize, concrete: u64, symbolic_mask: u8) -> Option<Byte<W>> {
         if symbolic_mask & (1 << i) != 0 {
-            self.inner.get(&(addr + i as u32)).copied()
+            self.get_byte(addr + i as u32).copied()
         } else {
             Some(self.public_byte((concrete >> (i * 8)) as u8))
         }
@@ -423,8 +504,9 @@ impl<W: Wire> LinearMemory<W> {
 
     /// Write `bytes.len()` consecutive bytes starting at `addr`.
     fn write_bytes(&mut self, addr: u32, bytes: &[Byte<W>]) {
+        let own = Arc::make_mut(&mut self.own);
         for (i, byte) in bytes.iter().enumerate() {
-            self.inner.insert(addr + i as u32, *byte);
+            own.insert(addr + i as u32, *byte);
         }
     }
 }

--- a/crates/vm-memory/src/registers.rs
+++ b/crates/vm-memory/src/registers.rs
@@ -1,23 +1,85 @@
-//! Sparse register file. Generic over the cell type so it can be
-//! reused for non-authenticated state and unit-tested with
-//! primitives.
+//! Sparse register file, layered for parallel seeding.
+//!
+//! A [`Registers`] is either a *plain* store — the carried chunk state, whose
+//! `own` map holds every entry — or a *layered* worker seed: an empty `own`
+//! overlay above a shared, read-only [`SharedRegs`] (the chunk-initial base
+//! plus each segment boundary's delta). A worker writes only into `own`; reads
+//! fall through `own` → newest visible delta → … → base. `own` is an [`Arc`]
+//! so a plain store can be shared as a [`SharedRegs`] base without copying.
+//!
+//! Generic over the cell type so it can be reused for non-authenticated state
+//! and unit-tested with primitives.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use mpz_vm_core::Reg;
 
-/// Sparse register file keyed by absolute [`Reg`] index. Frame
-/// layout is the caller's concern; this type is a typed key/value
-/// store, nothing more.
+/// One segment boundary's register delta: the registers it (re)wrote and the
+/// ranges it reclaimed. A reclaim masks the layers below; a set overrides them.
+#[derive(Debug, Clone)]
+pub struct RegDelta<T> {
+    pub sets: HashMap<Reg, T>,
+    pub dropped: Vec<(Reg, u32)>,
+}
+
+/// Read-only register layers shared by every worker in a pass: the
+/// chunk-initial base plus each boundary's [`RegDelta`], oldest first.
+#[derive(Debug, Clone)]
+pub struct SharedRegs<T> {
+    base: Arc<HashMap<Reg, T>>,
+    deltas: Vec<RegDelta<T>>,
+}
+
+impl<T> SharedRegs<T> {
+    /// Begin a shared layer set from `base`'s entries, shared (not copied).
+    pub fn new(base: &Registers<T>) -> Self {
+        Self {
+            base: Arc::clone(&base.own),
+            deltas: Vec::new(),
+        }
+    }
+
+    /// Append the next boundary's delta.
+    pub fn push(&mut self, delta: RegDelta<T>) {
+        self.deltas.push(delta);
+    }
+
+    /// Read `reg` across `deltas[..upto]` (newest first) then the base,
+    /// honouring each delta's reclaims as masks.
+    fn get(&self, reg: Reg, upto: usize) -> Option<&T> {
+        for delta in self.deltas[..upto].iter().rev() {
+            if let Some(v) = delta.sets.get(&reg) {
+                return Some(v);
+            }
+            if covers(&delta.dropped, reg) {
+                return None;
+            }
+        }
+        self.base.get(&reg)
+    }
+}
+
+/// Sparse register file keyed by absolute [`Reg`] index.
 #[derive(Debug, Clone)]
 pub struct Registers<T> {
-    inner: HashMap<Reg, T>,
+    /// Entries written at this layer: the whole store when plain, the worker's
+    /// own writes when layered. `Arc` so a plain store shares as a base for
+    /// free.
+    own: Arc<HashMap<Reg, T>>,
+    /// Ranges reclaimed at this layer, masking the shared layers below. Empty
+    /// for a plain store.
+    own_dropped: Vec<(Reg, u32)>,
+    /// The shared fallthrough and how many of its deltas this worker sees;
+    /// `None` for a plain store.
+    shared: Option<(Arc<SharedRegs<T>>, usize)>,
 }
 
 impl<T> Default for Registers<T> {
     fn default() -> Self {
         Self {
-            inner: HashMap::new(),
+            own: Arc::new(HashMap::new()),
+            own_dropped: Vec::new(),
+            shared: None,
         }
     }
 }
@@ -27,31 +89,91 @@ impl<T> Registers<T> {
         Self::default()
     }
 
-    /// Set (or overwrite) the value at `reg`.
-    pub fn set(&mut self, reg: Reg, value: T) {
-        self.inner.insert(reg, value);
-    }
-
-    /// Borrow the value at `reg`, if any.
+    /// Borrow the value at `reg`, falling through to the shared layers.
     pub fn get(&self, reg: Reg) -> Option<&T> {
-        self.inner.get(&reg)
-    }
-
-    /// Drop every register whose absolute index falls in
-    /// `[base, base + count)`.
-    pub fn drop_range(&mut self, base: Reg, count: u32) {
-        let end = base.saturating_add(count);
-        self.inner.retain(|&r, _| r < base || r >= end);
+        if let Some(v) = self.own.get(&reg) {
+            return Some(v);
+        }
+        if covers(&self.own_dropped, reg) {
+            return None;
+        }
+        match &self.shared {
+            Some((shared, upto)) => shared.get(reg, *upto),
+            None => None,
+        }
     }
 }
 
 impl<T: Clone> Registers<T> {
-    /// Copy `src`'s value to `dst`. No-op if `src` has no value.
-    pub fn copy(&mut self, dst: Reg, src: Reg) {
-        if let Some(v) = self.inner.get(&src).cloned() {
-            self.inner.insert(dst, v);
+    /// A layered worker store: an empty overlay above `shared`, seeing its
+    /// first `upto` deltas.
+    pub fn layered(shared: Arc<SharedRegs<T>>, upto: usize) -> Self {
+        Self {
+            own: Arc::new(HashMap::new()),
+            own_dropped: Vec::new(),
+            shared: Some((shared, upto)),
         }
     }
+
+    /// Set (or overwrite) the value at `reg` in this layer's overlay.
+    pub fn set(&mut self, reg: Reg, value: T) {
+        Arc::make_mut(&mut self.own).insert(reg, value);
+    }
+
+    /// Copy `src`'s value (read through the layers) to `dst`. No-op if `src`
+    /// has no value.
+    pub fn copy(&mut self, dst: Reg, src: Reg) {
+        if let Some(v) = self.get(src).cloned() {
+            self.set(dst, v);
+        }
+    }
+
+    /// Drop every register in `[base, base + count)` from this layer, masking
+    /// it in the shared layers below.
+    pub fn drop_range(&mut self, base: Reg, count: u32) {
+        let end = base.saturating_add(count);
+        Arc::make_mut(&mut self.own).retain(|&r, _| r < base || r >= end);
+        if self.shared.is_some() {
+            self.own_dropped.push((base, count));
+        }
+    }
+
+    /// Flatten a layered store into a plain one, materialising base + visible
+    /// deltas + own overlay into a single map. A no-op for a plain store.
+    pub fn flatten(self) -> Self {
+        let Some((shared, upto)) = self.shared else {
+            return self;
+        };
+        let mut map: HashMap<Reg, T> = (*shared.base).clone();
+        for delta in &shared.deltas[..upto] {
+            for &(b, c) in &delta.dropped {
+                let end = b.saturating_add(c);
+                map.retain(|&r, _| r < b || r >= end);
+            }
+            for (r, v) in &delta.sets {
+                map.insert(*r, v.clone());
+            }
+        }
+        for &(b, c) in &self.own_dropped {
+            let end = b.saturating_add(c);
+            map.retain(|&r, _| r < b || r >= end);
+        }
+        for (r, v) in self.own.iter() {
+            map.insert(*r, v.clone());
+        }
+        Self {
+            own: Arc::new(map),
+            own_dropped: Vec::new(),
+            shared: None,
+        }
+    }
+}
+
+/// Whether `reg` falls in any `[base, base + count)` range.
+fn covers(ranges: &[(Reg, u32)], reg: Reg) -> bool {
+    ranges
+        .iter()
+        .any(|&(base, count)| reg.0 >= base.0 && reg.0 < base.0 + count)
 }
 
 #[cfg(test)]
@@ -101,5 +223,42 @@ mod tests {
         r.set(Reg(5), 50);
         r.drop_range(Reg(5), 0);
         assert_eq!(r.get(Reg(5)), Some(&50));
+    }
+
+    #[test]
+    fn layered_reads_fall_through_and_mask() {
+        let mut base: Registers<u32> = Registers::new();
+        base.set(Reg(0), 1);
+        base.set(Reg(1), 2);
+        base.set(Reg(2), 3);
+
+        let mut shared = SharedRegs::new(&base);
+        // delta 0 overwrites reg 1, drops reg 2.
+        shared.push(RegDelta {
+            sets: HashMap::from([(Reg(1), 20)]),
+            dropped: vec![(Reg(2), 1)],
+        });
+        // delta 1 re-sets reg 2.
+        shared.push(RegDelta {
+            sets: HashMap::from([(Reg(2), 30)]),
+            dropped: vec![],
+        });
+        let shared = Arc::new(shared);
+
+        // Worker sees only delta 0.
+        let w0 = Registers::layered(shared.clone(), 1);
+        assert_eq!(w0.get(Reg(0)), Some(&1)); // base
+        assert_eq!(w0.get(Reg(1)), Some(&20)); // delta 0
+        assert_eq!(w0.get(Reg(2)), None); // dropped by delta 0
+
+        // Worker sees both deltas.
+        let mut w1 = Registers::layered(shared, 2);
+        assert_eq!(w1.get(Reg(2)), Some(&30)); // re-set by delta 1
+        w1.set(Reg(0), 100); // own overlay wins
+        assert_eq!(w1.get(Reg(0)), Some(&100));
+        w1.drop_range(Reg(1), 1); // own drop masks delta 0
+        assert_eq!(w1.get(Reg(1)), None);
+
+        assert_eq!(w1.flatten().get(Reg(2)), Some(&30));
     }
 }

--- a/crates/vm-memory/src/state.rs
+++ b/crates/vm-memory/src/state.rs
@@ -6,6 +6,8 @@
 //! [`LinearMemory<Byte>`]. Frame layout is the caller's concern; this
 //! type is a typed bag of authenticated values.
 
+use mpz_fields::gf2_128::Gf2_128;
+
 use crate::{
     auth::{AuthValue, Bit},
     memory::LinearMemory,
@@ -13,26 +15,40 @@ use crate::{
 };
 
 /// Authenticated state for every symbolic register, symbolic global,
-/// and tainted memory byte in the current run.
+/// and tainted memory byte in the current run, over wire type `W`.
+///
+/// The accumulate/verify passes instantiate `W = Gf2_128` (IT-MAC wires);
+/// the prover's cleartext commit pass uses `W = Gf2` (plaintext bits).
 ///
 /// `regs` is frame-scoped; `globals` and `memory` are long-lived
 /// (shared across calls), mirroring WASM's global and linear-memory
 /// semantics.
 #[derive(Debug, Clone)]
-pub struct AuthState {
-    pub regs: Registers<AuthValue>,
-    pub globals: Registers<AuthValue>,
-    pub memory: LinearMemory,
+pub struct AuthState<W = Gf2_128> {
+    pub regs: Registers<AuthValue<W>>,
+    pub globals: Registers<AuthValue<W>>,
+    pub memory: LinearMemory<W>,
 }
 
-impl AuthState {
+impl<W: Copy> AuthState<W> {
     /// Create empty state whose memory uses `zero`/`one` as its public-0
     /// and public-1 wires.
-    pub fn new(zero: Bit, one: Bit) -> Self {
+    pub fn new(zero: Bit<W>, one: Bit<W>) -> Self {
         Self {
             regs: Registers::default(),
             globals: Registers::default(),
             memory: LinearMemory::new(zero, one),
+        }
+    }
+
+    /// Flatten a layered seed (see [`Registers::layered`] /
+    /// [`LinearMemory::layered`]) into a plain, owned state for carrying to the
+    /// next chunk. A no-op when already plain.
+    pub fn flatten(self) -> Self {
+        Self {
+            regs: self.regs.flatten(),
+            globals: self.globals.flatten(),
+            memory: self.memory.flatten(),
         }
     }
 }

--- a/crates/vm-sys/src/lib.rs
+++ b/crates/vm-sys/src/lib.rs
@@ -47,9 +47,9 @@ pub fn reveal<T: Reveal>(v: T) -> T::Output {
 /// state words `h[0..8]` and `block` is 16 big-endian `u32` words parsed from
 /// its 64 bytes (standard SHA-256 byte order).
 ///
-/// Off wasm the bindings compress in the clear; under the VM the host proves the
-/// compression directly through the circuit instead of replaying the guest's
-/// gates.
+/// Off wasm the bindings compress in the clear; under the VM the host proves
+/// the compression directly through the circuit instead of replaying the
+/// guest's gates.
 pub fn sha256_compress(state: &mut [u32; 8], block: &[u8; 64]) {
     unsafe { imp::sha256_compress(state.as_mut_ptr() as i32, block.as_ptr() as i32) }
 }

--- a/crates/vm-sys/src/sys.rs
+++ b/crates/vm-sys/src/sys.rs
@@ -27,6 +27,7 @@ unsafe extern "C" {
 #[link(wasm_import_module = "crypto")]
 unsafe extern "C" {
     /// Compresses the 64-byte block at `block_ptr` into the 8-word (32-byte)
-    /// state at `state_ptr`, in place: `*state = sha256_compress(*block, *state)`.
+    /// state at `state_ptr`, in place: `*state = sha256_compress(*block,
+    /// *state)`.
     pub fn sha256_compress(state_ptr: i32, block_ptr: i32);
 }

--- a/crates/vm-zk/DESIGN.md
+++ b/crates/vm-zk/DESIGN.md
@@ -1,0 +1,932 @@
+# vm-zk — A streaming VOLE-based zero-knowledge VM for WASM-IR
+
+`vm-zk` is a designated-verifier zero-knowledge virtual machine built on a
+VOLE-based circuit argument (the QuickSilver family): no trusted setup, and no
+public-key cryptography on the hot path. It proves that a program — an
+`mpz-vm-ir` module compiled from WebAssembly — executed correctly on a private
+witness, without revealing that witness. Both parties drive the same program
+through the `Vm` trait; the prover holds the secret inputs and emits a proof,
+the verifier checks it against the public inputs and outputs.
+
+This document is the architectural reference for the system. It describes the
+target design as a whole, organised around the single concern that shapes every
+decision: **performance** — proving throughput, bounded memory, and parallel
+scaling. Mechanisms that are designed but not yet wired are marked *(target)* at
+the point of description and consolidated in §13.
+
+**Vocabulary.** Five nouns recur. A **wire** is one authenticated bit (§4.1). A
+**tape** is a vector of correlation drawn from sVOLE, consumed one entry per
+commitment (§4.1). The **skeleton** is the deterministic public structure of an
+execution both parties derive identically (§5.5). A **chunk** is one streamed,
+bounded unit of proving (§6); a **segment** is a parallel sub-range of a chunk
+(§7).
+
+---
+
+## 1. Purpose and scope
+
+The VM executes the integer subset of WebAssembly semantics (i32/i64 arithmetic,
+bitwise, shifts, comparisons, division with advice, linear memory, globals,
+calls, structured control flow) plus a small set of host calls (value reveals
+and cryptographic precompiles). Floating point is out of scope for the proof.
+
+The proof is **interactive and designated-verifier**: there is no public
+verifiability and no trusted setup. Interaction is one challenge round per chunk
+(commit → challenge), plus one closing round-trip for the whole-call memory check
+(§8.6). Soundness rests on the verifier holding a secret MAC key `Δ` and
+sampling fresh challenges; this trades universal verifiability for speed.
+
+---
+
+## 2. Trust and security model
+
+- **Parties.** A prover and a verifier connected by a transport-agnostic
+  channel. The protocol is executor- and transport-agnostic (`Sink`/`Stream`),
+  with correlated randomness supplied by an sVOLE channel.
+- **Privacy.** The verifier learns the program, the public inputs/outputs, any
+  values the prover explicitly reveals, and the *public skeleton* of execution
+  (control flow and addresses that are public — see §5.3, §5.5). It learns
+  nothing else about the witness.
+- **Soundness.** A cheating prover convinces the verifier with probability
+  negligible in the field size. Every authenticated value carries an IT-MAC
+  under `Δ`; challenges are sampled by the verifier *after* the prover commits,
+  so the witness cannot be adapted to them.
+- **Determinism.** Both parties derive an identical execution skeleton from the
+  program and public inputs. All protocol-shaping quantities (chunk boundaries,
+  segment marks (§7), tape sizes (§4.1), challenge counts) are functions of that
+  shared skeleton, never of private data or local machine characteristics. This
+  is what lets the two sides stay in lockstep without negotiation, and the same
+  guarantee that admits cross-chunk pipelining (§12).
+
+### 2.1 Security parameters
+
+| Component | Field / primitive | Per-check error |
+|-----------|-------------------|-----------------|
+| MAC and gate challenge | `GF(2^128)` | ≈ 2⁻¹²⁸ |
+| Memory grand product *(target)* | `GF(2^64)`, challenges `r`, `γ` | ≈ 2⁻⁶⁴ per entry, amortised over the trace |
+| Assertion binding | blake3 (256-bit) | 2⁻¹²⁸ collision |
+| Output mask | 128-bit VOPE line | information-theoretic |
+
+The MAC key satisfies `Δ` LSB = 1 (a protocol invariant): the low-bit pointer
+convention that lets a wire carry its bit in the MAC's LSB requires it. One
+fresh challenge is drawn per multiplication and per polynomial constraint; the
+overall soundness error is a union bound over all checks in a proof.
+
+---
+
+## 3. Design principles (the performance north star)
+
+Every structural choice below follows from one of these. Each names the section
+that realises it.
+
+1. **Public work is free** (§5.3). The proof pays only for *authenticated*
+   computation. Any value, branch, or address both parties can compute is
+   evaluated in the clear and contributes zero gates, zero commitment, zero
+   communication. The taint and skeleton machinery (§5.4–5.5) exists to separate
+   public structure from private witness so only the witness-dependent residue
+   enters the circuit.
+
+2. **Commit little, derive much** (§4.1, §4.5, §7.1, §8.3–8.4). sVOLE correlation is the
+   dominant cost, so the design minimises committed bits. IT-MACs combine
+   linearly for free, so only nonlinear gates and genuine inputs are committed.
+   Three mechanisms push this further: boundary *deltas* commit only what a
+   segment writes; the accelerated grand product commits only chunk-boundary
+   partial products; the composite polynomial check commits no intermediate
+   products at all.
+
+3. **Stream to bound memory** (§6). Execution is proven in fixed-size *chunks* so
+   that per-chunk proving buffers stay bounded regardless of trace length. A
+   chunk's gate budget is sized so its correlation demand typically fits a single
+   Ferret extension round.
+
+4. **Parallelise within the bound** (§7). Each chunk splits into *segments*
+   proven by independent workers. The accumulate pass is linear in the verifier's
+   challenge weights, so disjoint trace ranges fold independently and combine by
+   field addition; segment workers exchange no wires, only re-materialise shared
+   commitments off a common tape.
+
+5. **One allocation, two passes, fewest rounds** (§4.3, §6.2). Correlated
+   randomness is challenge-independent, so each chunk draws it in a single
+   allocation — and that same independence lets the allocation be prefetched for
+   the next chunk under the current one's proving (§12). The prover walks the
+   circuit twice — a cheap plaintext *commit* pass and a proof-folding
+   *accumulate* pass — separated by exactly the challenges soundness requires.
+
+6. **One field where it suffices, two where it pays** (§4.6). Bit-level VM
+   semantics run over `GF(2)`; the memory permutation argument runs over
+   `GF(2^64)`, where one element carries 64 packed bits and the grand product
+   shrinks accordingly. Both share the same `GF(2^128)` MACs and fold into one
+   proof.
+
+---
+
+## 4. Proof system foundation
+
+### 4.1 Authenticated wires
+
+Every secret bit `b` is carried as an information-theoretic MAC: the prover holds
+`M = K + b·Δ`, the verifier holds the key `K`, and only the verifier knows `Δ`.
+Addition of wires is local on both sides (XOR of MACs / keys), so linear circuit
+structure is free. The convention packs the bit into the low bit of the MAC, so a
+wire is a single `GF(2^128)` element. Public constants use fixed, agreed wires.
+
+A **tape** is a vector of such correlations drawn from sVOLE: the prover gets
+`(mask, MAC)` per entry, the verifier gets the matching key. Committing a witness
+bit means recording one *adjustment* bit (the difference between the bit and its
+mask); the verifier applies the adjustment to its key to reach the same wire.
+
+### 4.2 QuickSilver: the multiplication check and assertion binding
+
+Linear gates are free; the proof only has to certify multiplications and constant
+assertions. For each multiplication the prover accumulates two `GF(2^128)` running
+sums `(u, v)` weighted by a per-gate verifier challenge, and the verifier
+accumulates a single `w`. A correct circuit satisfies `w = u + Δ·v`; a single
+cheated gate breaks the identity with overwhelming probability — which is exactly
+why each gate draws an *independent* challenge rather than a shared power series.
+
+Constant assertions bind public facts into the proof. Each one folds the
+asserted wire (the MAC on the prover, the key on the verifier) into a running
+blake3 **assertion hash**; per-segment hashes are concatenated and re-hashed. The
+assertion hash is the binding primitive for outputs, reveals, and operand-bound
+traps: a cheated asserted value changes the folded wire and so the digest, and
+the verifier accepts only when its digest matches the prover's alongside the
+masked `(u, v)` check.
+
+### 4.3 The two-pass protocol
+
+The prover walks the circuit twice:
+
+- **Commit pass** — mask-only plaintext evaluation. It XORs each witness bit and
+  each gate output into the mask tape in place, never touching MACs, producing
+  the adjustment bits. It reads only wire LSBs — no field multiply, no challenge
+  draw — so it is far cheaper per gate than accumulate, and embarrassingly
+  parallel.
+- **Accumulate pass** — run from the committed tape with the verifier's challenge
+  stream installed, folding every multiplication and assertion into `(u, v)` and
+  the assertion hash.
+
+The verifier performs a single accumulate pass over the same circuit from the
+commitment it received, materialising its wires from the adjustment bits. The
+prover therefore does ~2× the gate walks of the verifier; the commit pass cannot
+be fused into allocation because it *produces* the adjustment bits the verifier
+needs before any challenge exists. Because both accumulate passes are *linear in
+the challenge weights*, a trace may be folded in disjoint sub-ranges — each over
+its slice of the tape with the challenge stream seeked to its gate offset — and
+the partials summed. This linearity is the foundation of segment parallelism
+(§7) and of cross-chunk pipelining (§12).
+
+### 4.4 VOPE masking
+
+The raw `(u, v)` would leak witness information, so before sending them the prover
+masks them with a VOPE (vector oblivious polynomial evaluation) correlation — a
+one-time affine line in `Δ` whose verifier-side value cancels in the final check.
+The verifier accepts iff the masked triple identity holds and the assertion
+hashes match. One VOPE line covers the whole chunk and is amortised across all
+its segments, so the proof is constant-size per chunk: an assertion hash, two
+field elements, and (when polynomial constraints are present) a fixed-length
+coefficient vector.
+
+### 4.5 Composite polynomial constraints *(target)*
+
+Some relations are naturally high-degree (the memory grand product is the leading
+example). Rather than committing every intermediate product, the system verifies
+a degree-`d` polynomial constraint `f(w) = 0` directly: the prover folds each
+constraint into per-degree accumulators and sends `d_max` masked coefficients per
+proof; the verifier batches all constraints into one check against powers of `Δ`.
+This keeps the committed footprint independent of constraint degree — the
+mechanism that makes the accelerated grand product worth its degree. The
+machinery is built (`zk-core::poly`); it is exercised once the memory argument is
+wired (§13).
+
+### 4.6 The GF(2^64) extension *(target)*
+
+The same machinery runs over `GF(2^64)` instead of single bits, keeping the
+`GF(2^128)` MACs (a subfield IT-MAC). Sixty-four committed boolean bits *pack*
+injectively into one `GF(2^64)` wire for free — the canonical lift the memory
+argument relies on to turn already-committed tuples into field elements without
+fresh correlation. Both the multiplication check and the polynomial check are
+available in this field. The two fields share the proof: their `(u, v)`
+accumulators add, their polynomial states merge, and one VOPE masks the combined
+result. The contexts are built (`zk-core::gf64`); they enter the pipeline with
+the memory argument (§13).
+
+---
+
+## 5. Execution model
+
+### 5.1 Programs and the IR
+
+A program is an `mpz-vm-ir` `Module`: function signatures, imported and local
+functions, linear memories, globals, tables, and data segments. Local functions
+are control-flow graphs over a register IR; imports are host calls (reveals and
+precompiles). Both parties load the same module and drive it through the `Vm`
+trait: `write` stages inputs, `call` proves a function, `read`/`reveal` query
+results.
+
+Execution is interpreted by a `Thread` over shared `Global` state (concrete
+memory, globals, tables, and per-byte/per-global visibility taints). Stepping the
+thread yields a stream of **directives** — `Op` (copy, global get/set, binary,
+unary, load, store), `Call`, `Return`, `Branch` — the linearised, register-level
+skeleton of execution.
+
+### 5.2 Public versus symbolic
+
+Each value is either **public** (concrete, known to both parties) or **symbolic**
+(authenticated, known in clear only to the holding party). Symbolic in turn
+splits into Private and Blind by which party holds the bits (§5.4), and the mask
+that blends mixed loads is read off memory taint. The distinction is per operand,
+per memory byte, and per global. Operations on entirely public operands are
+executed in the clear and never enter the circuit; mixed loads blend public and
+symbolic bytes by mask; a constant operand selects cheaper, constant-specialised
+gadget variants. This is principle 1: the cost of a program is the cost of its
+*symbolic* residue, not its instruction count.
+
+Control flow follows from this. The captured directive trace is already the
+linearised taken path, so a `Branch` is a no-op in replay and emits zero gates —
+free public structure. The current design supports only public (publicly
+deducible) branch conditions; a symbolic condition is rejected as unsupported,
+as are a symbolic indirect-call table index and a symbolic `memory.grow` count,
+because resolving them privately would diverge the shared skeleton (§5.5). These
+are the boundaries of the supported directive set.
+
+### 5.3 Authenticated state
+
+Alongside the concrete thread state, the proof tracks an `AuthState`:
+authenticated registers, globals, and byte-addressed linear memory, each value a
+bundle of authenticated bits (`I32`/`I64` as 32/64 wires). This is the witness as
+the circuit sees it. Public-addressed loads and stores of routable bytes are pure
+wire routing — slicing and concatenating bytes — and cost no gates; only
+arithmetic and logic gates do. Reads of unroutable bytes and writes under an open
+bracket instead enter the memory argument (§8).
+
+### 5.4 Memory tainting
+
+The public-versus-symbolic split of §5.2 is not a property a value carries on its
+own; it is read off **taint** — per-item visibility state both parties maintain
+in lockstep. Taint is the mechanism that decides what is authenticated and what
+is free, that keeps the two skeletons identical, and that stops either party from
+reading committed memory it is not entitled to.
+
+**Three classes.** Every register, global, and memory byte is one of three
+visibility classes: **Public** (concrete, both parties hold the cleartext),
+**Private** (symbolic, the *local* party holds the bits), or **Blind** (symbolic,
+*another* party holds the bits and the local party does not). The split between
+Private and Blind is purely local and dual: a private input the prover stages is
+exactly the blind input the verifier reserves for it — the same wire from both
+sides. Each taint domain stores a *symbolic* axis and a *held* axis, so an item
+is Public when not symbolic, Blind when symbolic and unheld, and Private when
+symbolic and held. The symbolic axis drives the proof; the held axis only records
+which side can read the plaintext and never differs in shape between the parties.
+
+**Three domains.** Taint lives wherever a value lives. Register taints travel
+with the executing thread — frame-scoped, reclaimed when a frame pops — while
+global taints and byte-granular memory taints live in the shared `Global`
+alongside the concrete state. Memory taint is per byte because WASM stores have
+partial widths: a `store8` can taint one byte of a word a later load reads whole.
+
+**Taint as the authenticated/free decision.** An operation enters the circuit
+only when a taint says it must. A binary op on two public operands is evaluated
+in the clear and emits no directive; a load whose address and bytes are all
+public returns a concrete value and never touches a wire. The pivotal case is the
+*mixed* load. Capture computes a per-byte **symbolic mask** over the loaded range
+straight from the memory taints — bit `i` set iff byte `i` is symbolic — and
+records it on the load directive together with the public bytes (symbolic
+positions zeroed). Replay consumes the mask byte by byte: a symbolic byte sources
+its committed wires from authenticated memory, a public byte is materialised as
+public-bit wires on the fly. The mask is the exact line between paid and free work
+*inside a single instruction*, and because it is read off shared taint both
+parties emit the identical blend. This is principle 1 at sub-instruction
+granularity, and the concrete reason memory taint is tracked per byte.
+
+**Propagation.** Public computation moves cleartext and clears taint: storing a
+concrete value marks its bytes Public, erasing any earlier symbolic taint there,
+so a region overwritten in the clear costs nothing downstream. Storing a symbolic
+value taints the written bytes — Private if the storing party holds them, Blind
+otherwise — and a load of any symbolic byte taints its destination register. This
+is why a boundary snapshot must consult live taint rather than the write log
+alone: a byte written symbolically inside a segment but publicly overwritten
+before the mark has a dead wire and must not be stitched across the boundary
+(§7.1).
+
+**Identical skeletons.** The symbolic axis is a function of public structure
+alone — which inputs were declared private or blind, and which operations touched
+them — so it is bit-for-bit identical on both parties, even though the held axis
+is local. Capture leans on this directly: at each segment mark both sides record
+the same symbolic registers, symbolic globals, and publicly-overwritten bytes,
+and so derive the same boundary layout, tape lengths, and challenge counts
+without exchanging them. Taint is the concrete reason the determinism principle
+(§2) extends to the witness-dependent structure of the proof, not just to control
+flow and addresses.
+
+**Symbolic addresses and the three contracts.** Everything above assumes the
+*address* of an access is public, so both parties name the same cell. A symbolic
+address breaks that: the prover holds the target, the verifier cannot, and the
+shared skeleton may depend only on public structure. Taint answers *who knows* a
+value; how the proof *names* that value once its address is symbolic is a
+proof-system concern that belongs to vm-zk alone (custody, §8). vm-core stays free
+of custody and discharges its part in three contracts, none of which name brackets
+or routability:
+
+- **Symmetric smear.** A symbolic-address *store* — any width — smears the
+  *symbolic* axis over the full reachable range identically on both parties: the
+  prover, who holds the address, marks the range Private; the verifier marks it
+  Blind. The held axis is where the two sides legitimately differ; the symbolic
+  axis never does, so the shared-skeleton invariant above — the symbolic axis is a
+  function of public structure alone — is preserved. A symbolic-address *load*
+  leaves memory taint untouched: it changes no byte's value, and taint answers
+  value knowledge — only the load's destination register is symbolic, as any
+  symbolic op's result is. Today the reachable range is the whole linear memory; a
+  declared or range-asserted region is the future refinement *(target)*.
+- **Observable overwrites.** A concrete store that overwrites symbolic bytes emits
+  its directive *before* clearing their taint, so every transition of committed
+  state is observable to the embedder. For vm-zk that directive is the re-anchoring
+  store (§8.2) whose logged tuple retires the cell's standing multiset entry. A
+  store whose target bytes are already fully public stays silent and free — the
+  common path is untouched.
+- **Observable stores under an open bracket** *(target)*. vm-core exposes an
+  embedder-controlled **store-observability mode**: while enabled, every store
+  emits its directive regardless of taint, so a value change in bytes that are
+  bracketed but publicly tainted still surfaces to the embedder. vm-zk enables the
+  mode at the first symbolic-address access; both parties see that access's
+  directive at the same step, so the mode flips identically on both sides and the
+  skeleton stays shared. The mechanism lives in vm-core, the policy in the
+  embedder — vm-core still knows nothing of brackets or routability.
+
+**The tainted-read guard.** A party may read linear memory through the `Vm`
+interface only where it is untainted. Reading a symbolic range fails by
+construction: the prover would be leaking witness it has not opened, and the
+verifier simply does not hold the cleartext. This guard is what makes "commit,
+then optionally open" sound — committed-but-unrevealed memory is unreadable on
+both sides until a reveal lifts it (§9.2).
+
+### 5.5 The deterministic skeleton (capture)
+
+Before proving, both parties *capture* a chunk: they step the thread in lockstep,
+recording an identical directive trace, its gate cost (§10), its segment marks
+(§7), the host-call actions, and (prover only) the plaintext snapshots needed at
+boundaries. The verifier reaches the same skeleton because control flow and
+public structure are shared; the prover announces only the unavoidable public
+outcomes (a trap and its location, the payloads of reveals) ahead of capture so
+the verifier can mirror them. Capture is where public work is discharged for free
+and where the protocol's shared shape — every tape length and challenge count —
+is fixed. It reads no MAC tape and no challenge, which is what lets it run ahead
+of proving for pipelining (§12).
+
+---
+
+## 6. Streaming: chunks
+
+### 6.1 Bounded buffers and the correlation budget
+
+A long execution is proven as a sequence of chunks, each capped at a fixed gate
+budget (`DEFAULT_CHUNK_CAP`). A chunk is the pipeline's lookahead window (§12); the
+cap bounds its gate-plus-advice op cost so that per-chunk proving buffers —
+capture, the plan, the mask and MAC tapes, the boundary tape — are bounded
+independent of trace length. The cap is chosen so the
+op cost fits comfortably within the net correlations one Ferret extension round
+delivers (one round produces a large batch, minus the seed it reserves for the
+next).
+
+The cap bounds op cost, not the full allocation: a chunk's sVOLE demand is its op
+cost *plus* the input/memory-commit prefix, the boundary-commitment bits, and the
+VOPE tail. This total typically still fits one extension round, but input- or
+write-heavy chunks can push it over and require a second. The cost accounting
+(§10) is responsible for keeping the worst-case overhead within budget.
+
+### 6.2 The per-chunk protocol
+
+Each chunk runs the two-pass protocol (§4.3) over a single sVOLE allocation:
+
+1. **Capture** the chunk (both, lockstep, §5.5) — challenge-independent, so it
+   can run ahead of the previous chunk's proof (§12).
+2. **Announce** trap/reveal outcomes (prover → verifier) — one one-way flight,
+   sent for every chunk, including fully-public ones.
+3. **Plan** the segmentation and memory layout from the shared skeleton (both).
+4. **Allocate** one sVOLE tape sized for the whole chunk — gates, advice,
+   boundary commitments, input commitments, the memory argument's commitments,
+   and the VOPE masks. Because the size is a deterministic function of the shared
+   skeleton and is challenge-independent, this allocation can be issued for the
+   *next* chunk while the current one is still proving, taking the Ferret flush
+   off the steady-state critical path (§12).
+5. **Commit pass** (parallel segments, §4.3): produce the adjustment bits.
+6. **Commit** the adjustments and squeeze the challenges soundness requires.
+7. **Accumulate pass** (parallel segments, §4.3): fold the proof.
+8. **Prove**: send the masked proof, the output, and any revealed cleartext.
+
+State that outlives the chunk — the authenticated registers, globals, and the
+working memory set — is carried forward to seed the next chunk.
+
+The wire messages, in protocol order, are: `ChunkOutcome` (trap announcement plus
+disclosed reveal payloads), `Commitment` (the adjustment bit-vector), the 32-byte
+challenge, and `ProofMessage` (output, revealed cleartext, and the `Proof` —
+assertion hash, masked `u`/`v`, coefficient vector). The verifier checks the
+commitment length against its own deterministically-derived tape size and rejects
+inconsistent trap fields.
+
+### 6.3 The fully-public fast path
+
+A chunk that reaches no authenticated work before the program ends or traps — no
+committed bits, no gates, only public computation — has nothing to prove. Both
+parties detect this from the shared skeleton and skip the
+allocate/commit/challenge/prove exchange in lockstep. Such a chunk incurs only
+the one-way `ChunkOutcome` announce (step 2) that keeps the two parties in
+lockstep — no proving round-trip.
+
+---
+
+## 7. Parallelism: segments
+
+### 7.1 Boundary deltas
+
+A chunk's trace is split at cost marks into segments proven by independent
+workers. The challenge is continuity: worker `j+1` must see the state worker `j`
+produced. The design avoids passing wires between workers — which would serialise
+them — by committing, at each segment boundary, a **delta**: only the registers,
+globals, and memory bytes that segment *wrote* (consulting live taint, §5.4, so a
+byte overwritten in the clear is not stitched, and skipping unroutable bytes (§8.3),
+whose values live only in the memory argument's committed tuples and need no worker
+stitching — re-anchored, routable bytes are stitched normally), plus tombstones for
+registers it reclaimed. Worker `j` asserts its final wires equal the delta; every later worker
+re-materialises the delta directly off the shared tape. An item written in
+segment `i` reaches all later workers as the *same* materialised wire, so
+cross-segment equality holds by construction.
+
+Two cost dimensions follow, and they are different. The committed boundary *tape*
+is linear in the chunk's writes — only a segment's own writes are committed, never
+quadratically across segments. But the *seeding work* is not: each worker
+re-materialises every boundary before its own segment, so cumulative per-worker
+replay is O(segments²) in the boundary widths. That quadratic seeding term, not
+the tape, is the binding constraint that fixes the segment count at a small target
+(`TARGET_SEGMENTS`) rather than scaling it with core count or trace length — large
+enough to oversubscribe typical cores for work-stealing balance, small enough that
+seeding stays well below the linear replay work. This boundary cost — the seeding
+plus the committed delta tape — is why the segment count tracks the core count
+rather than growing past it (§12): once segments fill the cores the proof is
+work-bound, and further splitting only adds boundary cost. A linear-work
+prefix-scan that materialises each cumulative seed once removes the `O(segments²)`
+term, leaving the committed boundary tape (fresh sVOLE per written item) as the
+residual cost that argues for keeping the count near the core count.
+
+### 7.2 The two parallel passes
+
+Both the commit and accumulate passes run as parallel maps over segments followed
+by a combine. The commit pass evaluates each segment in the clear over pointer-bit
+wires and writes its adjustment slice; those slices can stream to the verifier as
+workers finish, overlapping commit compute with serialisation and transmission
+(the verifier still needs the whole vector before it samples — §12). The
+accumulate pass seeds each worker's challenge stream at the segment's gate offset,
+folds its slice into local `(u, v)` and an assertion hash, and the combine sums
+them. The last segment additionally binds the chunk's output, trap, and reveals.
+
+### 7.3 Challenge-stream seeking
+
+Because the accumulate fold is linear in challenge weights, each worker draws from
+the *same* challenge seed positioned at its own gate offset. Disjoint workers
+therefore consume disjoint challenge ranges and their partials sum to the
+single-pass result. The memory argument's polynomial constraints fold the same way
+over a second, domain-separated challenge stream offset by the constraint count,
+and merge across workers.
+
+### 7.4 Single-segment fallback
+
+Planning degrades to one sequential segment whenever a chunk has no marks, is
+unbounded, or its layout scan hits a trace it cannot mirror. This is a determinism
+safety net, not just an optimisation: both parties fall back identically and
+surface the same error at the same protocol point, rather than disagreeing on
+layout and deadlocking. It is the local realisation of the §2 determinism
+invariant.
+
+---
+
+## 8. Memory consistency
+
+The guest's linear memory is small — low single-digit megabytes — and that bounds
+the whole design. The entire memory is held as committed wires for the life of a
+call, and the memory-checking argument is checked once over the call.
+
+Consistency turns on per-byte state vm-zk maintains alongside taint: **custody** —
+how the proof *names* a byte's value, where taint answers *who knows* it. Custody
+is two independent facts. A byte is **bracketed** when it sits inside the memory
+argument's open bracket: it was bridged into the multiset — the dangling committed
+write-half of §8.5 — at the first symbolic-address access that could reach it, and
+from then until the audit every write to it logs a committed tuple. Bracket
+membership is monotone within a call; only the audit closes it. A byte is
+**routable** when its current value is nameable by both parties as a specific
+committed wire or as public cleartext; reads of routable bytes are free and
+unlogged even while bracketed. Neither fact is vm-core state: both are derived
+state of vm-zk's access log (the `MemoryLog`), pure functions of the shared access
+stream, so the parties compute them identically without exchanging them. Routable
+reads and unbracketed writes cost only the wires they route (§8.2); bracketed
+writes and unroutable reads are proven by one offline memory-checking argument
+over committed `(address, value, time)` tuples that hides the address (§8.3). The
+committed product covers only that logged traffic — bracketed writes, the reads
+that restore routability, and the bridge and audit halves that open and close each
+cell's bracket (§8.5).
+
+### 8.1 Full-memory residence
+
+The entire linear memory is carried as committed bit-wires across every chunk of a
+call, densely and without eviction. A memory byte is eight IT-MAC wires (§4.1), so
+a low-megabyte guest fits in a few hundred megabytes per party. Every cell's wire
+is available to every chunk; the working set is never re-committed or re-derived at
+a boundary, and the end-of-call audit reads memory straight out of residence.
+
+An unroutable byte (§8.3) is the one exception: its carried wire is dead — the RAM
+argument, not the wire, names its current value. Residence still earns its keep for
+that byte, holding the prover's cleartext, the last nameable write that opened its
+bracket (§8.5), and the value the end-of-call audit reads out. A bracketed byte
+that is routable keeps a live wire like any other.
+
+### 8.2 Public addresses and re-anchoring
+
+Any public-addressed access re-anchors the bytes it touches: it restores their
+routability, pinning each byte's value to nameable wires at a public address and a
+public clock. Re-anchoring never ends bracket membership — only the audit does
+(§8.5). A store re-anchors with its operand's wires. A read re-anchors an
+unroutable byte by fresh-committing its value as advice — those advice wires ride
+the tape, nameable by both parties from then on — while a read of an
+already-routable byte simply reads off its existing wire, free and unlogged even
+while bracketed (§8.3). A write to a bracketed byte logs its tuple whether or not
+the byte was routable: its value wires stay nameable, so it commits no fresh value
+advice, but its retire read-half carries a committed timestamp and one comparator —
+the cell's last-write time may be private, because an intervening private load's
+rewrite may have bumped it. These one-time costs, and the cancellation that erases
+publicly matched pairs, are accounted in §8.3.
+
+A routable byte is exactly the free wire routing of the base design. A
+public-address load references the committed wire its store produced; across chunks
+this rides the carried memory (§8.1), and within a chunk the boundary deltas of §7.1
+propagate a segment's writes to the segments after it. Both parties name the same
+cell and materialise the same wire, so equality holds by construction — routable
+reads and unbracketed writes need no argument and cost only the wires they route.
+
+### 8.3 Private addresses and the multiset argument
+
+A symbolic-address access — one whose address is committed — cannot be routed: the
+verifier cannot name the target cell (§5.4). Its two effects on the reachable range
+are asymmetric. A symbolic-address **store** makes the range bracketed *and*
+unroutable: a value may have changed at an unknown cell, so no byte in the range
+may be read off a wire until it is re-anchored (§8.2). A symbolic-address **load**
+makes the range bracketed but *leaves it routable*: it changes no value, so public
+reads of the range stay free — only writes pay while the bracket is open. This
+asymmetry is what keeps private lookups into a public or committed table cheap:
+the lookup brackets the table, and subsequent public reads of it remain free wire
+routing. Today the reachable range is the whole linear memory; a declared or
+range-asserted region is the future refinement *(target)*.
+
+While a byte is bracketed, every write to it logs a committed tuple — including a
+concrete store over concrete bytes, whose value changes no taint (surfaced by the
+store-observability contract, §5.4): a later private read's tuple must match the
+cell's true current value in the multiset, so no value change inside a bracketed
+range may go unlogged. Reads divide by routability: a read of an unroutable byte
+logs — it is the re-anchoring read of §8.2, fresh-committing its value as advice —
+while a read of a routable byte is unlogged even while bracketed, since an unlogged
+read leaves the multiset balanced and its value is correct by construction.
+
+Consistency over the logged accesses is one offline memory-checking argument over
+committed `(address, value, time)` tuples, following the SpeakUp construction, which
+reveals nothing about which cell each tuple names. Every logged access contributes a
+**read-half** tuple `(addr, old value, last-write time)` and a **write-half** tuple
+`(addr, new value, current clock)` to a single whole-call multiset, indexed by a
+call-global clock that is monotone across chunks. Two facts establish consistency:
+
+- **Permutation** — the read multiset equals the write multiset, proven by a grand
+  product `∏(eᵢ + r)` over `GF(2^64)` under a verifier challenge `r`, where each
+  tuple compresses to one field element `eᵢ`.
+- **Timestamp** — every read sources a value written strictly in the past, proven
+  by a borrow-chain comparator asserting `t < c` (the terminal audit read is the
+  one exception, §8.5). The comparator runs in the
+  boolean path and folds into the per-chunk accumulate pass; the clock is public,
+  so its per-bit gate selection is free and it costs one multiplication per
+  timestamp bit.
+
+**Public accesses cancel.** The multiset notionally spans every access; both
+parties drop **publicly matched pairs** before committing to the product: a
+read-half cancels the preceding write-half on the same cell whenever no
+symbolic-address access lies between them. The matching is public structure — both
+sides compute it identically from the shared access log — and a matched pair is
+tuple-identical: same public address, the same value wires (that is what wire
+routing means), and the same public timestamp, so its two `(e + r)` factors are
+equal and dropping both preserves multiset equality exactly. The two custody facts
+are the per-byte residue of this predicate, one per intervening access kind: an
+intervening symbolic-address *store* may have changed the value — that is
+unroutability — while an intervening symbolic-address *load* may have privately
+bumped the last-write time, which is why a bracketed write's surviving retire
+read-half commits its timestamp (§8.2) even though its value wires still match. A
+cell with purely public-address history cancels entirely, including its
+initialisation and audit (§8.5), and contributes nothing to the committed product.
+A re-anchoring read pays the full one-time cost — fresh-committed old value and
+timestamp, one comparator, two product factors — after which its write-half is a
+new public anchor and the cell's subsequent history telescopes away for free until
+the next symbolic-address access or the audit.
+
+Because each logged access is a self-contained committed tuple, unroutable memory
+needs no boundary stitching between segment workers (§7.1) — its consistency is
+established globally by the permutation, not handed worker to worker. Routable
+bytes, bracketed or not, stitch through the ordinary deltas.
+
+### 8.4 The grand product
+
+The grand product is accelerated: its factors are tiled into groups of a fixed
+width (`CHUNK`), each verified as one degree-`d` polynomial constraint (§4.5)
+relating consecutive boundary partial products `accₖ`, so only those boundary
+products are committed. Entries bridge from the tuples' already-committed bits
+(§4.6) — no fresh `GF(2^64)` tape — and a tuple's low and high halves combine into
+one entry as `lo + γ·hi` under a second challenge `γ`.
+
+Because `pack` is independent of `γ`, each committed access is reduced at the moment
+it occurs to its two packed `Auth64` limbs (`lo` and `hi`), and only those limbs are
+retained for the call — on the order of tens of bytes per surviving tuple, in place
+of the per-bit tuple wires. The product is assembled from the held limbs once `(γ, r)`
+is known, and its tiles fold in parallel: each `accₖ` is committed witness, so no tile
+depends on another's intermediate state.
+
+*(open)* Tuple granularity versus re-anchor granularity is unresolved. Custody is
+per byte — a `store8` re-anchors one byte of a word — but the packing above treats
+an access tuple `(address, value, time)` as two `Auth64` limbs, so a word access
+spanning routable and unroutable bytes, or bracketed and unbracketed ones, does not
+map onto one tuple cleanly. The two candidates are byte-granular tuples (clean
+semantics, roughly `8×` the product factors per wide access) and access-granular
+tuples plus a rule that a partial-width access to a mixed range first demotes the
+whole range to the stricter state. This is settled together with the zk-ram
+`CHUNK`/limb design before the access-log format freezes.
+
+### 8.5 Initialisation and audit
+
+Initialisation and audit are not separate protocol events; they are the two multiset
+halves that fail to cancel. Initialisation is a write-half seeding each cell's
+starting value, bridged from the held memory wires (§8.1); audit is a read-half for
+every cell at the close of the call, read out of the held memory. For a cell with
+purely public-address history the two match each other through the cell's telescoped
+public chain and drop, so the cell leaves no residue (§8.3). What survives is exactly
+the bracket: the last nameable write before the first symbolic-address access that
+could reach the cell — initialisation itself, if none intervened — is the dangling
+write-half that opens it, and the audit read-half after the cell's last
+symbolic-address access closes it, ending the cell's bracket membership (§8). An
+audit read commits its timestamp but
+omits the comparator: it fires at the terminal clock, where the past-clock ordering is
+already implied by the balanced multiset. Because the memory is small and resident,
+initialisation and audit range over the held memory and are bounded by the guest
+memory size.
+
+### 8.6 The whole-call check
+
+The argument is checked once over the entire call, indexed by the call-global clock
+(§8.3). Tuple bits are committed chunk by chunk as execution proceeds; each chunk
+packs the access tuples that survive cancellation into limbs (§8.4) and folds their
+comparators and gates under that chunk's challenge `χ`. After the final chunk commits,
+the verifier samples the permutation challenges `(γ, r)`; the prover then commits the
+partial products `accₖ`, the product and the audit fold over the held limbs and
+memory, and the verifier runs one polynomial check (§4.5).
+
+Sampling `(γ, r)` after every tuple bit is committed binds the witness before the
+challenge is known. The commitment therefore arrives in two phases — the
+challenge-independent tuple, gate, and comparator commitments during the call, then
+the `accₖ` that depend on `(γ, r)` at the close — and the closing fold spans as many
+correlation rounds as the `accₖ` and audit require. Cancellation adds no protocol
+message and no phase: it only shrinks which entries produce limbs and factors, leaving
+the two-phase structure unchanged.
+
+---
+
+## 9. Input/output
+
+### 9.1 Inputs
+
+Private inputs are staged into linear memory and committed as authenticated bytes;
+public inputs are written in the clear and carry no commitment. On the prover a
+private input is staged with Private visibility (§5.4); the verifier reserves the
+same region as Blind and commits blanks, so the committed wire is identical on
+both sides while only the prover holds the cleartext. A third class, **Blind**
+inputs, inverts the roles: the bits are supplied by the *verifier*, so the prover
+commits placeholder zeros and the verifier's adjustment carries the real pattern.
+This role symmetry — a `Private` write on one side is the `Blind` reservation on
+the other — is the structural reason the two parties are peers running the same
+program. The commitment is fixed at stage time, so later in-place mutation of a
+staged region does not change what was committed.
+
+A **standalone commitment** path flushes pending inputs without running a
+function: it allocates only the input-commit tape plus a VOPE tail, runs the
+commit/challenge/proof exchange with a gate-free accumulate (folding only any
+reveal assertions), and installs the committed input and memory wires for a later
+call to consume.
+
+### 9.2 Reveals (prove-then-open)
+
+A program may open a memory range to the verifier. The range's cleartext is first
+proven correct — each byte's MAC is asserted against the disclosed value, binding
+it into the assertion hash (§4.2) — and only then disclosed and its range's memory
+taint dropped to Public, the step that lifts the tainted-read guard (§5.4) and
+makes the range readable. The prover's cleartext already lives in its memory from
+when it was stored; the verifier materialises it on disclosure.
+
+Reveals use an open/wait split. Opening returns a public **handle** — an id from a
+lockstep counter both parties advance identically — and a later wait binds the
+now-public value into a register. A shared `RevealState` carries the id counter and
+a payload map; the prover announces disclosed payloads with the chunk outcome and
+the verifier merges them before its own capture, so the two resolve every reveal in
+lockstep, and a handle opened in one chunk can be waited on in a later one. A
+pending reveal forces an otherwise-public chunk to prove.
+
+### 9.3 Outputs and traps
+
+A function's return value, when symbolic, is bound by asserting its authenticated
+wires against the value the prover discloses; a concrete return is already public
+and reconstructed locally by the verifier.
+
+A trap is a public outcome. The trap taxonomy splits in two. **Structural traps**
+(unreachable, a public out-of-bounds access, an explicit exit) are reached
+identically from the shared skeleton and need no constraint — both sides simply
+agree the chunk traps there. **Operand-bound traps** (a symbolic divide-by-zero or
+a symbolic multiply overflow) depend on hidden operands, so a dedicated pass proves
+the trap condition: that the divisor's bits are all zero, or that the operands are
+the overflow witness. Trapping ops are tape-free and terminate the chunk. The
+security property is that the verifier returns the reason it *proved*, not the one
+the prover *announced*, and rejects on any disagreement.
+
+### 9.4 Precompiles
+
+Cryptographic primitives that would be expensive as raw gates are provided as host
+calls. A precompile has a fully public fast path — when all inputs are public, both
+parties compute the result in the clear with no gates — and an authenticated path
+that emits the primitive's circuit once over mixed public/symbolic input wires and
+writes the result back to memory. The gate budget of an authenticated precompile is
+accounted in capture so segment and challenge layout line up with the circuit
+replay emits.
+
+---
+
+## 10. Cost model and accounting
+
+Both parties budget each chunk from the same published per-op gate costs, selecting
+the constant-specialised variant whenever an operand is public — exactly the choice
+replay makes when emitting the circuit. Costs distinguish **gates**
+(multiplications, which advance the challenge stream) from **advice** (committed
+witness such as division quotients, which consume tape but draw no challenge), so
+segment challenge offsets are computed from gate counts alone. The memory argument
+contributes its read-timestamp, comparator, partial-product, and
+initialisation/audit costs to the same budget. The public `chunk_cap` knob is measured in accumulated gate-plus-advice
+cost, not instruction count, so the doc, the configuration, and capture all use one
+unit. Because the budget is a deterministic function of the shared skeleton, both
+sides compute identical chunk boundaries, segment marks, tape sizes, and challenge
+counts without communicating them.
+
+The asymptotic "linear in symbolic gates" hides a large constant: the inner loop is
+a `GF(2^128)` carry-less multiply plus a challenge draw per symbolic gate (and, in
+the memory argument, a `GF(2^64)` multiply per grand-product factor). The field
+multiply is the throughput bottleneck, and its backend — hardware `pclmulqdq`,
+SIMD, or software, selected per target — is the dominant order-of-magnitude factor.
+A north-star implementation targets vectorised carry-less multiply with batched,
+deferred reduction.
+
+---
+
+## 11. Performance summary
+
+| Axis | Mechanism | Section |
+|------|-----------|---------|
+| Bounded proving memory | streamed chunks, gate-capped buffers | §6 |
+| Resident state | full guest memory held as committed wires (low MB) + the surviving (bracketed) access-tuple limbs | §6, §8 |
+| Commitment minimisation | linear IT-MACs; boundary deltas; accelerated grand product; composite poly check | §4.1, §7.1, §8.3 |
+| Parallelism | per-segment commit/accumulate, no inter-worker wires; segment count bounded by boundary cost | §7, §12 |
+| Rounds | one challenge round/chunk; one closing `(γ, r)` flight for the whole-call memory check (§8.6) | §6.2, §8.6, §12 |
+| Fields | `GF(2)` semantics + `GF(2^64)` permutation, one proof | §4.6 |
+| Free work | public values, control flow, addresses, precompile inputs; fully-public chunks | §5, §6.3 |
+
+Two qualifications matter. **Memory** holds the entire guest linear memory as
+committed wires for the life of a call — a few hundred megabytes at low-megabyte
+guest sizes (§8.1) — plus the packed limbs of every access that survives
+cancellation: the call's bracketed writes, unroutable reads, and bridge/audit
+halves (§8.3–8.5). Resident memory therefore scales with the guest memory size and
+the call's bracketed traffic rather than with its total access count or staying
+constant per chunk. The
+per-chunk gate, mask, and proof buffers remain bounded by the chunk cap. **Proof
+size** is constant per chunk — an assertion hash, two field elements, and a fixed
+`≤ d_max` coefficient vector when private-memory constraints are present — where
+"constant" means independent of trace length and gate count, since `d_max` is a fixed
+protocol constant.
+
+The asymptotic shape is: prover/verifier time linear in symbolic gates plus logged
+(bracketed) memory accesses; per-chunk proving buffers constant, resident
+memory proportional to guest memory size plus the call's bracketed traffic;
+proof size constant per chunk; and wall-clock bounded below by
+`total real-time work / cores` once segments fill the cores (§12). The recoverable headroom above that floor is round-trip idle, hidden
+by pipelining and sized by the window-to-RTT ratio; segment count tracks the core
+count and is not itself a performance lever.
+
+---
+
+## 12. Orchestration and the performance floor
+
+The proof is a pipeline whose floor is the work it cannot avoid. Per-gate work
+comes in two kinds (§4.2–4.3): the **commit pass**, a data-dependent walk of the
+circuit that emits the adjustment bits before the challenge, and the **accumulate
+fold**, an associative `(u, v)` reduction of one `GF(2^128)` multiply per gate.
+Correlation generation is a third, real-time stream — it cannot be precomputed.
+
+Given enough segments to fill the cores, all three parallelise to work-bound, and
+the wall-clock floor is
+
+```
+(commit + accumulate + correlation) · gates / cores
+```
+
+— the total real-time work over the cores, with nothing below it. The commit
+pass's data-dependence would bound a *single* segment by its depth, but that only
+surfaces if the cores outnumber the segments; keeping the segment count at or above
+the core count makes the commit pass work-bound like the fold, and gadget depths
+are shallow enough that this is never the binding constraint.
+
+**Segmentation exists only to reach that floor.** The segment count must be at
+least the core count, with light oversubscription so work-stealing smooths
+stragglers (a large precompile op is the worst case). Beyond that, finer
+segmentation buys no compute and only adds boundary cost — fresh sVOLE per delta
+plus, without the linear-work prefix-scan seed, `O(S²)` re-materialisation (§7.1) —
+so the segment count *tracks the core count* rather than being a tuning lever. A
+fixed target undersized for a high-core host is the one real mistake to avoid; past
+`S ≈ cores`, boundary cost only argues for fewer.
+
+**The recoverable headroom above the floor is round-trip idle.** Run sequentially,
+the cores stall during each window's commitment→challenge round-trip and its
+correlation flush — roughly two round-trips per window — while compute waits on the
+network. Pipelining hides these behind adjacent windows' compute; that is the
+entire win, and its size is the round-trip fraction: negligible when a window's
+compute exceeds the RTT (co-located parties, large windows), dominant when it does
+not (a wide-area link, or windows small enough that ~2·RTT rivals their compute).
+The lever that sets this fraction is the **window size** — one challenge per
+window, decoupled from the Ferret correlation batch — not the segment size.
+
+**The three streams pipeline across a memory window.** Correlation generation, the
+commit pass, and the accumulate fold for adjacent windows run concurrently, the
+cores split so their wall-clocks equalise. The enabling overlaps:
+
+- *Capture runs ahead* (§5.5) — challenge- and crypto-free, it produces the next
+  window's skeleton while the current one proves. It is not free: the trace it
+  produces is stored, so capture is a memory-bounded stage that back-pressures
+  against the lookahead budget rather than running arbitrarily ahead.
+- *Correlation is double-buffered* — the next window's sVOLE is extended while the
+  current window's is consumed, taking the Ferret flush off the steady-state
+  critical path.
+- *Challenges are squeezed under compute* — the verifier samples a window's
+  challenge (sampled, not derived, §2) the moment it holds that window's
+  commitment, while still folding the previous window, so the round-trip hides
+  under compute. Adjustment bits stream to the verifier per segment as commit
+  workers finish (§7.2).
+
+A **chunk is this memory window**: the lookahead held resident — the captured
+trace, the in-flight correlation, and the live tape. It is sized to keep the
+pipeline full — deep enough to cover the challenge round-trip and stage imbalance
+— and capped by the RAM that residence consumes. One challenge spans the whole
+window, so round-trips are one per window, not one per correlation batch.
+
+**The cross-window serial chain is the artifact to remove.** Carrying
+authenticated state forward from one window's accumulate to seed the next (§6.2)
+makes the accumulate passes a serial chain. Committing each window boundary
+instead — deterministic from capture, the same delta mechanism as segments — makes
+the windows independent, so work-stealing spans them. This matters precisely
+because a single window's accumulate fold may not saturate the cores: when it does
+not, ready folds from neighbouring windows must be available to steal, and the
+serial chain forbids exactly that.
+
+The immovable barriers are local: for each region the challenge must follow its
+commitment and its accumulate must follow its challenge, and the verifier must
+hold a window's whole adjustment vector before it samples. These are one barrier
+per window, hidden behind the window's own compute once the window is large
+enough. This pipeline is the target orchestration; the current implementation runs
+windows sequentially and does not yet overlap them (§13).
+
+---
+
+## 13. Implementation status
+
+Implemented: the execution model and memory tainting (§5), streaming chunks (§6),
+segment parallelism with boundary deltas (§7), the boolean proof system (§4.1–4.4),
+the input/reveal/output/trap/precompile paths (§9), and cost accounting (§10).
+
+Designed with building blocks in place, not yet wired into the pipeline: the
+composite polynomial check and the `GF(2^64)` extension (§4.5–4.6), and the memory
+argument's emitters — compression, comparator, and accelerated grand product
+(§8.3–8.4). The remaining integration is the memory argument's pipeline wiring:
+full-memory residence (§8.1), reducing each surviving access to packed limbs at
+capture (§8.4), the initialisation and audit passes (§8.5), the whole-call `(γ, r)`
+check and its closing two-phase commitment (§8.6), the `GF(2^64)` sidecar context,
+and the polynomial check at verification.
+
+Not yet built: private and committed addresses (§8.3), including per-byte bracket
+and routability tracking over the `MemoryLog`, the public-access cancellation
+predicate (whose tuple granularity is still open, §8.4), and the
+store-observability contract (§5.4); cross-chunk pipelining / correlation
+double-buffering (§12); and the linear-work prefix-scan for boundary seeding
+(§7.1).
+
+---
+
+## References
+
+- **QuickSilver** — the VOLE-based, designated-verifier multiplication check the
+  proof system is built on (§4.2).
+- **SpeakUp** — the offline memory-checking construction the RAM argument follows:
+  permutation grand product plus timestamp comparator (§8.3), and the accelerated
+  partial-product grand product (§8.4).
+- **Ferret** — the LPN-based correlation generator sized against the chunk cap
+  (§6.1).

--- a/crates/vm-zk/benches/vm.rs
+++ b/crates/vm-zk/benches/vm.rs
@@ -1,12 +1,3 @@
-//! Benchmark harness for the zk-vm over a real OT stack.
-//!
-//! Each measured iteration proves SHA-256 of a private message end to end
-//! through the [`Prover`]/[`Verifier`] pair, with correlated randomness drawn
-//! from a real `CO15 -> SoftSpoken -> Ferret` RCOT stack (Chou-Orlandi base OT,
-//! SoftSpoken extension, Ferret expansion) rather than an ideal functionality —
-//! so the measurement reflects the cost of the actual protocol, including
-//! OT/VOLE generation.
-
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use futures::executor::block_on;
 use mpz_common::{Context, context::test_mt_context, executor::Executor};
@@ -18,20 +9,9 @@ use mpz_vm_zk::{Prover, Verifier};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use sha2::{Digest, Sha256};
 
-/// The prover's RCOT receiver: Ferret over SoftSpoken over a Chou-Orlandi base
-/// OT.
 type ProverSvole = ferret::Receiver<softspoken::Receiver<chou_orlandi::Sender>>;
-/// The verifier's RCOT sender: Ferret over SoftSpoken over a Chou-Orlandi base
-/// OT.
 type VerifierSvole = ferret::Sender<softspoken::Sender<chou_orlandi::Receiver>>;
 
-/// Builds the real RCOT stack for both parties from `seed`.
-///
-/// The verifier is the RCOT sender and holds the correlation `delta` (its lsb
-/// forced to 1, as the zk-vm requires); the prover is the RCOT receiver. The
-/// base-OT roles are swapped relative to the extension: the verifier's
-/// SoftSpoken sender is bootstrapped by a Chou-Orlandi receiver, the prover's
-/// SoftSpoken receiver by a Chou-Orlandi sender.
 fn rcot_stack(seed: u64) -> (VerifierSvole, ProverSvole) {
     let mut rng = StdRng::seed_from_u64(seed);
     let mut delta: Block = rng.random();
@@ -68,11 +48,6 @@ fn func_idx(module: &Module, name: &str) -> u32 {
         .expect("function should be exported")
 }
 
-/// The long-lived transport between the parties: a multithreaded executor
-/// pair and one context per side. Created once and reused across iterations
-/// so worker-pool spawn/teardown stays out of the measurement; everything
-/// cryptographic (base OT, SoftSpoken, Ferret, prover/verifier state) is
-/// rebuilt inside each iteration so the measured time stays end-to-end.
 struct Session {
     exec_p: Executor,
     exec_v: Executor,
@@ -101,9 +76,6 @@ impl Drop for Session {
     }
 }
 
-/// Drives one `call` on the prover and verifier concurrently and returns their
-/// results. The two parties exchange messages during a call, so both must run
-/// together; they execute on separate OS threads, as in a real deployment.
 fn call_both(
     prover: &mut Prover<ProverSvole>,
     verifier: &mut Verifier<VerifierSvole>,
@@ -120,28 +92,14 @@ fn call_both(
     })
 }
 
-/// SHA-256 digest length, in bytes.
 const DIGEST_LEN: usize = 32;
 
-/// Proves SHA-256 over the private `msg` end to end and returns the revealed
-/// digest. Allocates the message buffer in-guest via `cabi_realloc`, stages the
-/// message privately, calls the guest export `func` (either `hash`, which
-/// compresses in wasm, or `hash_precompile`, which compresses through the host
-/// `sha256_compress` precompile), and reads the digest back at the pointer the
-/// call returns. Panics if the two sides disagree.
-///
-/// The whole crypto stack is rebuilt here — only `session`'s executors and
-/// contexts are reused — so the measured time stays end-to-end.
 fn prove_sha256(module: &Module, msg: &[u8], session: &mut Session, func: &str) -> Vec<u8> {
     let (v_svole, p_svole) = rcot_stack(0);
     let mut prover = Prover::new(module.clone(), p_svole).unwrap();
     let mut verifier = Verifier::new(module.clone(), v_svole).unwrap();
     let Session { ctx_p, ctx_v, .. } = session;
 
-    // Allocate the message buffer inside the running VM via the guest's
-    // `cabi_realloc` export, then stage the message privately at the returned
-    // pointer. Allocating in the measured instance grows memory so the region is
-    // always in bounds and exercises the real allocator.
     let realloc = func_idx(module, "cabi_realloc");
     let alloc_args = || {
         vec![
@@ -171,7 +129,6 @@ fn prove_sha256(module: &Module, msg: &[u8], session: &mut Session, func: &str) 
     prover.write(ptr, Write::Private(msg)).unwrap();
     verifier.write(ptr, Write::Blind(msg.len())).unwrap();
 
-    // `func(ptr, len)` returns the address of the revealed digest.
     let hash = func_idx(module, func);
     let hash_args = || {
         vec![
@@ -196,19 +153,6 @@ fn prove_sha256(module: &Module, msg: &[u8], session: &mut Session, func: &str) 
     verifier.read(digest_ptr, DIGEST_LEN).unwrap().to_vec()
 }
 
-/// Installs a tracing subscriber when `RUST_LOG` is set that prints, on each
-/// span's close, its `time.busy`/`time.idle` wall-clock alongside the full
-/// span scope (`chunk:allocate:ferret.flush`, etc.) and recorded fields — the
-/// per-stage proving profile. A no-op (no subscriber, zero span cost) when
-/// `RUST_LOG` is unset, so a plain `cargo bench` measures undisturbed
-/// throughput.
-///
-/// For a profile run:
-/// `RUST_LOG=mpz_vm_zk=debug,mpz_ot=debug cargo bench -p mpz-vm-zk --bench vm`.
-/// The prover and verifier run on separate threads into one subscriber; their
-/// close lines carry the `role`/target so the two sides stay distinguishable,
-/// or narrow to one with a target filter (e.g. `mpz_vm_zk::prover=debug`).
-/// Absolute throughput numbers should be read from a run with `RUST_LOG` unset.
 fn init_tracing() {
     use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
@@ -223,18 +167,10 @@ fn init_tracing() {
         .try_init();
 }
 
-/// Message sizes (bytes) to benchmark SHA-256 over. The headline is 4 KiB.
 const SHA256_SIZES: &[usize] = &[4096, 16384];
 
-/// SHA-256 proving variants: `wasm` compresses each block with guest
-/// instructions, `precompile` compresses through the host `sha256_compress`
-/// precompile (the per-block compression circuit, no guest gates).
 const SHA256_VARIANTS: &[(&str, &str)] = &[("wasm", "hash"), ("precompile", "hash_precompile")];
 
-/// Proves SHA-256 of a private message end to end, for both the wasm and
-/// precompile variants. Each (variant, size) is validated once against a
-/// reference SHA-256 (proving the guest + VM + reveal are correct) before being
-/// timed.
 fn bench_sha256(c: &mut Criterion) {
     init_tracing();
     let wasm = include_bytes!("guests/sha256.wasm");
@@ -246,7 +182,6 @@ fn bench_sha256(c: &mut Criterion) {
     for &len in SHA256_SIZES {
         let msg: Vec<u8> = (0..len).map(|i| i as u8).collect();
         for &(label, func) in SHA256_VARIANTS {
-            // Validate the revealed digest against a reference before timing.
             let digest = prove_sha256(&module, &msg, &mut session, func);
             assert_eq!(
                 digest,

--- a/crates/vm-zk/src/capture.rs
+++ b/crates/vm-zk/src/capture.rs
@@ -1,78 +1,29 @@
-//! Chunked capture of a thread's execution trace.
-//!
-//! [`capture_chunk`] drives a [`Thread`] forward, recording each emitted
-//! [`Directive`] until the chunk's gate-bit cap is reached, the thread
-//! completes, or it traps. Imported calls are serviced inline, with the reveal
-//! they carry recorded alongside the trace. The resulting [`ChunkCapture`]
-//! carries the trace, its accumulated gate/advice cost, and the terminal
-//! outcome (a return value or a [`TrapPoint`]).
-//!
-//! Both prover and verifier run this loop over the same program; driving them
-//! with the same module and inputs yields identical directive/frame skeletons,
-//! which is what lets the verifier check the prover's announced trace and trap.
-
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use mpz_vm_core::{
-    Directive, Global, Operand, Pending, Reg, StepResult, Thread, Trap, value::Value,
+    Directive, Global, Op, Operand, Pending, Reg, StepResult, Thread, Trap, value::Value,
 };
-use mpz_vm_ir::{Function, Module, StoreKind};
+use mpz_vm_ir::{Function, Module};
+
+use std::ops::Range;
 
 use crate::{
     cost,
     error::{Result, ZkVmError},
     host::{self, HostCallEvent, RevealPayload, RevealState},
-    memlog::{self, MemoryLog, Stored},
+    memlog::{self, ByteState},
+    segment::{BoundaryDelta, MemItem, ValItem},
 };
 
-/// Returns whether `func_idx` names an imported (host) function.
 pub(crate) fn is_import(module: &Module, func_idx: u32) -> bool {
     matches!(module.function(func_idx), Some(Function::Import(_)))
 }
 
-/// Returns whether `func_idx` names an import from the `crypto` host module
-/// (e.g. `crypto::sha256_compress`), serviced by the circuit precompile
-/// path rather than the `vc` reveal path.
 pub(crate) fn is_precompile(module: &Module, func_idx: u32) -> bool {
     matches!(
         module.function(func_idx),
         Some(Function::Import(import)) if import.module() == "crypto"
     )
-}
-
-/// Records a `sha256_compress` precompile's 32-byte in-place output into `log`,
-/// matching the action's path: symbolic bytes for the authenticated variant,
-/// public bytes for the public variant. Shared by capture and the segment scan
-/// so both derive the identical written-byte view (hence identical boundary
-/// layout). Byte-granular so a boundary cut commits exactly these 32 bytes.
-pub(crate) fn log_precompile_output(log: &mut MemoryLog, action: &HostCallEvent) {
-    match action {
-        HostCallEvent::Sha256Compress { state_ptr, .. } => {
-            for i in 0..32u32 {
-                log.record_store(StoreKind::I32Store8, state_ptr + i, Stored::Symbolic);
-            }
-        }
-        HostCallEvent::Sha256CompressPublic { state_ptr, digest } => {
-            for (i, b) in digest.iter().enumerate() {
-                log.record_store(
-                    StoreKind::I32Store8,
-                    state_ptr + i as u32,
-                    Stored::Public(Value::I32(*b as i32)),
-                );
-            }
-        }
-        _ => {}
-    }
-}
-
-/// Capture-side accounting for a precompile call: budget the circuit gates
-/// (only the authenticated variant has any) and log its in-place output stores.
-fn account_precompile(cost: &mut usize, log: &mut MemoryLog, action: Option<&HostCallEvent>) {
-    let Some(action) = action else { return };
-    if matches!(action, HostCallEvent::Sha256Compress { .. }) {
-        *cost += cost::SHA256_COMPRESS_COST;
-    }
-    log_precompile_output(log, action);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -81,8 +32,6 @@ pub(crate) enum Role {
     Verifier,
 }
 
-/// Capture limits: the chunk's op-cost cap and the per-segment cost target.
-/// Both must match between the prover and verifier.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct Limits {
     pub(crate) chunk_cap: Option<usize>,
@@ -96,45 +45,14 @@ pub(crate) struct TrapPoint {
     pub(crate) trap: Trap,
 }
 
-/// Plaintext state captured at a segment boundary, recorded by the prover so
-/// each segment's commit/accumulate workers can be seeded without walking the
-/// preceding segments.
-///
-/// The verifier records no snapshot: it derives the boundary *layout* from
-/// the directive skeleton (see [`segment`](crate::segment)) and obtains the
-/// committed values through the prover's adjustment bits.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct Snapshot {
-    /// The thread's flat register file (absolute registers).
-    pub(crate) regs: Vec<Value>,
-    /// The module's globals, by global index.
-    pub(crate) globals: Vec<Value>,
-    /// Plaintext of every byte stored to since the previous mark (boundaries
-    /// are per-segment deltas).
-    pub(crate) mem: BTreeMap<u32, u8>,
-}
-
-/// A segment boundary: the trace splits *before* `directive_idx`.
-///
-/// The `sym_*`/`pub_mem` fields record the thread's taint state at the mark.
-/// Public computation updates registers, globals, and (untainted) memory
-/// without emitting directives, so an item written symbolically during the
-/// segment may be publicly overwritten by the time of the mark — its auth
-/// wire is then dead (every later use surfaces as a concrete operand) and
-/// must not be stitched. Taint symbolic-ness is identical across parties, so
-/// both record the same sets and derive the same boundary layout.
 #[derive(Clone, Debug)]
-pub(crate) struct SegmentMark {
-    pub(crate) directive_idx: usize,
-    /// Registers symbolic per the thread at the mark, ascending.
-    pub(crate) sym_regs: Vec<u32>,
-    /// Globals symbolic at the mark, ascending.
-    pub(crate) sym_globals: Vec<u32>,
-    /// Bytes written since the previous mark that are *not* symbolic at the
-    /// mark (publicly overwritten or revealed), ascending.
-    pub(crate) pub_mem: Vec<u32>,
-    /// Plaintext at the boundary; `None` on the verifier.
-    pub(crate) snapshot: Option<Snapshot>,
+pub(crate) struct SegmentInfo {
+    pub(crate) directives: Range<usize>,
+    pub(crate) reveals: Range<usize>,
+    pub(crate) log: Range<u64>,
+    pub(crate) bits: usize,
+    pub(crate) gates: usize,
+    pub(crate) boundary: Option<BoundaryDelta>,
 }
 
 pub(crate) struct ChunkCapture {
@@ -144,16 +62,38 @@ pub(crate) struct ChunkCapture {
     pub(crate) result: Option<Value>,
     pub(crate) result_symbolic: bool,
     pub(crate) trap: Option<TrapPoint>,
-    /// Reveal events, one per imported `Directive::Call` in `trace` and in the
-    /// same order, that replay opens against the authenticated state.
     pub(crate) reveal_actions: Vec<HostCallEvent>,
-    /// Payloads newly disclosed by reveals in this chunk, to announce (prover)
-    /// or already merged (verifier). Keyed by reveal id.
     pub(crate) reveals: BTreeMap<u32, RevealPayload>,
-    /// Segment boundaries inside `trace`, in ascending directive order. Both
-    /// sides produce identical `directive_idx` sequences since cost accrues
-    /// identically over identical skeletons.
-    pub(crate) marks: Vec<SegmentMark>,
+    pub(crate) segments: Vec<SegmentInfo>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_segments(
+    mut segments: Vec<SegmentInfo>,
+    dir_start: usize,
+    rev_start: usize,
+    log_start: u64,
+    trace_len: usize,
+    reveal_len: usize,
+    log_end: u64,
+    bits: usize,
+    gates: usize,
+) -> Vec<SegmentInfo> {
+    if dir_start == trace_len && !segments.is_empty() {
+        let last = segments.last_mut().expect("non-empty");
+        last.boundary = None;
+        last.log.end = log_end;
+    } else {
+        segments.push(SegmentInfo {
+            directives: dir_start..trace_len,
+            reveals: rev_start..reveal_len,
+            log: log_start..log_end,
+            bits,
+            gates,
+            boundary: None,
+        });
+    }
+    segments
 }
 
 #[tracing::instrument(level = "debug", name = "capture", skip_all, fields(?role))]
@@ -170,20 +110,20 @@ pub(crate) fn capture_chunk(
     let mut cost: usize = 0;
     let mut reveal_actions: Vec<HostCallEvent> = Vec::new();
     let mut reveals: BTreeMap<u32, RevealPayload> = BTreeMap::new();
-    let mut marks: Vec<SegmentMark> = Vec::new();
-    // The chunk's memory accesses; each boundary snapshot reads the current
-    // plaintext of the bytes written since the previous mark, then drains the
-    // written view.
-    let mut log = MemoryLog::default();
+    let mut segments: Vec<SegmentInfo> = Vec::new();
+    let mut seg_dir_start = 0usize;
+    let mut seg_rev_start = 0usize;
+    let mut seg_log_start = global.access_log().expect("access log enabled").clock();
+    let mut seg_bits = 0usize;
+    let mut seg_gates = 0usize;
+    let mut seg_regs: BTreeSet<u32> = BTreeSet::new();
+    let mut seg_globals: BTreeSet<u32> = BTreeSet::new();
+    let mut seg_dropped: Vec<(Reg, u32)> = Vec::new();
     let mut next_mark = limits.segment_cost.unwrap_or(usize::MAX);
 
     loop {
         let directive = match thread.step(module, global)? {
             StepResult::Continue => continue,
-            // An imported call surfaces as a `Directive::Call`. Service it now —
-            // recording the reveal action and resolving the call — then push the
-            // directive so replay opens it in-order. Other directives fall
-            // through to cost accounting and the trace.
             StepResult::Directive(Directive::Call {
                 dst,
                 func_idx,
@@ -195,9 +135,6 @@ pub(crate) fn capture_chunk(
                         host::service_sha256_compress(role, global, &args)?;
                     reveal_actions.push(action);
                     thread.resolve_host_call(value, visibility)?;
-                    // Fall through (do not `continue`) so the tail budgets the
-                    // precompile's gates, logs its output stores, and runs the
-                    // mark/chunk-cap checks.
                     Directive::Call {
                         dst,
                         func_idx,
@@ -217,6 +154,9 @@ pub(crate) fn capture_chunk(
                     )?;
                     reveal_actions.push(action);
                     thread.resolve_host_call(value, visibility)?;
+                    if let Some(r) = reveal_written_reg(reveal_actions.last()) {
+                        seg_regs.insert(r);
+                    }
                     trace.push(Directive::Call {
                         dst,
                         func_idx,
@@ -226,18 +166,23 @@ pub(crate) fn capture_chunk(
                     continue;
                 }
             }
-            // A could-trap op (e.g. div/rem with an unheld operand) emits as an
-            // ordinary directive. `op_counter` was bumped past the op before
-            // `step` returned, so the emitted op sits at the announced index `i`
-            // when `op_counter() == i + 1`. This is the trapping op: validate it
-            // and end the chunk terminal — it is tape-free and never enters the
-            // trace.
             StepResult::Directive(d)
                 if let Some((i, reason)) = &announced_trap
                     && thread.op_counter() == *i + 1 =>
             {
                 validate_trap_directive(&d, reason)?;
-                trim_marks(&mut marks, trace.len());
+                let log_end = global.access_log().expect("access log enabled").clock();
+                let segments = finish_segments(
+                    segments,
+                    seg_dir_start,
+                    seg_rev_start,
+                    seg_log_start,
+                    trace.len(),
+                    reveal_actions.len(),
+                    log_end,
+                    seg_bits,
+                    seg_gates,
+                );
                 return Ok(ChunkCapture {
                     trace,
                     cost,
@@ -251,22 +196,15 @@ pub(crate) fn capture_chunk(
                     }),
                     reveal_actions,
                     reveals,
-                    marks,
+                    segments,
                 });
             }
             StepResult::Directive(d) => d,
-            // A could-trap op resolved to a trap by the stepping driver itself
-            // (the prover, or the verifier when the trap-determining operand is
-            // public). The trapping directive is not pushed into the trace: it
-            // is tape-free, consumes no cost, and rides on the capture for the
-            // separate trap-replay pass. The chunk ends terminal with no result.
             StepResult::Trapped {
                 index,
                 directive,
                 trap,
             } => {
-                // If the prover announced a trap index, a verifier reaching the
-                // trap locally must land on the same op.
                 if let Some((announced, _)) = &announced_trap
                     && *announced != index
                 {
@@ -274,7 +212,18 @@ pub(crate) fn capture_chunk(
                         "local trap at index {index} but prover announced {announced}"
                     )));
                 }
-                trim_marks(&mut marks, trace.len());
+                let log_end = global.access_log().expect("access log enabled").clock();
+                let segments = finish_segments(
+                    segments,
+                    seg_dir_start,
+                    seg_rev_start,
+                    seg_log_start,
+                    trace.len(),
+                    reveal_actions.len(),
+                    log_end,
+                    seg_bits,
+                    seg_gates,
+                );
                 return Ok(ChunkCapture {
                     trace,
                     cost,
@@ -288,22 +237,15 @@ pub(crate) fn capture_chunk(
                     }),
                     reveal_actions,
                     reveals,
-                    marks,
+                    segments,
                 });
             }
-            // Blocked on a condition the zk-vm does not support: private
-            // branching, indirect-call dispatch, and memory.grow all need a
-            // value fed back into execution. (A could-trap op no longer blocks —
-            // it emits as an ordinary directive and is matched by index below.)
             StepResult::Blocked(pending) => match pending {
                 Pending::Branch => {
                     return Err(ZkVmError::Unsupported(
                         "private branching not supported in zk-vm".into(),
                     ));
                 }
-                // Imported calls are serviced when their `Directive::Call` is
-                // emitted, so the thread is never stepped while a host call is
-                // unresolved here.
                 Pending::HostCall { .. } => {
                     return Err(ZkVmError::Internal(
                         "host call surfaced as blocked but should be serviced at its directive"
@@ -322,7 +264,18 @@ pub(crate) fn capture_chunk(
                 }
             },
             StepResult::Done { result, symbolic } => {
-                trim_marks(&mut marks, trace.len());
+                let log_end = global.access_log().expect("access log enabled").clock();
+                let segments = finish_segments(
+                    segments,
+                    seg_dir_start,
+                    seg_rev_start,
+                    seg_log_start,
+                    trace.len(),
+                    reveal_actions.len(),
+                    log_end,
+                    seg_bits,
+                    seg_gates,
+                );
                 return Ok(ChunkCapture {
                     trace,
                     cost,
@@ -332,81 +285,105 @@ pub(crate) fn capture_chunk(
                     trap: None,
                     reveal_actions,
                     reveals,
-                    marks,
+                    segments,
                 });
             }
         };
 
         match &directive {
             Directive::Op(op) => {
-                cost += cost::op_cost(op)?;
-                // Log accesses leniently: an unsupported (symbolic) address is
-                // replay's error to surface, at its natural protocol point.
+                let c = cost::op_cost(op)?;
+                cost += c;
+                seg_bits += c;
+                seg_gates += c - cost::op_advice_bits(op);
                 match op {
-                    mpz_vm_core::Op::Store {
-                        kind,
-                        addr,
-                        val,
-                        memarg,
-                    } => {
-                        if let Ok(eff) = memlog::eff_addr(addr, memarg) {
-                            let stored = match val {
-                                Operand::Concrete(v) => Stored::Public(*v),
-                                Operand::Symbol { .. } => Stored::Symbolic,
-                            };
-                            log.record_store(*kind, eff, stored);
-                        }
+                    Op::Copy { dst, .. }
+                    | Op::GlobalGet { dst, .. }
+                    | Op::Binary { dst, .. }
+                    | Op::Unary { dst, .. }
+                    | Op::Load { dst, .. } => {
+                        seg_regs.insert(dst.0);
                     }
-                    mpz_vm_core::Op::Load {
-                        kind,
-                        addr,
-                        memarg,
-                        symbolic_mask,
-                        ..
-                    } => {
-                        if let Ok(eff) = memlog::eff_addr(addr, memarg) {
-                            log.record_load(*kind, eff, *symbolic_mask);
-                        }
+                    Op::GlobalSet { global_idx, .. } => {
+                        seg_globals.insert(*global_idx);
                     }
                     _ => {}
                 }
             }
-            // A precompile call carries no `Op` cost; budget its circuit gates
-            // and log the 32-byte in-place output so boundaries commit it. The
-            // just-pushed action carries the path (authenticated vs public).
-            Directive::Call { func_idx, .. } if is_precompile(module, *func_idx) => {
-                account_precompile(&mut cost, &mut log, reveal_actions.last());
+            Directive::Call {
+                func_idx,
+                args,
+                param_base,
+                ..
+            } => {
+                if is_precompile(module, *func_idx) {
+                    if let Some(action) = reveal_actions.last() {
+                        if matches!(action, HostCallEvent::Sha256Compress { .. }) {
+                            cost += cost::SHA256_COMPRESS_COST;
+                            seg_bits += cost::SHA256_COMPRESS_COST;
+                            seg_gates += cost::SHA256_COMPRESS_COST;
+                        }
+                    }
+                } else if !is_import(module, *func_idx) {
+                    for (k, arg) in args.iter().enumerate() {
+                        if matches!(arg, Operand::Symbol { .. }) {
+                            seg_regs.insert(param_base.0 + k as u32);
+                        }
+                    }
+                }
             }
-            _ => {}
+            Directive::Return { dst, src, reclaim } => {
+                if let (Some(d), Some(_)) = (dst, src) {
+                    seg_regs.insert(d.0);
+                }
+                if let Some((base, count)) = reclaim {
+                    for r in base.0..base.0 + *count {
+                        seg_regs.remove(&r);
+                    }
+                    seg_dropped.push((*base, *count));
+                }
+            }
+            Directive::Branch {
+                cond: Some(Operand::Symbol { .. }),
+                ..
+            } => {
+                return Err(ZkVmError::Unsupported(
+                    "private branching not supported in zk-vm".into(),
+                ));
+            }
+            Directive::Branch { .. } => {}
         }
 
         trace.push(directive);
 
         if cost >= next_mark {
-            let snapshot = match role {
-                Role::Prover => Some(snapshot(global, thread, &log)?),
-                Role::Verifier => None,
-            };
-            let sym_regs = (0..thread.registers().len() as u32)
-                .filter(|&r| thread.is_register_symbolic(r))
-                .collect();
-            let sym_globals = (0..global.globals().len() as u32)
-                .filter(|&g| global.is_global_symbolic(g))
-                .collect();
-            let pub_mem = log
-                .written_addrs()
-                .filter(|&a| !global.memory_tainted(a, 1))
-                .collect();
-            // Boundaries are deltas: drain the written view so the next
-            // snapshot covers only bytes written after this mark.
-            log.take_written();
-            marks.push(SegmentMark {
-                directive_idx: trace.len(),
-                sym_regs,
-                sym_globals,
-                pub_mem,
-                snapshot,
+            let log_end = global.access_log().expect("access log enabled").clock();
+            let written = memlog::written_view(
+                global.access_log().expect("access log enabled"),
+                seg_log_start..log_end,
+            );
+            let boundary = build_boundary(
+                role,
+                thread,
+                global,
+                std::mem::take(&mut seg_regs),
+                std::mem::take(&mut seg_globals),
+                std::mem::take(&mut seg_dropped),
+                written,
+            )?;
+            segments.push(SegmentInfo {
+                directives: seg_dir_start..trace.len(),
+                reveals: seg_rev_start..reveal_actions.len(),
+                log: seg_log_start..log_end,
+                bits: seg_bits,
+                gates: seg_gates,
+                boundary: Some(boundary),
             });
+            seg_dir_start = trace.len();
+            seg_rev_start = reveal_actions.len();
+            seg_log_start = log_end;
+            seg_bits = 0;
+            seg_gates = 0;
             next_mark = cost
                 + limits
                     .segment_cost
@@ -416,7 +393,18 @@ pub(crate) fn capture_chunk(
         if let Some(c) = limits.chunk_cap
             && cost >= c
         {
-            trim_marks(&mut marks, trace.len());
+            let log_end = global.access_log().expect("access log enabled").clock();
+            let segments = finish_segments(
+                segments,
+                seg_dir_start,
+                seg_rev_start,
+                seg_log_start,
+                trace.len(),
+                reveal_actions.len(),
+                log_end,
+                seg_bits,
+                seg_gates,
+            );
             return Ok(ChunkCapture {
                 trace,
                 cost,
@@ -426,51 +414,84 @@ pub(crate) fn capture_chunk(
                 trap: None,
                 reveal_actions,
                 reveals,
-                marks,
+                segments,
             });
         }
     }
 }
 
-/// Reads the prover's plaintext at a segment boundary: the thread's flat
-/// register file, the module globals, and the current value of every byte
-/// stored to since the previous mark.
-fn snapshot(global: &Global, thread: &Thread, log: &MemoryLog) -> Result<Snapshot> {
-    let mut mem = BTreeMap::new();
-    if log.has_writes() {
-        let memory = global
-            .memory()
-            .ok_or(ZkVmError::Core(mpz_vm_core::Error::MemoryNotDefined))?;
-        for addr in log.written_addrs() {
-            mem.insert(
-                addr,
-                memory.read_bytes(addr, 1).map_err(ZkVmError::Trap)?[0],
-            );
+fn reveal_written_reg(action: Option<&HostCallEvent>) -> Option<u32> {
+    match action? {
+        HostCallEvent::OpenScalar { handle_dst, .. }
+        | HostCallEvent::OpenBytes { handle_dst, .. } => Some(handle_dst.0),
+        HostCallEvent::WaitScalar { dst, .. } => Some(dst.0),
+        _ => None,
+    }
+}
+
+fn build_boundary(
+    role: Role,
+    thread: &Thread,
+    global: &Global,
+    seg_regs: BTreeSet<u32>,
+    seg_globals: BTreeSet<u32>,
+    dropped: Vec<(Reg, u32)>,
+    written: BTreeMap<u32, ByteState>,
+) -> Result<BoundaryDelta> {
+    let prover = role == Role::Prover;
+
+    let vals =
+        |keys: BTreeSet<u32>, symbolic: &dyn Fn(u32) -> bool, read: &dyn Fn(u32) -> Value| {
+            keys.into_iter()
+                .map(|key| {
+                    let v = read(key);
+                    if symbolic(key) {
+                        ValItem::Sym {
+                            key,
+                            ty: v.ty(),
+                            value: prover.then_some(v),
+                        }
+                    } else {
+                        ValItem::Pub { key, value: v }
+                    }
+                })
+                .collect()
+        };
+
+    let regs = vals(seg_regs, &|r| thread.is_register_symbolic(r), &|r| {
+        thread.registers()[r as usize]
+    });
+    let globals = vals(seg_globals, &|g| global.is_global_symbolic(g), &|g| {
+        global.globals()[g as usize]
+    });
+
+    let mut mem = Vec::new();
+    for (a, state) in written {
+        if global.memory_tainted(a, 1) {
+            let value = if prover {
+                let byte = global
+                    .memory()
+                    .ok_or(ZkVmError::Core(mpz_vm_core::Error::MemoryNotDefined))?
+                    .read_bytes(a, 1)
+                    .map_err(ZkVmError::Trap)?[0];
+                Some(byte)
+            } else {
+                None
+            };
+            mem.push(MemItem::Sym { addr: a, value });
+        } else if let ByteState::Public(value) = state {
+            mem.push(MemItem::Pub { addr: a, value });
         }
     }
-    Ok(Snapshot {
-        regs: thread.registers().to_vec(),
-        globals: global.globals().to_vec(),
+
+    Ok(BoundaryDelta {
+        regs,
+        dropped,
+        globals,
         mem,
     })
 }
 
-/// Drops a trailing mark that coincides with the end of the trace, which
-/// would otherwise produce an empty final segment.
-fn trim_marks(marks: &mut Vec<SegmentMark>, trace_len: usize) {
-    while marks.last().is_some_and(|m| m.directive_idx >= trace_len) {
-        marks.pop();
-    }
-}
-
-/// Steps `thread` to completion using only local work, rejecting any step that
-/// would require a proving round (and thus communication with the other party).
-///
-/// Public computation is reproduced in-thread and runs to a
-/// [`StepResult::Done`] or a trap. A symbolic [`Op`](mpz_vm_core::Op), a
-/// private branch, or a host call (every zk-vm host call is a reveal) reports
-/// [`ZkVmError::RequiresCommunication`]; the remaining directives — local
-/// calls, returns, and public branches — are in-thread control flow.
 pub(crate) fn run_local(
     module: &Module,
     global: &mut Global,
@@ -535,8 +556,35 @@ fn validate_trap_directive(directive: &Directive, reason: &Trap) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mpz_vm_core::{Call, Op, Param};
+    use mpz_vm_core::{Access, AccessAddr, AccessKind, Call, Op, Param, Visibility};
     use mpz_vm_ir::{ExportKind, Module, ValType};
+
+    fn capture_full(
+        module: &Module,
+        func_idx: u32,
+        role: Role,
+        params: Vec<Param>,
+        limits: Limits,
+    ) -> (ChunkCapture, Global) {
+        let mut global = Global::new(module).unwrap();
+        global.enable_access_log();
+        let mut thread = Thread::new();
+        thread
+            .call(module, &mut global, Call { func_idx, params })
+            .unwrap();
+        let mut reveal_state = RevealState::default();
+        let capture = capture_chunk(
+            module,
+            &mut global,
+            &mut thread,
+            limits,
+            role,
+            None,
+            &mut reveal_state,
+        )
+        .unwrap();
+        (capture, global)
+    }
 
     fn capture_trace(
         module: &Module,
@@ -544,23 +592,46 @@ mod tests {
         role: Role,
         params: Vec<Param>,
     ) -> Vec<Directive> {
-        let mut global = Global::new(module).unwrap();
-        let mut thread = Thread::new();
-        thread
-            .call(module, &mut global, Call { func_idx, params })
-            .unwrap();
-        let mut reveal_state = RevealState::default();
-        capture_chunk(
-            module,
-            &mut global,
-            &mut thread,
-            Limits::default(),
-            role,
-            None,
-            &mut reveal_state,
-        )
-        .unwrap()
-        .trace
+        capture_full(module, func_idx, role, params, Limits::default())
+            .0
+            .trace
+    }
+
+    const SEGMENTED_WAT: &str = r#"(module
+        (memory 1)
+        (func (export "main") (param i32) (result i32)
+          (local $acc i32) (local $tmp i32)
+          local.get 0 local.get 0 i32.add local.set $acc
+          i32.const 0 local.get $acc i32.store
+          i32.const 64 i32.const 7 i32.store
+          local.get $acc local.get 0 i32.add local.set $acc
+          i32.const 4 local.get $acc i32.store
+          i32.const 0 i32.load local.set $tmp
+          local.get $acc local.get $tmp i32.add local.set $acc
+          i32.const 8 local.get $acc i32.store
+          local.get $acc local.get 0 i32.add local.set $acc
+          i32.const 4 i32.load local.get $acc i32.add))"#;
+
+    fn segmented_module() -> Module {
+        Module::parse(&wat::parse_str(SEGMENTED_WAT).unwrap()).unwrap()
+    }
+
+    fn main_idx(module: &Module) -> u32 {
+        module
+            .exports()
+            .iter()
+            .find_map(|e| match e.kind {
+                ExportKind::Func(i) if e.name == "main" => Some(i),
+                _ => None,
+            })
+            .unwrap()
+    }
+
+    fn segmented_limits() -> Limits {
+        Limits {
+            chunk_cap: None,
+            segment_cost: Some(1),
+        }
     }
 
     fn skeleton(directive: &Directive) -> String {
@@ -619,6 +690,347 @@ mod tests {
         assert!(
             ps.iter().any(|k| k.starts_with("call")),
             "the test program must exercise a Call"
+        );
+    }
+
+    #[test]
+    fn segment_log_ranges_are_contiguous() {
+        let module = segmented_module();
+        let idx = main_idx(&module);
+        let (chunk, global) = capture_full(
+            &module,
+            idx,
+            Role::Prover,
+            vec![Param::Private(Value::I32(7))],
+            segmented_limits(),
+        );
+
+        assert!(
+            chunk.segments.len() >= 2,
+            "the program must split into at least two segments (got {})",
+            chunk.segments.len()
+        );
+
+        let final_clock = global.access_log().expect("log enabled").clock();
+        assert_eq!(
+            chunk
+                .segments
+                .first()
+                .expect("at least one segment")
+                .log
+                .start,
+            0,
+            "the first segment starts at the chunk-start clock"
+        );
+        for seg in &chunk.segments {
+            assert!(
+                seg.log.start <= seg.log.end,
+                "segment log range must be well-formed: {:?}",
+                seg.log
+            );
+        }
+        for pair in chunk.segments.windows(2) {
+            assert_eq!(
+                pair[0].log.end, pair[1].log.start,
+                "each segment's log range must start where the previous ended"
+            );
+        }
+        assert_eq!(
+            chunk.segments.last().expect("at least one segment").log.end,
+            final_clock,
+            "the last segment must end at the final clock"
+        );
+    }
+
+    #[test]
+    fn emitted_log_entries_zip_segment_memory_directives() {
+        let module = segmented_module();
+        let idx = main_idx(&module);
+        let (chunk, global) = capture_full(
+            &module,
+            idx,
+            Role::Prover,
+            vec![Param::Private(Value::I32(7))],
+            segmented_limits(),
+        );
+        let entries = global.access_log().expect("log enabled").entries();
+
+        for seg in &chunk.segments {
+            let emitted: Vec<AccessKind> = entries[seg.log.start as usize..seg.log.end as usize]
+                .iter()
+                .filter(|a| a.emitted)
+                .map(|a| a.kind)
+                .collect();
+            let mem_dirs: Vec<&Directive> = chunk.trace[seg.directives.clone()]
+                .iter()
+                .filter(|d| {
+                    matches!(
+                        d,
+                        Directive::Op(Op::Load { .. }) | Directive::Op(Op::Store { .. })
+                    )
+                })
+                .collect();
+            assert_eq!(
+                emitted.len(),
+                mem_dirs.len(),
+                "segment (directives {:?}): emitted entries vs memory directives",
+                seg.directives
+            );
+            for (kind, directive) in emitted.iter().zip(&mem_dirs) {
+                match (kind, directive) {
+                    (AccessKind::Read, Directive::Op(Op::Load { .. })) => {}
+                    (AccessKind::Write, Directive::Op(Op::Store { .. })) => {}
+                    _ => panic!("emitted kind {kind:?} does not match directive {directive:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prover_and_verifier_segment_log_ranges_match() {
+        let module = segmented_module();
+        let idx = main_idx(&module);
+        let (prover, _) = capture_full(
+            &module,
+            idx,
+            Role::Prover,
+            vec![Param::Private(Value::I32(7))],
+            segmented_limits(),
+        );
+        let (verifier, _) = capture_full(
+            &module,
+            idx,
+            Role::Verifier,
+            vec![Param::Blind(ValType::I32)],
+            segmented_limits(),
+        );
+
+        let ps: Vec<_> = prover.segments.iter().map(|s| s.log.clone()).collect();
+        let vs: Vec<_> = verifier.segments.iter().map(|s| s.log.clone()).collect();
+        assert_eq!(
+            ps, vs,
+            "prover and verifier must derive identical per-segment log ranges"
+        );
+    }
+
+    const PRECOMPILE_WAT: &str = r#"(module
+        (import "crypto" "sha256_compress" (func $compress (param i32 i32)))
+        (memory 2)
+        (func (export "main") (param $state i32) (param $block i32)
+            (call $compress (local.get $state) (local.get $block))))"#;
+
+    const STATE_PTR: u32 = 256;
+    const BLOCK_PTR: u32 = 512;
+
+    fn capture_precompile(role: Role, state_symbolic: bool) -> (ChunkCapture, Global) {
+        let module = Module::parse(&wat::parse_str(PRECOMPILE_WAT).unwrap()).unwrap();
+        let idx = main_idx(&module);
+        let mut global = Global::new(&module).unwrap();
+        global.enable_access_log();
+        if state_symbolic {
+            let vis = match role {
+                Role::Prover => Visibility::Private,
+                Role::Verifier => Visibility::Blind,
+            };
+            global.set_memory_visibility(STATE_PTR, 32, vis);
+        }
+        let mut thread = Thread::new();
+        thread
+            .call(
+                &module,
+                &mut global,
+                Call {
+                    func_idx: idx,
+                    params: vec![
+                        Param::Public(Value::I32(STATE_PTR as i32)),
+                        Param::Public(Value::I32(BLOCK_PTR as i32)),
+                    ],
+                },
+            )
+            .unwrap();
+        let mut reveal_state = RevealState::default();
+        let capture = capture_chunk(
+            &module,
+            &mut global,
+            &mut thread,
+            Limits::default(),
+            role,
+            None,
+            &mut reveal_state,
+        )
+        .unwrap();
+        (capture, global)
+    }
+
+    fn assert_digest_entries(entries: &[Access], expected: [Option<u64>; 4], mask: u8) {
+        assert_eq!(
+            entries.len(),
+            4,
+            "one compress logs exactly four host writes"
+        );
+        for (i, (entry, value)) in entries.iter().zip(expected).enumerate() {
+            assert_eq!(
+                entry,
+                &Access {
+                    kind: AccessKind::Write,
+                    addr: AccessAddr::Public(STATE_PTR + 8 * i as u32),
+                    width: 8,
+                    symbolic_mask: mask,
+                    value,
+                    emitted: false,
+                    host: true,
+                },
+                "host-write entry {i} must cover its 8-byte digest chunk"
+            );
+        }
+    }
+
+    #[test]
+    fn precompile_public_output_logs_host_writes() {
+        let (chunk, global) = capture_precompile(Role::Prover, false);
+        let log = global.access_log().expect("log enabled");
+        let entries = log.entries();
+
+        let digest = global
+            .memory()
+            .unwrap()
+            .read_bytes(STATE_PTR, 32)
+            .unwrap()
+            .to_vec();
+        let expected = core::array::from_fn(|i| {
+            Some(u64::from_le_bytes(
+                digest[8 * i..8 * i + 8].try_into().unwrap(),
+            ))
+        });
+        assert_digest_entries(entries, expected, 0);
+
+        let seg = chunk
+            .segments
+            .iter()
+            .find(|s| s.log.start == 0)
+            .expect("a segment starts at the chunk-start clock");
+        assert!(
+            seg.log.start == 0 && seg.log.end >= 4,
+            "the covering segment must contain the four host writes: {:?}",
+            seg.log
+        );
+
+        let (_, verifier) = capture_precompile(Role::Verifier, false);
+        assert_eq!(
+            entries,
+            verifier.access_log().expect("log enabled").entries(),
+            "prover and verifier must log identical host writes"
+        );
+    }
+
+    #[test]
+    fn precompile_authenticated_output_logs_host_writes() {
+        let (_, prover) = capture_precompile(Role::Prover, true);
+        let (_, verifier) = capture_precompile(Role::Verifier, true);
+
+        let prover_entries = prover.access_log().expect("log enabled").entries();
+        let verifier_entries = verifier.access_log().expect("log enabled").entries();
+
+        assert_digest_entries(prover_entries, [None; 4], 0xff);
+        assert_eq!(
+            prover_entries, verifier_entries,
+            "prover and verifier must log identical host writes"
+        );
+    }
+
+    const SILENT_VS_SYMBOLIC_WAT: &str = r#"(module
+        (memory 1)
+        (func (export "main") (param i32) (result i32)
+          ;; silent concrete store at address 0 (public value, no directive)
+          i32.const 0 i32.const 42 i32.store
+          ;; symbolic-value store at address 8 (private input, emitted)
+          i32.const 8 local.get 0 i32.store
+          ;; trailing symbolic arithmetic so the store's segment is not the last
+          local.get 0 local.get 0 i32.add
+          local.get 0 i32.add))"#;
+
+    fn boundary_skeleton(delta: &BoundaryDelta) -> Vec<String> {
+        let vals = |items: &[ValItem]| -> Vec<String> {
+            items
+                .iter()
+                .map(|item| match item {
+                    ValItem::Sym { key, ty, .. } => format!("sym {key} {ty:?}"),
+                    ValItem::Pub { key, value } => format!("pub {key} {value:?}"),
+                })
+                .collect()
+        };
+        let mut out = vals(&delta.regs);
+        out.extend(vals(&delta.globals));
+        out.extend(delta.mem.iter().map(|item| match item {
+            MemItem::Sym { addr, .. } => format!("msym {addr}"),
+            MemItem::Pub { addr, value } => format!("mpub {addr} {value}"),
+        }));
+        out
+    }
+
+    #[test]
+    fn silent_store_excluded_from_written_view() {
+        let module = Module::parse(&wat::parse_str(SILENT_VS_SYMBOLIC_WAT).unwrap()).unwrap();
+        let idx = main_idx(&module);
+        let (prover, _) = capture_full(
+            &module,
+            idx,
+            Role::Prover,
+            vec![Param::Private(Value::I32(0x1122_3344))],
+            segmented_limits(),
+        );
+        let (verifier, _) = capture_full(
+            &module,
+            idx,
+            Role::Verifier,
+            vec![Param::Blind(ValType::I32)],
+            segmented_limits(),
+        );
+
+        let mem_boundaries: Vec<&BoundaryDelta> = prover
+            .segments
+            .iter()
+            .filter_map(|s| s.boundary.as_ref())
+            .filter(|b| !b.mem.is_empty())
+            .collect();
+        assert_eq!(
+            mem_boundaries.len(),
+            1,
+            "only the symbolic store contributes memory to a boundary"
+        );
+
+        let mem = &mem_boundaries[0].mem;
+        let addrs: Vec<u32> = mem
+            .iter()
+            .map(|item| match item {
+                MemItem::Sym { addr, .. } | MemItem::Pub { addr, .. } => *addr,
+            })
+            .collect();
+        assert_eq!(addrs, vec![8, 9, 10, 11], "the symbolic store covers 8..12");
+        assert!(
+            mem.iter().all(|item| matches!(item, MemItem::Sym { .. })),
+            "the symbolic store's bytes are committed"
+        );
+        assert!(
+            !addrs.iter().any(|&a| a < 8),
+            "the silent public store's bytes must not enter the written view"
+        );
+
+        let ps: Vec<_> = prover
+            .segments
+            .iter()
+            .filter_map(|s| s.boundary.as_ref())
+            .map(boundary_skeleton)
+            .collect();
+        let vs: Vec<_> = verifier
+            .segments
+            .iter()
+            .filter_map(|s| s.boundary.as_ref())
+            .map(boundary_skeleton)
+            .collect();
+        assert_eq!(
+            ps, vs,
+            "prover and verifier must commit identical boundary skeletons"
         );
     }
 }

--- a/crates/vm-zk/src/commit.rs
+++ b/crates/vm-zk/src/commit.rs
@@ -1,21 +1,17 @@
 use std::collections::BTreeMap;
 
-use mpz_fields::gf2_128::Gf2_128;
-use mpz_vm_core::{Param, Reg, value::Value};
+use mpz_vm_core::{Param, Reg, ValType, value::Value};
 use rangeset::set::RangeSet;
 
-use mpz_vm_memory::{AuthState, AuthValue, Bit, Byte};
-
-use crate::error::{Result, ZkVmError};
+use crate::{
+    capture::Role,
+    error::{Result, ZkVmError},
+    segment::{BoundaryDelta, MemItem, ValItem},
+};
 
 #[derive(Debug, Default)]
 pub(crate) struct PendingIo {
     write_private: RangeSet<u32>,
-    /// Prover-side snapshot of the staged private bytes, captured at stage time
-    /// so the commitment reflects the value as written — not whatever later
-    /// in-place execution leaves in memory (e.g. a precompile compressing a
-    /// region the host just staged). Keyed by address; empty on the verifier,
-    /// which commits blanks.
     bytes: BTreeMap<u32, u8>,
 }
 
@@ -24,15 +20,10 @@ impl PendingIo {
         self.write_private.len() * 8
     }
 
-    /// Records a committed private range, tracking only its extent. The verifier
-    /// uses this directly; the prover snapshots the bytes via
-    /// [`stage_private`](Self::stage_private).
     pub(crate) fn write_private(&mut self, addr: u32, len: usize) {
         self.write_private.union_mut(addr..addr + len as u32);
     }
 
-    /// Prover-side: records a committed private range and snapshots its bytes,
-    /// so the commitment is fixed at stage time regardless of later mutation.
     pub(crate) fn stage_private(&mut self, addr: u32, data: &[u8]) {
         self.write_private(addr, data.len());
         for (i, &b) in data.iter().enumerate() {
@@ -44,7 +35,6 @@ impl PendingIo {
         self.write_private.iter().flat_map(|r| r.start..r.end)
     }
 
-    /// The byte snapshotted at `addr` when it was staged (prover side).
     fn staged_byte(&self, addr: u32) -> Option<u8> {
         self.bytes.get(&addr).copied()
     }
@@ -80,121 +70,59 @@ pub(crate) fn prepare_params(params: &[Param]) -> Result<usize> {
     Ok(bits)
 }
 
-/// The prover's view of an input-commit tape region: each committed bit XORs
-/// into the mask in place and yields its authenticated wire directly off the
-/// tape. Input commits draw no challenge and fold nothing, so no circuit
-/// context is involved.
-pub(crate) struct ProverTape<'a> {
-    pub(crate) masks: &'a mut [bool],
-    pub(crate) macs: &'a [Gf2_128],
-    pub(crate) cursor: usize,
-}
-
-impl ProverTape<'_> {
-    fn bit(&mut self, b: bool) -> Gf2_128 {
-        let i = self.cursor;
-        self.masks[i] ^= b;
-        self.cursor = i + 1;
-        mpz_zk_core::prover_wire(self.macs[i], b)
-    }
-}
-
-/// The verifier's view of an input-commit tape region: each entry yields the
-/// key wire adjusted by the received commitment.
-pub(crate) struct VerifierTape<'a> {
-    pub(crate) keys: &'a [Gf2_128],
-    pub(crate) adjust: &'a [bool],
-    pub(crate) delta: Gf2_128,
-    pub(crate) cursor: usize,
-}
-
-impl VerifierTape<'_> {
-    fn bit(&mut self) -> Gf2_128 {
-        let i = self.cursor;
-        self.cursor = i + 1;
-        mpz_zk_core::verifier_wire(self.keys[i], self.adjust[i], self.delta)
-    }
-}
-
-#[tracing::instrument(level = "debug", skip_all, fields(num_params = params.len()))]
-pub(crate) fn commit_prover(
-    auth: &mut AuthState,
+pub(crate) fn prologue_delta(
+    role: Role,
     root_reg_base: Reg,
     params: &[Param],
     pending: &PendingIo,
-    tape: &mut ProverTape<'_>,
-) -> Result<()> {
+) -> Result<Option<BoundaryDelta>> {
+    let prover = role == Role::Prover;
+    let mut regs = Vec::new();
     for (i, p) in params.iter().enumerate() {
-        let (ty, bits): (mpz_vm_ir::ValType, Vec<bool>) = match p {
-            Param::Private(v) => (v.ty(), value_le_bits(*v, ty_width(v.ty()))),
-            // Prover can't see a blind param, so it commits zero bits; the verifier's
-            // adjust supplies the real bit pattern.
-            Param::Blind(ty) => (*ty, vec![false; ty_width(*ty)]),
-            Param::Public(_) => continue,
+        let (ty, value) = match (prover, p) {
+            (_, Param::Public(_)) => continue,
+            (true, Param::Private(v)) => (v.ty(), Some(*v)),
+            (true, Param::Blind(_)) => {
+                return Err(ZkVmError::Unsupported(
+                    "prover cannot receive blind params".into(),
+                ));
+            }
+            (false, Param::Private(v)) => (v.ty(), None),
+            (false, Param::Blind(ty)) => (*ty, None),
         };
-        let auth_bits: Vec<Bit> = bits.into_iter().map(|b| Bit(tape.bit(b))).collect();
-        auth.regs.set(
-            root_reg_base + i as u32,
-            AuthValue::from_bits(ty, &auth_bits)?,
-        );
+        if matches!(ty, ValType::F32 | ValType::F64) {
+            return Err(ZkVmError::Unsupported(format!(
+                "param {i}: float ({ty:?}) not supported by zk-vm"
+            )));
+        }
+        regs.push(ValItem::Sym {
+            key: (root_reg_base + i as u32).0,
+            ty,
+            value,
+        });
     }
-    commit_memory_prover(auth, pending, tape)
-}
 
-pub(crate) fn commit_memory_prover(
-    auth: &mut AuthState,
-    pending: &PendingIo,
-    tape: &mut ProverTape<'_>,
-) -> Result<()> {
-    // Iterate addresses in ascending order (matching the verifier's tape order)
-    // and commit each byte from the stage-time snapshot, not live memory, so a
-    // region overwritten in place after staging still commits its staged value.
+    let mut mem = Vec::new();
     for addr in pending.addrs() {
-        let value = pending.staged_byte(addr).ok_or_else(|| {
-            ZkVmError::Internal(format!("no staged byte for committed input addr {addr:#x}"))
-        })?;
-        let byte_bits = Byte::new(core::array::from_fn(|bit_idx| {
-            Bit(tape.bit((value >> bit_idx) & 1 != 0))
-        }));
-        auth.memory.set_byte(addr, byte_bits);
-    }
-    Ok(())
-}
-
-#[tracing::instrument(level = "debug", skip_all, fields(num_params = params.len()))]
-pub(crate) fn commit_verifier(
-    auth: &mut AuthState,
-    root_reg_base: Reg,
-    params: &[Param],
-    pending: &PendingIo,
-    tape: &mut VerifierTape<'_>,
-) -> Result<()> {
-    for (i, p) in params.iter().enumerate() {
-        let ty = match p {
-            Param::Private(v) => v.ty(),
-            Param::Blind(ty) => *ty,
-            Param::Public(_) => continue,
+        let value = if prover {
+            Some(pending.staged_byte(addr).ok_or_else(|| {
+                ZkVmError::Internal(format!("no staged byte for committed input addr {addr:#x}"))
+            })?)
+        } else {
+            None
         };
-        let width = ty_width(ty);
-        let auth_bits: Vec<Bit> = (0..width).map(|_| Bit(tape.bit())).collect();
-        auth.regs.set(
-            root_reg_base + i as u32,
-            AuthValue::from_bits(ty, &auth_bits)?,
-        );
+        mem.push(MemItem::Sym { addr, value });
     }
-    commit_memory_verifier(auth, pending, tape);
-    Ok(())
-}
 
-pub(crate) fn commit_memory_verifier(
-    auth: &mut AuthState,
-    pending: &PendingIo,
-    tape: &mut VerifierTape<'_>,
-) {
-    for addr in pending.addrs() {
-        let byte_bits = Byte::new(core::array::from_fn(|_| Bit(tape.bit())));
-        auth.memory.set_byte(addr, byte_bits);
+    if regs.is_empty() && mem.is_empty() {
+        return Ok(None);
     }
+    Ok(Some(BoundaryDelta {
+        regs,
+        dropped: Vec::new(),
+        globals: Vec::new(),
+        mem,
+    }))
 }
 
 pub(crate) fn value_le_bits(v: Value, width: usize) -> Vec<bool> {
@@ -202,4 +130,43 @@ pub(crate) fn value_le_bits(v: Value, width: usize) -> Vec<bool> {
     (0..width)
         .map(|i| (bytes[i / 8] >> (i % 8)) & 1 != 0)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prover_rejects_blind_param() {
+        let pending = PendingIo::default();
+        let err = prologue_delta(
+            Role::Prover,
+            Reg(0),
+            &[Param::Blind(ValType::I32)],
+            &pending,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ZkVmError::Unsupported(_)),
+            "prover must reject a blind param, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verifier_accepts_blind_param() {
+        let pending = PendingIo::default();
+        let delta = prologue_delta(
+            Role::Verifier,
+            Reg(0),
+            &[Param::Blind(ValType::I32)],
+            &pending,
+        )
+        .unwrap()
+        .expect("a committed blind param yields a delta");
+        assert_eq!(
+            delta.regs.len(),
+            1,
+            "the blind param is committed as one reg"
+        );
+    }
 }

--- a/crates/vm-zk/src/config.rs
+++ b/crates/vm-zk/src/config.rs
@@ -1,18 +1,5 @@
-//! Configuration for the [`Prover`](crate::Prover) and
-//! [`Verifier`](crate::Verifier).
-
 use crate::DEFAULT_CHUNK_CAP;
 
-/// Configuration shared by a [`Prover`](crate::Prover) and a
-/// [`Verifier`](crate::Verifier).
-///
-/// `chunk_cap` and `segment_cost` shape proving and MUST match on both sides
-/// for the parties to agree. `id` is a purely local logging label — it is
-/// attached to the party's tracing spans so concurrent instances can be told
-/// apart, and need not match (or be set on) the peer.
-///
-/// Build one with [`Config::builder`], or use [`Config::default`] for the
-/// standard settings.
 #[derive(Debug, Clone)]
 pub struct Config {
     id: Option<u64>,
@@ -31,37 +18,23 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Returns a [`ConfigBuilder`] initialized to the defaults.
     pub fn builder() -> ConfigBuilder {
         ConfigBuilder::default()
     }
 
-    /// The instance identifier attached to this party's tracing spans, if set.
-    ///
-    /// A logging label only: it lets one prover/verifier instance's spans be
-    /// distinguished from another's when several run concurrently in a process.
-    /// It does not affect the protocol.
     pub fn id(&self) -> Option<u64> {
         self.id
     }
 
-    /// The maximum number of operations executed per chunk. See
-    /// [`ConfigBuilder::chunk_cap`].
     pub fn chunk_cap(&self) -> Option<usize> {
         self.chunk_cap
     }
 
-    /// The gate-cost target per proving segment. See
-    /// [`ConfigBuilder::segment_cost`].
     pub fn segment_cost(&self) -> Option<usize> {
         self.segment_cost
     }
 }
 
-/// Builder for a [`Config`].
-///
-/// Created by [`Config::builder`]; starts from [`Config::default`] and overrides
-/// only the fields that are set.
 #[derive(Debug, Clone)]
 pub struct ConfigBuilder {
     config: Config,
@@ -76,40 +49,21 @@ impl Default for ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    /// Sets the instance identifier attached to this party's tracing spans.
-    ///
-    /// Purely a logging label to disambiguate concurrent instances; it has no
-    /// effect on the protocol and need not match the peer's.
     pub fn id(mut self, id: u64) -> Self {
         self.config.id = Some(id);
         self
     }
 
-    /// Sets the maximum number of operations executed per chunk.
-    ///
-    /// `Some(cap)` bounds each chunk to at most `cap` operations, trading proof
-    /// granularity against memory use; `None` places no bound and lets a chunk
-    /// run until the program completes or traps. Defaults to
-    /// [`Some(DEFAULT_CHUNK_CAP)`](crate::DEFAULT_CHUNK_CAP). Must match the
-    /// peer's setting for the two sides to agree.
     pub fn chunk_cap(mut self, cap: Option<usize>) -> Self {
         self.config.chunk_cap = cap;
         self
     }
 
-    /// Sets the gate-cost target per proving segment.
-    ///
-    /// `Some(cost)` splits each chunk's trace into segments of roughly `cost`
-    /// gate bits, committed and folded by parallel workers; `None` (the default)
-    /// auto-derives the target from the chunk cap so a full chunk splits into
-    /// about [`TARGET_SEGMENTS`](crate::TARGET_SEGMENTS) segments. Must match the
-    /// peer's setting for the two sides to agree.
     pub fn segment_cost(mut self, cost: Option<usize>) -> Self {
         self.config.segment_cost = cost;
         self
     }
 
-    /// Consumes the builder, returning the configured [`Config`].
     pub fn build(self) -> Config {
         self.config
     }
@@ -131,7 +85,6 @@ mod tests {
     fn builder_overrides_only_set_fields() {
         let config = Config::builder().id(7).segment_cost(Some(5_000)).build();
         assert_eq!(config.id(), Some(7));
-        // Untouched: still the default.
         assert_eq!(config.chunk_cap(), Some(DEFAULT_CHUNK_CAP));
         assert_eq!(config.segment_cost(), Some(5_000));
     }

--- a/crates/vm-zk/src/cost.rs
+++ b/crates/vm-zk/src/cost.rs
@@ -1,9 +1,3 @@
-//! AND-gate + advice cost of each op, used by capture to budget chunks.
-//!
-//! Costs come from the `mpz_vm_circuits` gadgets' published `COST*` constants,
-//! selecting the constant-specialized variant when an operand is public (the
-//! same choice `replay` makes when emitting the circuit).
-
 use mpz_vm_core::{Op, Operand};
 use mpz_vm_ir::{BinaryOp, UnaryOp};
 
@@ -11,26 +5,16 @@ use mpz_vm_circuits as circ;
 
 use crate::error::{Result, unsupported_binary, unsupported_op, unsupported_unary};
 
-/// Tape entries (AND gates) committed by an authenticated
-/// `crypto::sha256_compress` call: exactly one `mul` per AND gate in the
-/// compression circuit, with no advice. Capture and the segment planner both
-/// budget this so the gate tape and challenge offsets line up with replay's
-/// `mpz_circuits::sha256::compress` invocation.
 pub(crate) const SHA256_COMPRESS_COST: usize = mpz_circuits::sha256::AND_PER_BLOCK;
 
-/// Tape entries consumed by `op` as committed blind advice (rather than AND
-/// gates). The challenge stream advances only on gates, so segment chi
-/// offsets are computed from `op_cost - op_advice_bits`.
 pub(crate) fn op_advice_bits(op: &Op) -> usize {
     use mpz_vm_ir::{BinaryOp::*, UnaryOp::*};
     match op {
-        // Division advice commits the quotient and remainder.
         Op::Binary { op: bop, rhs, .. } if !rhs.is_concrete() => match bop {
             I32DivU | I32RemU | I32DivS | I32RemS => 64,
             I64DivU | I64RemU | I64DivS | I64RemS => 128,
             _ => 0,
         },
-        // Count advice commits one value of the operand's width.
         Op::Unary { op: uop, .. } => match uop {
             I32Clz | I32Ctz => 32,
             I64Clz | I64Ctz => 64,
@@ -56,7 +40,6 @@ pub(crate) fn op_cost(op: &Op) -> Result<usize> {
 fn binary_cost(op: BinaryOp, lhs: &Operand, rhs: &Operand) -> Result<usize> {
     use BinaryOp::*;
     Ok(match op {
-        // Comparisons are always symbolic.
         I32Eq => circ::I32Eq::COST,
         I32Ne => circ::I32Ne::COST,
         I32LtS => circ::I32LtS::COST,
@@ -77,7 +60,6 @@ fn binary_cost(op: BinaryOp, lhs: &Operand, rhs: &Operand) -> Result<usize> {
         I64LeU => circ::I64LeU::COST,
         I64GeS => circ::I64GeS::COST,
         I64GeU => circ::I64GeU::COST,
-        // Arithmetic. Multiply by a public constant uses the cheaper circuit.
         I32Add => circ::I32Add::COST,
         I32Sub => circ::I32Sub::COST,
         I32Mul if lhs.is_concrete() | rhs.is_concrete() => circ::I32Mul::COST_CONST,
@@ -86,8 +68,6 @@ fn binary_cost(op: BinaryOp, lhs: &Operand, rhs: &Operand) -> Result<usize> {
         I64Sub => circ::I64Sub::COST,
         I64Mul if lhs.is_concrete() | rhs.is_concrete() => circ::I64Mul::COST_CONST,
         I64Mul => circ::I64Mul::COST,
-        // Bitwise. `and`/`or` with a public constant use the cheaper circuit;
-        // `xor` is always a free wire shuffle.
         I32And if lhs.is_concrete() | rhs.is_concrete() => circ::I32And::COST_CONST,
         I32And => circ::I32And::COST,
         I32Or if lhs.is_concrete() | rhs.is_concrete() => circ::I32Or::COST_CONST,
@@ -98,7 +78,6 @@ fn binary_cost(op: BinaryOp, lhs: &Operand, rhs: &Operand) -> Result<usize> {
         I64Or if lhs.is_concrete() | rhs.is_concrete() => circ::I64Or::COST_CONST,
         I64Or => circ::I64Or::COST,
         I64Xor => circ::I64Xor::COST,
-        // Shifts/rotates by a public constant amount are free wire shuffles.
         I32Shl if rhs.is_concrete() => circ::I32Shl::COST_CONST_AMOUNT,
         I32Shl => circ::I32Shl::COST,
         I32ShrS if rhs.is_concrete() => circ::I32ShrS::COST_CONST_AMOUNT,
@@ -119,9 +98,6 @@ fn binary_cost(op: BinaryOp, lhs: &Operand, rhs: &Operand) -> Result<usize> {
         I64Rotl => circ::I64Rotl::COST,
         I64Rotr if rhs.is_concrete() => circ::I64Rotr::COST_CONST_AMOUNT,
         I64Rotr => circ::I64Rotr::COST,
-        // Division/remainder by a public constant divisor skips the advice
-        // entirely; otherwise `COST_WITH_ADVICE` already accounts for the
-        // committed advice.
         I32DivU if rhs.is_concrete() => circ::I32DivU::COST_CONST_DIVISOR,
         I32DivU => circ::I32DivU::COST_WITH_ADVICE,
         I32RemU if rhs.is_concrete() => circ::I32RemU::COST_CONST_DIVISOR,

--- a/crates/vm-zk/src/error.rs
+++ b/crates/vm-zk/src/error.rs
@@ -5,11 +5,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ZkVmError {
-    /// An interpreter or instantiation fault from `mpz-vm-core`.
     #[error(transparent)]
     Core(#[from] CoreError),
 
-    /// A runtime trap proven during execution.
     #[error("trap: {0}")]
     Trap(Trap),
 
@@ -67,8 +65,6 @@ pub enum ZkVmError {
 }
 
 impl ZkVmError {
-    /// Returns `true` if this error reflects a feature the zkVM intentionally
-    /// does not support (used by the spec harness to skip rather than fail).
     pub fn is_expected_unsupported(&self) -> bool {
         matches!(
             self,

--- a/crates/vm-zk/src/finalize.rs
+++ b/crates/vm-zk/src/finalize.rs
@@ -1,5 +1,5 @@
 use mpz_circuits::Context;
-use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
+use mpz_fields::gf2::Gf2;
 use mpz_vm_core::{Reg, value::Value};
 
 use mpz_vm_memory::AuthState;
@@ -12,11 +12,11 @@ use crate::{
 pub(crate) fn bind_output<C>(
     state: &ReplayState,
     exec: &mut C,
-    auth: &AuthState,
+    auth: &AuthState<C::Wire>,
     output: Option<Value>,
 ) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let reg = state.output_reg.ok_or(ZkVmError::OutputRegMissing)?;
@@ -24,9 +24,14 @@ where
     assert_output(exec, auth, reg, value)
 }
 
-pub(crate) fn assert_output<C>(exec: &mut C, auth: &AuthState, reg: Reg, value: Value) -> Result<()>
+pub(crate) fn assert_output<C>(
+    exec: &mut C,
+    auth: &AuthState<C::Wire>,
+    reg: Reg,
+    value: Value,
+) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let av = auth

--- a/crates/vm-zk/src/host.rs
+++ b/crates/vm-zk/src/host.rs
@@ -1,18 +1,3 @@
-//! Servicing of guest host calls during capture: `vc::reveal_*` disclosures and
-//! the `crypto::*` circuit precompiles.
-//!
-//! When the thread blocks on such an import, the servicer records a
-//! [`HostCallEvent`] into the captured trace and returns the value to resolve
-//! the call with. The event is applied in-order during replay against the live
-//! authenticated state, so a reveal's source register still holds its MAC at
-//! the reveal point (the free-list cannot have recycled it yet).
-//!
-//! Disclosure is eager: a `reveal_*` call commits its value to the chunk's
-//! announced payloads immediately, keyed by a unique reveal id; the matching
-//! `*_wait` only retrieves it. The id is allocated from a counter that advances
-//! identically on both parties (lockstep capture), so the handle the guest
-//! holds is the verifier's lookup key.
-
 use std::collections::BTreeMap;
 
 use mpz_vm_core::{Error as CoreError, Global, Operand, Reg, Visibility, value::Value};
@@ -24,53 +9,31 @@ use crate::{
     error::{Result, ZkVmError},
 };
 
-/// A disclosed reveal, announced in the chunk message keyed by reveal id and
-/// asserted against committed wires during replay.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum RevealPayload {
-    /// A scalar value.
     Scalar(Value),
-    /// A linear-memory range and its disclosed bytes.
     Bytes { ptr: u32, len: u32, bytes: Vec<u8> },
 }
 
-/// A serviced reveal host call, recorded in the trace so replay opens it
-/// in-order against the live authenticated state.
 #[derive(Clone, Debug)]
 pub(crate) enum HostCallEvent {
-    /// `vc::reveal_<ty>(value) -> handle`: open `src`'s MAC against `value`
-    /// (skipped when the value was already public, i.e. `src` is `None`), and
-    /// bind the public handle `id` into `handle_dst`.
     OpenScalar {
         src: Option<Reg>,
         value: Value,
         handle_dst: Reg,
         id: u32,
     },
-    /// `vc::reveal_<ty>_wait(handle) -> value`: bind the now-public revealed
-    /// value into `dst`.
-    WaitScalar { dst: Reg, value: Value },
-    /// `vc::reveal_bytes(ptr, len) -> handle`: open the range's byte MACs
-    /// against `bytes`, and bind the public handle `id` into `handle_dst`.
+    WaitScalar {
+        dst: Reg,
+        value: Value,
+    },
     OpenBytes {
         ptr: u32,
         bytes: Vec<u8>,
         handle_dst: Reg,
         id: u32,
     },
-    /// `vc::reveal_bytes_wait(handle)`: its effect (making the range public and
-    /// materializing the bytes) is applied to memory during capture, so replay
-    /// has nothing to do. Recorded to stay 1:1 with the import directives.
     WaitBytes,
-    /// `crypto::sha256_compress(state_ptr, block_ptr)` with at least one
-    /// tainted input byte: replay emits the SHA-256 compression circuit over
-    /// the input wires and writes the committed output back over the
-    /// 32-byte state at `state_ptr`. Inputs may mix committed and public
-    /// bytes (e.g. a public IV / SHA padding), so each region carries its
-    /// public bytes (symbolic positions zeroed) and a per-byte symbolic
-    /// mask, mirroring `Op::Load`'s `concrete`/`symbolic_mask`: replay
-    /// reads symbolic bytes from committed memory and materializes public
-    /// bytes as public-bit wires.
     Sha256Compress {
         state_ptr: u32,
         block_ptr: u32,
@@ -79,39 +42,29 @@ pub(crate) enum HostCallEvent {
         block_pub: [u8; 64],
         block_sym: u64,
     },
-    /// `crypto::sha256_compress` over fully public input: the digest is
-    /// computed in the clear during capture; replay writes it back as
-    /// public-bit wires (no gates). `digest` holds the 32-byte result.
-    Sha256CompressPublic { state_ptr: u32, digest: [u8; 32] },
+    Sha256CompressPublic {
+        state_ptr: u32,
+        digest: [u8; 32],
+    },
 }
 
-/// Per-execution reveal state, owned by the prover/verifier across chunks.
 #[derive(Debug, Default)]
 pub(crate) struct RevealState {
-    /// Monotonic reveal-id counter; identical on both parties (lockstep
-    /// capture).
     next_id: u32,
-    /// Every payload disclosed so far, keyed by reveal id. The prover fills
-    /// this as it services reveals; the verifier merges each chunk's
-    /// announced payloads before capturing it.
     payloads: BTreeMap<u32, RevealPayload>,
 }
 
 impl RevealState {
-    /// Merges a chunk's announced payloads (verifier side, before capture).
     pub(crate) fn merge(&mut self, announced: BTreeMap<u32, RevealPayload>) {
         self.payloads.extend(announced);
     }
 
-    /// Allocates the next reveal id.
     fn alloc(&mut self) -> u32 {
         let id = self.next_id;
         self.next_id += 1;
         id
     }
 
-    /// Records a disclosed payload (prover side) both for replay lookups and in
-    /// `new` to announce in this chunk's message.
     fn disclose(
         &mut self,
         new: &mut BTreeMap<u32, RevealPayload>,
@@ -123,15 +76,6 @@ impl RevealState {
     }
 }
 
-/// Services a reveal host call surfaced during capture.
-///
-/// Returns the trace event to record (if any) and the value to resolve the host
-/// call with (the handle for a `reveal`, the revealed value for a scalar
-/// `wait`, nothing for a byte `wait`). The prover inserts newly disclosed
-/// payloads into `new` (to announce) and into its own `payloads`; the verifier
-/// reads them from `payloads`, pre-merged from the chunk message. Byte waits
-/// apply their effect — making the range public and (verifier) materializing
-/// its bytes — to `global` directly and carry no trace event.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn service_reveal(
     role: Role,
@@ -156,7 +100,6 @@ pub(crate) fn service_reveal(
         "reveal_i32" | "reveal_i64" => {
             let id = state.alloc();
             let (src, value) = match args.first() {
-                // Already public: nothing to open.
                 Some(Operand::Concrete(v)) => (None, *v),
                 Some(Operand::Symbol { reg, value }) => {
                     let v = match role {
@@ -226,9 +169,6 @@ pub(crate) fn service_reveal(
             Ok((event, Some(Value::I32(id as i32)), Visibility::Public))
         }
         "reveal_bytes_wait" => {
-            // Eager disclosure already opened the range; the wait makes it public
-            // and, on the verifier, materializes the bytes it learned. These are
-            // capture-time effects on `global`, so there is no replay event.
             let handle = handle_arg(args)?;
             let (ptr, len, bytes) = bytes_payload(state.payloads.get(&handle), handle)?;
             if role == Role::Verifier {
@@ -247,16 +187,6 @@ pub(crate) fn service_reveal(
     }
 }
 
-/// Services a `crypto::sha256_compress(state_ptr, block_ptr)` host call
-/// surfaced during capture.
-///
-/// Both pointers are public concrete operands. The output is committed iff any
-/// of the 96 input bytes is tainted — a decision identical on both parties,
-/// since taint is identical on both. When all inputs are public, both parties
-/// compute the digest in the clear (public fast-path, no circuit). Otherwise
-/// the prover computes and writes the digest and marks the 32-byte output
-/// `Private`; the verifier only marks it `Blind`, and replay proves the
-/// compression circuit on both sides.
 pub(crate) fn service_sha256_compress(
     role: Role,
     global: &mut Global,
@@ -265,18 +195,14 @@ pub(crate) fn service_sha256_compress(
     let state_ptr = arg_u32(args, 0)?;
     let block_ptr = arg_u32(args, 1)?;
 
-    // Per-byte taint of each input region (identical on both parties), with the
-    // public bytes (symbolic positions zeroed) for replay's public-bit wires.
     let (state_pub, state_sym) = masked_input::<32>(global, state_ptr)?;
     let (block_pub, block_sym) = masked_input::<64>(global, block_ptr)?;
 
     if state_sym == 0 && block_sym == 0 {
-        // Public fast-path: every input byte is public, so both parties hold the
-        // full input (the masked bytes are the whole input), compute the digest
-        // in the clear, write it back, and keep the output public. No circuit.
         let digest = compress_block(&state_pub, &block_pub);
         write_state(global, state_ptr, &digest)?;
         global.set_memory_visibility(state_ptr, 32, Visibility::Public);
+        log_digest_write(global, state_ptr, Some(&digest));
         return Ok((
             HostCallEvent::Sha256CompressPublic { state_ptr, digest },
             None,
@@ -284,7 +210,6 @@ pub(crate) fn service_sha256_compress(
         ));
     }
 
-    // Authenticated path: a tainted input means the whole output is committed.
     match role {
         Role::Prover => {
             let (state, block) = read_inputs(global, state_ptr, block_ptr)?;
@@ -292,10 +217,9 @@ pub(crate) fn service_sha256_compress(
             write_state(global, state_ptr, &digest)?;
             global.set_memory_visibility(state_ptr, 32, Visibility::Private);
         }
-        // The verifier cannot compute the digest; it only marks the output
-        // region committed-and-blind so its taint matches the prover's.
         Role::Verifier => global.set_memory_visibility(state_ptr, 32, Visibility::Blind),
     }
+    log_digest_write(global, state_ptr, None);
     Ok((
         HostCallEvent::Sha256Compress {
             state_ptr,
@@ -310,11 +234,6 @@ pub(crate) fn service_sha256_compress(
     ))
 }
 
-/// Reads the `N`-byte input region at `ptr`, returning its public bytes (with
-/// symbolic positions zeroed) and a per-byte symbolic mask (bit `i` set means
-/// byte `i` is committed/symbolic). Both parties derive the same result: taint
-/// is identical across parties, public bytes match, and symbolic bytes are
-/// zeroed (their value comes from the committed wires at replay).
 fn masked_input<const N: usize>(global: &Global, ptr: u32) -> Result<([u8; N], u64)> {
     debug_assert!(N <= 64, "symbolic mask is a u64");
     let mem = global
@@ -333,8 +252,6 @@ fn masked_input<const N: usize>(global: &Global, ptr: u32) -> Result<([u8; N], u
     Ok((public, sym))
 }
 
-/// Reads the 32-byte state and 64-byte block from memory as owned arrays (so a
-/// subsequent mutable write-back doesn't alias the read borrow).
 fn read_inputs(global: &Global, state_ptr: u32, block_ptr: u32) -> Result<([u8; 32], [u8; 64])> {
     let mem = global
         .memory()
@@ -346,7 +263,20 @@ fn read_inputs(global: &Global, state_ptr: u32, block_ptr: u32) -> Result<([u8; 
     Ok((state, block))
 }
 
-/// Writes the 32-byte `digest` back over the state at `state_ptr`.
+fn log_digest_write(global: &mut Global, state_ptr: u32, digest: Option<&[u8; 32]>) {
+    for i in 0..4u32 {
+        let (symbolic_mask, value) = match digest {
+            Some(d) => {
+                let off = (i * 8) as usize;
+                let chunk = d[off..off + 8].try_into().expect("8-byte digest chunk");
+                (0, Some(u64::from_le_bytes(chunk)))
+            }
+            None => (0xff, None),
+        };
+        global.log_host_write(state_ptr + i * 8, 8, symbolic_mask, value);
+    }
+}
+
 fn write_state(global: &mut Global, state_ptr: u32, digest: &[u8; 32]) -> Result<()> {
     global
         .memory_mut()
@@ -356,11 +286,6 @@ fn write_state(global: &mut Global, state_ptr: u32, digest: &[u8; 32]) -> Result
     Ok(())
 }
 
-/// Computes one SHA-256 compression in the clear via the `sha2` crate. The
-/// `state` is eight native-endian `u32` words (the precompile's `[u32; 8]`
-/// state, little-endian in linear memory); the `block` is 16 big-endian `u32`
-/// words, per standard SHA-256. Capture works in the clear; only the
-/// witness/replay phase needs the circuit representation.
 fn compress_block(state: &[u8; 32], block: &[u8; 64]) -> [u8; 32] {
     let mut h: [u32; 8] = core::array::from_fn(|i| {
         u32::from_le_bytes([

--- a/crates/vm-zk/src/lib.rs
+++ b/crates/vm-zk/src/lib.rs
@@ -1,18 +1,3 @@
-//! A zero-knowledge virtual machine for proving execution of `mpz-vm-ir`
-//! modules.
-//!
-//! This crate provides the two parties of a designated-verifier
-//! zero-knowledge proof of program execution. A program is expressed as an
-//! `mpz-vm-ir` [`Module`](mpz_vm_ir::Module) and run through the
-//! [`Vm`](mpz_vm_core::Vm) interface implemented by both parties.
-//!
-//! The [`Prover`] holds the private witness and produces a proof that the
-//! module was executed correctly, while the [`Verifier`] checks that proof
-//! against the public inputs and outputs without learning the witness. The two
-//! parties communicate over a shared channel and are driven through the same
-//! [`Vm`](mpz_vm_core::Vm) trait, so the same program description executes
-//! on both sides.
-
 use std::collections::BTreeMap;
 
 use mpz_vm_core::{Trap, value::Value};
@@ -41,44 +26,12 @@ pub use verifier::Verifier;
 
 pub(crate) const VOPE_BITS: usize = 128;
 
-/// Default per-chunk op-cost cap, sized to sit within the net correlations one
-/// Ferret extension can deliver. A single round of the largest regular-LPN
-/// params ([`mpz_ot_core::ferret::REGULAR_PARAMS`]) yields `n` correlations but
-/// must reserve `t·log2(n/t) + k + CSP` of them as seed for the next iteration,
-/// so the usable yield is `n - iteration_cost = 15_015_684`. Capping below that
-/// keeps a chunk's sVOLE demand serviceable by one extension round, with margin
-/// left for the per-chunk commit and VOPE overhead.
 pub const DEFAULT_CHUNK_CAP: usize = 15_000_000;
 
-/// Number of proving segments a full chunk is split into when the per-segment
-/// cost is auto-derived (the default).
-///
-/// Segments are committed and folded by independent rayon workers, so the
-/// count sets the available intra-chunk parallelism. Chosen to comfortably
-/// oversubscribe a typical core count (≈4× a 16-core host) for good
-/// work-stealing balance, while staying small enough that the per-segment
-/// boundary overhead — each worker re-seeds from every prior boundary, an
-/// O(segments²) cost — stays well below the linear replay work. The actual
-/// segment count scales down for chunks smaller than the cap, since the target
-/// is derived from the shared [`DEFAULT_CHUNK_CAP`].
 pub(crate) const TARGET_SEGMENTS: usize = 64;
 
-/// Floor on the auto-derived per-segment gate-bit cost, so a small
-/// [`chunk_cap`](ConfigBuilder::chunk_cap) never produces segments too tiny to
-/// amortize their boundary commitment ("a segment for every gate").
 pub(crate) const MIN_SEGMENT_COST: usize = 50_000;
 
-/// Resolves the effective per-segment gate-bit target both parties use to
-/// place segment marks.
-///
-/// `Some(cost)` is honored verbatim — an explicit
-/// [`segment_cost`](ConfigBuilder::segment_cost) override. `None`
-/// auto-derives a target from the shared `chunk_cap` so a full chunk splits
-/// into about [`TARGET_SEGMENTS`] segments: workload-proportional, and
-/// identical on both sides because it depends only on protocol-shared values,
-/// never on local core count (which may differ between prover and verifier).
-/// An unbounded chunk (`chunk_cap = None`) has no basis to divide and proves
-/// as a single segment.
 pub(crate) fn effective_segment_cost(
     segment_cost: Option<usize>,
     chunk_cap: Option<usize>,
@@ -100,9 +53,6 @@ pub(crate) struct ProofMessage {
 pub(crate) struct ChunkOutcome {
     pub(crate) trap_at: Option<u64>,
     pub(crate) trap: Option<Trap>,
-    /// Payloads disclosed by reveals in this chunk, keyed by reveal id. The
-    /// verifier merges these before capturing so it can resolve the reveals in
-    /// lockstep; replay then opens each against its committed wires.
     pub(crate) revealed: BTreeMap<u32, RevealPayload>,
 }
 
@@ -110,15 +60,8 @@ pub(crate) struct ChunkOutcome {
 mod tests {
     use super::DEFAULT_CHUNK_CAP;
 
-    /// `DEFAULT_CHUNK_CAP` must stay within the net correlations one Ferret
-    /// extension delivers — its output `n` less the `t·log2(n/t) + k + CSP`
-    /// seed it reserves for the next iteration — so a chunk's sVOLE demand fits
-    /// a single extension round. Guards against a future params change that
-    /// would shrink the net yield below the cap.
     #[test]
     fn default_chunk_cap_fits_ferret_iteration() {
-        // Ferret's computational security parameter (`config::CSP`), inlined
-        // since it is private to `mpz_ot_core`.
         const CSP: usize = 128;
         let net = mpz_ot_core::ferret::REGULAR_PARAMS
             .iter()

--- a/crates/vm-zk/src/memlog.rs
+++ b/crates/vm-zk/src/memlog.rs
@@ -1,160 +1,40 @@
-//! Ordered, byte-granular log of a chunk's memory accesses.
-//!
-//! [`MemoryLog`] records every load and store in execution order, each with
-//! its position in the chunk's access sequence. This is the *schedule* of the
-//! chunk's memory traffic — addresses, widths, kinds, and symbolic masks —
-//! which both parties derive identically from the directive skeleton. It
-//! serves two consumers today and one to come:
-//!
-//! - capture reads the written-byte view ([`written_addrs`](MemoryLog::written_addrs))
-//!   to know which bytes a boundary snapshot must record, draining it at each
-//!   mark ([`take_written`](MemoryLog::take_written)) so snapshots are
-//!   per-segment deltas;
-//! - the segment scan drains the written-byte states ([`take_written`](MemoryLog::take_written))
-//!   to lay out the memory part of each delta boundary commitment;
-//! - a future RAM argument consumes the full access log
-//!   ([`accesses`](MemoryLog::accesses)): each entry becomes an
-//!   `(op, addr, time)` tuple whose value wires are attached during replay,
-//!   with a permutation proof checking read-after-write consistency. That
-//!   also subsumes boundary memory commitments and lifts the public-address
-//!   restriction, since consistency no longer rides on resolving addresses
-//!   at capture time.
-//!
-//! Wasm linear memory is byte-addressed and stores have partial widths, so an
-//! arbitrary trace cut preserves only byte granularity: a later `store8` may
-//! overwrite one byte of an earlier 4-byte store. The written-byte view is
-//! therefore tracked per byte.
+use std::{collections::BTreeMap, ops::Range};
 
-use std::collections::BTreeMap;
-
-use mpz_vm_core::{Operand, value::Value};
-use mpz_vm_ir::{LoadKind, MemArg, StoreKind};
+use mpz_vm_core::{AccessAddr, AccessKind, AccessLog, Operand, value::Value};
+use mpz_vm_ir::MemArg;
 
 use crate::error::{Result, ZkVmError};
 
-/// What a store wrote, as far as the proof is concerned.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum Stored {
-    /// An authenticated value: the bytes carry wires.
-    Symbolic,
-    /// A public value: both parties know the bytes.
-    Public(Value),
-}
-
-/// The state of one written byte.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ByteState {
     Symbolic,
     Public(u8),
 }
 
-/// Whether an access reads or writes memory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum AccessKind {
-    Read,
-    Write,
-}
-
-/// One logged memory access.
-// The access log's consumer is the future RAM argument; nothing reads the
-// entries yet.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Access {
-    /// Position in the chunk's access sequence: the RAM-argument timestamp.
-    pub(crate) index: u32,
-    pub(crate) kind: AccessKind,
-    /// Effective byte address of the first accessed byte.
-    pub(crate) addr: u32,
-    /// Access width in bytes.
-    pub(crate) width: u32,
-    /// Which accessed bytes carry wires, LSB = `addr`: a load's symbolic
-    /// mask, or all accessed bytes for a symbolic store (none for a public
-    /// one).
-    pub(crate) symbolic_mask: u8,
-}
-
-/// Ordered log of the memory accesses in a chunk.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct MemoryLog {
-    accesses: Vec<Access>,
-    /// Net per-byte effect of the writes so far, in address order.
-    written: BTreeMap<u32, ByteState>,
-}
-
-impl MemoryLog {
-    /// Records a store of `kind` at effective address `eff` writing the low
-    /// `store_width(kind)` bytes of the stored value.
-    pub(crate) fn record_store(&mut self, kind: StoreKind, eff: u32, stored: Stored) {
-        let width = store_width(kind);
-        let symbolic_mask = match stored {
-            Stored::Symbolic => ((1u16 << width) - 1) as u8,
-            Stored::Public(_) => 0,
+pub(crate) fn written_view(log: &AccessLog, range: Range<u64>) -> BTreeMap<u32, ByteState> {
+    let mut written = BTreeMap::new();
+    for clock in range {
+        let entry = &log.entries()[(clock - log.base()) as usize];
+        if entry.kind != AccessKind::Write || !(entry.emitted || entry.host) {
+            continue;
+        }
+        let AccessAddr::Public(a) = entry.addr else {
+            continue;
         };
-        self.push(AccessKind::Write, eff, width, symbolic_mask);
-        match stored {
-            Stored::Symbolic => {
-                for b in 0..width {
-                    self.written.insert(eff + b, ByteState::Symbolic);
-                }
-            }
-            Stored::Public(v) => {
-                let le = v.to_le_bytes();
-                for b in 0..width {
-                    self.written
-                        .insert(eff + b, ByteState::Public(le[b as usize]));
-                }
+        for b in 0..entry.width as u32 {
+            if entry.symbolic_mask & (1 << b) != 0 {
+                written.insert(a + b, ByteState::Symbolic);
+            } else {
+                let value = entry
+                    .value
+                    .expect("a public written byte should carry its concrete value");
+                written.insert(a + b, ByteState::Public(value.to_le_bytes()[b as usize]));
             }
         }
     }
-
-    /// Records a load of `kind` at effective address `eff`. `symbolic_mask`
-    /// is the directive's: which loaded bytes come from authenticated memory
-    /// rather than the public `concrete` value.
-    pub(crate) fn record_load(&mut self, kind: LoadKind, eff: u32, symbolic_mask: u8) {
-        self.push(AccessKind::Read, eff, load_width(kind), symbolic_mask);
-    }
-
-    fn push(&mut self, kind: AccessKind, addr: u32, width: u32, symbolic_mask: u8) {
-        self.accesses.push(Access {
-            index: self.accesses.len() as u32,
-            kind,
-            addr,
-            width,
-            symbolic_mask,
-        });
-    }
-
-    /// Every access so far, in execution order.
-    #[allow(dead_code)]
-    pub(crate) fn accesses(&self) -> &[Access] {
-        &self.accesses
-    }
-
-    /// Whether any byte has been written since the last drain.
-    pub(crate) fn has_writes(&self) -> bool {
-        !self.written.is_empty()
-    }
-
-    /// The byte addresses written since the last drain, ascending.
-    pub(crate) fn written_addrs(&self) -> impl Iterator<Item = u32> + '_ {
-        self.written.keys().copied()
-    }
-
-    /// Drains the written-byte view, returning the net per-byte effect of the
-    /// writes since the last drain (in address order). Capture and the
-    /// segment scan drain at each mark, so each boundary covers only its own
-    /// segment's writes; the access log is unaffected.
-    pub(crate) fn take_written(&mut self) -> BTreeMap<u32, ByteState> {
-        std::mem::take(&mut self.written)
-    }
+    written
 }
 
-/// The effective byte address of a memory access: `addr + memarg.offset`.
-///
-/// zk-vm memory addresses must be public; a symbolic address is unsupported
-/// (until accesses are checked by a RAM argument instead of resolved at
-/// capture time).
 pub(crate) fn eff_addr(addr: &Operand, memarg: &MemArg) -> Result<u32> {
     match addr {
         Operand::Concrete(Value::I32(a)) => Ok((*a as u64 + memarg.offset as u64) as u32),
@@ -164,27 +44,5 @@ pub(crate) fn eff_addr(addr: &Operand, memarg: &MemArg) -> Result<u32> {
         other => Err(ZkVmError::Internal(format!(
             "memory address operand is not i32: {other:?}"
         ))),
-    }
-}
-
-/// Bytes written by a store of `kind`: the access width, not the value width.
-pub(crate) fn store_width(kind: StoreKind) -> u32 {
-    use StoreKind::*;
-    match kind {
-        I32Store8 | I64Store8 => 1,
-        I32Store16 | I64Store16 => 2,
-        I32 | F32 | I64Store32 => 4,
-        I64 | F64 => 8,
-    }
-}
-
-/// Bytes read by a load of `kind`: the access width, not the result width.
-pub(crate) fn load_width(kind: LoadKind) -> u32 {
-    use LoadKind::*;
-    match kind {
-        I32Load8U | I32Load8S | I64Load8U | I64Load8S => 1,
-        I32Load16U | I32Load16S | I64Load16U | I64Load16S => 2,
-        I32 | F32 | I64Load32U | I64Load32S => 4,
-        I64 | F64 => 8,
     }
 }

--- a/crates/vm-zk/src/prover.rs
+++ b/crates/vm-zk/src/prover.rs
@@ -1,6 +1,6 @@
 use mpz_common::{Context, Flush};
 use mpz_core::Block;
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_ot_core::rcot::{RCOTReceiver, RCOTReceiverOutput};
 use mpz_vm_core::{
     Call, Error as CoreError, Global, Param, Reg, Thread, Visibility, Vm, Write, value::Value,
@@ -9,8 +9,7 @@ use mpz_vm_ir::{Function, Module};
 
 use mpz_vm_memory::{AuthState, Bit, Registers};
 use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, Proof, ProverOutput, prover_wire, vope_receiver};
-use rand_chacha::ChaCha12Rng;
-use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::{ChaCha12Rng, rand_core::SeedableRng};
 use rangeset::set::RangeSet;
 use rayon::prelude::*;
 use serio::{SinkExt, stream::IoStreamExt};
@@ -20,24 +19,13 @@ use tracing::Instrument;
 use crate::{
     ChunkOutcome, Config, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
-    commit::{self, PendingIo, ProverTape, prepare_params},
+    commit::{self, PendingIo, prepare_params},
     error::ZkVmError,
     finalize, host,
     replay::{self, ReplayState},
     reveal, segment,
 };
 
-/// A zero-knowledge prover that executes a [`Module`] and proves correct
-/// execution to a [`Verifier`](crate::Verifier).
-///
-/// The prover holds the private witness and produces a proof that the module
-/// was executed correctly without revealing that witness. It implements the
-/// [`Vm`] trait, through which a program is loaded with inputs
-/// ([`write`](Vm::write)), run ([`call`](Vm::call)), and queried
-/// ([`read`](Vm::read), [`reveal`](Vm::reveal)).
-///
-/// The type parameter `T` is the correlated-randomness channel shared with the
-/// verifier.
 #[derive(Debug)]
 pub struct Prover<T> {
     module: Module,
@@ -47,29 +35,20 @@ pub struct Prover<T> {
     pending_reveal: RangeSet<u32>,
     reveal_state: host::RevealState,
     auth: AuthState,
+    auth_clear: AuthState<Gf2>,
     config: Config,
 }
 
 impl<T> Prover<T> {
-    /// Creates a new prover for `module`, drawing its correlated randomness
-    /// from `svole`, with the default [`Config`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ZkVmError`] if state for `module` cannot be initialized.
     pub fn new(module: Module, svole: T) -> Result<Self, ZkVmError> {
         Self::new_with_config(module, svole, Config::default())
     }
 
-    /// Creates a new prover for `module`, drawing its correlated randomness
-    /// from `svole` and configured by `config`.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ZkVmError`] if state for `module` cannot be initialized.
     pub fn new_with_config(module: Module, svole: T, config: Config) -> Result<Self, ZkVmError> {
-        let global = Global::new(&module)?;
+        let mut global = Global::new(&module)?;
+        global.enable_access_log();
         let auth = AuthState::new(Bit(MAC_ZERO), Bit(MAC_ONE));
+        let auth_clear = AuthState::new(Bit(Gf2(false)), Bit(Gf2(true)));
         Ok(Self {
             module,
             global,
@@ -78,8 +57,19 @@ impl<T> Prover<T> {
             pending_reveal: RangeSet::default(),
             reveal_state: host::RevealState::default(),
             auth,
+            auth_clear,
             config,
         })
+    }
+
+    fn publish_revealed(&mut self, ranges: &[Range<u32>]) {
+        for r in ranges {
+            self.global.set_memory_visibility(
+                r.start,
+                (r.end - r.start) as usize,
+                Visibility::Public,
+            );
+        }
     }
 }
 
@@ -112,174 +102,99 @@ where
         Ok((masks, macs))
     }
 
-    /// Runs the two-pass proof of one chunk: the parallel per-segment commit
-    /// pass over `exec_masks`, and — once `chi` is known — the parallel
-    /// per-segment accumulate pass yielding the combined `(u, v, assertions)`
-    /// plus the chunk-final state.
-    ///
-    /// `commit_bits` is the input-commit prefix length; the segment region
-    /// (gates, advice, and boundary commitments) follows it.
-    #[tracing::instrument(
-        level = "debug",
-        name = "commit",
-        skip_all
-    )]
-    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(level = "debug", name = "commit", skip_all)]
     fn commit_pass(
         &mut self,
         chunk: &ChunkCapture,
         plan: &segment::Plan,
-        commit_bits: usize,
-        root_reg_base: Reg,
-        params: &[Param],
-        exec_masks: &mut [bool],
-        exec_macs: &[Gf2_128],
-    ) -> Result<Vec<Option<Vec<bool>>>, ZkVmError> {
-        // Input-commit prefix: pure tape materialization. Installs the real
-        // MAC wires into the persistent auth state, which every segment
-        // worker starts from (in both passes — the commit pass only reads
-        // their pointer bits).
-        let (prefix_masks, seg_masks) = exec_masks.split_at_mut(commit_bits);
-        let (prefix_macs, _) = exec_macs.split_at(commit_bits);
-        if commit_bits > 0 {
-            let mut tape = ProverTape {
-                masks: prefix_masks,
-                macs: prefix_macs,
-                cursor: 0,
-            };
-            commit::commit_prover(
-                &mut self.auth,
-                root_reg_base,
-                params,
-                &self.pending_io,
-                &mut tape,
-            )?;
+    ) -> Result<Vec<bool>, ZkVmError> {
+        let mut witness = vec![false; plan.tape_len];
+
+        let mut delta_wires: Vec<Vec<Gf2>> = Vec::with_capacity(plan.deltas.len());
+        for d in &plan.deltas {
+            let bits = segment::plaintext_bits(&d.delta)?;
+            witness[d.tape.clone()].copy_from_slice(&bits);
+            delta_wires.push(bits.iter().map(|&bit| Gf2(bit)).collect());
         }
 
-        // Boundary plaintext, resolved from the capture snapshots, and the
-        // boundary commitments XORed straight into the mask region.
-        let mut boundary_bits: Vec<Option<Vec<bool>>> = Vec::with_capacity(plan.segments.len());
-        for seg in &plan.segments {
-            match &seg.boundary {
-                Some(b) => {
-                    let bits = segment::boundary_bits(b)?;
-                    for (i, &bit) in bits.iter().enumerate() {
-                        seg_masks[b.tape.start + i] ^= bit;
-                    }
-                    boundary_bits.push(Some(bits));
-                }
-                None => boundary_bits.push(None),
-            }
-        }
+        let shared = segment::build_shared(&self.auth_clear, plan, &delta_wires, &pub_bit_witness)?;
 
-        // Pointer-bit wires for every delta boundary, shared across workers:
-        // worker `j` seeds from all deltas before its segment.
-        let ptr_wires: Vec<Option<Vec<Gf2_128>>> = boundary_bits
-            .iter()
-            .map(|bits| {
-                bits.as_ref()
-                    .map(|b| b.iter().map(|&bit| Gf2_128::new(bit as u128)).collect())
-            })
-            .collect();
-
-        // Parallel per-segment commit workers: plaintext circuit evaluation
-        // over pointer-bit wires, adjusting each segment's gate/advice masks
-        // in place.
-        let gate_masks = gate_mask_slices(seg_masks, &plan.segments);
+        let gate_slices = gate_mask_slices(&mut witness, &plan.segments);
         let module = &self.module;
-        let auth_base = &self.auth;
-        plan.segments
+        let auth_base = &self.auth_clear;
+        let last = plan.segments.len() - 1;
+        let finals: Vec<Option<AuthState<Gf2>>> = plan
+            .segments
             .par_iter()
-            .zip(gate_masks)
+            .zip(gate_slices)
             .enumerate()
-            .map(|(j, (seg, gmasks))| -> Result<(), ZkVmError> {
-                let mut auth = auth_base.clone();
-                for (prev_seg, prev_wires) in plan.segments.iter().zip(&ptr_wires).take(j) {
-                    let prev = prev_seg
-                        .boundary
-                        .as_ref()
-                        .expect("non-final segments carry a boundary");
-                    let wires = prev_wires.as_ref().expect("wires for boundary");
-                    segment::apply_boundary(&mut auth, prev, wires, &pub_bit_prover)?;
-                }
-                let mut ctx = mpz_zk_core::Commit::new(gmasks);
-                let mut state = ReplayState::root();
-                replay::replay(
-                    &chunk.trace[seg.directives.clone()],
-                    &chunk.reveal_actions[seg.reveals.clone()],
-                    module,
-                    &mut auth,
-                    &mut ctx,
-                    &mut state,
-                )?;
-                ctx.finish()
-                    .map_err(|e| ZkVmError::Internal(e.to_string()))?;
-                Ok(())
-            })
-            .collect::<Result<(), ZkVmError>>()?;
+            .map(
+                |(j, (seg, gslice))| -> Result<Option<AuthState<Gf2>>, ZkVmError> {
+                    let mut auth = segment::layered_auth(auth_base, &shared, seg.layers);
+                    let mut ctx = mpz_zk_core::Witness::new(gslice);
+                    let mut state = ReplayState::root();
+                    replay::replay(
+                        &chunk.trace[seg.directives.clone()],
+                        &chunk.reveal_actions[seg.reveals.clone()],
+                        module,
+                        &mut auth,
+                        &mut ctx,
+                        &mut state,
+                    )?;
+                    ctx.finish()
+                        .map_err(|e| ZkVmError::Internal(e.to_string()))?;
+                    Ok((j == last).then(|| auth.flatten()))
+                },
+            )
+            .collect::<Result<_, _>>()?;
 
-        Ok(boundary_bits)
+        self.auth_clear = finals
+            .into_iter()
+            .flatten()
+            .next_back()
+            .expect("last segment produces final cleartext state");
+
+        Ok(witness)
     }
 
-    /// The parallel per-segment accumulate pass. Returns the combined
-    /// `(u, v, assertions)`, the opened reveal cleartext, and the chunk-final
-    /// authenticated state to persist.
-    #[tracing::instrument(
-        level = "debug",
-        name = "accumulate",
-        skip_all
-    )]
+    #[tracing::instrument(level = "debug", name = "accumulate", skip_all)]
     #[allow(clippy::too_many_arguments)]
     fn accumulate_pass(
         &self,
         chunk: &ChunkCapture,
         plan: &segment::Plan,
-        boundary_bits: &[Option<Vec<bool>>],
-        seg_macs: &[Gf2_128],
+        exec_macs: &[Gf2_128],
         chi: [u8; 32],
         reveal_ranges: &[Range<u32>],
         reveal_pending: bool,
     ) -> Result<AccOut, ZkVmError> {
-        // Boundary commitment wires, materialized straight off the tape.
-        let boundary_wires: Vec<Option<Vec<Gf2_128>>> = plan
-            .segments
-            .iter()
-            .zip(boundary_bits)
-            .map(|(seg, bits)| {
-                seg.boundary.as_ref().map(|b| {
-                    let bits = bits.as_ref().expect("bits for boundary");
-                    bits.iter()
-                        .enumerate()
-                        .map(|(i, &bit)| prover_wire(seg_macs[b.tape.start + i], bit))
-                        .collect()
-                })
-            })
-            .collect();
+        let mut delta_wires: Vec<Vec<Gf2_128>> = Vec::with_capacity(plan.deltas.len());
+        for d in &plan.deltas {
+            let bits = segment::plaintext_bits(&d.delta)?;
+            delta_wires.push(
+                bits.iter()
+                    .enumerate()
+                    .map(|(i, &bit)| prover_wire(exec_macs[d.tape.start + i], bit))
+                    .collect(),
+            );
+        }
 
         let module = &self.module;
         let auth_base = &self.auth;
         let memory = self.global.memory();
         let last = plan.segments.len() - 1;
+        let shared = segment::build_shared(auth_base, plan, &delta_wires, &pub_bit_prover)?;
 
         let results: Vec<(Gf2_128, Gf2_128, [u8; 32], Option<LastOut>)> = plan
             .segments
             .par_iter()
             .enumerate()
             .map(|(j, seg)| -> Result<_, ZkVmError> {
-                let mut auth = auth_base.clone();
-                for (prev_seg, prev_wires) in plan.segments.iter().zip(&boundary_wires).take(j) {
-                    let prev = prev_seg
-                        .boundary
-                        .as_ref()
-                        .expect("non-final segments carry a boundary");
-                    let wires = prev_wires.as_ref().expect("wires for boundary");
-                    segment::apply_boundary(&mut auth, prev, wires, &pub_bit_prover)?;
-                }
+                let mut auth = segment::layered_auth(auth_base, &shared, seg.layers);
 
                 let mut rng = ChaCha12Rng::from_seed(chi);
                 rng.set_word_pos((seg.chi_gates as u128) * 4);
-                let mut ctx =
-                    mpz_zk_core::Prover::committed(&seg_macs[seg.tape.clone()]).accumulate(rng);
+                let mut ctx = mpz_zk_core::Accumulate::new(&exec_macs[seg.tape.clone()], rng);
                 let mut state = ReplayState::root();
                 replay::replay(
                     &chunk.trace[seg.directives.clone()],
@@ -290,9 +205,9 @@ where
                     &mut state,
                 )?;
 
-                if let Some(b) = &seg.boundary {
-                    let wires = boundary_wires[j].as_ref().expect("wires for boundary");
-                    segment::assert_boundary(&auth, b, wires, &mut ctx).map_err(|e| {
+                if let Some(b) = plan.deltas.get(seg.layers) {
+                    let wires = &delta_wires[seg.layers];
+                    segment::assert_boundary(&auth, &b.delta, wires, &mut ctx).map_err(|e| {
                         ZkVmError::Internal(format!(
                             "segment {j} (directives {:?}): {e}",
                             seg.directives
@@ -304,17 +219,12 @@ where
                 if j == last {
                     let mut revealed = Vec::new();
                     match &chunk.trap {
-                        // A trapping chunk produces no output to bind. When the
-                        // trap is tied to a committed op, prove its divisor is
-                        // zero; a fully public trap has no committed divisor.
                         Some(t) => {
                             if let Some(directive) = &t.directive {
                                 replay::replay_trap(directive, &t.trap, &auth, &mut ctx)?;
                             }
                         }
                         None => {
-                            // Only a symbolic return is revealed/bound; a concrete
-                            // return is already public to both parties.
                             if chunk.result_symbolic {
                                 finalize::bind_output(&state, &mut ctx, &auth, chunk.result)?;
                             }
@@ -324,10 +234,15 @@ where
                         let memory = memory.ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
                         revealed = reveal::reveal_prover(&mut ctx, &auth, memory, reveal_ranges)?;
                     }
-                    last_out = Some(LastOut { auth, revealed });
+                    last_out = Some(LastOut {
+                        auth: auth.flatten(),
+                        revealed,
+                    });
                 }
 
-                let ProverOutput { u, v, assertions, .. } = ctx
+                let ProverOutput {
+                    u, v, assertions, ..
+                } = ctx
                     .finish()
                     .map_err(|e| ZkVmError::Internal(e.to_string()))?;
                 Ok((u, v, assertions, last_out))
@@ -356,9 +271,79 @@ where
             auth,
         })
     }
+
+    async fn prove_chunk(
+        &mut self,
+        io: &mut Context,
+        chunk: &ChunkCapture,
+        plan: &segment::Plan,
+        reveal_ranges: &[Range<u32>],
+        reveal_pending: bool,
+    ) -> Result<(), ZkVmError> {
+        let execute_bits = plan.tape_len;
+        let total = execute_bits + VOPE_BITS;
+        tracing::info!(
+            cost = chunk.cost,
+            total,
+            segments = plan.segments.len(),
+            "cost plan"
+        );
+
+        let witness = self.commit_pass(chunk, plan)?;
+
+        let (mut masks, macs) = self.allocate(io, total).await?;
+        let (exec_masks, vope_masks, exec_macs, vope_macs) =
+            split_vope(&mut masks, &macs, execute_bits);
+
+        for (m, w) in exec_masks.iter_mut().zip(&witness) {
+            *m ^= *w;
+        }
+
+        let commitment = Commitment {
+            adjust: exec_masks.iter().copied().collect(),
+        };
+        let chi: [u8; 32] = async {
+            io.io_mut()
+                .send(commitment)
+                .await
+                .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+            io.io_mut()
+                .expect_next()
+                .await
+                .map_err(|e| ZkVmError::IoRecv(e.to_string()))
+        }
+        .instrument(tracing::debug_span!("exchange"))
+        .await?;
+
+        let out =
+            self.accumulate_pass(chunk, plan, exec_macs, chi, reveal_ranges, reveal_pending)?;
+        self.auth = out.auth;
+
+        let out_val = if chunk.result_symbolic {
+            chunk.result
+        } else {
+            None
+        };
+        let (a_0, a_1) = vope_receiver(vope_masks, vope_macs);
+        let proof = Proof {
+            assertions: out.assertions,
+            u: out.u + a_0,
+            v: out.v + a_1,
+            coefficients: Vec::new(),
+        };
+        io.io_mut()
+            .send(ProofMessage {
+                output: out_val,
+                revealed: out.revealed,
+                proof,
+            })
+            .await
+            .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
+
+        Ok(())
+    }
 }
 
-/// Output of the prover's accumulate pass over one chunk.
 struct AccOut {
     u: Gf2_128,
     v: Gf2_128,
@@ -372,27 +357,49 @@ struct LastOut {
     revealed: Vec<u8>,
 }
 
-/// The prover's wire for a public bit.
 fn pub_bit_prover(bit: bool) -> Gf2_128 {
     if bit { MAC_ONE } else { MAC_ZERO }
 }
 
-/// Splits the segment mask region into per-segment gate/advice slices,
-/// skipping the (already finalized) boundary blocks between them.
+fn pub_bit_witness(bit: bool) -> Gf2 {
+    Gf2(bit)
+}
+
 fn gate_mask_slices<'m>(
-    mut region: &'m mut [bool],
+    witness: &'m mut [bool],
     segments: &[segment::Segment],
 ) -> Vec<&'m mut [bool]> {
     let mut out = Vec::with_capacity(segments.len());
+    let mut region = witness;
+    let mut cursor = 0usize;
     for seg in segments {
+        region = region.split_at_mut(seg.tape.start - cursor).1;
         let (gates, rest) = region.split_at_mut(seg.tape.len());
         out.push(gates);
-        region = match &seg.boundary {
-            Some(b) => rest.split_at_mut(b.tape.len()).1,
-            None => rest,
-        };
+        region = rest;
+        cursor = seg.tape.end;
     }
     out
+}
+
+fn split_vope<'a>(
+    masks: &'a mut [bool],
+    macs: &'a [Gf2_128],
+    execute_bits: usize,
+) -> (
+    &'a mut [bool],
+    &'a [bool; VOPE_BITS],
+    &'a [Gf2_128],
+    &'a [Gf2_128; VOPE_BITS],
+) {
+    let (exec_masks, vope_masks) = masks.split_at_mut(execute_bits);
+    let vope_masks: &[bool; VOPE_BITS] = (&*vope_masks)
+        .try_into()
+        .expect("vope tail is VOPE_BITS wide");
+    let (exec_macs, vope_macs) = macs.split_at(execute_bits);
+    let vope_macs: &[Gf2_128; VOPE_BITS] =
+        vope_macs.try_into().expect("vope tail is VOPE_BITS wide");
+    (exec_masks, vope_masks, exec_macs, vope_macs)
 }
 
 impl<T> Vm for Prover<T>
@@ -401,18 +408,6 @@ where
 {
     type Error = ZkVmError;
 
-    /// Writes the input `w` to linear memory at byte offset `ptr`.
-    ///
-    /// A [`Write::Private`] input is committed and contributes to the proof; a
-    /// [`Write::Public`] input is visible to both parties and carries no
-    /// commitment.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::Core`] if the module defines no memory,
-    /// [`ZkVmError::Trap`] if the write falls outside the bounds of memory, and
-    /// [`ZkVmError::Unsupported`] for a [`Write::Blind`] input, which the
-    /// prover cannot supply.
     fn write(&mut self, ptr: u32, w: Write<'_>) -> Result<(), ZkVmError> {
         let memory = self
             .global
@@ -439,28 +434,11 @@ where
         Ok(())
     }
 
-    /// Marks the `len` bytes of memory starting at `ptr` to be opened to the
-    /// verifier on the next [`call`](Vm::call).
-    ///
-    /// The cleartext of the range is proven correct before it is revealed, and
-    /// the range becomes readable afterwards.
-    ///
-    /// # Errors
-    ///
-    /// This method does not currently return an error.
     fn reveal(&mut self, ptr: u32, len: usize) -> Result<(), ZkVmError> {
         self.pending_reveal.union_mut(ptr..ptr + len as u32);
         Ok(())
     }
 
-    /// Returns the `len` bytes of memory starting at `ptr`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::Internal`] if the requested range is tainted, that
-    /// is, holds a committed value not yet opened via [`reveal`](Vm::reveal),
-    /// [`ZkVmError::Core`] if the module defines no memory, and
-    /// [`ZkVmError::Trap`] if the range falls outside the bounds of memory.
     fn read(&self, ptr: u32, len: usize) -> Result<&[u8], ZkVmError> {
         if self.global.memory_tainted(ptr, len) {
             return Err(ZkVmError::Internal(format!(
@@ -475,22 +453,6 @@ where
         memory.read_bytes(ptr, len).map_err(ZkVmError::Trap)
     }
 
-    /// Executes the function `func_idx` with arguments `params`, proving its
-    /// execution to the verifier over `io`, and returns its result.
-    ///
-    /// The prover proves the call correct without revealing its witness,
-    /// including the cleartext of any bytes queued by [`reveal`](Vm::reveal).
-    /// Pending inputs and reveals are cleared once the call returns.
-    ///
-    /// Returns `Some(value)` when the function yields a value and `None`
-    /// otherwise.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::InvalidFunction`] if `func_idx` does not name a
-    /// local function. Returns a [`ZkVmError`] if proving fails or
-    /// communication over `io` fails, and [`ZkVmError::Trap`] if execution
-    /// is proven to trap.
     #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "prover", func = self.module.func_name(func_idx).unwrap_or("?")))]
     async fn call(
         &mut self,
@@ -502,13 +464,12 @@ where
             Some(Function::Local(f)) => f,
             _ => return Err(ZkVmError::Core(CoreError::InvalidFunction(func_idx))),
         };
-        let input_bits = prepare_params(&params)?;
         let num_args = params.len() as u32;
-        // The root frame's registers begin after its result slot(s), so its
-        // parameters occupy absolute registers `root_reg_base + i`. This
-        // mirrors `Thread::call`'s layout (results, then params).
         let num_results = func.func_type().results.len() as u32;
         let root_reg_base = Reg(num_results + num_args);
+
+        let mut prologue =
+            commit::prologue_delta(Role::Prover, root_reg_base, &params, &self.pending_io)?;
 
         let mut thread = Thread::new();
         thread.call(
@@ -520,29 +481,18 @@ where
             },
         )?;
 
-        // Input + memory commit cost; zeroed after it rides on the
-        // first chunk.
-        let mut commit_bits = input_bits + self.pending_io.cost_bits();
-
         self.auth.regs = Registers::new();
+        self.auth_clear.regs = Registers::new();
         let mut final_result = None;
         let mut chunk_idx: usize = 0;
-        // Memory ranges to open on the first proving chunk. Draining them
-        // forces that chunk to prove even if it is otherwise public.
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
         let mut reveal_pending = !reveal_ranges.is_empty();
-        // Set once a chunk traps; the proven public outcome.
-        let mut trapped: Option<mpz_vm_core::Trap> = None;
-        // Set once any chunk performs authenticated work (a commit or proof).
-        // A fully public chunk before this point has nothing to prove.
         let mut any_zk_work = false;
 
-        loop {
+        let trapped: Option<mpz_vm_core::Trap> = loop {
             let chunk_span = tracing::info_span!("prover.chunk", idx = chunk_idx);
             let _enter = chunk_span.enter();
 
-            // The prover self-discovers traps via `StepResult::Trapped`,
-            // so it announces nothing to its own capture.
             let chunk = capture::capture_chunk(
                 &self.module,
                 &mut self.global,
@@ -562,22 +512,13 @@ where
                 events = chunk.trace.len(),
                 cost = chunk.cost,
                 done = chunk.done,
-                segments = chunk.marks.len() + 1,
+                segments = chunk.segments.len(),
                 "captured chunk"
             );
 
-            // Announce the chunk's trap outcome and disclosed reveals before any
-            // allocation, commit, or challenge. `op_counter` is the
-            // authoritative global index, identical on both sides for every op
-            // up to and including the trap; the reveal payloads let the verifier
-            // resolve reveals in lockstep during its own capture.
-            let (trap_at, trap) = match &chunk.trap {
-                Some(t) => (Some(t.index), Some(t.trap.clone())),
-                None => (None, None),
-            };
             let outcome = ChunkOutcome {
-                trap_at,
-                trap,
+                trap_at: chunk.trap.as_ref().map(|t| t.index),
+                trap: chunk.trap.as_ref().map(|t| t.trap.clone()),
                 revealed: chunk.reveals.clone(),
             };
             io.io_mut()
@@ -585,153 +526,40 @@ where
                 .await
                 .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
 
-            let plan = segment::plan(&chunk, &self.module, &self.auth, &params, root_reg_base);
-            let execute_bits = commit_bits + plan.tape_len;
+            let plan = segment::plan(&chunk, prologue.take());
+            let log_end = plan.segments.last().expect("at least one segment").log.end;
+            let execute_bits = plan.tape_len;
 
-            // A fully public chunk reached before any authenticated work has
-            // nothing to prove: no committed bits, no gates, and any trap it
-            // carries is public (no committed divisor). Both sides compute
-            // `execute_bits` and the trap shape identically, so they skip the
-            // allocate/commit/challenge/proof exchange in lockstep — running it
-            // would deadlock on a zero-cost tape. Once a chunk does ZK work the
-            // output may be authenticated, so every later chunk must run the
-            // exchange to carry the binding forward.
             let needs_zk = execute_bits > 0
                 || any_zk_work
                 || reveal_pending
                 || chunk.trap.as_ref().is_some_and(|t| t.directive.is_some());
-            if !needs_zk {
-                commit_bits = 0;
-                if chunk.done {
-                    final_result = chunk.result;
+            if needs_zk {
+                any_zk_work = true;
+                self.prove_chunk(io, &chunk, &plan, &reveal_ranges, reveal_pending)
+                    .await?;
+
+                if reveal_pending {
+                    self.publish_revealed(&reveal_ranges);
+                    reveal_pending = false;
                 }
-                chunk_idx += 1;
-                if let Some(t) = chunk.trap {
-                    trapped = Some(t.trap);
-                    break;
-                }
-                if chunk.done {
-                    break;
-                }
-                continue;
             }
-            any_zk_work = true;
-
-            let total = execute_bits + VOPE_BITS;
-            tracing::info!(
-                commit_bits,
-                cost = chunk.cost,
-                total,
-                segments = plan.segments.len(),
-                "cost plan"
-            );
-
-            let (mut masks, macs) = self.allocate(io, total).await?;
-            let (exec_masks, vope_masks) = masks.split_at_mut(execute_bits);
-            let vope_masks: &[bool; VOPE_BITS] = (&*vope_masks)
-                .try_into()
-                .expect("vope tail is VOPE_BITS wide");
-            let (exec_macs, vope_macs) = macs.split_at(execute_bits);
-            let vope_macs: &[Gf2_128; VOPE_BITS] =
-                vope_macs.try_into().expect("vope tail is VOPE_BITS wide");
-
-            // ---- Commit pass: parallel plaintext evaluation ----
-            let boundary_bits = self.commit_pass(
-                &chunk,
-                &plan,
-                commit_bits,
-                root_reg_base,
-                &params,
-                exec_masks,
-                exec_macs,
-            )?;
-            commit_bits = 0;
-
-            // The whole execute tape's adjust witness (commit prefix, gates,
-            // and boundary commitments) ships in one Commitment message, sent
-            // before the prover learns the verifier's challenge. The verifier
-            // samples its challenge only after holding the commitment, so the
-            // prover cannot tailor its witness to it.
-            let commitment = Commitment {
-                adjust: exec_masks.iter().copied().collect(),
-            };
-            let chi: [u8; 32] = async {
-                io.io_mut()
-                    .send(commitment)
-                    .await
-                    .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
-                io.io_mut()
-                    .expect_next()
-                    .await
-                    .map_err(|e| ZkVmError::IoRecv(e.to_string()))
-            }
-            .instrument(tracing::debug_span!("exchange"))
-            .await?;
-
-            // ---- Accumulate pass: parallel proof folding ----
-            let seg_macs = &exec_macs[exec_macs.len() - plan.tape_len..];
-            let out = self.accumulate_pass(
-                &chunk,
-                &plan,
-                &boundary_bits,
-                seg_macs,
-                chi,
-                &reveal_ranges,
-                reveal_pending,
-            )?;
-            // The chunk-final worker state carries every wire forward.
-            self.auth = out.auth;
 
             if chunk.done {
                 final_result = chunk.result;
             }
-            // Only a *symbolic* return value is revealed over the wire; a
-            // concrete return is already public, so the verifier reconstructs
-            // it from its own local result.
-            let out_val = if chunk.result_symbolic {
-                chunk.result
-            } else {
-                None
-            };
-            let (a_0, a_1) = vope_receiver(vope_masks, vope_macs);
-            let proof = Proof {
-                assertions: out.assertions,
-                u: out.u + a_0,
-                v: out.v + a_1,
-                coefficients: Vec::new(),
-            };
-            io.io_mut()
-                .send(ProofMessage {
-                    output: out_val,
-                    revealed: out.revealed,
-                    proof,
-                })
-                .await
-                .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
-
-            // The opened ranges are now concrete to both parties: drop their
-            // taint so subsequent reads succeed. The cleartext already lives in
-            // the prover's linear memory (written when it was first stored).
-            if reveal_pending {
-                for r in &reveal_ranges {
-                    self.global.set_memory_visibility(
-                        r.start,
-                        (r.end - r.start) as usize,
-                        Visibility::Public,
-                    );
-                }
-                reveal_pending = false;
-            }
-
+            self.global
+                .access_log_mut()
+                .expect("access log enabled")
+                .drain_upto(log_end);
             chunk_idx += 1;
             if let Some(t) = chunk.trap {
-                trapped = Some(t.trap);
-                break;
+                break Some(t.trap);
             }
             if chunk.done {
-                break;
+                break None;
             }
-        }
+        };
 
         self.pending_io.clear();
         self.pending_reveal = RangeSet::default();
@@ -743,47 +571,37 @@ where
         Ok(final_result)
     }
 
-    /// Commits any queued private writes and opens any queued reveals over `io`
-    /// without running a function.
-    ///
-    /// This performs a single proving round that commits the wires of every
-    /// pending [`Write::Private`] region and proves-then-opens every pending
-    /// [`reveal`](Vm::reveal) range, leaving nothing queued. The committed
-    /// memory wires persist and are consumed by a later [`call`](Vm::call).
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ZkVmError`] if proving fails or communication over `io`
-    /// fails.
     #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "prover"))]
     async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
-        let commit_bits = self.pending_io.cost_bits();
+        let prologue = commit::prologue_delta(Role::Prover, Reg(0), &[], &self.pending_io)?;
+        let witness = match &prologue {
+            Some(delta) => segment::plaintext_bits(delta)?,
+            None => Vec::new(),
+        };
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
         let reveal_pending = !reveal_ranges.is_empty();
-        if commit_bits == 0 && !reveal_pending {
+        if witness.is_empty() && !reveal_pending {
             return Ok(());
         }
 
-        // A commit round runs no gates, so the only authenticated bits are the
-        // committed inputs.
-        let execute_bits = commit_bits;
+        let execute_bits = witness.len();
         let total = execute_bits + VOPE_BITS;
         let (mut masks, macs) = self.allocate(io, total).await?;
-        let (exec_masks, vope_masks) = masks.split_at_mut(execute_bits);
-        let vope_masks: &[bool; VOPE_BITS] = (&*vope_masks)
-            .try_into()
-            .expect("vope tail is VOPE_BITS wide");
-        let (exec_macs, vope_macs) = macs.split_at(execute_bits);
-        let vope_macs: &[Gf2_128; VOPE_BITS] =
-            vope_macs.try_into().expect("vope tail is VOPE_BITS wide");
+        let (exec_masks, vope_masks, exec_macs, vope_macs) =
+            split_vope(&mut masks, &macs, execute_bits);
 
-        if commit_bits > 0 {
-            let mut tape = ProverTape {
-                masks: exec_masks,
-                macs: exec_macs,
-                cursor: 0,
-            };
-            commit::commit_memory_prover(&mut self.auth, &self.pending_io, &mut tape)?;
+        if let Some(delta) = &prologue {
+            for (m, w) in exec_masks.iter_mut().zip(&witness) {
+                *m ^= *w;
+            }
+            let clear_wires: Vec<Gf2> = witness.iter().map(|&b| Gf2(b)).collect();
+            segment::apply_delta(&mut self.auth_clear, delta, &clear_wires, &pub_bit_witness)?;
+            let mac_wires: Vec<Gf2_128> = witness
+                .iter()
+                .enumerate()
+                .map(|(i, &b)| prover_wire(exec_macs[i], b))
+                .collect();
+            segment::apply_delta(&mut self.auth, delta, &mac_wires, &pub_bit_prover)?;
         }
 
         let commitment = Commitment {
@@ -799,10 +617,8 @@ where
             .await
             .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
 
-        // The commit round folds no gates; a tape-free accumulate context
-        // hashes the reveal assertions into the proof.
         let mut revealed: Vec<u8> = Vec::new();
-        let mut ctx = mpz_zk_core::Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+        let mut ctx = mpz_zk_core::Accumulate::new(&[], ChaCha12Rng::from_seed(chi));
         if reveal_pending {
             let memory = self
                 .global
@@ -810,7 +626,9 @@ where
                 .ok_or(ZkVmError::Core(CoreError::MemoryNotDefined))?;
             revealed = reveal::reveal_prover(&mut ctx, &self.auth, memory, &reveal_ranges)?;
         }
-        let ProverOutput { u, v, assertions, .. } = ctx
+        let ProverOutput {
+            u, v, assertions, ..
+        } = ctx
             .finish()
             .map_err(|e| ZkVmError::Internal(e.to_string()))?;
 
@@ -830,37 +648,14 @@ where
             .await
             .map_err(|e| ZkVmError::IoSend(e.to_string()))?;
 
-        // Opened ranges are now public to both parties; drop their taint so
-        // later reads succeed. The cleartext already lives in linear memory.
         if reveal_pending {
-            for r in &reveal_ranges {
-                self.global.set_memory_visibility(
-                    r.start,
-                    (r.end - r.start) as usize,
-                    Visibility::Public,
-                );
-            }
+            self.publish_revealed(&reveal_ranges);
         }
         self.pending_io.clear();
         self.pending_reveal = RangeSet::default();
         Ok(())
     }
 
-    /// Runs `func_idx` with `params` using only local work, without an `io`
-    /// context.
-    ///
-    /// Public computation is reproduced in-thread, so a function with public
-    /// inputs runs with no communication. Any authenticated work — a symbolic
-    /// op, a private branch, or a reveal host call — reports
-    /// [`ZkVmError::RequiresCommunication`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private
-    /// or blind values, if inputs or reveals remain queued (commit them first),
-    /// or if execution reaches authenticated work. Otherwise returns
-    /// [`ZkVmError::InvalidFunction`] for a bad `func_idx` or
-    /// [`ZkVmError::Trap`] on a trap.
     fn call_local(
         &mut self,
         func_idx: u32,

--- a/crates/vm-zk/src/replay.rs
+++ b/crates/vm-zk/src/replay.rs
@@ -1,20 +1,3 @@
-//! Replay of a captured execution trace into a zero-knowledge circuit.
-//!
-//! Re-executes the [`Directive`](mpz_vm_core::Directive) sequence recorded
-//! during evaluation, applying each directive to the
-//! [`AuthState`] of authenticated values while emitting the corresponding
-//! gadget operations through a [`ZkExec`] backend. This is the step that turns
-//! a witnessed run into the constraints proven by the
-//! [`Prover`](crate::Prover) and checked by the [`Verifier`](crate::Verifier).
-//!
-//! Directive registers are absolute (see [`Op`]), so replay applies them to
-//! [`AuthState::regs`] directly without tracking per-frame register bases. A
-//! returning frame's register range is reclaimed so a later call reuses those
-//! slots, mirroring the thread's bounded register file.
-//!
-//! Trapping directives are replayed separately so that the committed trap
-//! reason can be re-derived and constrained against its operands.
-
 use itybity::{GetBit, Lsb0};
 use mpz_circuits::Context;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
@@ -33,45 +16,31 @@ use crate::{
     host::HostCallEvent,
 };
 
-// ============================================================
-// Execution backend
-// ============================================================
+pub(crate) type ProverCtx<'a> = mpz_zk_core::prover::Accumulate<'a, ChaCha12Rng>;
 
-/// The prover's accumulate-pass circuit context over a segment's MAC tape.
-pub(crate) type ProverCtx<'a> =
-    mpz_zk_core::prover::Prover<'a, mpz_zk_core::prover::Accumulate<ChaCha12Rng>>;
+pub(crate) type VerifierCtx<'a> = mpz_zk_core::verifier::Verifier<'a, ChaCha12Rng>;
 
-/// The verifier's accumulate-pass circuit context over a segment's key tape.
-pub(crate) type VerifierCtx<'a> =
-    mpz_zk_core::verifier::Verifier<'a, mpz_zk_core::verifier::Accumulate<ChaCha12Rng>>;
+pub(crate) trait ZkExec: Context<Field = Gf2, Wire: GetBit<Lsb0>> {
+    fn public_bit(&mut self, value: bool) -> Self::Wire;
 
-/// The prover/verifier-side capabilities replay needs on top of a circuit
-/// [`Context`]: public-bit constants and blind witness advice.
-pub(crate) trait ZkExec: Context<Wire = Gf2_128, Field = Gf2> {
-    fn public_bit(&mut self, value: bool) -> Gf2_128;
+    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32<Self::Wire>;
 
-    /// Commits a 32-bit witness value as blind advice and returns the
-    /// authenticated bundle. The prover commits the bits of `compute()`; the
-    /// verifier commits blanks and never runs `compute`.
-    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32;
-
-    /// 64-bit [`advise_i32`](ZkExec::advise_i32).
-    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64;
+    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64<Self::Wire>;
 }
 
-impl ZkExec for mpz_zk_core::Commit<'_> {
-    fn public_bit(&mut self, value: bool) -> Gf2_128 {
-        self.input_public(value)
+impl ZkExec for mpz_zk_core::Witness<'_> {
+    fn public_bit(&mut self, value: bool) -> Gf2 {
+        self.input_public(Gf2(value))
     }
 
-    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32 {
+    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32<Gf2> {
         let v = compute();
-        I32::from(core::array::from_fn(|i| self.input((v >> i) & 1 != 0)))
+        I32::from(core::array::from_fn(|i| self.input(Gf2((v >> i) & 1 != 0))))
     }
 
-    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64 {
+    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64<Gf2> {
         let v = compute();
-        I64::from(core::array::from_fn(|i| self.input((v >> i) & 1 != 0)))
+        I64::from(core::array::from_fn(|i| self.input(Gf2((v >> i) & 1 != 0))))
     }
 }
 
@@ -80,12 +49,12 @@ impl ZkExec for ProverCtx<'_> {
         self.input_public(value)
     }
 
-    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32 {
+    fn advise_i32(&mut self, compute: impl FnOnce() -> u32) -> I32<Gf2_128> {
         let v = compute();
         I32::from(core::array::from_fn(|i| self.input((v >> i) & 1 != 0)))
     }
 
-    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64 {
+    fn advise_i64(&mut self, compute: impl FnOnce() -> u64) -> I64<Gf2_128> {
         let v = compute();
         I64::from(core::array::from_fn(|i| self.input((v >> i) & 1 != 0)))
     }
@@ -96,18 +65,14 @@ impl ZkExec for VerifierCtx<'_> {
         self.input_public(value)
     }
 
-    fn advise_i32(&mut self, _compute: impl FnOnce() -> u32) -> I32 {
+    fn advise_i32(&mut self, _compute: impl FnOnce() -> u32) -> I32<Gf2_128> {
         I32::from(core::array::from_fn(|_| self.input()))
     }
 
-    fn advise_i64(&mut self, _compute: impl FnOnce() -> u64) -> I64 {
+    fn advise_i64(&mut self, _compute: impl FnOnce() -> u64) -> I64<Gf2_128> {
         I64::from(core::array::from_fn(|_| self.input()))
     }
 }
-
-// ============================================================
-// Replay loop
-// ============================================================
 
 #[derive(Debug)]
 pub(crate) struct ReplayState {
@@ -125,7 +90,7 @@ pub(crate) fn replay<C>(
     trace: &[Directive],
     reveal_actions: &[HostCallEvent],
     module: &Module,
-    auth: &mut AuthState,
+    auth: &mut AuthState<C::Wire>,
     exec: &mut C,
     state: &mut ReplayState,
 ) -> Result<()>
@@ -203,9 +168,6 @@ where
                 ..
             } => {
                 if is_import(module, *func_idx) {
-                    // Imported calls carry a per-call action, applied in-order:
-                    // a reveal opens live MACs, a precompile emits its circuit
-                    // over the input wires (or writes a public result).
                     let action = reveal_actions.get(reveal_cursor).ok_or_else(|| {
                         ZkVmError::Internal("reveal action missing for imported call".into())
                     })?;
@@ -240,13 +202,11 @@ where
     Ok(())
 }
 
-// ============================================================
-// Operand resolution
-// ============================================================
-
-/// Resolves an operand to its authenticated value: a symbol is cloned from the
-/// register file; a public constant is materialized as public-bit MACs.
-fn operand_value<C>(operand: &Operand, auth: &AuthState, exec: &mut C) -> Result<AuthValue>
+fn operand_value<C>(
+    operand: &Operand,
+    auth: &AuthState<C::Wire>,
+    exec: &mut C,
+) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
 {
@@ -260,13 +220,12 @@ where
     }
 }
 
-/// Encodes a public constant as an [`AuthValue`] of public-bit MACs.
-fn const_auth<C>(exec: &mut C, v: &Value) -> Result<AuthValue>
+fn const_auth<C>(exec: &mut C, v: &Value) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
 {
     let (ty, width, raw) = decode_concrete(v)?;
-    let bits: Vec<Bit> = (0..width)
+    let bits: Vec<Bit<C::Wire>> = (0..width)
         .map(|i| Bit(exec.public_bit((raw >> i) & 1 != 0)))
         .collect();
     Ok(AuthValue::from_bits(ty, &bits)?)
@@ -282,8 +241,6 @@ fn decode_concrete(v: &Value) -> Result<(ValType, usize, u64)> {
     }
 }
 
-/// The `i32` value of a concrete operand (used for the public-constant gadget
-/// paths in [`binary_eval`]).
 fn const_i32(op: &Operand) -> Result<i32> {
     match op {
         Operand::Concrete(Value::I32(x)) => Ok(*x),
@@ -293,7 +250,6 @@ fn const_i32(op: &Operand) -> Result<i32> {
     }
 }
 
-/// The `i64` value of a concrete operand.
 fn const_i64(op: &Operand) -> Result<i64> {
     match op {
         Operand::Concrete(Value::I64(x)) => Ok(*x),
@@ -303,10 +259,7 @@ fn const_i64(op: &Operand) -> Result<i64> {
     }
 }
 
-/// Concrete integer value carried by a wire bundle, read from the pointer bit
-/// (LSB) of each wire. Meaningful only on the prover, where it feeds the advice
-/// closures that compute a gadget's witness.
-fn wire_value(wires: &[Gf2_128]) -> u64 {
+fn wire_value<W: GetBit<Lsb0>>(wires: &[W]) -> u64 {
     let mut out = 0u64;
     for (i, w) in wires.iter().enumerate() {
         if GetBit::<Lsb0>::get_bit(w, 0) {
@@ -316,25 +269,18 @@ fn wire_value(wires: &[Gf2_128]) -> u64 {
     out
 }
 
-// ============================================================
-// Op dispatch
-// ============================================================
-
 fn binary_eval<C>(
     exec: &mut C,
-    auth: &AuthState,
+    auth: &AuthState<C::Wire>,
     op: BinaryOp,
     lhs: &Operand,
     rhs: &Operand,
-) -> Result<AuthValue>
+) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
 {
     use BinaryOp::*;
-    // Both operands are resolved up front. A public-constant right operand takes
-    // the cheaper constant-specialized circuit (guarded arms below); resolving
-    // `b` anyway is free (public-bit MACs, no tape/gates).
     let a = operand_value(lhs, auth, exec)?;
     let b = operand_value(rhs, auth, exec)?;
     Ok(match op {
@@ -464,10 +410,12 @@ where
     })
 }
 
-/// Commits the `(q, r)` advice for a 32-bit division/remainder and emits the
-/// verifying circuit. The quotient/remainder are computed by the gadget on the
-/// prover and committed as blind advice; the verifier commits blanks.
-fn div_rem_i32<C>(exec: &mut C, a: I32, b: I32, op: BinaryOp) -> Result<AuthValue>
+fn div_rem_i32<C>(
+    exec: &mut C,
+    a: I32<C::Wire>,
+    b: I32<C::Wire>,
+    op: BinaryOp,
+) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -497,8 +445,12 @@ where
     Ok(out.into())
 }
 
-/// 64-bit counterpart of [`div_rem_i32`].
-fn div_rem_i64<C>(exec: &mut C, a: I64, b: I64, op: BinaryOp) -> Result<AuthValue>
+fn div_rem_i64<C>(
+    exec: &mut C,
+    a: I64<C::Wire>,
+    b: I64<C::Wire>,
+    op: BinaryOp,
+) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -528,9 +480,7 @@ where
     Ok(out.into())
 }
 
-/// Commits the count-leading/trailing-zeros advice and emits the verifying
-/// circuit for a 32-bit value.
-fn count_i32<C>(exec: &mut C, a: I32, clz: bool) -> Result<AuthValue>
+fn count_i32<C>(exec: &mut C, a: I32<C::Wire>, clz: bool) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -552,8 +502,7 @@ where
     Ok(out.into())
 }
 
-/// 64-bit counterpart of [`count_i32`].
-fn count_i64<C>(exec: &mut C, a: I64, clz: bool) -> Result<AuthValue>
+fn count_i64<C>(exec: &mut C, a: I64<C::Wire>, clz: bool) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -575,7 +524,7 @@ where
     Ok(out.into())
 }
 
-fn unary_eval<C>(op: UnaryOp, exec: &mut C, a: AuthValue) -> Result<AuthValue>
+fn unary_eval<C>(op: UnaryOp, exec: &mut C, a: AuthValue<C::Wire>) -> Result<AuthValue<C::Wire>>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -602,14 +551,8 @@ where
     })
 }
 
-// ============================================================
-// Memory
-// ============================================================
-
-/// Loads `kind` at the effective address, taking symbolic bytes from committed
-/// memory and the remaining (public) bytes from `concrete` per `symbolic_mask`.
-fn mem_load(
-    auth: &mut AuthState,
+fn mem_load<W: Copy>(
+    auth: &mut AuthState<W>,
     dst: Reg,
     kind: LoadKind,
     addr: &Operand,
@@ -620,7 +563,7 @@ fn mem_load(
     use LoadKind::*;
     let eff = crate::memlog::eff_addr(addr, memarg)?;
     let m = &auth.memory;
-    let av: AuthValue = match kind {
+    let av: AuthValue<W> = match kind {
         I32 => m
             .load_i32_mixed(eff, concrete, symbolic_mask)
             .map(Into::into),
@@ -670,7 +613,7 @@ fn mem_load(
 
 fn mem_store<C>(
     exec: &mut C,
-    auth: &mut AuthState,
+    auth: &mut AuthState<C::Wire>,
     kind: StoreKind,
     addr: &Operand,
     val: &Operand,
@@ -699,11 +642,7 @@ where
     Ok(())
 }
 
-// ============================================================
-// Reveals, returns, traps
-// ============================================================
-
-fn apply_reveal<C>(event: &HostCallEvent, auth: &mut AuthState, exec: &mut C) -> Result<()>
+fn apply_reveal<C>(event: &HostCallEvent, auth: &mut AuthState<C::Wire>, exec: &mut C) -> Result<()>
 where
     C: ZkExec,
     C::Error: core::fmt::Debug,
@@ -715,16 +654,11 @@ where
             handle_dst,
             id,
         } => {
-            // Open the disclosed value against the live source MAC. A `None`
-            // source means the value was already public, so there is nothing to
-            // open.
             if let Some(src) = src {
                 finalize::assert_output(exec, auth, *src, *value)?;
             }
-            // The reveal returns the public handle id.
             set_public_reg(auth, exec, *handle_dst, &Value::I32(*id as i32))?;
         }
-        // The wait binds the now-public revealed value into its destination.
         HostCallEvent::WaitScalar { dst, value } => {
             set_public_reg(auth, exec, *dst, value)?;
         }
@@ -734,14 +668,10 @@ where
             handle_dst,
             id,
         } => {
-            // Open the disclosed bytes against the live byte MACs at this point
-            // in the trace (before any later store could overwrite them).
             crate::reveal::assert_bytes(exec, auth, *ptr, bytes)?;
             set_public_reg(auth, exec, *handle_dst, &Value::I32(*id as i32))?;
         }
-        // The byte wait's effect was applied to memory during capture.
         HostCallEvent::WaitBytes => {}
-        // Precompile actions are dispatched before `apply_reveal`.
         HostCallEvent::Sha256Compress { .. } | HostCallEvent::Sha256CompressPublic { .. } => {
             return Err(ZkVmError::Internal(
                 "precompile action routed to apply_reveal".into(),
@@ -751,20 +681,10 @@ where
     Ok(())
 }
 
-// ============================================================
-// Precompiles
-// ============================================================
-
-/// Emits the SHA-256 compression circuit for an authenticated
-/// `crypto::sha256_compress`: assembles the 256-bit state and 512-bit block
-/// wires (symbolic bytes from committed memory, public bytes as public-bit
-/// wires from the recorded plaintext), runs `mpz_circuits::sha256::compress`
-/// through the live circuit context (consuming exactly `AND_PER_BLOCK` gates),
-/// and writes the 256-bit committed output back over the state in place.
 #[allow(clippy::too_many_arguments)]
 fn apply_sha256_compress<C>(
     exec: &mut C,
-    auth: &mut AuthState,
+    auth: &mut AuthState<C::Wire>,
     state_ptr: u32,
     state_pub: &[u8; 32],
     state_sym: u64,
@@ -776,8 +696,6 @@ where
     C: ZkExec,
     C::Error: core::fmt::Debug,
 {
-    // State and block are read in memory (little-endian) order; the SHA-256
-    // gadget groups the big-endian schedule words from the block itself.
     let state = read_mixed::<256, _>(exec, auth, state_ptr, state_pub, state_sym)?;
     let msg = read_mixed::<512, _>(exec, auth, block_ptr, block_pub, block_sym)?;
     let out = mpz_circuits::sha256::compress(exec, msg, state);
@@ -785,9 +703,7 @@ where
     Ok(())
 }
 
-/// Writes a public digest back over the 32-byte state as public-bit wires (no
-/// gates), for the public fast-path where all inputs were public.
-fn write_public_bytes<C>(exec: &mut C, auth: &mut AuthState, base: u32, digest: &[u8; 32])
+fn write_public_bytes<C>(exec: &mut C, auth: &mut AuthState<C::Wire>, base: u32, digest: &[u8; 32])
 where
     C: ZkExec,
 {
@@ -799,26 +715,19 @@ where
     }
 }
 
-/// Assembles `N` input wires from the `N / 8` bytes at `base` in memory order:
-/// bit `8*bo + k` of the output is bit `k` of memory byte `bo`. This is the
-/// little-endian `u32`-word layout the SHA-256 gadget expects (it groups the
-/// big-endian schedule words itself). A byte marked symbolic in `sym` (bit `i`
-/// = byte `i`) is read from committed memory (a `MemAuthMissing` error if
-/// absent); a public byte is materialized as public-bit wires from `public[i]`
-/// (no gates).
 fn read_mixed<const N: usize, C>(
     exec: &mut C,
-    auth: &AuthState,
+    auth: &AuthState<C::Wire>,
     base: u32,
     public: &[u8],
     sym: u64,
-) -> Result<[Gf2_128; N]>
+) -> Result<[C::Wire; N]>
 where
     C: ZkExec,
 {
-    let mut out = [Gf2_128::new(0); N];
+    let mut out = [exec.public_bit(false); N];
     for bo in 0..N / 8 {
-        let bits: [Gf2_128; 8] = if (sym >> bo) & 1 != 0 {
+        let bits: [C::Wire; 8] = if (sym >> bo) & 1 != 0 {
             let off = base + bo as u32;
             let byte = auth
                 .memory
@@ -833,17 +742,19 @@ where
     Ok(out)
 }
 
-/// Writes `wires` back to memory at `base` in memory order — bit `8*bo + k` of
-/// the wire stream is bit `k` of byte `bo` — the inverse layout of
-/// [`read_mixed`].
-fn write_words(auth: &mut AuthState, base: u32, wires: &[Gf2_128]) {
+fn write_words<W: Copy>(auth: &mut AuthState<W>, base: u32, wires: &[W]) {
     for bo in 0..wires.len() / 8 {
         let byte = Byte::new(core::array::from_fn(|k| Bit(wires[bo * 8 + k])));
         auth.memory.set_byte(base + bo as u32, byte);
     }
 }
 
-fn set_public_reg<C>(auth: &mut AuthState, exec: &mut C, reg: Reg, value: &Value) -> Result<()>
+fn set_public_reg<C>(
+    auth: &mut AuthState<C::Wire>,
+    exec: &mut C,
+    reg: Reg,
+    value: &Value,
+) -> Result<()>
 where
     C: ZkExec,
 {
@@ -851,19 +762,15 @@ where
     Ok(())
 }
 
-fn handle_return(
-    auth: &mut AuthState,
+fn handle_return<W: Copy>(
+    auth: &mut AuthState<W>,
     state: &mut ReplayState,
     dst: Option<Reg>,
     src: Option<Reg>,
     reclaim: Option<(Reg, u32)>,
 ) {
     match (dst, src) {
-        // Non-root return into a caller register: bind the result's MAC there
-        // before the source range is reclaimed below.
         (Some(d), Some(s)) => auth.regs.copy(d, s),
-        // Outermost return (carries `dst = None`, `reclaim = None`): record the
-        // result register for finalize to open.
         (None, Some(s)) if reclaim.is_none() => state.output_reg = Some(s),
         _ => {}
     }
@@ -875,7 +782,7 @@ fn handle_return(
 pub(crate) fn replay_trap<C>(
     directive: &Directive,
     reason: &Trap,
-    auth: &AuthState,
+    auth: &AuthState<C::Wire>,
     exec: &mut C,
 ) -> Result<()>
 where
@@ -915,9 +822,14 @@ fn trap_operands(directive: &Directive) -> Result<(&Operand, &Operand, usize)> {
     }
 }
 
-fn assert_const_bits<C>(ctx: &mut C, value: &AuthValue, width: usize, bits: u64) -> Result<()>
+fn assert_const_bits<C>(
+    ctx: &mut C,
+    value: &AuthValue<C::Wire>,
+    width: usize,
+    bits: u64,
+) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: core::fmt::Debug,
 {
     let wires = match width {
@@ -936,17 +848,22 @@ where
     Ok(())
 }
 
-fn assert_divisor_zero<C>(ctx: &mut C, divisor: &AuthValue, width: usize) -> Result<()>
+fn assert_divisor_zero<C>(ctx: &mut C, divisor: &AuthValue<C::Wire>, width: usize) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: core::fmt::Debug,
 {
     assert_const_bits(ctx, divisor, width, 0)
 }
 
-fn assert_overflow<C>(ctx: &mut C, lhs: &AuthValue, rhs: &AuthValue, width: usize) -> Result<()>
+fn assert_overflow<C>(
+    ctx: &mut C,
+    lhs: &AuthValue<C::Wire>,
+    rhs: &AuthValue<C::Wire>,
+    width: usize,
+) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: core::fmt::Debug,
 {
     let all_ones = if width == 64 {
@@ -959,10 +876,8 @@ where
     assert_const_bits(ctx, lhs, width, int_min)
 }
 
-fn propagate_args(auth: &mut AuthState, param_base: Reg, args: &[Operand]) {
+fn propagate_args<W: Copy>(auth: &mut AuthState<W>, param_base: Reg, args: &[Operand]) {
     for (i, arg) in args.iter().enumerate() {
-        // Call-arg operands carry absolute source registers; bind each to the
-        // callee's parameter register `param_base + i`.
         if let Operand::Symbol { reg, .. } = arg {
             auth.regs.copy(param_base + i as u32, *reg);
         }

--- a/crates/vm-zk/src/reveal.rs
+++ b/crates/vm-zk/src/reveal.rs
@@ -56,11 +56,14 @@ where
     Ok(())
 }
 
-/// Opens the `bytes` at `[ptr, ptr + bytes.len())` against their committed
-/// wires, asserting each byte's MAC equals the disclosed value.
-pub(crate) fn assert_bytes<C>(exec: &mut C, auth: &AuthState, ptr: u32, bytes: &[u8]) -> Result<()>
+pub(crate) fn assert_bytes<C>(
+    exec: &mut C,
+    auth: &AuthState<C::Wire>,
+    ptr: u32,
+    bytes: &[u8],
+) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     for (i, &b) in bytes.iter().enumerate() {
@@ -69,9 +72,9 @@ where
     Ok(())
 }
 
-fn assert_byte<C>(exec: &mut C, auth: &AuthState, addr: u32, value: u8) -> Result<()>
+fn assert_byte<C>(exec: &mut C, auth: &AuthState<C::Wire>, addr: u32, value: u8) -> Result<()>
 where
-    C: Context<Wire = Gf2_128, Field = Gf2>,
+    C: Context<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let byte = auth

--- a/crates/vm-zk/src/segment.rs
+++ b/crates/vm-zk/src/segment.rs
@@ -1,626 +1,196 @@
-//! Segmentation of a captured chunk for parallel proving.
-//!
-//! A chunk's directive trace is split at the [`SegmentMark`]s recorded during
-//! capture. Each segment is committed and folded by an independent worker;
-//! the workers are stitched together at the marks by *boundary commitments*:
-//! the boundary after segment `j` is a *delta* — only the registers, globals,
-//! and memory bytes written during segment `j` are freshly committed on the
-//! tape (plus tombstones for registers the segment reclaimed). Worker `j`
-//! asserts that its final wires for those items equal the delta commitment,
-//! and worker `j + 1` seeds its state by materializing every prior delta in
-//! order, directly off the tape ([`mpz_zk_core::prover_wire`] /
-//! [`mpz_zk_core::verifier_wire`]), so no wire ever crosses between workers.
-//! An item last written in segment `i` reaches every later worker as the
-//! same materialized delta-`i` wire, so cross-segment equality holds by
-//! construction and only a segment's own writes ever need committing —
-//! total boundary tape is linear in the chunk's writes rather than
-//! quadratic.
-//!
-//! [`plan`] derives the layout purely from the directive skeleton plus the
-//! symbolic types of pre-existing (persistent) state, so the prover and
-//! verifier compute identical layouts. Only the boundary *values* are
-//! prover-side data, resolved from the capture [`Snapshot`]s.
-
-use std::{collections::BTreeMap, ops::Range};
+use std::{collections::HashMap, ops::Range, sync::Arc};
 
 use mpz_circuits::Context;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
-use mpz_vm_core::{Directive, Op, Operand, Param, Reg, ValType, value::Value};
-use mpz_vm_ir::{BinaryOp, LoadKind, Module, UnaryOp};
-use mpz_vm_memory::{AuthState, AuthValue, Bit, Byte};
-
-use crate::{
-    capture::{ChunkCapture, SegmentMark, Snapshot, is_import},
-    commit::{ty_width, value_le_bits},
-    cost,
-    error::{Result, ZkVmError},
-    host::HostCallEvent,
-    memlog::{self, ByteState, MemoryLog, Stored},
+use mpz_vm_core::{Reg, ValType, value::Value};
+use mpz_vm_memory::{
+    AuthState, AuthValue, Bit, Byte, RegDelta, Registers, SharedMemory, SharedRegs,
 };
 
-/// The chunk's parallel-proving layout: per-segment directive, tape, and
-/// challenge ranges, with the stitch boundaries between them.
+use crate::{
+    capture::ChunkCapture,
+    commit::{ty_width, value_le_bits},
+    error::{Result, ZkVmError},
+};
+
 #[derive(Debug)]
 pub(crate) struct Plan {
+    pub(crate) deltas: Vec<Boundary>,
     pub(crate) segments: Vec<Segment>,
-    /// Total execute-tape entries: segment gate/advice entries plus boundary
-    /// commitments. Excludes any input-commit prefix and the VOPE tail.
     pub(crate) tape_len: usize,
 }
 
 #[derive(Debug)]
 pub(crate) struct Segment {
-    /// Directive range in the chunk trace.
     pub(crate) directives: Range<usize>,
-    /// Reveal-action range (one action per imported call in `directives`).
     pub(crate) reveals: Range<usize>,
-    /// Tape entries consumed by this segment's gates and advice, relative to
-    /// the start of the chunk's execute region.
+    pub(crate) log: Range<u64>,
     pub(crate) tape: Range<usize>,
-    /// AND gates preceding this segment: the challenge-stream offset.
     pub(crate) chi_gates: usize,
-    /// The boundary committed after this segment; `None` for the last.
-    pub(crate) boundary: Option<Boundary>,
+    pub(crate) layers: usize,
 }
 
-/// A stitch boundary: the committed delta of one segment — every register,
-/// global, and memory byte written during that segment, plus tombstones for
-/// the registers it reclaimed.
 #[derive(Debug)]
 pub(crate) struct Boundary {
-    /// Tape entries of the symbolic items' commitments, relative to the start
-    /// of the chunk's execute region.
     pub(crate) tape: Range<usize>,
-    pub(crate) items: Vec<Item>,
-    /// Register ranges reclaimed during the segment, in trace order. Applied
-    /// (before `items`) when seeding a later worker, mirroring the sequential
-    /// `drop_range` a single replay would have performed.
+    pub(crate) delta: BoundaryDelta,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BoundaryDelta {
+    pub(crate) regs: Vec<ValItem>,
     pub(crate) dropped: Vec<(Reg, u32)>,
-    /// Prover-side plaintext at the boundary; `None` on the verifier.
-    pub(crate) snapshot: Option<Snapshot>,
+    pub(crate) globals: Vec<ValItem>,
+    pub(crate) mem: Vec<MemItem>,
 }
 
-/// One stitched state item. Symbolic items consume tape entries (in `items`
-/// order); public items are rematerialized from their known value.
-#[derive(Debug)]
-pub(crate) enum Item {
-    Reg { reg: Reg, ty: ValType },
-    Global { idx: u32, ty: ValType },
-    Mem { addr: u32 },
-    PubReg { reg: Reg, value: Value },
-    PubGlobal { idx: u32, value: Value },
-    PubMem { addr: u32, value: u8 },
+impl BoundaryDelta {
+    pub(crate) fn tape_len(&self) -> usize {
+        self.regs.iter().map(ValItem::tape_bits).sum::<usize>()
+            + self.globals.iter().map(ValItem::tape_bits).sum::<usize>()
+            + self.mem.iter().map(MemItem::tape_bits).sum::<usize>()
+    }
 }
 
-impl Item {
-    /// Tape entries this item consumes (0 for public items).
+#[derive(Debug, Clone)]
+pub(crate) enum ValItem {
+    Sym {
+        key: u32,
+        ty: ValType,
+        value: Option<Value>,
+    },
+    Pub {
+        key: u32,
+        value: Value,
+    },
+}
+
+impl ValItem {
     fn tape_bits(&self) -> usize {
         match self {
-            Item::Reg { ty, .. } | Item::Global { ty, .. } => ty_width(*ty),
-            Item::Mem { .. } => 8,
-            _ => 0,
+            ValItem::Sym { ty, .. } => ty_width(*ty),
+            ValItem::Pub { .. } => 0,
         }
     }
 }
 
 #[derive(Debug, Clone)]
-enum RegState {
-    Sym(ValType),
-    Pub(Value),
+pub(crate) enum MemItem {
+    Sym { addr: u32, value: Option<u8> },
+    Pub { addr: u32, value: u8 },
 }
 
-/// Scan state mirroring the `AuthState` updates `replay` performs, tracking
-/// only which items the chunk has written and whether they are symbolic.
-///
-/// `pre_regs` holds the registers the input-commit prefix installs before any
-/// segment runs (the call's committed params); they resolve like persistent
-/// state and never enter a boundary unless overwritten.
-///
-/// `regs`/`globals` are chunk-cumulative and drive operand resolution; the
-/// `seg_*` fields accumulate the *current segment's* writes and reclaims and
-/// are drained into a delta [`Boundary`] at each mark.
-#[derive(Debug, Default)]
-struct Scan {
-    pre_regs: BTreeMap<u32, ValType>,
-    regs: BTreeMap<u32, RegState>,
-    globals: BTreeMap<u32, RegState>,
-    mem: MemoryLog,
-    seg_regs: BTreeMap<u32, RegState>,
-    seg_globals: BTreeMap<u32, RegState>,
-    seg_dropped: Vec<(Reg, u32)>,
-}
-
-impl Scan {
-    fn reg(&self, auth: &AuthState, reg: Reg) -> Result<RegState> {
-        self.try_reg(auth, reg)
-            .ok_or(ZkVmError::RegAuthMissing { reg })
-    }
-
-    /// Like [`reg`](Self::reg), but `None` when the register has no auth
-    /// state anywhere — a register holding a public value tracked only by the
-    /// thread. Mirrors `Registers::copy`, which silently skips such sources.
-    fn try_reg(&self, auth: &AuthState, reg: Reg) -> Option<RegState> {
-        if let Some(s) = self.regs.get(&reg.0) {
-            return Some(s.clone());
+impl MemItem {
+    fn tape_bits(&self) -> usize {
+        match self {
+            MemItem::Sym { .. } => 8,
+            MemItem::Pub { .. } => 0,
         }
-        if let Some(ty) = self.pre_regs.get(&reg.0) {
-            return Some(RegState::Sym(*ty));
-        }
-        auth.regs.get(reg).map(|av| RegState::Sym(av.ty()))
-    }
-
-    fn operand(&self, auth: &AuthState, op: &Operand) -> Result<RegState> {
-        match op {
-            Operand::Symbol { reg, .. } => self.reg(auth, *reg),
-            Operand::Concrete(v) => Ok(RegState::Pub(*v)),
-        }
-    }
-
-    /// Records a register write into both the cumulative and segment views.
-    fn set_reg(&mut self, reg: u32, s: RegState) {
-        self.regs.insert(reg, s.clone());
-        self.seg_regs.insert(reg, s);
-    }
-
-    /// Records a global write into both the cumulative and segment views.
-    fn set_global(&mut self, idx: u32, s: RegState) {
-        self.globals.insert(idx, s.clone());
-        self.seg_globals.insert(idx, s);
-    }
-
-    /// Records a frame reclaim: the range leaves both views and a tombstone
-    /// enters the segment delta so later workers drop it at seeding.
-    fn reclaim(&mut self, base: Reg, count: u32) {
-        for r in base.0..base.0 + count {
-            self.regs.remove(&r);
-            self.seg_regs.remove(&r);
-        }
-        self.seg_dropped.push((base, count));
-    }
-
-    /// Drains the current segment's writes and reclaims into delta boundary
-    /// items, resetting the segment views for the next segment.
-    ///
-    /// Items the thread no longer considers symbolic at the mark are dropped:
-    /// public computation overwrites registers, globals, and revealed memory
-    /// without emitting directives, so the auth wire behind such an item is
-    /// dead — every later use of the value surfaces as a concrete operand —
-    /// and committing it would assert a stale wire against the fresh
-    /// plaintext.
-    fn take_boundary(&mut self, mark: &SegmentMark) -> (Vec<Item>, Vec<(Reg, u32)>) {
-        let mut items = Vec::new();
-        for (r, s) in std::mem::take(&mut self.seg_regs) {
-            match s {
-                RegState::Sym(ty) if mark.sym_regs.binary_search(&r).is_ok() => {
-                    items.push(Item::Reg { reg: Reg(r), ty });
-                }
-                RegState::Sym(_) => {}
-                RegState::Pub(value) => items.push(Item::PubReg { reg: Reg(r), value }),
-            }
-        }
-        for (g, s) in std::mem::take(&mut self.seg_globals) {
-            match s {
-                RegState::Sym(ty) if mark.sym_globals.binary_search(&g).is_ok() => {
-                    items.push(Item::Global { idx: g, ty });
-                }
-                RegState::Sym(_) => {}
-                RegState::Pub(value) => items.push(Item::PubGlobal { idx: g, value }),
-            }
-        }
-        for (a, s) in self.mem.take_written() {
-            match s {
-                ByteState::Symbolic if mark.pub_mem.binary_search(&a).is_err() => {
-                    items.push(Item::Mem { addr: a });
-                }
-                ByteState::Symbolic => {}
-                ByteState::Public(value) => items.push(Item::PubMem { addr: a, value }),
-            }
-        }
-        (items, std::mem::take(&mut self.seg_dropped))
     }
 }
 
-/// Derives the chunk's segmentation layout.
-///
-/// Deterministic in the directive skeleton, the reveal actions, and the
-/// symbolic types of the persistent `auth` state, all of which the prover and
-/// verifier share.
-///
-/// With no segment marks the chunk is one segment and needs no layout scan.
-/// A trace the scan cannot mirror (e.g. one that replay will reject anyway)
-/// also degrades to a single sequential segment, so the proving pass surfaces
-/// the same error at the same protocol point on both sides.
 #[tracing::instrument(
     level = "debug",
     skip_all,
     fields(segments = tracing::field::Empty, tape_len = tracing::field::Empty)
 )]
-pub(crate) fn plan(
-    chunk: &ChunkCapture,
-    module: &Module,
-    auth: &AuthState,
-    params: &[Param],
-    root_reg_base: Reg,
-) -> Plan {
-    let plan = if chunk.marks.is_empty() {
-        single_segment(chunk)
-    } else {
-        match scan_plan(chunk, module, auth, params, root_reg_base) {
-            Ok(plan) => plan,
-            Err(e) => {
-                tracing::warn!(error = %e, "segment scan failed; falling back to one segment");
-                single_segment(chunk)
-            }
-        }
-    };
-    let span = tracing::Span::current();
-    span.record("segments", plan.segments.len());
-    span.record("tape_len", plan.tape_len);
-    plan
-}
-
-fn single_segment(chunk: &ChunkCapture) -> Plan {
-    Plan {
-        segments: vec![Segment {
-            directives: 0..chunk.trace.len(),
-            reveals: 0..chunk.reveal_actions.len(),
-            tape: 0..chunk.cost,
-            chi_gates: 0,
-            boundary: None,
-        }],
-        tape_len: chunk.cost,
-    }
-}
-
-fn scan_plan(
-    chunk: &ChunkCapture,
-    module: &Module,
-    auth: &AuthState,
-    params: &[Param],
-    root_reg_base: Reg,
-) -> Result<Plan> {
-    let mut scan = Scan::default();
-    for (i, p) in params.iter().enumerate() {
-        let ty = match p {
-            Param::Private(v) => v.ty(),
-            Param::Blind(ty) => *ty,
-            Param::Public(_) => continue,
-        };
-        scan.pre_regs.insert(root_reg_base.0 + i as u32, ty);
-    }
-
-    // Per-segment accumulators.
-    let mut seg_dir_start = 0usize;
-    let mut seg_rev_start = 0usize;
-    let mut seg_bits = 0usize;
-    let mut seg_gates = 0usize;
-
-    // (directives, reveals, tape_bits, gates, boundary delta+snapshot)
-    type RawSeg = (
-        Range<usize>,
-        Range<usize>,
-        usize,
-        usize,
-        Option<(Vec<Item>, Vec<(Reg, u32)>, Option<Snapshot>)>,
-    );
-    let mut raw: Vec<RawSeg> = Vec::new();
-
-    let mut marks = chunk.marks.iter().peekable();
-    let mut reveal_cursor = 0usize;
-
-    for (i, directive) in chunk.trace.iter().enumerate() {
-        match directive {
-            Directive::Op(op) => {
-                let bits = cost::op_cost(op)?;
-                let advice = cost::op_advice_bits(op);
-                seg_bits += bits;
-                seg_gates += bits - advice;
-                scan_op(&mut scan, auth, op)?;
-            }
-            Directive::Call {
-                func_idx,
-                args,
-                param_base,
-                ..
-            } => {
-                if is_import(module, *func_idx) {
-                    let action = chunk.reveal_actions.get(reveal_cursor).ok_or_else(|| {
-                        ZkVmError::Internal("reveal action missing for imported call".into())
-                    })?;
-                    reveal_cursor += 1;
-                    // Mirror capture's precompile accounting: budget the circuit
-                    // gates (authenticated variant only) and record the in-place
-                    // output stores so a boundary after the precompile commits
-                    // exactly those bytes.
-                    match action {
-                        HostCallEvent::Sha256Compress { .. } => {
-                            seg_bits += cost::SHA256_COMPRESS_COST;
-                            seg_gates += cost::SHA256_COMPRESS_COST;
-                            crate::capture::log_precompile_output(&mut scan.mem, action);
-                        }
-                        HostCallEvent::Sha256CompressPublic { .. } => {
-                            crate::capture::log_precompile_output(&mut scan.mem, action);
-                        }
-                        _ => {}
-                    }
-                    scan_reveal(&mut scan, action);
-                } else {
-                    for (k, arg) in args.iter().enumerate() {
-                        if let Operand::Symbol { reg, .. } = arg
-                            && let Some(s) = scan.try_reg(auth, *reg)
-                        {
-                            scan.set_reg(param_base.0 + k as u32, s);
-                        }
-                    }
-                }
-            }
-            Directive::Return { dst, src, reclaim } => {
-                if let (Some(d), Some(s)) = (dst, src)
-                    && let Some(st) = scan.try_reg(auth, *s)
-                {
-                    scan.set_reg(d.0, st);
-                }
-                if let Some((base, count)) = reclaim {
-                    scan.reclaim(*base, *count);
-                }
-            }
-            Directive::Branch { .. } => {}
-        }
-
-        // A mark splits the trace *after* directive `i`.
-        if marks.peek().is_some_and(|m| m.directive_idx == i + 1) {
-            let mark = marks.next().expect("peeked");
-            let (items, dropped) = scan.take_boundary(mark);
-            raw.push((
-                seg_dir_start..i + 1,
-                seg_rev_start..reveal_cursor,
-                seg_bits,
-                seg_gates,
-                Some((items, dropped, mark.snapshot.clone())),
-            ));
-            seg_dir_start = i + 1;
-            seg_rev_start = reveal_cursor;
-            seg_bits = 0;
-            seg_gates = 0;
-        }
-    }
-    raw.push((
-        seg_dir_start..chunk.trace.len(),
-        seg_rev_start..reveal_cursor,
-        seg_bits,
-        seg_gates,
-        None,
-    ));
-
-    // Lay the tape out: [seg 1][boundary 1][seg 2][boundary 2]…[seg S].
-    let mut segments = Vec::with_capacity(raw.len());
+pub(crate) fn plan(chunk: &ChunkCapture, prologue: Option<BoundaryDelta>) -> Plan {
+    let mut segments = Vec::with_capacity(chunk.segments.len());
+    let mut deltas = Vec::new();
     let mut offset = 0usize;
+    if let Some(delta) = prologue {
+        let len = delta.tape_len();
+        let tape = offset..offset + len;
+        offset += len;
+        deltas.push(Boundary { tape, delta });
+    }
     let mut chi = 0usize;
-    for (directives, reveals, bits, gates, boundary) in raw {
-        let tape = offset..offset + bits;
-        offset += bits;
+    for info in &chunk.segments {
+        let layers = deltas.len();
+        let tape = offset..offset + info.bits;
+        offset += info.bits;
         let chi_gates = chi;
-        chi += gates;
-        let boundary = boundary.map(|(items, dropped, snapshot)| {
-            let len: usize = items.iter().map(Item::tape_bits).sum();
+        chi += info.gates;
+        if let Some(delta) = info.boundary.as_ref() {
+            let len = delta.tape_len();
             let tape = offset..offset + len;
             offset += len;
-            Boundary {
+            deltas.push(Boundary {
                 tape,
-                items,
-                dropped,
-                snapshot,
-            }
-        });
+                delta: delta.clone(),
+            });
+        }
         segments.push(Segment {
-            directives,
-            reveals,
+            directives: info.directives.clone(),
+            reveals: info.reveals.clone(),
+            log: info.log.clone(),
             tape,
             chi_gates,
-            boundary,
+            layers,
         });
     }
-
-    Ok(Plan {
+    let span = tracing::Span::current();
+    span.record("segments", segments.len());
+    span.record("tape_len", offset);
+    Plan {
+        deltas,
         segments,
         tape_len: offset,
-    })
-}
-
-fn scan_op(scan: &mut Scan, auth: &AuthState, op: &Op) -> Result<()> {
-    match op {
-        Op::Copy { dst, src } => {
-            // `Registers::copy` semantics: no-op when the source carries no
-            // auth state (a public value tracked only by the thread).
-            if let Some(s) = scan.try_reg(auth, *src) {
-                scan.set_reg(dst.0, s);
-            }
-        }
-        Op::GlobalGet { dst, global_idx } => {
-            let s = if let Some(s) = scan.globals.get(global_idx) {
-                s.clone()
-            } else {
-                auth.globals
-                    .get(Reg(*global_idx))
-                    .map(|av| RegState::Sym(av.ty()))
-                    .ok_or(ZkVmError::GlobalAuthMissing { idx: *global_idx })?
-            };
-            scan.set_reg(dst.0, s);
-        }
-        Op::GlobalSet { global_idx, src } => {
-            let s = scan.operand(auth, src)?;
-            scan.set_global(*global_idx, s);
-        }
-        Op::Binary { dst, op, .. } => {
-            scan.set_reg(dst.0, RegState::Sym(binary_result_ty(*op)));
-        }
-        Op::Unary { dst, op, .. } => {
-            scan.set_reg(dst.0, RegState::Sym(unary_result_ty(*op)));
-        }
-        Op::Load {
-            dst,
-            kind,
-            addr,
-            memarg,
-            symbolic_mask,
-            ..
-        } => {
-            let eff = memlog::eff_addr(addr, memarg)?;
-            scan.mem.record_load(*kind, eff, *symbolic_mask);
-            scan.set_reg(dst.0, RegState::Sym(load_result_ty(*kind)));
-        }
-        Op::Store {
-            kind,
-            addr,
-            val,
-            memarg,
-        } => {
-            let eff = memlog::eff_addr(addr, memarg)?;
-            let stored = match scan.operand(auth, val)? {
-                RegState::Sym(_) => Stored::Symbolic,
-                RegState::Pub(v) => Stored::Public(v),
-            };
-            scan.mem.record_store(*kind, eff, stored);
-        }
-        _ => return Err(crate::error::unsupported_op(op)),
-    }
-    Ok(())
-}
-
-fn scan_reveal(scan: &mut Scan, action: &HostCallEvent) {
-    match action {
-        HostCallEvent::OpenScalar { handle_dst, id, .. } => {
-            scan.set_reg(handle_dst.0, RegState::Pub(Value::I32(*id as i32)));
-        }
-        HostCallEvent::WaitScalar { dst, value } => {
-            scan.set_reg(dst.0, RegState::Pub(*value));
-        }
-        HostCallEvent::OpenBytes { handle_dst, id, .. } => {
-            scan.set_reg(handle_dst.0, RegState::Pub(Value::I32(*id as i32)));
-        }
-        HostCallEvent::WaitBytes => {}
-        // Precompiles write no register; their memory effect is recorded into
-        // `scan.mem` by the caller.
-        HostCallEvent::Sha256Compress { .. } | HostCallEvent::Sha256CompressPublic { .. } => {}
     }
 }
 
-fn binary_result_ty(op: BinaryOp) -> ValType {
-    use BinaryOp::*;
-    match op {
-        // Comparisons always produce i32.
-        I64Eq | I64Ne | I64LtS | I64LtU | I64GtS | I64GtU | I64LeS | I64LeU | I64GeS | I64GeU => {
-            ValType::I32
-        }
-        I64Add | I64Sub | I64Mul | I64And | I64Or | I64Xor | I64Shl | I64ShrS | I64ShrU
-        | I64Rotl | I64Rotr | I64DivU | I64RemU | I64DivS | I64RemS => ValType::I64,
-        _ => ValType::I32,
-    }
+pub(crate) struct Shared<W> {
+    regs: Arc<SharedRegs<AuthValue<W>>>,
+    globals: Arc<SharedRegs<AuthValue<W>>>,
+    memory: Arc<SharedMemory<W>>,
 }
 
-fn unary_result_ty(op: UnaryOp) -> ValType {
-    use UnaryOp::*;
-    match op {
-        I64Clz | I64Ctz | I64Popcnt | I64ExtendI32S | I64ExtendI32U | I64Extend8S
-        | I64Extend16S | I64Extend32S => ValType::I64,
-        _ => ValType::I32,
-    }
-}
+type Deltas<W> = (
+    RegDelta<AuthValue<W>>,
+    RegDelta<AuthValue<W>>,
+    HashMap<u32, Byte<W>>,
+);
 
-fn load_result_ty(kind: LoadKind) -> ValType {
-    use LoadKind::*;
-    match kind {
-        I64 | I64Load8U | I64Load8S | I64Load16U | I64Load16S | I64Load32U | I64Load32S => {
-            ValType::I64
-        }
-        _ => ValType::I32,
-    }
-}
-
-// ============================================================
-// Boundary materialization
-// ============================================================
-
-/// The prover-side plaintext of a boundary's symbolic items, one bit per tape
-/// entry, in `items` order.
-pub(crate) fn boundary_bits(boundary: &Boundary) -> Result<Vec<bool>> {
-    let snapshot = boundary
-        .snapshot
-        .as_ref()
-        .ok_or_else(|| ZkVmError::Internal("boundary snapshot missing on prover".into()))?;
-    let mut bits = Vec::with_capacity(boundary.tape.len());
-    for item in &boundary.items {
-        match item {
-            Item::Reg { reg, ty } => {
-                let v = snapshot.regs.get(reg.0 as usize).copied().ok_or_else(|| {
-                    ZkVmError::Internal(format!("snapshot missing register {reg}"))
-                })?;
-                bits.extend(value_le_bits(v, ty_width(*ty)));
-            }
-            Item::Global { idx, ty } => {
-                let v = snapshot
-                    .globals
-                    .get(*idx as usize)
-                    .copied()
-                    .ok_or_else(|| ZkVmError::Internal(format!("snapshot missing global {idx}")))?;
-                bits.extend(value_le_bits(v, ty_width(*ty)));
-            }
-            Item::Mem { addr } => {
-                let b = *snapshot.mem.get(addr).ok_or_else(|| {
-                    ZkVmError::Internal(format!("snapshot missing byte {addr:#x}"))
-                })?;
-                bits.extend((0..8).map(|i| (b >> i) & 1 != 0));
-            }
-            _ => {}
-        }
-    }
-    Ok(bits)
-}
-
-/// Installs one delta boundary's effect into `auth`. A worker seeds its
-/// starting state by applying every boundary before its segment, in order;
-/// reclaims apply first so a reclaim-then-rewrite within the segment nets to
-/// the rewrite. `wires` holds one wire per symbolic tape entry (already
-/// materialized from the tape); `pub_bit` materializes a public-bit wire.
-pub(crate) fn apply_boundary(
-    auth: &mut AuthState,
-    boundary: &Boundary,
-    wires: &[Gf2_128],
-    pub_bit: &dyn Fn(bool) -> Gf2_128,
-) -> Result<()> {
-    for (base, count) in &boundary.dropped {
-        auth.regs.drop_range(*base, *count);
-    }
+fn materialize_boundary<W: Copy>(
+    delta: &BoundaryDelta,
+    wires: &[W],
+    pub_bit: &dyn Fn(bool) -> W,
+) -> Result<Deltas<W>> {
     let mut k = 0usize;
-    let mut take = |n: usize| -> Vec<Bit> {
-        let out = wires[k..k + n].iter().map(|w| Bit(*w)).collect();
-        k += n;
-        out
-    };
-    for item in &boundary.items {
+
+    let mut reg_sets = HashMap::new();
+    let mut glob_sets = HashMap::new();
+    for (items, sets) in [
+        (&delta.regs, &mut reg_sets),
+        (&delta.globals, &mut glob_sets),
+    ] {
+        for item in items {
+            match item {
+                ValItem::Sym { key, ty, .. } => {
+                    let bits: Vec<Bit<W>> = wires[k..k + ty_width(*ty)]
+                        .iter()
+                        .map(|w| Bit(*w))
+                        .collect();
+                    k += ty_width(*ty);
+                    sets.insert(Reg(*key), AuthValue::from_bits(*ty, &bits)?);
+                }
+                ValItem::Pub { key, value } => {
+                    sets.insert(Reg(*key), pub_value(*value, pub_bit)?);
+                }
+            }
+        }
+    }
+
+    let mut mem = HashMap::new();
+    for item in &delta.mem {
         match item {
-            Item::Reg { reg, ty } => {
-                let bits = take(ty_width(*ty));
-                auth.regs.set(*reg, AuthValue::from_bits(*ty, &bits)?);
+            MemItem::Sym { addr, .. } => {
+                let bits: Vec<Bit<W>> = wires[k..k + 8].iter().map(|w| Bit(*w)).collect();
+                k += 8;
+                mem.insert(*addr, Byte::new(core::array::from_fn(|i| bits[i])));
             }
-            Item::Global { idx, ty } => {
-                let bits = take(ty_width(*ty));
-                auth.globals
-                    .set(Reg(*idx), AuthValue::from_bits(*ty, &bits)?);
-            }
-            Item::Mem { addr } => {
-                let bits = take(8);
-                auth.memory
-                    .set_byte(*addr, Byte::new(core::array::from_fn(|i| bits[i])));
-            }
-            Item::PubReg { reg, value } => {
-                auth.regs.set(*reg, pub_value(*value, pub_bit)?);
-            }
-            Item::PubGlobal { idx, value } => {
-                auth.globals.set(Reg(*idx), pub_value(*value, pub_bit)?);
-            }
-            Item::PubMem { addr, value } => {
-                auth.memory.set_byte(
+            MemItem::Pub { addr, value } => {
+                mem.insert(
                     *addr,
                     Byte::new(core::array::from_fn(|i| {
                         Bit(pub_bit((value >> i) & 1 != 0))
@@ -630,17 +200,96 @@ pub(crate) fn apply_boundary(
         }
     }
     debug_assert_eq!(k, wires.len());
+    Ok((
+        RegDelta {
+            sets: reg_sets,
+            dropped: delta.dropped.clone(),
+        },
+        RegDelta {
+            sets: glob_sets,
+            dropped: Vec::new(),
+        },
+        mem,
+    ))
+}
+
+pub(crate) fn plaintext_bits(delta: &BoundaryDelta) -> Result<Vec<bool>> {
+    let mut bits = Vec::with_capacity(delta.tape_len());
+    for item in delta.regs.iter().chain(&delta.globals) {
+        if let ValItem::Sym { ty, value, .. } = item {
+            let v = value.ok_or_else(|| {
+                ZkVmError::Internal("boundary plaintext missing on prover".into())
+            })?;
+            bits.extend(value_le_bits(v, ty_width(*ty)));
+        }
+    }
+    for item in &delta.mem {
+        if let MemItem::Sym { value, .. } = item {
+            let b = value.ok_or_else(|| {
+                ZkVmError::Internal("boundary plaintext missing on prover".into())
+            })?;
+            bits.extend((0..8).map(|i| (b >> i) & 1 != 0));
+        }
+    }
+    Ok(bits)
+}
+
+pub(crate) fn build_shared<W: Copy>(
+    base: &AuthState<W>,
+    plan: &Plan,
+    delta_wires: &[Vec<W>],
+    pub_bit: &dyn Fn(bool) -> W,
+) -> Result<Shared<W>> {
+    let mut regs = SharedRegs::new(&base.regs);
+    let mut globals = SharedRegs::new(&base.globals);
+    let mut memory = SharedMemory::new(&base.memory);
+    for (b, wires) in plan.deltas.iter().zip(delta_wires) {
+        let (rd, gd, md) = materialize_boundary(&b.delta, wires, pub_bit)?;
+        regs.push(rd);
+        globals.push(gd);
+        memory.push(md);
+    }
+    Ok(Shared {
+        regs: Arc::new(regs),
+        globals: Arc::new(globals),
+        memory: Arc::new(memory),
+    })
+}
+
+pub(crate) fn layered_auth<W: Copy>(
+    base: &AuthState<W>,
+    shared: &Shared<W>,
+    layers: usize,
+) -> AuthState<W> {
+    AuthState {
+        regs: Registers::layered(shared.regs.clone(), layers),
+        globals: Registers::layered(shared.globals.clone(), layers),
+        memory: base.memory.layered(shared.memory.clone(), layers),
+    }
+}
+
+pub(crate) fn apply_delta<W: Copy>(
+    base: &mut AuthState<W>,
+    delta: &BoundaryDelta,
+    wires: &[W],
+    pub_bit: &dyn Fn(bool) -> W,
+) -> Result<()> {
+    let (rd, gd, md) = materialize_boundary(delta, wires, pub_bit)?;
+    for (reg, value) in rd.sets {
+        base.regs.set(reg, value);
+    }
+    for (reg, value) in gd.sets {
+        base.globals.set(reg, value);
+    }
+    for (addr, byte) in md {
+        base.memory.set_byte(addr, byte);
+    }
     Ok(())
 }
 
-/// Asserts that the worker's final wires for every symbolic item its own
-/// segment wrote equal the delta commitment `wires`, stitching this segment
-/// to the rest of the chunk. Items written by earlier segments need no
-/// assertion: this worker and every later one hold the same materialized
-/// delta wires for them by construction.
 pub(crate) fn assert_boundary<C>(
     auth: &AuthState,
-    boundary: &Boundary,
+    delta: &BoundaryDelta,
     wires: &[Gf2_128],
     ctx: &mut C,
 ) -> Result<()>
@@ -649,11 +298,11 @@ where
     C::Error: std::fmt::Debug,
 {
     let mut k = 0usize;
-    let mut assert_wires = |ctx: &mut C, state: &[Bit], n: usize, item: &Item| -> Result<()> {
+    let mut assert_wires = |ctx: &mut C, state: &[Bit], n: usize, label: &str| -> Result<()> {
         for i in 0..n {
             ctx.assert_eq(state[i].0, wires[k + i]).map_err(|e| {
                 ZkVmError::Internal(format!(
-                    "boundary assert at {item:?} bit {i}: wire lsb {} vs committed lsb {} ({e:?})",
+                    "boundary assert at {label} bit {i}: wire lsb {} vs committed lsb {} ({e:?})",
                     state[i].0.to_inner() & 1,
                     wires[k + i].to_inner() & 1,
                 ))
@@ -662,41 +311,40 @@ where
         k += n;
         Ok(())
     };
-    for item in &boundary.items {
-        match item {
-            Item::Reg { reg, ty } => {
-                let av = auth
-                    .regs
-                    .get(*reg)
-                    .ok_or(ZkVmError::RegAuthMissing { reg: *reg })?;
-                assert_wires(ctx, av.bits(), ty_width(*ty), item)?;
-            }
-            Item::Global { idx, ty } => {
-                let av = auth
-                    .globals
-                    .get(Reg(*idx))
-                    .ok_or(ZkVmError::GlobalAuthMissing { idx: *idx })?;
-                assert_wires(ctx, av.bits(), ty_width(*ty), item)?;
-            }
-            Item::Mem { addr } => {
-                let byte = auth
-                    .memory
-                    .get_byte(*addr)
-                    .ok_or(ZkVmError::MemAuthMissing { addr: *addr })?;
-                assert_wires(ctx, byte.bits(), 8, item)?;
-            }
-            // Public items are rematerialized identically by both parties at
-            // worker seeding; nothing to bind.
-            _ => {}
+    for item in &delta.regs {
+        if let ValItem::Sym { key, ty, .. } = item {
+            let av = auth
+                .regs
+                .get(Reg(*key))
+                .ok_or(ZkVmError::RegAuthMissing { reg: Reg(*key) })?;
+            assert_wires(ctx, av.bits(), ty_width(*ty), &format!("reg {key}"))?;
+        }
+    }
+    for item in &delta.globals {
+        if let ValItem::Sym { key, ty, .. } = item {
+            let av = auth
+                .globals
+                .get(Reg(*key))
+                .ok_or(ZkVmError::GlobalAuthMissing { idx: *key })?;
+            assert_wires(ctx, av.bits(), ty_width(*ty), &format!("global {key}"))?;
+        }
+    }
+    for item in &delta.mem {
+        if let MemItem::Sym { addr, .. } = item {
+            let byte = auth
+                .memory
+                .get_byte(*addr)
+                .ok_or(ZkVmError::MemAuthMissing { addr: *addr })?;
+            assert_wires(ctx, byte.bits(), 8, &format!("mem {addr:#x}"))?;
         }
     }
     debug_assert_eq!(k, wires.len());
     Ok(())
 }
 
-fn pub_value(value: Value, pub_bit: &dyn Fn(bool) -> Gf2_128) -> Result<AuthValue> {
+fn pub_value<W: Copy>(value: Value, pub_bit: &dyn Fn(bool) -> W) -> Result<AuthValue<W>> {
     let ty = value.ty();
-    let bits: Vec<Bit> = value_le_bits(value, ty_width(ty))
+    let bits: Vec<Bit<W>> = value_le_bits(value, ty_width(ty))
         .into_iter()
         .map(|b| Bit(pub_bit(b)))
         .collect();

--- a/crates/vm-zk/src/verifier.rs
+++ b/crates/vm-zk/src/verifier.rs
@@ -7,8 +7,7 @@ use mpz_vm_core::{
 };
 use mpz_vm_ir::{Function, Module};
 use rand::Rng;
-use rand_chacha::ChaCha12Rng;
-use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::{ChaCha12Rng, rand_core::SeedableRng};
 use rangeset::set::RangeSet;
 use rayon::prelude::*;
 use serio::{SinkExt, stream::IoStreamExt};
@@ -21,23 +20,13 @@ use mpz_zk_core::{Commitment, MAC_ONE, MAC_ZERO, VerifierOutput, verifier_wire, 
 use crate::{
     ChunkOutcome, Config, ProofMessage, VOPE_BITS,
     capture::{self, ChunkCapture, Role},
-    commit::{self, PendingIo, VerifierTape, prepare_params},
+    commit::{self, PendingIo, prepare_params},
     error::ZkVmError,
     finalize, host,
     replay::{self, ReplayState},
     reveal, segment,
 };
 
-/// A zero-knowledge verifier for an [`mpz-vm-ir`](mpz_vm_ir) [`Module`].
-///
-/// A `Verifier` checks a [`Prover`](crate::Prover)'s proof that a module was
-/// executed correctly against the public inputs and outputs, without learning
-/// the witness. It implements the [`Vm`] trait, through which a program is
-/// loaded with inputs ([`write`](Vm::write)), run ([`call`](Vm::call)), and
-/// queried ([`read`](Vm::read), [`reveal`](Vm::reveal)).
-///
-/// The type parameter `T` is the correlated-randomness channel shared with the
-/// prover.
 #[derive(Debug)]
 pub struct Verifier<T> {
     module: Module,
@@ -55,29 +44,14 @@ impl<T> Verifier<T>
 where
     T: RCOTSender<Block>,
 {
-    /// Creates a verifier for `module` backed by `svole`, with the default
-    /// [`Config`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError`] if state for `module` cannot be initialized, or if
-    /// `svole` provides a correlation that the protocol cannot use.
     pub fn new(module: Module, svole: T) -> Result<Self, ZkVmError> {
         Self::new_with_config(module, svole, Config::default())
     }
 
-    /// Creates a verifier for `module` backed by `svole` and configured by
-    /// `config`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError`] if state for `module` cannot be initialized, or if
-    /// `svole` provides a correlation that the protocol cannot use.
     pub fn new_with_config(module: Module, svole: T, config: Config) -> Result<Self, ZkVmError> {
-        let global = Global::new(&module)?;
+        let mut global = Global::new(&module)?;
+        global.enable_access_log();
         let delta: Gf2_128 = zerocopy::transmute!(svole.delta());
-        // Pointer-bit convention: delta.lsb must be 1 so the per-wire
-        // identity `mac.lsb XOR key.lsb == bit * delta.lsb` holds bitwise.
         if delta.to_inner() & 1 != 1 {
             return Err(ZkVmError::DeltaLsb);
         }
@@ -120,21 +94,14 @@ where
         Ok(keys.into_iter().map(|k| zerocopy::transmute!(k)).collect())
     }
 
-    /// The parallel per-segment accumulate pass: checks the prover's
-    /// commitment by folding every segment with the sampled challenge.
-    /// Returns the combined `(w, assertions)` and the chunk-final state.
-    #[tracing::instrument(
-        level = "debug",
-        name = "accumulate",
-        skip_all
-    )]
+    #[tracing::instrument(level = "debug", name = "accumulate", skip_all)]
     #[allow(clippy::too_many_arguments)]
     fn accumulate_pass(
         &self,
         chunk: &ChunkCapture,
         plan: &segment::Plan,
-        seg_keys: &[Gf2_128],
-        seg_adjust: &[bool],
+        exec_keys: &[Gf2_128],
+        exec_adjust: &[bool],
         chi: [u8; 32],
         output: Option<Value>,
         revealed: &[u8],
@@ -142,17 +109,14 @@ where
         reveal_pending: bool,
     ) -> Result<VAccOut, ZkVmError> {
         let delta = self.delta;
-        // Boundary commitment wires, materialized straight off the tape.
-        let boundary_wires: Vec<Option<Vec<Gf2_128>>> = plan
-            .segments
+        let delta_wires: Vec<Vec<Gf2_128>> = plan
+            .deltas
             .iter()
-            .map(|seg| {
-                seg.boundary.as_ref().map(|b| {
-                    b.tape
-                        .clone()
-                        .map(|i| verifier_wire(seg_keys[i], seg_adjust[i], delta))
-                        .collect()
-                })
+            .map(|d| {
+                d.tape
+                    .clone()
+                    .map(|i| verifier_wire(exec_keys[i], exec_adjust[i], delta))
+                    .collect()
             })
             .collect();
 
@@ -160,31 +124,24 @@ where
         let auth_base = &self.auth;
         let last = plan.segments.len() - 1;
         let pub_bit = move |b: bool| if b { MAC_ONE + delta } else { MAC_ZERO };
+        let shared = segment::build_shared(auth_base, plan, &delta_wires, &pub_bit)?;
 
         let results: Vec<(Gf2_128, [u8; 32], Option<AuthState>)> = plan
             .segments
             .par_iter()
             .enumerate()
             .map(|(j, seg)| -> Result<_, ZkVmError> {
-                let mut auth = auth_base.clone();
-                for (prev_seg, prev_wires) in plan.segments.iter().zip(&boundary_wires).take(j) {
-                    let prev = prev_seg
-                        .boundary
-                        .as_ref()
-                        .expect("non-final segments carry a boundary");
-                    let wires = prev_wires.as_ref().expect("wires for boundary");
-                    segment::apply_boundary(&mut auth, prev, wires, &pub_bit)?;
-                }
+                let mut auth = segment::layered_auth(auth_base, &shared, seg.layers);
 
                 let mut rng = ChaCha12Rng::from_seed(chi);
                 rng.set_word_pos((seg.chi_gates as u128) * 4);
                 let mut ctx = mpz_zk_core::Verifier::new(
                     delta,
-                    &seg_keys[seg.tape.clone()],
-                    &seg_adjust[seg.tape.clone()],
+                    &exec_keys[seg.tape.clone()],
+                    &exec_adjust[seg.tape.clone()],
+                    rng,
                 )
-                .map_err(|e| ZkVmError::Internal(e.to_string()))?
-                .accumulate(rng);
+                .map_err(|e| ZkVmError::Internal(e.to_string()))?;
                 let mut state = ReplayState::root();
                 replay::replay(
                     &chunk.trace[seg.directives.clone()],
@@ -195,26 +152,20 @@ where
                     &mut state,
                 )?;
 
-                if let Some(b) = &seg.boundary {
-                    let wires = boundary_wires[j].as_ref().expect("wires for boundary");
-                    segment::assert_boundary(&auth, b, wires, &mut ctx)?;
+                if let Some(b) = plan.deltas.get(seg.layers) {
+                    let wires = &delta_wires[seg.layers];
+                    segment::assert_boundary(&auth, &b.delta, wires, &mut ctx)?;
                 }
 
                 let mut last_auth = None;
                 if j == last {
                     match &chunk.trap {
-                        // A trapping chunk carries no output to authenticate.
-                        // When the trap is tied to a committed op, check its
-                        // divisor is zero; a fully public trap has no
-                        // committed divisor.
                         Some(t) => {
                             if let Some(directive) = &t.directive {
                                 replay::replay_trap(directive, &t.trap, &auth, &mut ctx)?;
                             }
                         }
                         None => {
-                            // Only a symbolic return is revealed/authenticated;
-                            // a concrete return is already public.
                             if chunk.result_symbolic {
                                 finalize::bind_output(&state, &mut ctx, &auth, output)?;
                             }
@@ -223,7 +174,7 @@ where
                     if reveal_pending {
                         reveal::reveal_verifier(&mut ctx, &auth, reveal_ranges, revealed)?;
                     }
-                    last_auth = Some(auth);
+                    last_auth = Some(auth.flatten());
                 }
 
                 let VerifierOutput { w, assertions, .. } = ctx
@@ -252,7 +203,6 @@ where
     }
 }
 
-/// Output of the verifier's accumulate pass over one chunk.
 struct VAccOut {
     w: Gf2_128,
     assertions: [u8; 32],
@@ -265,19 +215,6 @@ where
 {
     type Error = ZkVmError;
 
-    /// Writes a value into linear memory at byte offset `ptr`.
-    ///
-    /// A [`Write::Public`] value is written directly and marked public. A
-    /// [`Write::Blind`] reserves `len` bytes of blinded input whose cleartext
-    /// the prover holds; the bytes are marked blind and committed on the next
-    /// [`call`](Self::call). A [`Write::Private`] is not supported on the
-    /// verifier, which never supplies private inputs.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::Core`] if the module has no linear
-    /// memory. Returns [`ZkVmError::Trap`] if a public write is out of bounds.
-    /// Returns [`ZkVmError::Unsupported`] for a [`Write::Private`] value.
     fn write(&mut self, ptr: u32, w: Write<'_>) -> Result<(), ZkVmError> {
         let memory = self
             .global
@@ -303,23 +240,11 @@ where
         Ok(())
     }
 
-    /// Marks the `len` bytes of memory at `ptr` to be opened by the prover.
-    ///
-    /// The prover's opened cleartext is checked correct on the next
-    /// [`call`](Self::call), after which the bytes become readable.
     fn reveal(&mut self, ptr: u32, len: usize) -> Result<(), ZkVmError> {
         self.pending_reveal.union_mut(ptr..ptr + len as u32);
         Ok(())
     }
 
-    /// Returns the `len` bytes of linear memory at byte offset `ptr`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::Internal`] if the range is tainted, i.e. holds
-    /// blinded or not-yet-revealed data whose cleartext the verifier does not
-    /// know. Returns [`ZkVmError::Core`] if the module has no linear
-    /// memory, or [`ZkVmError::Trap`] if the range is out of bounds.
     fn read(&self, ptr: u32, len: usize) -> Result<&[u8], ZkVmError> {
         if self.global.memory_tainted(ptr, len) {
             return Err(ZkVmError::Internal(format!(
@@ -334,20 +259,6 @@ where
         memory.read_bytes(ptr, len).map_err(ZkVmError::Trap)
     }
 
-    /// Verifies the prover's proof of the call to function `func_idx` with
-    /// `params` over `io`, and returns its result.
-    ///
-    /// Public computation is reproduced locally, so a function with public
-    /// inputs and outputs yields the same value the prover computed. Returns
-    /// `Some(value)` when the function yields a value and `None` otherwise.
-    /// Pending inputs and reveals are cleared once the call returns.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::InvalidFunction`] if `func_idx` is not a local
-    /// function. Returns [`ZkVmError::Trap`] if the proven computation traps
-    /// (e.g. divide by zero). Returns a [`ZkVmError`] if verification fails or
-    /// communication over `io` fails.
     #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "verifier", func = self.module.func_name(func_idx).unwrap_or("?")))]
     async fn call(
         &mut self,
@@ -359,13 +270,12 @@ where
             Some(Function::Local(f)) => f,
             _ => return Err(ZkVmError::Core(CoreError::InvalidFunction(func_idx))),
         };
-        let input_bits = prepare_params(&params)?;
         let num_args = params.len() as u32;
-        // The root frame's registers begin after its result slot(s), so its
-        // parameters occupy absolute registers `root_reg_base + i`. This
-        // mirrors `Thread::call`'s layout (results, then params).
         let num_results = func.func_type().results.len() as u32;
         let root_reg_base = Reg(num_results + num_args);
+
+        let mut prologue =
+            commit::prologue_delta(Role::Verifier, root_reg_base, &params, &self.pending_io)?;
 
         let mut thread = Thread::new();
         thread.call(
@@ -377,48 +287,28 @@ where
             },
         )?;
 
-        // Input + memory commit cost; zeroed after it rides on the
-        // first chunk.
-        let mut commit_bits = input_bits + self.pending_io.cost_bits();
-
         self.auth.regs = Registers::new();
         let mut final_output = None;
         let mut chunk_idx: usize = 0;
-        // Memory ranges to open on the first proving chunk; mirrors the prover.
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
         let mut reveal_pending = !reveal_ranges.is_empty();
-        // Set once a chunk's proof of a public trap verifies.
         let mut trapped: Option<mpz_vm_core::Trap> = None;
-        // Mirror of the prover's flag: set once any chunk performs
-        // authenticated work, gating the skip of fully public chunks.
         let mut any_zk_work = false;
 
         loop {
             let chunk_span = tracing::info_span!("verifier.chunk", idx = chunk_idx);
             let _enter = chunk_span.enter();
 
-            // Receive the prover's trap outcome *before* capture: the
-            // announced index lets the verifier's Thread resolve its own
-            // blocking `Blocked` inline and stop naturally at the trap
-            // (no truncation). The prover sent this right after its own
-            // capture.
             let outcome: ChunkOutcome = io
                 .io_mut()
                 .expect_next()
                 .await
                 .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
-            // `trap_at` shapes the proof (the verifier's Thread stop point,
-            // the trap-replay pass, skipped output binding) while `trap`
-            // is the returned reason; they must be present together or the
-            // prover could skip output binding without claiming a trap (or
-            // vice versa).
             if outcome.trap_at.is_some() != outcome.trap.is_some() {
                 return Err(ZkVmError::Internal(
                     "trap outcome inconsistent: trap_at and trap must agree".into(),
                 ));
             }
-            // Merge the announced reveal payloads before capture so the verifier
-            // can resolve this chunk's reveals (and any later wait) in lockstep.
             self.reveal_state.merge(outcome.revealed.clone());
 
             let chunk = capture::capture_chunk(
@@ -440,22 +330,23 @@ where
                 events = chunk.trace.len(),
                 cost = chunk.cost,
                 done = chunk.done,
-                segments = chunk.marks.len() + 1,
+                segments = chunk.segments.len(),
                 "captured chunk"
             );
 
-            let plan = segment::plan(&chunk, &self.module, &self.auth, &params, root_reg_base);
-            let execute_bits = commit_bits + plan.tape_len;
+            let plan = segment::plan(&chunk, prologue.take());
+            let log_end = plan.segments.last().expect("at least one segment").log.end;
+            let execute_bits = plan.tape_len;
 
-            // Mirror the prover's skip exactly: a fully public chunk reached
-            // before any authenticated work has nothing to prove, so both sides
-            // bypass the allocate/commit/challenge/proof exchange in lockstep.
             let needs_zk = execute_bits > 0
                 || any_zk_work
                 || reveal_pending
                 || chunk.trap.as_ref().is_some_and(|t| t.directive.is_some());
             if !needs_zk {
-                commit_bits = 0;
+                self.global
+                    .access_log_mut()
+                    .expect("access log enabled")
+                    .drain_upto(log_end);
                 chunk_idx += 1;
                 if let Some(point) = &chunk.trap {
                     if outcome.trap.as_ref() != Some(&point.trap) {
@@ -467,9 +358,6 @@ where
                     break;
                 }
                 if chunk.done {
-                    // A fully public output is recomputed identically by the
-                    // verifier's own Thread, so the result is taken from the
-                    // local capture rather than an (unsent) proof message.
                     final_output = chunk.result;
                     break;
                 }
@@ -479,7 +367,6 @@ where
 
             let total = execute_bits + VOPE_BITS;
             tracing::info!(
-                commit_bits,
                 cost = chunk.cost,
                 total,
                 segments = plan.segments.len(),
@@ -491,9 +378,6 @@ where
             let vope_keys: &[Gf2_128; VOPE_BITS] =
                 vope_keys.try_into().expect("vope tail is VOPE_BITS wide");
 
-            // Receive the prover's commitment to the whole execute tape
-            // (commit prefix, gates, and boundary commitments), then sample
-            // and send the challenge.
             let (adjust, chi): (Vec<bool>, [u8; 32]) = async {
                 let commitment: Commitment = io
                     .io_mut()
@@ -528,41 +412,18 @@ where
                 .await
                 .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
 
-            // Input-commit prefix: pure tape materialization into the
-            // persistent auth state shared by every segment worker.
-            if commit_bits > 0 {
-                let mut tape = VerifierTape {
-                    keys: &exec_keys[..commit_bits],
-                    adjust: &adjust[..commit_bits],
-                    delta: self.delta,
-                    cursor: 0,
-                };
-                commit::commit_verifier(
-                    &mut self.auth,
-                    root_reg_base,
-                    &params,
-                    &self.pending_io,
-                    &mut tape,
-                )?;
-            }
-
-            // ---- Accumulate pass: parallel proof checking ----
-            let seg_keys = &exec_keys[commit_bits..];
-            let seg_adjust = &adjust[commit_bits..];
             let out = self.accumulate_pass(
                 &chunk,
                 &plan,
-                seg_keys,
-                seg_adjust,
+                exec_keys,
+                &adjust,
                 chi,
                 output,
                 &revealed,
                 &reveal_ranges,
                 reveal_pending,
             )?;
-            // The chunk-final worker state carries every wire forward.
             self.auth = out.auth;
-            commit_bits = 0;
 
             if out.assertions != proof.assertions {
                 return Err(ZkVmError::BatchCheckFailed);
@@ -572,8 +433,6 @@ where
                 return Err(ZkVmError::BatchCheckFailed);
             }
 
-            // The opening verified: write the revealed cleartext into linear
-            // memory and drop the ranges' taint so later reads succeed.
             if reveal_pending {
                 let mut idx = 0;
                 for r in &reveal_ranges {
@@ -591,19 +450,12 @@ where
                 }
                 reveal_pending = false;
             }
+            self.global
+                .access_log_mut()
+                .expect("access log enabled")
+                .drain_upto(log_end);
             chunk_idx += 1;
-            // Derive the trapped result from `chunk.trap` — the field that
-            // actually shaped the proof and caused output binding to be
-            // skipped — so a trapped chunk can never fall through to the
-            // unbound `final_output = output` branch. The reason is taken
-            // from `chunk.trap`, which `capture_chunk` set to the reason
-            // proven by the validated trapping directive (divisor==0 =>
-            // `Trap::DivideByZero`), so the returned reason is bound to the
-            // proof rather than trusting the prover's announcement.
             if let Some(point) = &chunk.trap {
-                // `outcome.trap` is the prover's announced reason; it must
-                // match the reason actually proven, else the prover claimed
-                // a different trap than the constraint attests.
                 if outcome.trap.as_ref() != Some(&point.trap) {
                     return Err(ZkVmError::Internal(
                         "announced trap reason does not match proven trap".into(),
@@ -613,9 +465,6 @@ where
                 break;
             }
             if chunk.done {
-                // A symbolic return was revealed by the prover (`output`); a
-                // concrete return is already public, taken from the verifier's
-                // own locally-computed result.
                 final_output = if chunk.result_symbolic {
                     output
                 } else {
@@ -635,31 +484,16 @@ where
         Ok(final_output)
     }
 
-    /// Commits any queued blind writes and checks any queued reveals over `io`
-    /// without running a function.
-    ///
-    /// This mirrors the prover's [`commit`](crate::Prover::commit): a single
-    /// proving round commits the wires of every pending [`Write::Blind`] region
-    /// and verifies the prover's opening of every pending
-    /// [`reveal`](Vm::reveal) range, leaving nothing queued. The committed
-    /// memory wires persist and are consumed by a later [`call`](Vm::call).
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ZkVmError`] if verification fails or communication over `io`
-    /// fails.
     #[tracing::instrument(level = "info", skip_all, fields(id = ?self.config.id(), role = "verifier"))]
     async fn commit(&mut self, io: &mut Context) -> Result<(), ZkVmError> {
-        let commit_bits = self.pending_io.cost_bits();
+        let prologue = commit::prologue_delta(Role::Verifier, Reg(0), &[], &self.pending_io)?;
         let reveal_ranges: Vec<Range<u32>> = self.pending_reveal.iter().collect();
         let reveal_pending = !reveal_ranges.is_empty();
-        if commit_bits == 0 && !reveal_pending {
+        if prologue.is_none() && !reveal_pending {
             return Ok(());
         }
 
-        // A commit round runs no gates, so the only authenticated bits are the
-        // committed inputs.
-        let execute_bits = commit_bits;
+        let execute_bits = prologue.as_ref().map_or(0, |d| d.tape_len());
         let total = execute_bits + VOPE_BITS;
         let keys = self.allocate(io, total).await?;
         let (exec_keys, vope_keys) = keys.split_at(execute_bits);
@@ -695,21 +529,16 @@ where
             .await
             .map_err(|e| ZkVmError::IoRecv(e.to_string()))?;
 
-        if commit_bits > 0 {
-            let mut tape = VerifierTape {
-                keys: exec_keys,
-                adjust: &adjust,
-                delta: self.delta,
-                cursor: 0,
-            };
-            commit::commit_memory_verifier(&mut self.auth, &self.pending_io, &mut tape);
+        if let Some(delta) = &prologue {
+            let pub_bit = |b: bool| if b { MAC_ONE + self.delta } else { MAC_ZERO };
+            let wires: Vec<Gf2_128> = (0..execute_bits)
+                .map(|i| verifier_wire(exec_keys[i], adjust[i], self.delta))
+                .collect();
+            segment::apply_delta(&mut self.auth, delta, &wires, &pub_bit)?;
         }
 
-        // The commit round folds no gates; a tape-free accumulate context
-        // hashes the reveal assertions, mirroring the prover.
-        let mut ctx = mpz_zk_core::Verifier::new(self.delta, &[], &[])
-            .map_err(|e| ZkVmError::Internal(e.to_string()))?
-            .accumulate(ChaCha12Rng::from_seed(chi));
+        let mut ctx = mpz_zk_core::Verifier::new(self.delta, &[], &[], ChaCha12Rng::from_seed(chi))
+            .map_err(|e| ZkVmError::Internal(e.to_string()))?;
         if reveal_pending {
             reveal::reveal_verifier(&mut ctx, &self.auth, &reveal_ranges, &revealed)?;
         }
@@ -725,8 +554,6 @@ where
             return Err(ZkVmError::BatchCheckFailed);
         }
 
-        // The opening verified: write the revealed cleartext into linear memory
-        // and drop the ranges' taint so later reads succeed.
         if reveal_pending {
             let mut idx = 0;
             for r in &reveal_ranges {
@@ -748,20 +575,6 @@ where
         Ok(())
     }
 
-    /// Runs `func_idx` with `params` using only local work, without an `io`
-    /// context.
-    ///
-    /// Public computation is reproduced in-thread, so a function with public
-    /// inputs yields the same value the prover computes, with no communication.
-    /// Any authenticated work reports [`ZkVmError::RequiresCommunication`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZkVmError::RequiresCommunication`] if `params` carry private
-    /// or blind values, if inputs or reveals remain queued (commit them
-    /// first), or if execution reaches authenticated work. Otherwise
-    /// returns [`ZkVmError::InvalidFunction`] for a bad `func_idx` or
-    /// [`ZkVmError::Trap`] on a trap.
     fn call_local(
         &mut self,
         func_idx: u32,

--- a/crates/vm-zk/tests/add.rs
+++ b/crates/vm-zk/tests/add.rs
@@ -1,8 +1,3 @@
-//! End-to-end integration test for the zero-authenticated-work path: an
-//! all-public, non-trapping call must not deadlock. Op/result correctness with
-//! private inputs is covered far more broadly by the shared spec harness
-//! (`tests/spec.rs`).
-
 mod common;
 
 use futures::{executor::block_on, future::join};
@@ -24,11 +19,6 @@ fn func_idx(module: &Module, name: &str) -> u32 {
         .expect("function should be exported")
 }
 
-// An all-public, non-trapping call does zero authenticated work (no committed
-// inputs, no gates), so both sides must skip the
-// allocate/commit/challenge/proof exchange in lockstep. `join` (not `try_join`)
-// and `block_on` give a hang nowhere to hide: if either side blocks, the test
-// never returns.
 #[test]
 fn test_add_public_no_deadlock() {
     common::init_tracing();

--- a/crates/vm-zk/tests/common/mod.rs
+++ b/crates/vm-zk/tests/common/mod.rs
@@ -1,15 +1,9 @@
-//! Shared test utilities.
-
 use std::sync::Once;
 
 use tracing_subscriber::{EnvFilter, fmt};
 
 static INIT_TRACING: Once = Once::new();
 
-/// Install a `tracing-subscriber` once per test process. Filter
-/// defaults to `mpz_vm_zk=info` and is overridable via `RUST_LOG`.
-/// Output goes to stderr; cargo test captures it unless `--nocapture`
-/// is passed.
 pub fn init_tracing() {
     INIT_TRACING.call_once(|| {
         let filter =

--- a/crates/vm-zk/tests/mem_behavior.rs
+++ b/crates/vm-zk/tests/mem_behavior.rs
@@ -1,12 +1,3 @@
-//! Behavioral memory I/O tests for the zkVM, via the shared
-//! [`mpz_vm_test_harness::behavior`] harness. Distinct from the WASM spec
-//! conformance tests in `spec.rs`: these drive the host-side write/reveal/read
-//! surface through the real prover/verifier protocol.
-//!
-//! The verifier is the blind party and never holds private data, so scenarios
-//! that write a private value on party B are expected to surface an
-//! `Unsupported` error and are recorded as skips.
-
 use futures::{
     executor::block_on,
     future::{join, try_join},
@@ -94,9 +85,6 @@ impl MemVm for ZkPair {
                         .ok_or_else(|| ZkVmError::Internal(format!("no export {func}")))?;
                     let params: Vec<Param> = args.iter().copied().map(Param::Public).collect();
                     let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
-                    // `join` (not `try_join`): drive both parties to completion
-                    // so a divergence surfaces as a disagreement rather than
-                    // aborting the scenario.
                     let (a, b) = block_on(join(
                         self.prover.call(&mut ctx_p, idx, params.clone()),
                         self.verifier.call(&mut ctx_v, idx, params),
@@ -147,8 +135,6 @@ fn agreement(
 
 mpz_vm_test_harness::mem_behavior_tests!(ZkPair);
 
-/// `call_local` refuses a private parameter: committing it requires a proving
-/// round.
 #[test]
 fn call_local_rejects_private_param() {
     let module =
@@ -166,10 +152,6 @@ fn call_local_rejects_private_param() {
     );
 }
 
-/// `call_local` refuses to run once execution turns symbolic: a committed
-/// private write feeds a load, which can only be evaluated under proof. The
-/// same program runs fine through a full `call` (see
-/// `commit_then_call_consumes_memory`).
 #[test]
 fn call_local_rejects_symbolic_execution() {
     let module = parse_module(

--- a/crates/vm-zk/tests/ops.rs
+++ b/crates/vm-zk/tests/ops.rs
@@ -1,15 +1,3 @@
-//! Integration tests that route a PRIVATE value through linear memory under the
-//! real prover/verifier protocol — store an authenticated value, load it back
-//! (incl. partial widths and sign/zero extension), and check both parties
-//! agree.
-//!
-//! Plain op/result correctness (arithmetic, bitwise, compare, count, div/rem,
-//! conversions, call-arg propagation) with private inputs is covered far more
-//! broadly by the shared spec harness (`tests/spec.rs`), which runs the whole
-//! WASM corpus under all-public, per-argument-private, all-private, and
-//! alternating passes; only the store→load wire-routing of a private value is
-//! kept here as a focused diagnostic.
-
 mod common;
 
 use futures::{executor::block_on, future::join};
@@ -31,14 +19,10 @@ fn func_idx(module: &Module, name: &str) -> u32 {
         .expect("function should be exported")
 }
 
-/// A blind param of the same type as `v`, for the verifier side.
 fn blind_of(v: &Value) -> Param {
     Param::Blind(v.ty())
 }
 
-/// Run `func` on both sides: the prover supplies `inputs` as PRIVATE values,
-/// the verifier supplies matching BLIND params. Asserts both sides return
-/// `expected`.
 fn run_private(wat: &str, func: &str, inputs: &[Value], expected: Value) {
     common::init_tracing();
     let binary = wat::parse_str(wat).expect("valid WAT");
@@ -67,9 +51,6 @@ fn run_private(wat: &str, func: &str, inputs: &[Value], expected: Value) {
     assert_eq!(result_v, Some(expected), "verifier result for `{func}`");
 }
 
-/// A module that stores its private param at a fixed address and loads it back:
-/// `(func (param ty) (result ty) i32.const 16 local.get 0 <store> i32.const 16
-/// <load>)`.
 fn mem_roundtrip_module(ty: &str, store: &str, load: &str) -> String {
     format!(
         "(module (memory 1) \
@@ -98,19 +79,16 @@ fn i64_mem_roundtrip_private() {
 
 #[test]
 fn i32_mem_partial_widths_private() {
-    // store8 then load8_u / load8_s of 0x80 -> 128 (zero) / -128 (sign).
     let z = mem_roundtrip_module("i32", "i32.store8", "i32.load8_u");
     run_private(&z, "f", &[Value::I32(0x80)], Value::I32(0x80));
     let s = mem_roundtrip_module("i32", "i32.store8", "i32.load8_s");
     run_private(&s, "f", &[Value::I32(0x80)], Value::I32(-128));
-    // store16 then load16_s of 0x8000 -> -32768.
     let s16 = mem_roundtrip_module("i32", "i32.store16", "i32.load16_s");
     run_private(&s16, "f", &[Value::I32(0x8000)], Value::I32(-32768));
 }
 
 #[test]
 fn i64_mem_partial_widths_private() {
-    // store32 then load32_s of 0x8000_0000 -> sign-extended to i64.
     let s = mem_roundtrip_module("i64", "i64.store32", "i64.load32_s");
     run_private(
         &s,
@@ -122,11 +100,6 @@ fn i64_mem_partial_widths_private() {
     run_private(&u, "f", &[Value::I64(0x8000_0000)], Value::I64(0x8000_0000));
 }
 
-/// Run `func` on both sides expecting it to trap. The prover holds the operands
-/// and self-discovers the trap; the verifier's operands are blind, so it cannot
-/// decide the trap locally and must detect it by matching the prover's
-/// announced trap index against the emitted (could-trap) directive. Asserts
-/// both sides surface `expected`.
 fn run_private_trap(wat: &str, func: &str, inputs: &[Value], expected: Trap) {
     common::init_tracing();
     let binary = wat::parse_str(wat).expect("valid WAT");
@@ -175,8 +148,6 @@ fn div_u_by_zero_traps_private() {
 
 #[test]
 fn div_s_overflow_traps_private() {
-    // i32::MIN / -1 overflows; the verifier needs both blind operands' trap to
-    // be announced, exercising the needs-lhs path.
     let wat = "(module (func $f (export \"f\") (param i32 i32) (result i32) \
                local.get 0 local.get 1 i32.div_s))";
     run_private_trap(

--- a/crates/vm-zk/tests/public_output.rs
+++ b/crates/vm-zk/tests/public_output.rs
@@ -1,8 +1,3 @@
-//! A function that does symbolic work (real gates over a private input) but
-//! returns a public constant. Per the VC spec, a concrete return value is
-//! already public, so the prover transmits no output and binds nothing — the
-//! verifier reconstructs the result locally.
-
 mod common;
 
 use futures::{executor::block_on, future::join};
@@ -27,8 +22,6 @@ fn func_idx(module: &Module, name: &str) -> u32 {
 #[test]
 fn symbolic_work_public_const_return() {
     common::init_tracing();
-    // Adds the private input to itself (a symbolic gate), discards it into an
-    // unused local, then returns the public constant 42.
     let wat = r#"
         (module
             (func $f (export "f") (param i32) (result i32)
@@ -53,8 +46,6 @@ fn symbolic_work_public_const_return() {
 
     let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
 
-    // Plain `join`: if the prover still errored mid-protocol on the concrete
-    // output, the verifier would block on a recv and this would never return.
     let (result_p, result_v) = block_on(join(
         async {
             prover

--- a/crates/vm-zk/tests/reveal.rs
+++ b/crates/vm-zk/tests/reveal.rs
@@ -1,10 +1,3 @@
-//! End-to-end tests of guest VCI reveal: a program that reveals private data
-//! must disclose it to the blind verifier, with the disclosure bound to the
-//! committed witness. Each scalar case runs the same program on the prover
-//! (with a private input) and the blind verifier, asserting both return the
-//! expected value — so a verifier that failed to learn the reveal, or learned a
-//! wrong value, fails the test.
-
 mod common;
 
 use futures::{executor::block_on, future::join};
@@ -35,10 +28,6 @@ fn blind(v: &Value) -> Param {
     }
 }
 
-/// Runs `func` on the prover (with `inputs` as private parameters) and the
-/// blind verifier (the same inputs as blinds), under `chunk_cap`, asserting
-/// both return `expected`. The verifier assertion is the substance: it only
-/// holds if the reveal disclosed the value to the party that never held it.
 fn run(wat: &str, func: &str, inputs: &[Value], expected: Value, chunk_cap: Option<usize>) {
     common::init_tracing();
     let module = Module::parse(&wat::parse_str(wat).expect("valid WAT")).expect("valid module");
@@ -72,8 +61,6 @@ fn run(wat: &str, func: &str, inputs: &[Value], expected: Value, chunk_cap: Opti
     );
 }
 
-/// `disclose(x)` reveals its private argument and returns the revealed value:
-/// the baseline scalar disclosure.
 #[test]
 fn scalar_reveal_discloses_private_input() {
     let wat = r#"
@@ -86,10 +73,6 @@ fn scalar_reveal_discloses_private_input() {
     run(wat, "disclose", &[Value::I32(42)], Value::I32(42), None);
 }
 
-/// A revealed value is public, so the program can branch on it — the only way
-/// to get data-dependent control flow in zk-vm, which rejects private
-/// branching. If the reveal failed to make the value public, the verifier would
-/// block on the branch and the call would error.
 #[test]
 fn revealed_value_drives_a_branch() {
     let wat = r#"
@@ -107,10 +90,6 @@ fn revealed_value_drives_a_branch() {
     run(wat, "branch", &[Value::I32(3)], Value::I32(200), None);
 }
 
-/// With one op per chunk, the reveal and its wait land in different chunks, so
-/// the disclosed payload must survive across chunk boundaries: announced when
-/// the reveal is captured, retrieved when the wait is captured a chunk or more
-/// later.
 #[test]
 fn reveal_and_wait_span_chunks() {
     let wat = r#"
@@ -128,9 +107,6 @@ fn reveal_and_wait_span_chunks() {
     run(wat, "spanned", &[Value::I32(99)], Value::I32(99), Some(1));
 }
 
-/// Two reveals are staged before either wait, so they take distinct ids and the
-/// waits resolve them by handle — exercising the reveal-id keying and the
-/// one-action-per-import-call ordering that replay relies on.
 #[test]
 fn two_staged_reveals_resolve_by_handle() {
     let wat = r#"
@@ -152,10 +128,6 @@ fn two_staged_reveals_resolve_by_handle() {
     );
 }
 
-/// `disclose_bytes(x)` stores its private argument to memory, reveals those 4
-/// bytes, then reads them back. The blind verifier learns the bytes through the
-/// reveal (materialized into its memory on wait) and reads back the same value,
-/// with the open bound to the stored witness.
 #[test]
 fn byte_reveal_discloses_private_memory() {
     common::init_tracing();

--- a/crates/vm-zk/tests/sha256_precompile.rs
+++ b/crates/vm-zk/tests/sha256_precompile.rs
@@ -1,10 +1,3 @@
-//! Integration tests for the `crypto::sha256_compress` host call: the VM
-//! runs the SHA-256 compression circuit directly instead of replaying guest
-//! gates. Covers the authenticated path (committed inputs, output committed and
-//! revealed for the check), the public fast-path (all inputs public, no gates),
-//! and segmented boundary stitching of the in-place output across two chained
-//! compressions.
-
 use futures::{executor::block_on, future::try_join};
 use mpz_common::context::test_st_context;
 use mpz_core::Block;
@@ -14,11 +7,6 @@ use mpz_vm_ir::{ExportKind, Module};
 use mpz_vm_zk::{Config, Prover, Verifier};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-/// A guest exposing the compression precompile: `compress_once` compresses one
-/// block into the state in place; `compress_twice` chains two blocks into the
-/// same state. The state is compressed in place with no copy — the precompile
-/// reads the state (public IV, then the committed prior output) and the block
-/// and writes the new state back over `$state` atomically.
 const GUEST: &str = r#"(module
     (import "crypto" "sha256_compress" (func $compress (param i32 i32)))
     (memory (export "mem") 2)
@@ -42,9 +30,6 @@ fn func_idx(module: &Module, name: &str) -> u32 {
         .expect("function should be exported")
 }
 
-/// Reference SHA-256 compression of `blocks` into `state`. The state is the
-/// precompile's `[u32; 8]`, little-endian in linear memory; the blocks are raw
-/// bytes parsed as big-endian SHA-256 words.
 fn reference(state: &[u8; 32], blocks: &[[u8; 64]]) -> [u8; 32] {
     let mut h: [u32; 8] =
         core::array::from_fn(|i| u32::from_le_bytes(state[4 * i..4 * i + 4].try_into().unwrap()));
@@ -57,10 +42,6 @@ fn reference(state: &[u8; 32], blocks: &[[u8; 64]]) -> [u8; 32] {
     out
 }
 
-/// Proves `blocks.len()` chained compressions of `blocks` into `state0` through
-/// the precompile and returns the resulting 32-byte state. With `public`, the
-/// inputs are staged public (the fast-path); otherwise they are committed and
-/// the output is revealed to read it back.
 fn prove_compress(
     config: Config,
     state0: &[u8; 32],
@@ -80,10 +61,6 @@ fn prove_compress(
     let mut verifier = Verifier::new_with_config(module.clone(), svole_sender, config).unwrap();
     let (mut ctx_p, mut ctx_v) = test_st_context(8 << 20);
 
-    // Stage the initial state and the blocks, each either public (both parties)
-    // or private (prover) / blind (verifier). The state is compressed in place,
-    // so staging it private exercises committing a region the host call then
-    // overwrites.
     let mut staged: Vec<(u32, &[u8], bool)> = vec![(STATE_PTR, &state0[..], state_private)];
     for (b, &ptr) in blocks.iter().zip(&BLOCK_PTRS) {
         staged.push((ptr, &b[..], block_private));
@@ -99,7 +76,14 @@ fn prove_compress(
     }
 
     let n = blocks.len();
-    let func = func_idx(&module, if n == 1 { "compress_once" } else { "compress_twice" });
+    let func = func_idx(
+        &module,
+        if n == 1 {
+            "compress_once"
+        } else {
+            "compress_twice"
+        },
+    );
     let params = || {
         let mut v = vec![Param::Public(Value::I32(STATE_PTR as i32))];
         for &ptr in BLOCK_PTRS.iter().take(n) {
@@ -114,9 +98,6 @@ fn prove_compress(
     ))
     .unwrap();
 
-    // The output is committed unless every input byte was public (the fast
-    // path). Open it so the verifier can read it; this also checks the committed
-    // output wires equal the proven circuit's.
     if state_private || block_private {
         prover.reveal(STATE_PTR, 32).unwrap();
         verifier.reveal(STATE_PTR, 32).unwrap();
@@ -133,7 +114,6 @@ fn prove_compress(
 fn precompile_authenticated_single_block() {
     let state0: [u8; 32] = core::array::from_fn(|i| (i as u8).wrapping_mul(7).wrapping_add(3));
     let block: [u8; 64] = core::array::from_fn(|i| i as u8);
-    // Public IV state, private message block.
     let got = prove_compress(Config::builder().build(), &state0, &[block], false, true);
     assert_eq!(got.as_slice(), reference(&state0, &[block]));
 }
@@ -142,7 +122,6 @@ fn precompile_authenticated_single_block() {
 fn precompile_public_fast_path() {
     let state0: [u8; 32] = core::array::from_fn(|i| (i as u8).wrapping_mul(5).wrapping_add(1));
     let block: [u8; 64] = core::array::from_fn(|i| (i as u8) ^ 0xa5);
-    // All inputs public: the precompile computes in the clear, output public.
     let got = prove_compress(Config::builder().build(), &state0, &[block], false, false);
     assert_eq!(got.as_slice(), reference(&state0, &[block]));
 }
@@ -151,9 +130,6 @@ fn precompile_public_fast_path() {
 fn precompile_private_state_in_place() {
     let state0: [u8; 32] = core::array::from_fn(|i| (i as u8).wrapping_mul(13).wrapping_add(2));
     let block: [u8; 64] = core::array::from_fn(|i| (i as u8).wrapping_mul(3));
-    // The state is staged as a private host input at the very region the
-    // compression overwrites in place: the commitment must capture the staged
-    // value, not the digest written during capture.
     let got = prove_compress(Config::builder().build(), &state0, &[block], true, true);
     assert_eq!(got.as_slice(), reference(&state0, &[block]));
 }
@@ -163,8 +139,6 @@ fn precompile_segmented_two_blocks() {
     let state0: [u8; 32] = core::array::from_fn(|i| (i as u8).wrapping_mul(11));
     let b1: [u8; 64] = core::array::from_fn(|i| i as u8);
     let b2: [u8; 64] = core::array::from_fn(|i| (i as u8).wrapping_add(64));
-    // A low segment cost forces a boundary between the two 22,696-gate
-    // precompiles, stitching the first's in-place output state into the second.
     let config = Config::builder().segment_cost(Some(5_000)).build();
     let got = prove_compress(config, &state0, &[b1, b2], false, true);
     assert_eq!(got.as_slice(), reference(&state0, &[b1, b2]));

--- a/crates/vm-zk/tests/sha256_seg.rs
+++ b/crates/vm-zk/tests/sha256_seg.rs
@@ -1,7 +1,3 @@
-//! Segmented proving repro for the sha256 guest: the bench workload over
-//! ideal sVOLE, small message, low segment cost — fails fast and
-//! deterministically if boundary stitching is broken.
-
 use futures::{executor::block_on, future::try_join};
 use mpz_common::context::test_st_context;
 use mpz_core::Block;
@@ -41,7 +37,6 @@ fn sha256_segmented() {
         Prover::new_with_config(module.clone(), svole_receiver, config.clone()).unwrap();
     let mut verifier = Verifier::new_with_config(module.clone(), svole_sender, config).unwrap();
 
-    // Allocate the input buffer in-guest, mirroring the bench.
     let realloc = func_idx(&module, "cabi_realloc");
     let alloc_args = || {
         vec![
@@ -80,7 +75,6 @@ fn sha256_segmented() {
     .unwrap();
     assert_eq!(rp, rv);
 
-    // `hash` returns the address of the revealed digest.
     let digest_ptr = match rp {
         Some(Value::I32(p)) => p as u32,
         other => panic!("hash returned {other:?}"),

--- a/crates/vm-zk/tests/spec.rs
+++ b/crates/vm-zk/tests/spec.rs
@@ -1,11 +1,3 @@
-//! WebAssembly spec-conformance tests for the zkVM, via the shared
-//! [`mpz_vm_test_harness`] harness.
-//!
-//! `spec_all` runs the entire WASM core spec suite through the real
-//! prover/verifier protocol. The zkVM supports only a subset of WebAssembly, so
-//! the harness is configured to treat unsupported ops, private control flow,
-//! and symbolic value/address errors as expected skips rather than failures.
-
 use futures::{executor::block_on, future::try_join};
 use mpz_common::context::test_st_context;
 use mpz_core::Block;
@@ -16,7 +8,6 @@ use mpz_vm_test_harness::{SpecConfig, SpecVm, run_suite, suites};
 use mpz_vm_zk::{Config, Prover, Verifier, ZkVmError};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
-/// A prover/verifier pair wired over ideal sVOLE.
 struct ZkPair {
     prover: Prover<IdealRCOTReceiver>,
     verifier: Verifier<IdealRCOTSender>,
@@ -26,12 +17,6 @@ impl SpecVm for ZkPair {
     type Error = ZkVmError;
 
     fn variants() -> Vec<String> {
-        // Default (unbounded chunk) plus a small-cap variant that drives the
-        // whole spec corpus through multi-chunk proving (exercising
-        // cross-chunk authenticated-state liveness), plus a small
-        // segment-cost variant that drives it through multi-segment parallel
-        // proving (exercising boundary-commitment stitching) on every
-        // construct rather than on a few hand-written programs.
         vec![
             String::new(),
             "chunk64".to_string(),
@@ -70,8 +55,6 @@ impl SpecVm for ZkPair {
         params_b: Vec<Param>,
     ) -> Result<(Option<Value>, Option<Value>), ZkVmError> {
         let (mut ctx_p, mut ctx_v) = test_st_context(1024 * 1024);
-        // `try_join` (not `join`) so that if one party errors mid-protocol the
-        // other future is dropped rather than left blocked on a recv.
         block_on(try_join(
             self.prover.call(&mut ctx_p, func_idx, params_a),
             self.verifier.call(&mut ctx_v, func_idx, params_b),
@@ -89,8 +72,6 @@ fn zk_config() -> SpecConfig {
     }
 }
 
-/// Run the entire WASM spec suite against the zkVM through the real
-/// prover/verifier protocol.
 #[test]
 fn spec_all() {
     let (mut passed, mut failed, mut skipped) = (0usize, 0usize, 0usize);

--- a/crates/vm-zk/tests/streaming_dense.rs
+++ b/crates/vm-zk/tests/streaming_dense.rs
@@ -1,7 +1,3 @@
-//! Stress the chunk-loop with a tight cap that forces a chunk per
-//! `i32.add`. Catches AuthMap-across-chunks regressions: each gate's
-//! output is needed by the next chunk's gate.
-
 mod common;
 
 use futures::{executor::block_on, future::join};
@@ -26,9 +22,6 @@ fn func_idx(module: &Module, name: &str) -> u32 {
 #[test]
 fn chunk_per_gate() {
     common::init_tracing();
-    // Five chained adds = 5 × 32 = 160 sVOLE bits. Cap at 1 forces
-    // one chunk per i32.add — the AuthMap entry written by chunk N
-    // must still be live in chunk N+1.
     let wat = r#"
         (module
             (func $sum6 (export "sum6")

--- a/crates/vm-zk/tests/unsupported.rs
+++ b/crates/vm-zk/tests/unsupported.rs
@@ -1,6 +1,3 @@
-//! Float parameters must be rejected at `Vm::call` entry, not later
-//! deep in the pipeline.
-
 mod common;
 
 use futures::executor::block_on;

--- a/crates/zk-core/benches/poly.rs
+++ b/crates/zk-core/benches/poly.rs
@@ -1,10 +1,10 @@
 //! Polynomial-constraint prover/verifier benchmark.
 //!
 //! **`mux{2,4,8,16}`**: a 1-of-`w` multiplexer over 32-bit values. Each output
-//! bit is a depth-`log2(w)` binary mux tree `a + sel·(a + b)` over the committed
-//! inputs and `log2(w)` committed selector bits, giving 32 degree-`(log2(w)+1)`
-//! constraints per multiplexer. The variants sweep the mux degree: 1-of-2
-//! (degree 2) through 1-of-16 (degree 5).
+//! bit is a depth-`log2(w)` binary mux tree `a + sel·(a + b)` over the
+//! committed inputs and `log2(w)` committed selector bits, giving 32
+//! degree-`(log2(w)+1)` constraints per multiplexer. The variants sweep the mux
+//! degree: 1-of-2 (degree 2) through 1-of-16 (degree 5).
 //!
 //! The workload uses only `lift` + `assert_zero` (no AND gates and no
 //! `materialize`), so the triple check is trivial and the measured cost is the
@@ -13,14 +13,14 @@
 //!
 //! Run with: `cargo bench -p mpz-zk-core --bench poly`
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use mpz_core::Block;
 use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_ot_core::ideal::rcot::IdealRCOT;
 use mpz_zk_core::{
-    Commit, DeltaPowers, Proof, Prover, ProverOutput, Verifier, VerifierOutput,
+    Accumulate, DeltaPowers, Proof, ProverOutput, Verifier, VerifierOutput, Witness,
     poly::{Expr, PolyContext},
     vope_receiver, vope_sender,
 };
@@ -39,18 +39,19 @@ const VOPE_COST: usize = 128;
 // out as `input·32 + bit`) and output (`out`, 32 wires) are flat committed-wire
 // slices. The mux level `a + sel·(a + b)` raises the expression degree by one
 // per tree level, so the top constraint is degree `log2(w)+1`. The degree is
-// part of the `Expr` *type*, so each width is spelled out statically rather than
-// folded over a runtime-sized tree.
+// part of the `Expr` *type*, so each width is spelled out statically rather
+// than folded over a runtime-sized tree.
 
 /// 1-of-2 mux, depth 1, degree-2 constraints.
-fn mux2_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+fn mux2_u32<C>(ctx: &mut C, sel: &[C::Wire], inputs: &[C::Wire], out: &[C::Wire])
 where
-    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C: PolyContext<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let s0 = ctx.lift(sel[0]);
     for bit in 0..32 {
-        let leaf: [Expr<C::Coeffs, U1>; 2] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let leaf: [Expr<C::Coeffs, U1>; 2] =
+            core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
         let top = leaf[0] + s0 * (leaf[0] + leaf[1]); // degree 2
         let o = ctx.lift(out[bit]);
         ctx.assert_zero(top - o).expect("mux output");
@@ -58,14 +59,15 @@ where
 }
 
 /// 1-of-4 mux, depth 2, degree-3 constraints.
-fn mux4_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+fn mux4_u32<C>(ctx: &mut C, sel: &[C::Wire], inputs: &[C::Wire], out: &[C::Wire])
 where
-    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C: PolyContext<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let s: [Expr<C::Coeffs, U1>; 2] = core::array::from_fn(|i| ctx.lift(sel[i]));
     for bit in 0..32 {
-        let leaf: [Expr<C::Coeffs, U1>; 4] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let leaf: [Expr<C::Coeffs, U1>; 4] =
+            core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
         let l0: [Expr<C::Coeffs, _>; 2] =
             core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
         let top = l0[0] + s[1] * (l0[0] + l0[1]); // degree 3
@@ -75,14 +77,15 @@ where
 }
 
 /// 1-of-8 mux, depth 3, degree-4 constraints.
-fn mux8_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+fn mux8_u32<C>(ctx: &mut C, sel: &[C::Wire], inputs: &[C::Wire], out: &[C::Wire])
 where
-    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C: PolyContext<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let s: [Expr<C::Coeffs, U1>; 3] = core::array::from_fn(|i| ctx.lift(sel[i]));
     for bit in 0..32 {
-        let leaf: [Expr<C::Coeffs, U1>; 8] = core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
+        let leaf: [Expr<C::Coeffs, U1>; 8] =
+            core::array::from_fn(|n| ctx.lift(inputs[n * 32 + bit]));
         let l0: [Expr<C::Coeffs, _>; 4] =
             core::array::from_fn(|j| leaf[2 * j] + s[0] * (leaf[2 * j] + leaf[2 * j + 1]));
         let l1: [Expr<C::Coeffs, _>; 2] =
@@ -94,9 +97,9 @@ where
 }
 
 /// 1-of-16 mux, depth 4, degree-5 constraints.
-fn mux16_u32<C>(ctx: &mut C, sel: &[Gf2_128], inputs: &[Gf2_128], out: &[Gf2_128])
+fn mux16_u32<C>(ctx: &mut C, sel: &[C::Wire], inputs: &[C::Wire], out: &[C::Wire])
 where
-    C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+    C: PolyContext<Field = Gf2>,
     C::Error: std::fmt::Debug,
 {
     let s: [Expr<C::Coeffs, U1>; 4] = core::array::from_fn(|i| ctx.lift(sel[i]));
@@ -129,9 +132,9 @@ trait PolyCircuit {
     fn d_max(&self) -> usize;
     /// Evaluates the circuit over the committed wires (same order as the
     /// witness), emitting its constraints.
-    fn eval<C>(&self, ctx: &mut C, wires: &[Gf2_128])
+    fn eval<C>(&self, ctx: &mut C, wires: &[C::Wire])
     where
-        C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+        C: PolyContext<Field = Gf2>,
         C::Error: std::fmt::Debug;
 }
 
@@ -181,9 +184,9 @@ impl PolyCircuit for MuxCircuit {
         self.depth() + 1
     }
 
-    fn eval<C>(&self, ctx: &mut C, wires: &[Gf2_128])
+    fn eval<C>(&self, ctx: &mut C, wires: &[C::Wire])
     where
-        C: PolyContext<Field = Gf2, Wire = Gf2_128>,
+        C: PolyContext<Field = Gf2>,
         C::Error: std::fmt::Debug,
     {
         let depth = self.depth();
@@ -240,14 +243,11 @@ fn set_lsb(g: Gf2_128, bit: bool) -> Gf2_128 {
 /// circuit: pre-committed input wires and a precomputed (valid) proof.
 struct PolyInputs {
     delta: Gf2_128,
-    d_max: usize,
     /// Prover input wires (MACs, LSB = committed bit).
     mac_wires: Vec<Gf2_128>,
     /// Verifier input wires (keys, pre-adjusted off-band).
     key_wires: Vec<Gf2_128>,
     chi: [u8; 32],
-    vope_choices: [bool; VOPE_COST],
-    vope_ev: [Gf2_128; VOPE_COST],
     vope_keys: [Gf2_128; VOPE_COST],
     /// Powers of `delta` for the polynomial check.
     powers: DeltaPowers,
@@ -298,13 +298,18 @@ fn setup<Circ: PolyCircuit>(circ: &Circ) -> PolyInputs {
     }
 
     // Run the prover once to produce the proof and the masked coefficients.
-    let mut commit = Commit::new(&mut []);
-    circ.eval(&mut commit, &ptr_wires(&witness));
+    let mut commit = Witness::new(&mut []);
+    circ.eval(&mut commit, &bit_wires(&witness));
     commit.finish().expect("commit finish");
 
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(chi));
     circ.eval(&mut prover, &mac_wires);
-    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
+    let ProverOutput {
+        u,
+        v,
+        poly,
+        assertions,
+    } = prover.finish().expect("accumulate finish");
 
     let coefficients: Vec<Gf2_128> = poly
         .coefficients(d_max)
@@ -324,12 +329,9 @@ fn setup<Circ: PolyCircuit>(circ: &Circ) -> PolyInputs {
 
     PolyInputs {
         delta,
-        d_max,
         mac_wires,
         key_wires,
         chi,
-        vope_choices,
-        vope_ev,
         vope_keys,
         powers,
         poly_vope_sum,
@@ -338,35 +340,32 @@ fn setup<Circ: PolyCircuit>(circ: &Circ) -> PolyInputs {
     }
 }
 
-/// Pointer-bit wires for the commit pass: each wire's LSB carries the bit.
-fn ptr_wires(witness: &[bool]) -> Vec<Gf2_128> {
-    witness.iter().map(|&b| Gf2_128::new(b as u128)).collect()
+/// Cleartext bit wires for the witness pass.
+fn bit_wires(witness: &[bool]) -> Vec<Gf2> {
+    witness.iter().map(|&b| Gf2(b)).collect()
 }
 
-fn run_prover<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
-    let mut commit = Commit::new(&mut []);
-    circ.eval(&mut commit, &ptr_wires(&circ.witness()));
-    commit.finish().expect("commit finish");
+fn run_witness<Circ: PolyCircuit>(circ: &Circ, _inputs: &PolyInputs) {
+    let mut commit = Witness::new(&mut []);
+    circ.eval(&mut commit, black_box(&bit_wires(&circ.witness())));
+    commit.finish().expect("witness finish");
+}
 
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(inputs.chi));
-    circ.eval(&mut prover, &inputs.mac_wires);
-    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
-
-    let coefficients: Vec<Gf2_128> = poly.coefficients(inputs.d_max).expect("coefficients");
-    let (a_0, a_1) = vope_receiver(&inputs.vope_choices, &inputs.vope_ev);
-    let _proof = Proof {
-        assertions,
-        u: u + a_0,
-        v: v + a_1,
-        coefficients,
-    };
+fn run_accumulate<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(inputs.chi));
+    circ.eval(&mut prover, black_box(&inputs.mac_wires));
+    black_box(prover.finish().expect("accumulate finish"));
 }
 
 fn run_verifier<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
-    let verifier = Verifier::new(inputs.delta, &[], &[]).expect("new");
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    let mut verifier =
+        Verifier::new(inputs.delta, &[], &[], ChaCha12Rng::from_seed(inputs.chi)).expect("new");
     circ.eval(&mut verifier, &inputs.key_wires);
-    let VerifierOutput { w, poly, assertions } = verifier.finish().expect("finish");
+    let VerifierOutput {
+        w,
+        poly,
+        assertions,
+    } = verifier.finish().expect("finish");
 
     poly.check(&inputs.powers, &inputs.coefficients, inputs.poly_vope_sum)
         .expect("poly check");
@@ -383,12 +382,19 @@ fn run_verifier<Circ: PolyCircuit>(circ: &Circ, inputs: &PolyInputs) {
 fn bench_circuit<Circ: PolyCircuit>(c: &mut Criterion, name: &str, circ: Circ, units: u64) {
     let inputs = setup(&circ);
 
-    let mut pg = c.benchmark_group(format!("poly_prover_{name}"));
-    pg.sample_size(10);
-    pg.measurement_time(Duration::from_secs(10));
-    pg.throughput(Throughput::Elements(units));
-    pg.bench_function("run", |b| b.iter(|| run_prover(&circ, &inputs)));
-    pg.finish();
+    let mut wg = c.benchmark_group(format!("poly_witness_{name}"));
+    wg.sample_size(10);
+    wg.measurement_time(Duration::from_secs(10));
+    wg.throughput(Throughput::Elements(units));
+    wg.bench_function("run", |b| b.iter(|| run_witness(&circ, &inputs)));
+    wg.finish();
+
+    let mut ag = c.benchmark_group(format!("poly_accumulate_{name}"));
+    ag.sample_size(10);
+    ag.measurement_time(Duration::from_secs(10));
+    ag.throughput(Throughput::Elements(units));
+    ag.bench_function("run", |b| b.iter(|| run_accumulate(&circ, &inputs)));
+    ag.finish();
 
     let mut vg = c.benchmark_group(format!("poly_verifier_{name}"));
     vg.sample_size(10);

--- a/crates/zk-core/benches/product_gf64.rs
+++ b/crates/zk-core/benches/product_gf64.rs
@@ -29,13 +29,13 @@
 //!
 //! Run with: `cargo bench -p mpz-zk-core --bench product_gf64`
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mpz_fields::{ExtensionField, gf2_64::Gf2_64, gf2_128::Gf2_128};
 use mpz_zk_core::{
-    DeltaPowers, PolyContext, Proof, ProverOutput, VerifierOutput,
-    gf64::{Auth64, Commit, Prover, Verifier},
+    DeltaPowers, PolyContext, ProverOutput, VerifierOutput,
+    gf64::{Accumulate, Auth64, Verifier, Witness},
     poly::Expr,
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -276,9 +276,8 @@ fn witness<Ch: Chunk>(rng: &mut StdRng) -> (Vec<Gf2_64>, Gf2_64) {
 
 struct Inputs {
     delta: Gf2_128,
-    d_max: usize,
     r: Gf2_64,
-    /// Cleartext committed values (for the commit pass).
+    /// Cleartext committed values (for the witness pass).
     values: Vec<Gf2_64>,
     /// Prover input wires (value + raw MAC).
     mac_wires: Vec<Auth64>,
@@ -325,10 +324,10 @@ fn setup<Ch: Chunk>() -> Inputs {
     let chi: [u8; 32] = rng.random();
 
     // One prover run to produce the masked coefficients.
-    let mut commit = Commit::new(&mut []);
+    let mut commit = Witness::new(&mut []);
     eval::<Ch, _>(&mut commit, &values, r);
     commit.finish().expect("commit finish");
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(chi));
     eval::<Ch, _>(&mut prover, &mac_wires, r);
     let ProverOutput { poly, .. } = prover.finish().expect("accumulate finish");
     let coefficients: Vec<Gf2_128> = poly
@@ -341,7 +340,6 @@ fn setup<Ch: Chunk>() -> Inputs {
 
     Inputs {
         delta,
-        d_max,
         r,
         values,
         mac_wires,
@@ -353,27 +351,21 @@ fn setup<Ch: Chunk>() -> Inputs {
     }
 }
 
-fn run_prover<Ch: Chunk>(inputs: &Inputs) {
-    let mut commit = Commit::new(&mut []);
-    eval::<Ch, _>(&mut commit, &inputs.values, inputs.r);
-    commit.finish().expect("commit finish");
+fn run_witness<Ch: Chunk>(inputs: &Inputs) {
+    let mut commit = Witness::new(&mut []);
+    eval::<Ch, _>(&mut commit, black_box(&inputs.values), inputs.r);
+    commit.finish().expect("witness finish");
+}
 
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(inputs.chi));
-    eval::<Ch, _>(&mut prover, &inputs.mac_wires, inputs.r);
-    let ProverOutput { u, v, poly, assertions } = prover.finish().expect("accumulate finish");
-
-    let coefficients: Vec<Gf2_128> = poly.coefficients(inputs.d_max).expect("coefficients");
-    let _proof = Proof {
-        assertions,
-        u,
-        v,
-        coefficients,
-    };
+fn run_accumulate<Ch: Chunk>(inputs: &Inputs) {
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(inputs.chi));
+    eval::<Ch, _>(&mut prover, black_box(&inputs.mac_wires), inputs.r);
+    black_box(prover.finish().expect("accumulate finish"));
 }
 
 fn run_verifier<Ch: Chunk>(inputs: &Inputs) {
-    let verifier = Verifier::new(inputs.delta, &[], &[]).expect("new");
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
+    let mut verifier =
+        Verifier::new(inputs.delta, &[], &[], ChaCha12Rng::from_seed(inputs.chi)).expect("new");
     eval::<Ch, _>(&mut verifier, &inputs.key_wires, inputs.r);
     let VerifierOutput { poly, .. } = verifier.finish().expect("finish");
 
@@ -384,14 +376,23 @@ fn run_verifier<Ch: Chunk>(inputs: &Inputs) {
 fn bench_one<Ch: Chunk>(c: &mut Criterion, label: &str) {
     let inputs = setup::<Ch>();
 
-    let mut pg = c.benchmark_group("product_prover");
-    pg.sample_size(10);
-    pg.measurement_time(Duration::from_secs(10));
-    pg.throughput(Throughput::Elements(M as u64));
-    pg.bench_function(BenchmarkId::new("chunk", label), |b| {
-        b.iter(|| run_prover::<Ch>(&inputs))
+    let mut wg = c.benchmark_group("product_witness");
+    wg.sample_size(10);
+    wg.measurement_time(Duration::from_secs(10));
+    wg.throughput(Throughput::Elements(M as u64));
+    wg.bench_function(BenchmarkId::new("chunk", label), |b| {
+        b.iter(|| run_witness::<Ch>(&inputs))
     });
-    pg.finish();
+    wg.finish();
+
+    let mut ag = c.benchmark_group("product_accumulate");
+    ag.sample_size(10);
+    ag.measurement_time(Duration::from_secs(10));
+    ag.throughput(Throughput::Elements(M as u64));
+    ag.bench_function(BenchmarkId::new("chunk", label), |b| {
+        b.iter(|| run_accumulate::<Ch>(&inputs))
+    });
+    ag.finish();
 
     let mut vg = c.benchmark_group("product_verifier");
     vg.sample_size(10);

--- a/crates/zk-core/benches/sha256.rs
+++ b/crates/zk-core/benches/sha256.rs
@@ -3,7 +3,7 @@
 //!
 //! Run with: `cargo bench -p mpz-zk-core --bench sha256`
 
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use itybity::ToBits;
@@ -12,9 +12,11 @@ use mpz_circuits::{
     sha256::{AND_PER_BLOCK, H0, compress as sha256_compress},
 };
 use mpz_core::Block;
-use mpz_fields::gf2_128::Gf2_128;
+use mpz_fields::{gf2::Gf2, gf2_128::Gf2_128};
 use mpz_ot_core::ideal::rcot::IdealRCOT;
-use mpz_zk_core::{Commit, Proof, Prover, ProverOutput, Verifier, VerifierOutput, vope_receiver, vope_sender};
+use mpz_zk_core::{
+    Accumulate, Proof, ProverOutput, Verifier, VerifierOutput, Witness, vope_receiver, vope_sender,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rand_chacha::ChaCha12Rng;
 
@@ -49,11 +51,11 @@ fn set_lsb(g: Gf2_128, bit: bool) -> Gf2_128 {
 }
 
 /// Iterated SHA-256 compression over a sequence of message blocks.
-fn sha256_chain<C: Context<Field = mpz_fields::gf2::Gf2, Wire = Gf2_128>>(
+fn sha256_chain<C: Context<Field = Gf2>>(
     ctx: &mut C,
-    initial_state: [Gf2_128; 256],
-    msg_blocks: &[[Gf2_128; 512]],
-) -> [Gf2_128; 256] {
+    initial_state: [C::Wire; 256],
+    msg_blocks: &[[C::Wire; 512]],
+) -> [C::Wire; 256] {
     let mut state = initial_state;
     for block in msg_blocks {
         state = sha256_compress(ctx, *block, state);
@@ -61,27 +63,27 @@ fn sha256_chain<C: Context<Field = mpz_fields::gf2::Gf2, Wire = Gf2_128>>(
     state
 }
 
-const SIZES: &[(usize, &str)] = &[
-    (64, "64B"),
-    (1024, "1KiB"),
-    (16 * 1024, "16KiB"),
-    (64 * 1024, "64KiB"),
-    (128 * 1024, "128KiB"),
-];
+const SIZES: &[(usize, &str)] = &[(16 * 1024, "16KiB")];
 
 struct BenchInputs {
     delta: Gf2_128,
-    input_mac_wires: Vec<Gf2_128>,
-    input_key_wires: Vec<Gf2_128>,
+    /// Prover witness pass: initial state + message blocks as cleartext bit
+    /// wires, laid out once so the benched pass measures only evaluation.
+    state_p_bits: [Gf2; 256],
+    msg_p_bits: Vec<[Gf2; 512]>,
+    /// Prover accumulate pass: initial state + message blocks (MAC wires).
+    state_p: [Gf2_128; 256],
+    msg_p: Vec<[Gf2_128; 512]>,
+    /// Verifier initial state + message blocks (key wires).
+    state_v: [Gf2_128; 256],
+    msg_v: Vec<[Gf2_128; 512]>,
     /// Gate masks as committed (cloned per prover iteration, since
-    /// the commit pass overwrites them with the adjust bits in place).
+    /// the witness pass overwrites them with the adjust bits in place).
     gate_masks: Vec<bool>,
     gate_macs: Vec<Gf2_128>,
     gate_keys: Vec<Gf2_128>,
     /// Gate adjust bits the prover produced, fed to the verifier.
     gate_adjust: Vec<bool>,
-    vope_choices: [bool; VOPE_COST],
-    vope_ev: [Gf2_128; VOPE_COST],
     vope_keys: [Gf2_128; VOPE_COST],
     /// Seed of the consistency-check challenge stream.
     chi: [u8; 32],
@@ -128,20 +130,32 @@ fn setup_inputs(num_blocks: usize) -> BenchInputs {
     let vope_keys: [Gf2_128; VOPE_COST] = core::array::from_fn(|i| raw_keys[main_cost + i]);
     let chi: [u8; 32] = rng.random();
 
-    // Run the prover once to produce a valid proof and the gate adjust
-    // bits for the verifier benchmark.
+    // Lay out the prover (MAC) and verifier (key) wires as initial state +
+    // message blocks once, so the benched passes never rebuild them.
     let state_p: [Gf2_128; 256] = core::array::from_fn(|i| input_mac_wires[i]);
     let msg_p: Vec<[Gf2_128; 512]> = (0..num_blocks)
         .map(|b| core::array::from_fn(|i| input_mac_wires[256 + b * 512 + i]))
         .collect();
+    let state_v: [Gf2_128; 256] = core::array::from_fn(|i| input_key_wires[i]);
+    let msg_v: Vec<[Gf2_128; 512]> = (0..num_blocks)
+        .map(|b| core::array::from_fn(|i| input_key_wires[256 + b * 512 + i]))
+        .collect();
+    let state_p_bits: [Gf2; 256] = core::array::from_fn(|i| Gf2(input_bits[i]));
+    let msg_p_bits: Vec<[Gf2; 512]> = (0..num_blocks)
+        .map(|b| core::array::from_fn(|i| Gf2(input_bits[256 + b * 512 + i])))
+        .collect();
 
+    // Run the prover once to produce a valid proof and the gate adjust
+    // bits for the verifier benchmark.
     let mut gate_adjust = gate_masks.clone();
-    let mut commit = Commit::new(&mut gate_adjust);
-    let _ = sha256_chain(&mut commit, state_p, &msg_p);
+    let mut commit = Witness::new(&mut gate_adjust);
+    let _ = sha256_chain(&mut commit, state_p_bits, &msg_p_bits);
     commit.finish().expect("commit finish");
-    let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
     let _ = sha256_chain(&mut prover, state_p, &msg_p);
-    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
+    let ProverOutput {
+        u, v, assertions, ..
+    } = prover.finish().expect("accumulate finish");
 
     let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
     let proof = Proof {
@@ -153,54 +167,45 @@ fn setup_inputs(num_blocks: usize) -> BenchInputs {
 
     BenchInputs {
         delta,
-        input_mac_wires,
-        input_key_wires,
+        state_p_bits,
+        msg_p_bits,
+        state_p,
+        msg_p,
+        state_v,
+        msg_v,
         gate_masks,
         gate_macs,
         gate_keys,
         gate_adjust,
-        vope_choices,
-        vope_ev,
         vope_keys,
         chi,
         proof,
     }
 }
 
-fn run_prover(inputs: &BenchInputs, num_blocks: usize) {
-    let state: [Gf2_128; 256] = core::array::from_fn(|i| inputs.input_mac_wires[i]);
-    let msg_blocks: Vec<[Gf2_128; 512]> = (0..num_blocks)
-        .map(|b| core::array::from_fn(|i| inputs.input_mac_wires[256 + b * 512 + i]))
-        .collect();
-
+fn run_witness(inputs: &BenchInputs) {
     let mut masks = inputs.gate_masks.clone();
-    let mut commit = Commit::new(&mut masks);
-    let _ = sha256_chain(&mut commit, state, &msg_blocks);
-    commit.finish().expect("commit finish");
-    let mut prover =
-        Prover::committed(&inputs.gate_macs).accumulate(ChaCha12Rng::from_seed(inputs.chi));
-    let _ = sha256_chain(&mut prover, state, &msg_blocks);
-    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
-
-    let (a_0, a_1) = vope_receiver(&inputs.vope_choices, &inputs.vope_ev);
-    let _proof = Proof {
-        assertions,
-        u: u + a_0,
-        v: v + a_1,
-        coefficients: Vec::new(),
-    };
+    let mut commit = Witness::new(&mut masks);
+    let _ = sha256_chain(&mut commit, inputs.state_p_bits, &inputs.msg_p_bits);
+    commit.finish().expect("witness finish");
+    black_box(&masks);
 }
 
-fn run_verifier(inputs: &BenchInputs, num_blocks: usize) {
-    let state: [Gf2_128; 256] = core::array::from_fn(|i| inputs.input_key_wires[i]);
-    let msg_blocks: Vec<[Gf2_128; 512]> = (0..num_blocks)
-        .map(|b| core::array::from_fn(|i| inputs.input_key_wires[256 + b * 512 + i]))
-        .collect();
+fn run_accumulate(inputs: &BenchInputs) {
+    let mut prover = Accumulate::new(&inputs.gate_macs, ChaCha12Rng::from_seed(inputs.chi));
+    let _ = sha256_chain(&mut prover, inputs.state_p, &inputs.msg_p);
+    black_box(prover.finish().expect("accumulate finish"));
+}
 
-    let verifier =
-        Verifier::new(inputs.delta, &inputs.gate_keys, &inputs.gate_adjust).expect("new");
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(inputs.chi));
-    let _ = sha256_chain(&mut verifier, state, &msg_blocks);
+fn run_verifier(inputs: &BenchInputs) {
+    let mut verifier = Verifier::new(
+        inputs.delta,
+        &inputs.gate_keys,
+        &inputs.gate_adjust,
+        ChaCha12Rng::from_seed(inputs.chi),
+    )
+    .expect("new");
+    let _ = sha256_chain(&mut verifier, inputs.state_v, &inputs.msg_v);
     let VerifierOutput { w, assertions, .. } = verifier.finish().expect("finish");
 
     let b = vope_sender(&inputs.vope_keys);
@@ -221,21 +226,30 @@ fn bench_sha256(c: &mut Criterion) {
         let num_blocks = bytes / 64;
         let inputs = setup_inputs(num_blocks);
 
-        let mut prover_group = c.benchmark_group("sha256_prover");
-        prover_group.sample_size(10);
-        prover_group.measurement_time(Duration::from_secs(10));
-        prover_group.throughput(Throughput::Bytes(bytes as u64));
-        prover_group.bench_function(BenchmarkId::new("message", name), |b| {
-            b.iter(|| run_prover(&inputs, num_blocks));
+        let mut witness_group = c.benchmark_group("sha256_witness");
+        witness_group.sample_size(10);
+        witness_group.measurement_time(Duration::from_secs(10));
+        witness_group.throughput(Throughput::Bytes(bytes as u64));
+        witness_group.bench_function(BenchmarkId::new("message", name), |b| {
+            b.iter(|| run_witness(&inputs));
         });
-        prover_group.finish();
+        witness_group.finish();
+
+        let mut accumulate_group = c.benchmark_group("sha256_accumulate");
+        accumulate_group.sample_size(10);
+        accumulate_group.measurement_time(Duration::from_secs(10));
+        accumulate_group.throughput(Throughput::Bytes(bytes as u64));
+        accumulate_group.bench_function(BenchmarkId::new("message", name), |b| {
+            b.iter(|| run_accumulate(&inputs));
+        });
+        accumulate_group.finish();
 
         let mut verifier_group = c.benchmark_group("sha256_verifier");
         verifier_group.sample_size(10);
         verifier_group.measurement_time(Duration::from_secs(10));
         verifier_group.throughput(Throughput::Bytes(bytes as u64));
         verifier_group.bench_function(BenchmarkId::new("message", name), |b| {
-            b.iter(|| run_verifier(&inputs, num_blocks));
+            b.iter(|| run_verifier(&inputs));
         });
         verifier_group.finish();
     }

--- a/crates/zk-core/src/gf64.rs
+++ b/crates/zk-core/src/gf64.rs
@@ -1,6 +1,7 @@
 //! Circuits over `GF(2^64)` with `GF(2^128)` MACs (a subfield IT-MAC).
 //!
-//! The boolean path ([`Prover`](crate::Prover)/[`Verifier`](crate::Verifier))
+//! The boolean path
+//! ([`Accumulate`](crate::Accumulate)/[`Verifier`](crate::Verifier))
 //! packs the committed bit into the MAC's LSB (the pointer-bit trick); a 64-bit
 //! value cannot be packed that way, so this path carries the value explicitly.
 //!
@@ -11,8 +12,8 @@
 //! `GF(2^128)`. The prover wire is [`Auth64`] (value + MAC); the verifier wire
 //! is the key alone.
 //!
-//! The protocol matches the boolean path otherwise: a mask-only commit pass
-//! ([`Commit`]) records the per-wire adjustment `adjust = value − choice ∈
+//! The protocol matches the boolean path otherwise: a mask-only witness pass
+//! ([`Witness`]) records the per-wire adjustment `adjust = value − choice ∈
 //! GF(2^64)`, and the accumulate passes fold each multiplication into the
 //! QuickSilver triple check under a streamed challenge. The two specializations
 //! relative to the boolean path are (1) the value is tracked in [`Auth64`]
@@ -58,10 +59,10 @@ pub struct Auth64 {
 }
 
 // ===========================================================================
-// Commit pass
+// Witness pass
 // ===========================================================================
 
-/// The prover's commit-pass context over `GF(2^64)`.
+/// The prover's witness-pass context over `GF(2^64)`.
 ///
 /// Pure cleartext evaluation over the values. Each input and multiplication
 /// records its adjustment `value − choice` into the mask tape in place (the
@@ -69,13 +70,13 @@ pub struct Auth64 {
 /// are sent to the verifier. Circuits must be re-walked with the same inputs in
 /// the accumulate pass.
 #[derive(Debug)]
-pub struct Commit<'a> {
+pub struct Witness<'a> {
     masks: &'a mut [Gf2_64],
     cursor: usize,
 }
 
-impl<'a> Commit<'a> {
-    /// Creates a commit-pass context over the mask tape.
+impl<'a> Witness<'a> {
+    /// Creates a witness-pass context over the mask tape.
     pub fn new(masks: &'a mut [Gf2_64]) -> Self {
         Self { masks, cursor: 0 }
     }
@@ -102,7 +103,7 @@ impl<'a> Commit<'a> {
         value
     }
 
-    /// Completes the commit pass.
+    /// Completes the witness pass.
     ///
     /// # Errors
     ///
@@ -116,7 +117,7 @@ impl<'a> Commit<'a> {
     }
 }
 
-impl Context for Commit<'_> {
+impl Context for Witness<'_> {
     type Error = Error;
     type Wire = Gf2_64;
     type Field = Gf2_64;
@@ -155,7 +156,7 @@ impl Context for Commit<'_> {
     }
 }
 
-impl PolyContext for Commit<'_> {
+impl PolyContext for Witness<'_> {
     /// Plaintext evaluation: an expression is just its cleartext `GF(2^64)`
     /// value, so polynomial gadgets compile down to field operations.
     type Coeffs = PlainCoeffs<Gf2_64>;
@@ -188,27 +189,16 @@ impl PolyContext for Commit<'_> {
 // Prover
 // ===========================================================================
 
-/// The prover side of the `GF(2^64)` protocol.
+/// The prover's accumulate-pass context over `GF(2^64)`.
 ///
-/// Mirrors [`Prover`](crate::Prover): a mask-only [`Commit`] pass, then an
-/// accumulate pass from [`Prover::committed`] that folds every multiplication
-/// into the running proof under the installed challenge stream.
-/// [`finish`](Prover::finish) yields a [`ProverOutput`], which the caller
-/// masks with the VOPE correlation.
+/// Mirrors [`Accumulate`](crate::Accumulate): the second pass after the
+/// mask-only [`Witness`] pass, folding every multiplication into the running
+/// proof under the installed challenge stream. [`finish`](Self::finish) yields
+/// a [`ProverOutput`], which the caller masks with the VOPE correlation.
 #[derive(Debug)]
-pub struct Prover<'a, S> {
+pub struct Accumulate<'a, R> {
     macs: &'a [Gf2_128],
     cursor: usize,
-    state: S,
-}
-
-/// Committed state for the [`Prover`].
-#[derive(Debug)]
-pub struct Committed;
-
-/// Accumulate-phase state for the [`Prover`].
-#[derive(Debug)]
-pub struct Accumulate<R> {
     assertions: Hasher,
     rng: R,
     u: Gf2_128Accumulator,
@@ -216,36 +206,24 @@ pub struct Accumulate<R> {
     poly: ProverPoly,
 }
 
-impl<'a> Prover<'a, Committed> {
-    /// Creates a prover directly in the committed state over the MAC tape.
-    pub fn committed(macs: &'a [Gf2_128]) -> Self {
-        Self {
-            macs,
-            cursor: 0,
-            state: Committed,
-        }
-    }
-
-    /// Begins the accumulate pass, drawing challenge weights from `rng`.
+impl<'a, R> Accumulate<'a, R> {
+    /// Creates the accumulate context over the MAC tape, drawing challenge
+    /// weights from `rng`.
     ///
     /// Each multiplication consumes 16 bytes of the stream, so `rng` must be
     /// positioned to match the gates evaluated.
-    pub fn accumulate<R: RngCore>(self, rng: R) -> Prover<'a, Accumulate<R>> {
-        Prover {
-            macs: self.macs,
-            cursor: self.cursor,
-            state: Accumulate {
-                assertions: Hasher::default(),
-                rng,
-                u: Gf2_128Accumulator::zero(),
-                v: Gf2_128Accumulator::zero(),
-                poly: ProverPoly::default(),
-            },
+    pub fn new(macs: &'a [Gf2_128], rng: R) -> Self {
+        Self {
+            macs,
+            cursor: 0,
+            assertions: Hasher::default(),
+            rng,
+            u: Gf2_128Accumulator::zero(),
+            v: Gf2_128Accumulator::zero(),
+            poly: ProverPoly::default(),
         }
     }
-}
 
-impl<'a, R> Prover<'a, Accumulate<R>> {
     /// Consumes the next tape entry for a private input `value`, returning its
     /// authenticated wire (the raw sVOLE MAC; the verifier adjusts its key).
     ///
@@ -281,15 +259,15 @@ impl<'a, R> Prover<'a, Accumulate<R>> {
             return Err(Error::tape_unconsumed(self.cursor, self.macs.len()));
         }
         Ok(ProverOutput {
-            u: self.state.u.reduce(),
-            v: self.state.v.reduce(),
-            poly: self.state.poly,
-            assertions: *self.state.assertions.finalize().as_bytes(),
+            u: self.u.reduce(),
+            v: self.v.reduce(),
+            poly: self.poly,
+            assertions: *self.assertions.finalize().as_bytes(),
         })
     }
 }
 
-impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
+impl<R: RngCore> Context for Accumulate<'_, R> {
     type Error = Error;
     type Wire = Auth64;
     type Field = Gf2_64;
@@ -314,13 +292,13 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
         self.cursor = i + 1;
 
         let value = a.value * b.value;
-        let chi = draw_chi(&mut self.state.rng);
+        let chi = draw_chi(&mut self.rng);
 
         // QuickSilver triple check: u accumulates `M_x·M_y`, v accumulates
         // `embed(x)·M_y + embed(y)·M_x + M_z` (the subfield-scaled body).
         let body_v = scale(b.mac, a.value) + scale(a.mac, b.value) + mac;
-        self.state.u.add_product(a.mac * b.mac, chi);
-        self.state.v.add_product(body_v, chi);
+        self.u.add_product(a.mac * b.mac, chi);
+        self.v.add_product(body_v, chi);
 
         Auth64 { value, mac }
     }
@@ -333,12 +311,12 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
         if v.value != expected {
             return Err(Error::assert());
         }
-        self.state.assertions.update(v.mac.as_bytes());
+        self.assertions.update(v.mac.as_bytes());
         Ok(())
     }
 }
 
-impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
+impl<R: RngCore> PolyContext for Accumulate<'_, R> {
     type Coeffs = ProverCoeffs<Gf2_64>;
 
     fn lift(&self, wire: Auth64) -> Expr<ProverCoeffs<Gf2_64>, U1> {
@@ -357,14 +335,14 @@ impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
         let wire = self.input(expr.value());
         // Pin the fresh wire to the expression: `expr - wire == 0`.
         let constraint = expr - self.lift(wire);
-        let chi = draw_chi(&mut self.state.rng);
-        self.state.poly.fold_expr(&constraint, chi);
+        let chi = draw_chi(&mut self.rng);
+        self.poly.fold_expr(&constraint, chi);
         wire
     }
 
     fn assert_zero<N: Degree>(&mut self, expr: Expr<ProverCoeffs<Gf2_64>, N>) -> Result<()> {
-        let Self { state, .. } = self;
-        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+        let Self { poly, rng, .. } = self;
+        poly.assert_expr(&expr, || draw_chi(&mut *rng))
     }
 }
 
@@ -375,26 +353,16 @@ impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
 /// The verifier side of the `GF(2^64)` protocol.
 ///
 /// Mirrors [`Verifier`](crate::Verifier): constructed from the commitment
-/// (per-wire adjustments) and the key tape, it installs the challenge stream
-/// and folds every multiplication into the check state. [`finish`](Self::finish)
-/// yields a [`VerifierOutput`]; the caller accepts iff `w == u + Δ·v` (after
-/// VOPE masking) and the assertion hashes match.
+/// (per-wire adjustments), the key tape, and the challenge stream, it folds
+/// every multiplication into the check state. [`finish`](Self::finish) yields a
+/// [`VerifierOutput`]; the caller accepts iff `w == u + Δ·v` (after VOPE
+/// masking) and the assertion hashes match.
 #[derive(Debug)]
-pub struct Verifier<'a, S> {
+pub struct Verifier<'a, R> {
     keys: &'a [Gf2_128],
     adjust: &'a [Gf2_64],
     delta: Gf2_128,
     cursor: usize,
-    state: S,
-}
-
-/// Committed state for the [`Verifier`].
-#[derive(Debug)]
-pub struct VerifierCommitted;
-
-/// Accumulate-phase state for the [`Verifier`].
-#[derive(Debug)]
-pub struct VerifierAccumulate<R> {
     assertions: Hasher,
     rng: R,
     xy: Gf2_128Accumulator,
@@ -402,14 +370,15 @@ pub struct VerifierAccumulate<R> {
     poly: VerifierPoly,
 }
 
-impl<'a> Verifier<'a, VerifierCommitted> {
-    /// Creates a verifier with the global MAC key `delta`, the key tape, and
-    /// the adjustment tape received as the commitment.
+impl<'a, R> Verifier<'a, R> {
+    /// Creates a verifier with the global MAC key `delta`, the key tape, the
+    /// adjustment tape received as the commitment, and the challenge stream
+    /// `rng`.
     ///
     /// # Errors
     ///
     /// Returns [`Error`] if `keys` and `adjust` differ in length.
-    pub fn new(delta: Gf2_128, keys: &'a [Gf2_128], adjust: &'a [Gf2_64]) -> Result<Self> {
+    pub fn new(delta: Gf2_128, keys: &'a [Gf2_128], adjust: &'a [Gf2_64], rng: R) -> Result<Self> {
         if keys.len() != adjust.len() {
             return Err(Error::tape_len("adjust", keys.len(), adjust.len()));
         }
@@ -418,29 +387,14 @@ impl<'a> Verifier<'a, VerifierCommitted> {
             adjust,
             delta,
             cursor: 0,
-            state: VerifierCommitted,
+            assertions: Hasher::default(),
+            rng,
+            xy: Gf2_128Accumulator::zero(),
+            z: Gf2_128Accumulator::zero(),
+            poly: VerifierPoly::default(),
         })
     }
 
-    /// Begins the accumulate pass, drawing challenge weights from `rng`.
-    pub fn accumulate<R: RngCore>(self, rng: R) -> Verifier<'a, VerifierAccumulate<R>> {
-        Verifier {
-            keys: self.keys,
-            adjust: self.adjust,
-            delta: self.delta,
-            cursor: self.cursor,
-            state: VerifierAccumulate {
-                assertions: Hasher::default(),
-                rng,
-                xy: Gf2_128Accumulator::zero(),
-                z: Gf2_128Accumulator::zero(),
-                poly: VerifierPoly::default(),
-            },
-        }
-    }
-}
-
-impl<'a, R> Verifier<'a, VerifierAccumulate<R>> {
     /// Consumes the next input from the tapes and returns its verifier key,
     /// adjusted by `embed(adjust)·Δ`.
     ///
@@ -475,16 +429,16 @@ impl<'a, R> Verifier<'a, VerifierAccumulate<R>> {
         if self.cursor != self.adjust.len() {
             return Err(Error::tape_unconsumed(self.cursor, self.adjust.len()));
         }
-        let w = self.state.xy.reduce() + self.delta * self.state.z.reduce();
+        let w = self.xy.reduce() + self.delta * self.z.reduce();
         Ok(VerifierOutput {
             w,
-            poly: self.state.poly,
-            assertions: *self.state.assertions.finalize().as_bytes(),
+            poly: self.poly,
+            assertions: *self.assertions.finalize().as_bytes(),
         })
     }
 }
 
-impl<R: RngCore> Context for Verifier<'_, VerifierAccumulate<R>> {
+impl<R: RngCore> Context for Verifier<'_, R> {
     type Error = Error;
     type Wire = Gf2_128;
     type Field = Gf2_64;
@@ -510,10 +464,10 @@ impl<R: RngCore> Context for Verifier<'_, VerifierAccumulate<R>> {
         self.cursor = i + 1;
 
         let key = raw + scale(self.delta, adj);
-        let chi = draw_chi(&mut self.state.rng);
+        let chi = draw_chi(&mut self.rng);
 
-        self.state.xy.add_product(a * b, chi);
-        self.state.z.add_product(key, chi);
+        self.xy.add_product(a * b, chi);
+        self.z.add_product(key, chi);
 
         key
     }
@@ -526,12 +480,12 @@ impl<R: RngCore> Context for Verifier<'_, VerifierAccumulate<R>> {
         // If the committed value is `expected`, the prover's MAC equals
         // `v + embed(expected)·Δ`; hash that to match the prover.
         let mac = v + scale(self.delta, expected);
-        self.state.assertions.update(mac.as_bytes());
+        self.assertions.update(mac.as_bytes());
         Ok(())
     }
 }
 
-impl<R: RngCore> PolyContext for Verifier<'_, VerifierAccumulate<R>> {
+impl<R: RngCore> PolyContext for Verifier<'_, R> {
     type Coeffs = VerifierCoeffs;
 
     fn lift(&self, wire: Gf2_128) -> Expr<VerifierCoeffs, U1> {
@@ -550,15 +504,14 @@ impl<R: RngCore> PolyContext for Verifier<'_, VerifierAccumulate<R>> {
         let wire = self.input();
         // Pin the fresh wire to the expression: `expr - wire == 0`.
         let constraint = expr - self.lift(wire);
-        let chi = draw_chi(&mut self.state.rng);
-        self.state
-            .poly
+        let chi = draw_chi(&mut self.rng);
+        self.poly
             .fold_expr(&constraint, Maximum::<N, U1>::USIZE, chi);
         wire
     }
 
     fn assert_zero<N: Degree>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Result<()> {
-        let Self { state, .. } = self;
-        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+        let Self { poly, rng, .. } = self;
+        poly.assert_expr(&expr, || draw_chi(&mut *rng))
     }
 }

--- a/crates/zk-core/src/lib.rs
+++ b/crates/zk-core/src/lib.rs
@@ -1,29 +1,29 @@
 //! Core building blocks for the designated-verifier zero-knowledge proof
 //! system.
 //!
-//! The protocol runs a boolean circuit between a [`Prover`] and a [`Verifier`].
+//! The protocol runs a boolean circuit between a prover ([`Witness`] then
+//! [`Accumulate`]) and a [`Verifier`].
 //!
-//! The prover walks the circuits twice. The commit pass ([`Commit`]) is
+//! The prover walks the circuits twice. The witness pass ([`Witness`]) is
 //! mask-only plaintext evaluation: it XORs each witness bit into the mask
 //! tape in place, never touching the MAC tape, and the adjustment bits are
-//! sent to the verifier (see [`Commitment`]). For the second pass the caller
-//! starts from [`prover::Prover::committed`], installs the challenge stream,
-//! and the accumulate pass
-//! ([`prover::Accumulate`]) folds every multiplication and assertion into the
-//! proof, yielding a [`ProverOutput`], which the caller masks with the VOPE
+//! sent to the verifier (see [`Commitment`]). The second pass is the
+//! accumulate pass ([`prover::Accumulate`], constructed with the challenge
+//! stream): it folds every multiplication and assertion into the proof,
+//! yielding a [`ProverOutput`], which the caller masks with the VOPE
 //! correlation ([`vope_receiver`]) to form a [`Proof`].
 //!
-//! The verifier starts from the received commitment
-//! ([`verifier::Committed`]), installs the challenge stream it sampled, and
-//! performs a single accumulate pass ([`verifier::Accumulate`]) over the same
-//! circuits, yielding a [`VerifierOutput`]. The caller masks `w` with the VOPE
-//! correlation ([`vope_sender`]) and accepts iff `w == u + delta * v` and the
-//! assertion hashes match.
+//! The verifier ([`Verifier`]) is constructed from the received commitment
+//! (the adjustment bits) and the challenge stream it sampled, then performs a
+//! single accumulate pass over the same circuits, yielding a
+//! [`VerifierOutput`]. The caller masks `w` with the VOPE correlation
+//! ([`vope_sender`]) and accepts iff `w == u + delta * v` and the assertion
+//! hashes match.
 //!
 //! Both accumulate passes are linear in the challenge weights, so a trace may
 //! be folded in disjoint sub-ranges — each over its slice of the tapes with
 //! the challenge stream seeked to its gate offset — and the partial results
-//! combined by field addition. See [`prover::Prover::committed`].
+//! combined by field addition. See [`prover::Accumulate::new`].
 //!
 //! Two extensions reuse the same machinery:
 //!
@@ -47,14 +47,14 @@ pub mod verifier;
 mod vope;
 
 pub use poly::{DeltaPowers, MAX_DEGREE, PolyContext, ProverPoly, VerifierPoly};
-pub use prover::{Commit, Prover};
+pub use prover::{Accumulate, Witness};
 pub use verifier::Verifier;
 pub use vope::{vope_receiver, vope_sender};
 
 use mpz_core::bitvec::BitVec;
 use mpz_fields::gf2_128::Gf2_128;
 
-/// The output of a prover accumulate pass ([`Prover::finish`] and its
+/// The output of a prover accumulate pass ([`Accumulate::finish`] and its
 /// [`gf64`] counterpart).
 ///
 /// The caller masks `(u, v)` with the VOPE correlation
@@ -229,8 +229,8 @@ mod tests {
     use rand_chacha::ChaCha12Rng;
 
     use super::{
-        Commit, DeltaPowers, Error, ErrorRepr, PolyContext, Proof, Prover, ProverOutput, Verifier,
-        VerifierOutput, util::set_lsb, vope_receiver, vope_sender,
+        Accumulate, DeltaPowers, Error, ErrorRepr, PolyContext, Proof, ProverOutput, Verifier,
+        VerifierOutput, Witness, util::set_lsb, vope_receiver, vope_sender,
     };
     use mpz_fields::gf2::Gf2;
 
@@ -256,6 +256,8 @@ mod tests {
 
     struct Inputs {
         delta: Gf2_128,
+        msg_bits: [Gf2; 512],
+        state_bits: [Gf2; 256],
         msg_macs: [Gf2_128; 512],
         msg_keys: [Gf2_128; 512],
         state_macs: [Gf2_128; 256],
@@ -290,6 +292,8 @@ mod tests {
         let msg_keys: [Gf2_128; 512] = core::array::from_fn(|i| msg_pairs[i].1);
         let state_macs: [Gf2_128; 256] = core::array::from_fn(|i| state_pairs[i].0);
         let state_keys: [Gf2_128; 256] = core::array::from_fn(|i| state_pairs[i].1);
+        let msg_bits_w: [Gf2; 512] = core::array::from_fn(|i| Gf2(msg_bits[i]));
+        let state_bits_w: [Gf2; 256] = core::array::from_fn(|i| Gf2(state_bits[i]));
 
         let gates: Vec<_> = (0..AND_PER_BLOCK).map(|_| corr(&mut rng, delta)).collect();
         let gate_masks: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
@@ -303,6 +307,8 @@ mod tests {
 
         Inputs {
             delta,
+            msg_bits: msg_bits_w,
+            state_bits: state_bits_w,
             msg_macs,
             msg_keys,
             state_macs,
@@ -320,12 +326,14 @@ mod tests {
     /// Runs the prover's two passes over a single sha256 compression and
     /// returns the masked proof.
     fn prove_compress(i: &Inputs, masks: &mut [bool]) -> Proof {
-        let mut commit = Commit::new(masks);
-        let _ = compress(&mut commit, i.msg_macs, i.state_macs);
+        let mut commit = Witness::new(masks);
+        let _ = compress(&mut commit, i.msg_bits, i.state_bits);
         commit.finish().unwrap();
-        let mut prover = Prover::committed(&i.gate_macs).accumulate(ChaCha12Rng::from_seed(i.chi));
+        let mut prover = Accumulate::new(&i.gate_macs, ChaCha12Rng::from_seed(i.chi));
         let _ = compress(&mut prover, i.msg_macs, i.state_macs);
-        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
+        let ProverOutput {
+            u, v, assertions, ..
+        } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&i.vope_choices, &i.vope_ev);
         Proof {
@@ -339,8 +347,8 @@ mod tests {
     /// Runs the verifier's accumulate pass over a single sha256 compression
     /// and returns `(w, assertions)`.
     fn verify_compress(i: &Inputs, masks: &[bool], gate_keys: &[Gf2_128]) -> (Gf2_128, [u8; 32]) {
-        let verifier = Verifier::new(i.delta, gate_keys, masks).unwrap();
-        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(i.chi));
+        let mut verifier =
+            Verifier::new(i.delta, gate_keys, masks, ChaCha12Rng::from_seed(i.chi)).unwrap();
         let _ = compress(&mut verifier, i.msg_keys, i.state_keys);
         let VerifierOutput { w, assertions, .. } = verifier.finish().unwrap();
         (w, assertions)
@@ -403,7 +411,13 @@ mod tests {
         // Adjust slice one bit shorter than the key tape.
         let bad_adjust = vec![false; i.gate_keys.len() - 1];
 
-        let Error(repr) = Verifier::new(i.delta, &i.gate_keys, &bad_adjust).unwrap_err();
+        let Error(repr) = Verifier::new(
+            i.delta,
+            &i.gate_keys,
+            &bad_adjust,
+            ChaCha12Rng::from_seed([0; 32]),
+        )
+        .unwrap_err();
         assert!(matches!(repr, ErrorRepr::TapeLength { .. }));
     }
 
@@ -425,14 +439,14 @@ mod tests {
 
     #[test]
     fn prover_tape_mismatch_rejected() {
-        // A commit pass that consumes fewer entries than the tape provides.
+        // A witness pass that consumes fewer entries than the tape provides.
         let mut masks = vec![false];
-        let Error(repr) = Commit::new(&mut masks).finish().unwrap_err();
+        let Error(repr) = Witness::new(&mut masks).finish().unwrap_err();
         assert!(matches!(repr, ErrorRepr::TapeUnconsumed { .. }));
 
         // An accumulate pass that consumes fewer entries than the tape.
         let macs = [Gf2_128::new(0)];
-        let prover = Prover::committed(&macs).accumulate(ChaCha12Rng::from_seed([0; 32]));
+        let prover = Accumulate::new(&macs, ChaCha12Rng::from_seed([0; 32]));
         let Error(repr) = prover.finish().unwrap_err();
         assert!(matches!(repr, ErrorRepr::TapeUnconsumed { .. }));
     }
@@ -445,11 +459,10 @@ mod tests {
 
         let run = |chi: [u8; 32]| {
             let mut masks = i.gate_masks.clone();
-            let mut commit = Commit::new(&mut masks);
-            let _ = compress(&mut commit, i.msg_macs, i.state_macs);
+            let mut commit = Witness::new(&mut masks);
+            let _ = compress(&mut commit, i.msg_bits, i.state_bits);
             commit.finish().unwrap();
-            let mut prover =
-                Prover::committed(&i.gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+            let mut prover = Accumulate::new(&i.gate_macs, ChaCha12Rng::from_seed(chi));
             let _ = compress(&mut prover, i.msg_macs, i.state_macs);
             let ProverOutput { u, v, .. } = prover.finish().unwrap();
             (u, v)
@@ -478,29 +491,32 @@ mod tests {
         let mut adjust: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
         let macs: Vec<Gf2_128> = gates.iter().map(|(_, m, _)| *m).collect();
         let keys: Vec<Gf2_128> = gates.iter().map(|(_, _, k)| *k).collect();
-        let wires: Vec<(Gf2_128, Gf2_128, Gf2_128, Gf2_128)> = (0..N)
+        // Tuple per gate: (bit_a, bit_b, mac_a, mac_b, key_a, key_b). The
+        // witness pass folds the cleartext bits, the prover the MACs, the
+        // verifier the keys.
+        let wires: Vec<(Gf2, Gf2, Gf2_128, Gf2_128, Gf2_128, Gf2_128)> = (0..N)
             .map(|_| {
                 let (x, y): (bool, bool) = (rng.random(), rng.random());
                 let (mac_a, key_a) = input(&mut rng, x, delta);
                 let (mac_b, key_b) = input(&mut rng, y, delta);
-                (mac_a, mac_b, key_a, key_b)
+                (Gf2(x), Gf2(y), mac_a, mac_b, key_a, key_b)
             })
             .collect();
 
-        // Commit pass over the full trace produces the adjust bits.
-        let mut commit = Commit::new(&mut adjust);
-        for (a, b, _, _) in &wires {
+        // Witness pass over the full trace produces the adjust bits.
+        let mut commit = Witness::new(&mut adjust);
+        for (a, b, _, _, _, _) in &wires {
             let _ = commit.mul(*a, *b);
         }
         commit.finish().unwrap();
 
         let prover_fold = |macs: &[Gf2_128],
-                           wires: &[(Gf2_128, Gf2_128, Gf2_128, Gf2_128)],
+                           wires: &[(Gf2, Gf2, Gf2_128, Gf2_128, Gf2_128, Gf2_128)],
                            gate_offset: usize| {
             let mut rng = ChaCha12Rng::from_seed(chi);
             rng.set_word_pos((gate_offset * 4) as u128);
-            let mut p = Prover::committed(macs).accumulate(rng);
-            for (a, b, _, _) in wires {
+            let mut p = Accumulate::new(macs, rng);
+            for (_, _, a, b, _, _) in wires {
                 let _ = p.mul(*a, *b);
             }
             let ProverOutput { u, v, .. } = p.finish().unwrap();
@@ -509,14 +525,12 @@ mod tests {
 
         let verifier_fold = |keys: &[Gf2_128],
                              adjust: &[bool],
-                             wires: &[(Gf2_128, Gf2_128, Gf2_128, Gf2_128)],
+                             wires: &[(Gf2, Gf2, Gf2_128, Gf2_128, Gf2_128, Gf2_128)],
                              gate_offset: usize| {
             let mut rng = ChaCha12Rng::from_seed(chi);
             rng.set_word_pos((gate_offset * 4) as u128);
-            let mut v = Verifier::new(delta, keys, adjust)
-                .unwrap()
-                .accumulate(rng);
-            for (_, _, a, b) in wires {
+            let mut v = Verifier::new(delta, keys, adjust, rng).unwrap();
+            for (_, _, _, _, a, b) in wires {
                 let _ = v.mul(*a, *b);
             }
             let VerifierOutput { w, .. } = v.finish().unwrap();
@@ -556,12 +570,14 @@ mod tests {
         let vope_keys: [Gf2_128; 128] = core::array::from_fn(|i| vope[i].2);
         let chi: [u8; 32] = rng.random();
 
-        let mut commit = Commit::new(&mut gate_masks);
-        commit.assert_eq(mac_a, mac_b).unwrap();
+        let mut commit = Witness::new(&mut gate_masks);
+        commit.assert_eq(Gf2(true), Gf2(true)).unwrap();
         commit.finish().unwrap();
-        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
         prover.assert_eq(mac_a, mac_b).unwrap();
-        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
+        let ProverOutput {
+            u, v, assertions, ..
+        } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
         let proof = Proof {
@@ -571,10 +587,14 @@ mod tests {
             coefficients: Vec::new(),
         };
 
-        let verifier = Verifier::new(delta, &gate_keys, &gate_masks).unwrap();
-        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        let mut verifier =
+            Verifier::new(delta, &gate_keys, &gate_masks, ChaCha12Rng::from_seed(chi)).unwrap();
         verifier.assert_eq(key_a, key_b).unwrap();
-        let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().unwrap();
+        let VerifierOutput {
+            w,
+            assertions: v_assertions,
+            ..
+        } = verifier.finish().unwrap();
         let b = vope_sender(&vope_keys);
 
         assert_eq!(v_assertions, proof.assertions);
@@ -594,11 +614,11 @@ mod tests {
         let gate_macs: Vec<Gf2_128> = Vec::new();
         let chi: [u8; 32] = rng.random();
 
-        let mut commit = Commit::new(&mut []);
-        let Error(repr) = commit.assert_eq(mac_a, mac_b).unwrap_err();
+        let mut commit = Witness::new(&mut []);
+        let Error(repr) = commit.assert_eq(Gf2(true), Gf2(false)).unwrap_err();
         assert!(matches!(repr, ErrorRepr::Assert));
 
-        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
         let Error(repr) = prover.assert_eq(mac_a, mac_b).unwrap_err();
         assert!(matches!(repr, ErrorRepr::Assert));
     }
@@ -624,9 +644,11 @@ mod tests {
         let chi: [u8; 32] = rng.random();
 
         // Prover skips the assertion (simulating a malicious party).
-        Commit::new(&mut gate_masks).finish().unwrap();
-        let prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
-        let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
+        Witness::new(&mut gate_masks).finish().unwrap();
+        let prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
+        let ProverOutput {
+            u, v, assertions, ..
+        } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
         let proof = Proof {
@@ -637,10 +659,14 @@ mod tests {
         };
 
         // Verifier honestly performs the assertion.
-        let verifier = Verifier::new(delta, &gate_keys, &gate_masks).unwrap();
-        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        let mut verifier =
+            Verifier::new(delta, &gate_keys, &gate_masks, ChaCha12Rng::from_seed(chi)).unwrap();
         verifier.assert_eq(key_a, key_b).unwrap();
-        let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().unwrap();
+        let VerifierOutput {
+            w,
+            assertions: v_assertions,
+            ..
+        } = verifier.finish().unwrap();
         let b = vope_sender(&vope_keys);
 
         assert_ne!(v_assertions, proof.assertions);
@@ -710,6 +736,7 @@ mod tests {
             bits.iter().map(|&b| input(&mut rng, b, delta)).collect();
         let macs_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
         let keys_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+        let bits_in: [Gf2; 6] = core::array::from_fn(|i| Gf2(bits[i]));
 
         let gates: Vec<_> = (0..3).map(|_| corr(&mut rng, delta)).collect();
         let mut masks: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
@@ -722,14 +749,19 @@ mod tests {
         let vope_keys: [Gf2_128; 128] = core::array::from_fn(|i| vope[i].2);
         let (poly_masks, poly_vope_sum) = mock_poly_vope(&mut rng, &powers, D_MAX);
 
-        // Prover: commit pass, then accumulate pass.
-        let mut commit = Commit::new(&mut masks);
-        poly_trace(&mut commit, macs_in).unwrap();
+        // Prover: witness pass, then accumulate pass.
+        let mut commit = Witness::new(&mut masks);
+        poly_trace(&mut commit, bits_in).unwrap();
         commit.finish().unwrap();
 
-        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
         poly_trace(&mut prover, macs_in).unwrap();
-        let ProverOutput { u, v, poly, assertions } = prover.finish().unwrap();
+        let ProverOutput {
+            u,
+            v,
+            poly,
+            assertions,
+        } = prover.finish().unwrap();
 
         let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
         let coefficients: Vec<Gf2_128> = poly
@@ -747,10 +779,14 @@ mod tests {
         };
 
         // Verifier: single accumulate pass over the same trace.
-        let verifier = Verifier::new(delta, &gate_keys, &masks).unwrap();
-        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        let mut verifier =
+            Verifier::new(delta, &gate_keys, &masks, ChaCha12Rng::from_seed(chi)).unwrap();
         poly_trace(&mut verifier, keys_in).unwrap();
-        let VerifierOutput { w, poly: v_poly, assertions: v_assertions } = verifier.finish().unwrap();
+        let VerifierOutput {
+            w,
+            poly: v_poly,
+            assertions: v_assertions,
+        } = verifier.finish().unwrap();
         let b = vope_sender(&vope_keys);
 
         assert_eq!(v_assertions, proof.assertions);
@@ -775,6 +811,7 @@ mod tests {
             bits.iter().map(|&b| input(&mut rng, b, delta)).collect();
         let macs_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
         let keys_in: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
+        let bits_in: [Gf2; 6] = core::array::from_fn(|i| Gf2(bits[i]));
 
         let gates: Vec<_> = (0..3).map(|_| corr(&mut rng, delta)).collect();
         let mut masks: Vec<bool> = gates.iter().map(|(c, _, _)| *c).collect();
@@ -782,11 +819,11 @@ mod tests {
         let gate_keys: Vec<Gf2_128> = gates.iter().map(|(_, _, k)| *k).collect();
         let (poly_masks, poly_vope_sum) = mock_poly_vope(&mut rng, &powers, D_MAX);
 
-        let mut commit = Commit::new(&mut masks);
-        poly_trace(&mut commit, macs_in).unwrap();
+        let mut commit = Witness::new(&mut masks);
+        poly_trace(&mut commit, bits_in).unwrap();
         commit.finish().unwrap();
 
-        let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+        let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
         poly_trace(&mut prover, macs_in).unwrap();
         let ProverOutput { poly, .. } = prover.finish().unwrap();
         let coefficients: Vec<Gf2_128> = poly
@@ -800,15 +837,13 @@ mod tests {
         // Flip the adjust bit of the materialized wire (tape entry 1).
         masks[1] = !masks[1];
 
-        let verifier = Verifier::new(delta, &gate_keys, &masks).unwrap();
-        let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+        let mut verifier =
+            Verifier::new(delta, &gate_keys, &masks, ChaCha12Rng::from_seed(chi)).unwrap();
         poly_trace(&mut verifier, keys_in).unwrap();
         let VerifierOutput { poly: v_poly, .. } = verifier.finish().unwrap();
 
         assert!(
-            v_poly
-                .check(&powers, &coefficients, poly_vope_sum)
-                .is_err(),
+            v_poly.check(&powers, &coefficients, poly_vope_sum).is_err(),
             "flipped materialize commitment must break the poly check"
         );
     }
@@ -836,10 +871,9 @@ mod tests {
         let fold_prover = |range: core::ops::Range<usize>, offset: usize| {
             let mut rng = ChaCha12Rng::from_seed(chi);
             rng.set_word_pos((offset * 4) as u128);
-            let mut p = Prover::committed(&[]).accumulate(rng);
+            let mut p = Accumulate::new(&[], rng);
             for w in &wires[range] {
-                let [y, a, ww, s, u0, u1] =
-                    core::array::from_fn(|i| p.lift(w[i].0));
+                let [y, a, ww, s, u0, u1] = core::array::from_fn(|i| p.lift(w[i].0));
                 let r = u0 * (ww + a);
                 let t = u1 * (s + a + r);
                 p.assert_zero(y + a + r + t).unwrap();
@@ -862,11 +896,9 @@ mod tests {
         let fold_verifier = |range: core::ops::Range<usize>, offset: usize| {
             let mut rng = ChaCha12Rng::from_seed(chi);
             rng.set_word_pos((offset * 4) as u128);
-            let v = Verifier::new(delta, &[], &[]).unwrap();
-            let mut v = v.accumulate(rng);
+            let mut v = Verifier::new(delta, &[], &[], rng).unwrap();
             for w in &wires[range] {
-                let [y, a, ww, s, u0, u1] =
-                    core::array::from_fn(|i| v.lift(w[i].1));
+                let [y, a, ww, s, u0, u1] = core::array::from_fn(|i| v.lift(w[i].1));
                 let r = u0 * (ww + a);
                 let t = u1 * (s + a + r);
                 v.assert_zero(y + a + r + t).unwrap();
@@ -878,11 +910,7 @@ mod tests {
         let mut v_lo = fold_verifier(0..MID, 0);
         let v_hi = fold_verifier(MID..N, MID);
         v_lo.merge(&v_hi);
-        v_lo.check(
-            &powers,
-            &full.coefficients(D_MAX).unwrap(),
-            Gf2_128::new(0),
-        )
-        .unwrap();
+        v_lo.check(&powers, &full.coefficients(D_MAX).unwrap(), Gf2_128::new(0))
+            .unwrap();
     }
 }

--- a/crates/zk-core/src/poly.rs
+++ b/crates/zk-core/src/poly.rs
@@ -7,9 +7,9 @@
 //! polynomial in `Δ`:
 //!
 //! - The prover holds, per wire, the linear form `mac + value·X`; building `f`
-//!   over these forms yields the coefficient vector of
-//!   `g(X) = Σ_h f_h(mac + value·X)·X^{d-h}` ([`ProverCoeffs<V>`]). The top
-//!   coefficient (`X^d`) is `f(w)`, dropped by the protocol.
+//!   over these forms yields the coefficient vector of `g(X) = Σ_h f_h(mac +
+//!   value·X)·X^{d-h}` ([`ProverCoeffs<V>`]). The top coefficient (`X^d`) is
+//!   `f(w)`, dropped by the protocol.
 //! - The verifier holds, per wire, the key `k = mac + value·Δ`; building `f`
 //!   over the keys yields `g(Δ)` directly ([`VerifierCoeffs`]).
 //!
@@ -35,7 +35,7 @@
 //! The carrier `C` is what differs between the two sides ([`ProverCoeffs<V>`]
 //! keeps a coefficient vector, [`VerifierCoeffs`] keeps the single value
 //! `g(Δ)`); [`PlainCoeffs<V>`] collapses an expression to its cleartext value
-//! for the prover's commit pass.
+//! for the prover's witness pass.
 //!
 //! # Representation
 //!
@@ -99,9 +99,9 @@ impl<N: ArraySize<ArrayType<Gf2_128>: Copy>> Degree for N {}
 /// Build a degree-`d` constraint symbolically over committed wires with the
 /// `+`/`-`/`*` operators on [`Expr`] (free, degree-raising, uncommitted), then
 /// either [`materialize`](Self::materialize) its output as a fresh committed
-/// wire pinned by a degree-`d` constraint, or [`assert_zero`](Self::assert_zero)
-/// it as a pure check. Implemented by the same contexts that implement
-/// [`Context`].
+/// wire pinned by a degree-`d` constraint, or
+/// [`assert_zero`](Self::assert_zero) it as a pure check. Implemented by the
+/// same contexts that implement [`Context`].
 pub trait PolyContext: Context {
     /// The coefficient carrier for this context's side of the protocol.
     type Coeffs: Coeffs;
@@ -126,8 +126,7 @@ pub trait PolyContext: Context {
     ///
     /// Consumes 16 bytes of the challenge stream when `d ≥ 1`; a degree-0
     /// expression is a public assertion checked locally.
-    fn assert_zero<N: Degree>(&mut self, expr: Expr<Self::Coeffs, N>)
-    -> Result<(), Self::Error>;
+    fn assert_zero<N: Degree>(&mut self, expr: Expr<Self::Coeffs, N>) -> Result<(), Self::Error>;
 }
 
 /// Maximum supported constraint degree.
@@ -216,8 +215,8 @@ where
 /// `At<N>` is the storage for a degree-`N` expression. The two non-trivial
 /// operations — top-aligned [`add`](Self::add) and degree-raising
 /// [`mul`](Self::mul) — are degree-generic so [`Expr`]'s operators can delegate
-/// to them. Implemented by [`PlainCoeffs<V>`] (commit pass), [`ProverCoeffs<V>`],
-/// and [`VerifierCoeffs`].
+/// to them. Implemented by [`PlainCoeffs<V>`] (witness pass),
+/// [`ProverCoeffs<V>`], and [`VerifierCoeffs`].
 pub trait Coeffs: Copy {
     /// Storage for a degree-`N` expression.
     type At<N: Degree>: Copy;
@@ -238,9 +237,9 @@ pub trait Coeffs: Copy {
         Sum<A, B>: Degree;
 }
 
-// --- commit-pass carrier ----------------------------------------------------
+// --- witness-pass carrier ----------------------------------------------------
 
-/// Plaintext carrier for the prover's commit pass over the subfield `V`: an
+/// Plaintext carrier for the prover's witness pass over the subfield `V`: an
 /// expression is just its cleartext value, so polynomial gadgets compile down
 /// to subfield operations.
 pub struct PlainCoeffs<V>(PhantomData<V>);
@@ -587,9 +586,10 @@ impl ProverPoly {
 
     /// Records a degree-`d` constraint that `expr == 0`.
     ///
-    /// Surfaces a witness bug early via the top coefficient `f(w) = expr.value`,
-    /// short-circuits the degree-0 public case (no fold, no challenge drawn),
-    /// and otherwise folds the lower coefficients under a freshly drawn `chi`.
+    /// Surfaces a witness bug early via the top coefficient `f(w) =
+    /// expr.value`, short-circuits the degree-0 public case (no fold, no
+    /// challenge drawn), and otherwise folds the lower coefficients under a
+    /// freshly drawn `chi`.
     ///
     /// # Errors
     ///
@@ -928,10 +928,9 @@ mod tests {
             let chi = Gf2_128::new(rng.random());
 
             let pe = {
-                let [a, b, c] =
-                    core::array::from_fn(|i| {
-                        Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(pairs[i].0, lsb(pairs[i].0))
-                    });
+                let [a, b, c] = core::array::from_fn(|i| {
+                    Expr::<ProverCoeffs<Gf2>, U1>::lift_wire(pairs[i].0, lsb(pairs[i].0))
+                });
                 a * b + c
             };
             assert_eq!(pe.value(), Gf2::ZERO, "constraint must be satisfied");
@@ -1036,8 +1035,7 @@ mod tests {
         let delta = random_delta(&mut rng);
         let powers = DeltaPowers::new(delta);
 
-        let pairs: [(Gf2_128, Gf2_128); 6] =
-            core::array::from_fn(|_| wire(&mut rng, false, delta));
+        let pairs: [(Gf2_128, Gf2_128); 6] = core::array::from_fn(|_| wire(&mut rng, false, delta));
         let macs: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].0);
         let keys: [Gf2_128; 6] = core::array::from_fn(|i| pairs[i].1);
 
@@ -1081,8 +1079,10 @@ mod tests {
     /// level, so the gadget stays generic over the carrier with no extra
     /// bounds.
     fn mux_tree<C: Coeffs>(s: [Expr<C, U1>; 3], x: [Expr<C, U1>; 8]) -> Expr<C, U4> {
-        let m0: [Expr<C, U2>; 4] = core::array::from_fn(|j| x[2 * j] + s[0] * (x[2 * j] + x[2 * j + 1]));
-        let m1: [Expr<C, U3>; 2] = core::array::from_fn(|j| m0[2 * j] + s[1] * (m0[2 * j] + m0[2 * j + 1]));
+        let m0: [Expr<C, U2>; 4] =
+            core::array::from_fn(|j| x[2 * j] + s[0] * (x[2 * j] + x[2 * j + 1]));
+        let m1: [Expr<C, U3>; 2] =
+            core::array::from_fn(|j| m0[2 * j] + s[1] * (m0[2 * j] + m0[2 * j + 1]));
         m1[0] + s[2] * (m1[0] + m1[1])
     }
 

--- a/crates/zk-core/src/prover.rs
+++ b/crates/zk-core/src/prover.rs
@@ -16,82 +16,45 @@ use crate::{
     util::{draw_chi, lsb, set_lsb},
 };
 
-/// The prover side of the zero-knowledge protocol.
-///
-/// The prover walks the circuits twice. The first pass is the mask-only
-/// [`Commit`] context, which never touches the MAC tape. The second pass is
-/// `Prover<Accumulate>`: starting from [`Prover::committed`], the caller
-/// installs the challenge stream via [`accumulate`](Self::accumulate) and
-/// re-evaluates the same circuits in the same order, folding every
-/// multiplication and assertion directly into the running proof state.
-/// [`finish`](Self::finish) yields a [`ProverOutput`].
-///
-/// The caller masks `(u, v)` with the VOPE correlation
-/// ([`vope_receiver`](crate::vope_receiver)) before sending the proof.
+/// The prover's witness-pass circuit context.
 #[derive(Debug)]
-pub struct Prover<'a, S> {
-    macs: &'a [Gf2_128],
-    cursor: usize,
-    state: S,
-}
-
-/// The prover's commit-pass circuit context.
-///
-/// Distinct from [`Commitment`](crate::Commitment): this is the evaluation
-/// *context*, whereas `Commitment` is the adjustment-bit *message* this pass
-/// produces and sends to the verifier.
-///
-/// Walks the circuits over *pointer-bit wires*: each wire is a [`Gf2_128`]
-/// whose LSB carries the plaintext bit and whose remaining bits are
-/// meaningless. The commit pass only ever reads wire LSBs, so it needs no MAC
-/// tape — each input and AND gate XORs its witness bit into the mask tape in
-/// place, producing the adjustment bits sent to the verifier (see
-/// [`Commitment`](crate::Commitment)).
-///
-/// This makes the commit pass pure plaintext evaluation: circuits walked with
-/// a `Commit` context must be re-walked with the same inputs in the
-/// accumulate pass, which reconstructs the same LSBs on the real MAC wires.
-#[derive(Debug)]
-pub struct Commit<'a> {
-    masks: &'a mut [bool],
+pub struct Witness<'a> {
+    witness: &'a mut [bool],
     cursor: usize,
 }
 
-impl<'a> Commit<'a> {
-    /// Creates a commit-pass context over the mask tape.
-    ///
-    /// The `masks` tape is adjusted in place as circuits are evaluated: entry
-    /// `i` is XORed with the bit committed by the `i`-th input or AND gate.
-    pub fn new(masks: &'a mut [bool]) -> Self {
-        Self { masks, cursor: 0 }
+impl<'a> Witness<'a> {
+    /// Creates a witness-pass context.
+    pub fn new(witness: &'a mut [bool]) -> Self {
+        Self { witness, cursor: 0 }
     }
 
-    /// Consumes the next tape entry to commit a private input `bit` and
-    /// returns its pointer-bit wire.
+    /// Consumes the next tape entry to commit a private input `value` and
+    /// returns its cleartext wire.
     ///
     /// # Panics
     ///
-    /// Panics if the mask tape has been exhausted.
-    pub fn input(&mut self, bit: bool) -> Gf2_128 {
+    /// Panics if the witness tape has been exhausted.
+    pub fn input(&mut self, value: Gf2) -> Gf2 {
         let i = self.cursor;
         let slot = self
-            .masks
+            .witness
             .get_mut(i)
-            .expect("mask tape exhausted during input");
-        *slot ^= bit;
+            .expect("witness tape exhausted during input");
+        *slot ^= value.0;
         self.cursor = i + 1;
-        Gf2_128::new(bit as u128)
+        value
     }
 
-    /// Returns the wire for a public input `bit`.
+    /// Returns the wire for a public input `value`.
     ///
     /// Public inputs consume no tape entry, since their value is known to both
     /// parties.
-    pub fn input_public(&self, bit: bool) -> Gf2_128 {
-        if bit { MAC_ONE } else { MAC_ZERO }
+    pub fn input_public(&self, value: Gf2) -> Gf2 {
+        value
     }
 
-    /// Completes the commit pass.
+    /// Completes the witness pass.
     ///
     /// # Errors
     ///
@@ -99,32 +62,32 @@ impl<'a> Commit<'a> {
     /// the tape length, indicating the circuits drew fewer inputs and AND
     /// gates than the tape provides.
     pub fn finish(self) -> Result<()> {
-        if self.cursor != self.masks.len() {
-            return Err(Error::tape_unconsumed(self.cursor, self.masks.len()));
+        if self.cursor != self.witness.len() {
+            return Err(Error::tape_unconsumed(self.cursor, self.witness.len()));
         }
         Ok(())
     }
 }
 
-impl PolyContext for Commit<'_> {
-    /// Plaintext evaluation: an expression is just its cleartext bit, so the
-    /// commit pass compiles polynomial gadgets down to bit operations.
+impl PolyContext for Witness<'_> {
+    /// Plaintext evaluation: an expression is just its cleartext value, so the
+    /// witness pass compiles polynomial gadgets down to field operations.
     type Coeffs = PlainCoeffs<Gf2>;
 
-    fn lift(&self, wire: Gf2_128) -> Expr<PlainCoeffs<Gf2>, U1> {
-        Expr::new(lsb(wire))
+    fn lift(&self, wire: Gf2) -> Expr<PlainCoeffs<Gf2>, U1> {
+        Expr::new(wire)
     }
 
     fn lift_const(&self, value: Gf2) -> Expr<PlainCoeffs<Gf2>, U0> {
         Expr::new(value)
     }
 
-    fn materialize<N>(&mut self, expr: Expr<PlainCoeffs<Gf2>, N>) -> Gf2_128
+    fn materialize<N>(&mut self, expr: Expr<PlainCoeffs<Gf2>, N>) -> Gf2
     where
         N: Degree + Max<U1>,
         Maximum<N, U1>: Degree,
     {
-        self.input(expr.plain().0)
+        self.input(expr.plain())
     }
 
     fn assert_zero<N: Degree>(&mut self, expr: Expr<PlainCoeffs<Gf2>, N>) -> Result<()> {
@@ -137,60 +100,59 @@ impl PolyContext for Commit<'_> {
     }
 }
 
-impl Context for Commit<'_> {
+impl Context for Witness<'_> {
     type Error = Error;
-    type Wire = Gf2_128;
+    type Wire = Gf2;
     type Field = Gf2;
 
-    fn add(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+    fn add(&mut self, a: Gf2, b: Gf2) -> Gf2 {
         a + b
     }
 
-    fn sub(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
+    fn sub(&mut self, a: Gf2, b: Gf2) -> Gf2 {
         a - b
     }
 
-    fn mul(&mut self, a: Gf2_128, b: Gf2_128) -> Gf2_128 {
-        let z = GetBit::<Lsb0>::get_bit(&a, 0) & GetBit::<Lsb0>::get_bit(&b, 0);
+    fn mul(&mut self, a: Gf2, b: Gf2) -> Gf2 {
+        let z = a * b;
         let i = self.cursor;
         let slot = self
-            .masks
+            .witness
             .get_mut(i)
-            .expect("mask tape exhausted: circuit has more AND gates than the tape");
-        *slot ^= z;
+            .expect("witness tape exhausted: circuit has more AND gates than the tape");
+        *slot ^= z.0;
         self.cursor = i + 1;
-        Gf2_128::new(z as u128)
+        z
     }
 
-    fn constant(&mut self, v: Gf2) -> Gf2_128 {
-        self.input_public(v.0)
+    fn constant(&mut self, v: Gf2) -> Gf2 {
+        self.input_public(v)
     }
 
-    fn assert_const(&mut self, v: Gf2_128, expected: Gf2) -> Result<()> {
+    fn assert_const(&mut self, v: Gf2, expected: Gf2) -> Result<()> {
         // The hash binding assertions into the proof is built during the
         // accumulate pass; here the check only surfaces witness bugs early.
-        let got = GetBit::<Lsb0>::get_bit(&v, 0);
-        if got != expected.0 {
+        if v != expected {
             return Err(Error::assert());
         }
         Ok(())
     }
 }
 
-/// Committed state for the [`Prover`].
+/// The prover's accumulate-pass circuit context (pass 2).
 ///
-/// The witness is committed; the prover awaits the challenge before beginning
-/// the accumulate pass.
-#[derive(Debug)]
-pub struct Committed;
-
-/// Accumulate-phase state for the [`Prover`].
+/// Walks the circuits a second time after the [`Witness`] pass, over the real
+/// MAC tape and an installed challenge stream, folding every multiplication and
+/// assertion directly into the running proof state. The `u` and `v`
+/// accumulators defer reduction to [`finish`](Self::finish), which yields a
+/// [`ProverOutput`].
 ///
-/// Holds the challenge stream and the running proof state folded during the
-/// second pass. The `u` and `v` accumulators defer reduction to
-/// [`finish`](Prover::finish).
+/// The caller masks `(u, v)` with the VOPE correlation
+/// ([`vope_receiver`](crate::vope_receiver)) before sending the proof.
 #[derive(Debug)]
-pub struct Accumulate<R> {
+pub struct Accumulate<'a, R> {
+    macs: &'a [Gf2_128],
+    cursor: usize,
     assertions: Hasher,
     rng: R,
     u: Gf2_128Accumulator,
@@ -198,51 +160,36 @@ pub struct Accumulate<R> {
     poly: ProverPoly,
 }
 
-impl<'a> Prover<'a, Committed> {
-    /// Creates a prover directly in the committed state.
+impl<'a, R> Accumulate<'a, R> {
+    /// Creates the accumulate context over the MAC tape, drawing challenge
+    /// weights from `rng`.
     ///
     /// Used to fold a sub-range of a trace whose commitment was produced
-    /// elsewhere: `macs` covers the sub-range's tape entries, and the
-    /// challenge stream passed to [`accumulate`](Self::accumulate) is
+    /// elsewhere: `macs` covers the sub-range's tape entries, and `rng` is
     /// positioned to the sub-range's gate offset. The `(u, v)` outputs of the
-    /// sub-ranges sum to the full trace's `(u, v)`, so sub-ranges can be
-    /// folded in parallel and combined by field addition.
-    pub fn committed(macs: &'a [Gf2_128]) -> Self {
-        Self {
-            macs,
-            cursor: 0,
-            state: Committed,
-        }
-    }
-
-    /// Begins the accumulate pass, drawing challenge weights from `rng`.
+    /// sub-ranges sum to the full trace's `(u, v)`, so sub-ranges can be folded
+    /// in parallel and combined by field addition.
     ///
     /// Each multiplication and each polynomial constraint
     /// ([`PolyContext::assert_zero`] of degree ≥ 1, or
     /// [`PolyContext::materialize`]) consumes 16 bytes of the stream, so `rng`
-    /// must be positioned to match the trace evaluated: the caller derives it
-    /// from the agreed challenge and seeks it when folding a sub-range of the
-    /// trace.
-    pub fn accumulate<R: RngCore>(self, rng: R) -> Prover<'a, Accumulate<R>> {
-        Prover {
-            macs: self.macs,
-            cursor: self.cursor,
-            state: Accumulate {
-                assertions: Hasher::default(),
-                rng,
-                u: Gf2_128Accumulator::zero(),
-                v: Gf2_128Accumulator::zero(),
-                poly: ProverPoly::default(),
-            },
+    /// must be positioned to match the trace evaluated.
+    pub fn new(macs: &'a [Gf2_128], rng: R) -> Self {
+        Self {
+            macs,
+            cursor: 0,
+            assertions: Hasher::default(),
+            rng,
+            u: Gf2_128Accumulator::zero(),
+            v: Gf2_128Accumulator::zero(),
+            poly: ProverPoly::default(),
         }
     }
-}
 
-impl<'a, R> Prover<'a, Accumulate<R>> {
     /// Consumes the next tape entry for a private input `bit` and returns its
     /// authenticated wire.
     ///
-    /// Inputs must be supplied in the same order as during the commit phase.
+    /// Inputs must be supplied in the same order as during the witness pass.
     ///
     /// # Panics
     ///
@@ -280,15 +227,15 @@ impl<'a, R> Prover<'a, Accumulate<R>> {
             return Err(Error::tape_unconsumed(self.cursor, self.macs.len()));
         }
         Ok(ProverOutput {
-            u: self.state.u.reduce(),
-            v: self.state.v.reduce(),
-            poly: self.state.poly,
-            assertions: *self.state.assertions.finalize().as_bytes(),
+            u: self.u.reduce(),
+            v: self.v.reduce(),
+            poly: self.poly,
+            assertions: *self.assertions.finalize().as_bytes(),
         })
     }
 }
 
-impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
+impl<R: RngCore> Context for Accumulate<'_, R> {
     type Error = Error;
     type Wire = Gf2_128;
     type Field = Gf2;
@@ -312,18 +259,17 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
         set_lsb(&mut mac, x & y);
         self.cursor = i + 1;
 
-        let chi = draw_chi(&mut self.state.rng);
+        let chi = draw_chi(&mut self.rng);
 
         // `a_10 = b if lsb(a) else 0`, `a_11 = a if lsb(b) else 0`,
-        // expressed as `a · mask` with `mask ∈ {0, u128::MAX}` so there
+        // expressed as `a · w` with `w ∈ {0, u128::MAX}` so there
         // is no data-dependent branch.
-        let mask_x = (x as u128).wrapping_neg();
-        let mask_y = (y as u128).wrapping_neg();
-        let body_v =
-            Gf2_128::new(b.to_inner() & mask_x) + Gf2_128::new(a.to_inner() & mask_y) + mac;
+        let w_x = (x as u128).wrapping_neg();
+        let w_y = (y as u128).wrapping_neg();
+        let body_v = Gf2_128::new(b.to_inner() & w_x) + Gf2_128::new(a.to_inner() & w_y) + mac;
 
-        self.state.u.add_product(a * b, chi);
-        self.state.v.add_product(body_v, chi);
+        self.u.add_product(a * b, chi);
+        self.v.add_product(body_v, chi);
 
         mac
     }
@@ -338,13 +284,13 @@ impl<R: RngCore> Context for Prover<'_, Accumulate<R>> {
             return Err(Error::assert());
         }
 
-        self.state.assertions.update(&v.to_inner().to_le_bytes());
+        self.assertions.update(&v.to_inner().to_le_bytes());
 
         Ok(())
     }
 }
 
-impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
+impl<R: RngCore> PolyContext for Accumulate<'_, R> {
     type Coeffs = ProverCoeffs<Gf2>;
 
     fn lift(&self, wire: Gf2_128) -> Expr<ProverCoeffs<Gf2>, U1> {
@@ -366,13 +312,13 @@ impl<R: RngCore> PolyContext for Prover<'_, Accumulate<R>> {
         // constraint's top coefficient is `expr.value + lsb(wire) = 0` by
         // construction, so it folds without a witness check.
         let constraint = expr - self.lift(wire);
-        let chi = draw_chi(&mut self.state.rng);
-        self.state.poly.fold_expr(&constraint, chi);
+        let chi = draw_chi(&mut self.rng);
+        self.poly.fold_expr(&constraint, chi);
         wire
     }
 
     fn assert_zero<N: Degree>(&mut self, expr: Expr<ProverCoeffs<Gf2>, N>) -> Result<()> {
-        let Self { state, .. } = self;
-        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+        let Self { poly, rng, .. } = self;
+        poly.assert_expr(&expr, || draw_chi(&mut *rng))
     }
 }

--- a/crates/zk-core/src/verifier.rs
+++ b/crates/zk-core/src/verifier.rs
@@ -17,46 +17,22 @@ use crate::{
 
 /// The verifier side of the zero-knowledge protocol.
 ///
-/// A `Verifier` holds the global MAC key `delta` and walks the circuits once,
-/// with the flow tracked as a typestate:
-///
-/// 1. [`Verifier<Committed>`](Committed) is constructed from the received
-///    commitment (the adjustment bits) and the key tape.
-///    [`accumulate`](Self::accumulate) installs the challenge stream provided
-///    by the caller.
-/// 2. [`Verifier<Accumulate>`](Accumulate) implements [`Context`] directly,
-///    folding every multiplication and assertion into the running check state
-///    as the circuits are evaluated. [`finish`](Self::finish) yields a
-///    [`VerifierOutput`].
+/// A `Verifier` holds the global MAC key `delta`, the key and adjustment tapes,
+/// and the installed challenge stream. It walks the circuits once, implementing
+/// [`Context`] directly: every multiplication and assertion is folded into the
+/// running check state as the circuits are evaluated. [`finish`](Self::finish)
+/// yields a [`VerifierOutput`].
 ///
 /// The caller masks `w` with the VOPE correlation
 /// ([`vope_sender`](crate::vope_sender)) and accepts the prover's proof iff
 /// `w == u + delta * v` and the assertion hashes match.
 #[derive(Debug)]
-pub struct Verifier<'a, S> {
+pub struct Verifier<'a, R> {
     keys: &'a [Gf2_128],
     adjust: &'a [bool],
     delta: Gf2_128,
     key_one: Gf2_128,
     cursor: usize,
-    state: S,
-}
-
-/// Committed state for the [`Verifier`].
-///
-/// The prover's commitment has been received; the verifier awaits the
-/// challenge stream before beginning the accumulate pass.
-#[derive(Debug)]
-pub struct Committed;
-
-/// Accumulate-phase state for the [`Verifier`].
-///
-/// Holds the challenge stream and the running check state folded during
-/// evaluation, split into the `Σ χᵢ·xᵢyᵢ` and `Σ χᵢ·zᵢ` accumulators so
-/// reduction and the `delta` factor are both applied once at
-/// [`finish`](Verifier::finish).
-#[derive(Debug)]
-pub struct Accumulate<R> {
     assertions: Hasher,
     rng: R,
     xy: Gf2_128Accumulator,
@@ -64,8 +40,9 @@ pub struct Accumulate<R> {
     poly: VerifierPoly,
 }
 
-impl<'a> Verifier<'a, Committed> {
-    /// Creates a new verifier with the global MAC key `delta`.
+impl<'a, R> Verifier<'a, R> {
+    /// Creates a new verifier with the global MAC key `delta`, drawing
+    /// challenge weights from `rng`.
     ///
     /// `keys` is the tape of verifier keys, one entry per input bit and per
     /// AND gate, consumed in evaluation order. `adjust` is the corresponding
@@ -73,8 +50,10 @@ impl<'a> Verifier<'a, Committed> {
     /// each entry selects whether the matching key is offset by `delta`.
     ///
     /// When folding a sub-range of a trace, pass the sub-range's tape slices
-    /// and seek the challenge stream to the sub-range's gate offset: the `w`
-    /// outputs of the sub-ranges sum to the full trace's `w`.
+    /// and seek `rng` to the sub-range's gate offset: the `w` outputs of the
+    /// sub-ranges sum to the full trace's `w`. Each multiplication and each
+    /// polynomial constraint ([`PolyContext::assert_zero`] of degree ≥ 1, or
+    /// [`PolyContext::materialize`]) consumes 16 bytes of the stream.
     ///
     /// The polynomial check ([`VerifierPoly::check`]) needs the powers of
     /// `delta` ([`DeltaPowers`](crate::poly::DeltaPowers)); the accumulate pass
@@ -84,7 +63,7 @@ impl<'a> Verifier<'a, Committed> {
     /// # Errors
     ///
     /// Returns [`Error`] if `keys` and `adjust` differ in length.
-    pub fn new(delta: Gf2_128, keys: &'a [Gf2_128], adjust: &'a [bool]) -> Result<Self> {
+    pub fn new(delta: Gf2_128, keys: &'a [Gf2_128], adjust: &'a [bool], rng: R) -> Result<Self> {
         if keys.len() != adjust.len() {
             return Err(Error::tape_len("adjust", keys.len(), adjust.len()));
         }
@@ -94,37 +73,14 @@ impl<'a> Verifier<'a, Committed> {
             delta,
             key_one: MAC_ONE + delta,
             cursor: 0,
-            state: Committed,
+            assertions: Hasher::default(),
+            rng,
+            xy: Gf2_128Accumulator::zero(),
+            z: Gf2_128Accumulator::zero(),
+            poly: VerifierPoly::default(),
         })
     }
 
-    /// Begins the accumulate pass, drawing challenge weights from `rng`.
-    ///
-    /// Each multiplication and each polynomial constraint
-    /// ([`PolyContext::assert_zero`] of degree ≥ 1, or
-    /// [`PolyContext::materialize`]) consumes 16 bytes of the stream, so `rng`
-    /// must be positioned to match the trace evaluated: the caller derives it
-    /// from the challenge it sampled and seeks it when folding a sub-range of
-    /// the trace.
-    pub fn accumulate<R: RngCore>(self, rng: R) -> Verifier<'a, Accumulate<R>> {
-        Verifier {
-            keys: self.keys,
-            adjust: self.adjust,
-            delta: self.delta,
-            key_one: self.key_one,
-            cursor: self.cursor,
-            state: Accumulate {
-                assertions: Hasher::default(),
-                rng,
-                xy: Gf2_128Accumulator::zero(),
-                z: Gf2_128Accumulator::zero(),
-                poly: VerifierPoly::default(),
-            },
-        }
-    }
-}
-
-impl<'a, R> Verifier<'a, Accumulate<R>> {
     /// Consumes the next input from the tapes and returns its verifier key.
     ///
     /// The key is offset by `delta` when the corresponding adjustment bit is
@@ -170,16 +126,16 @@ impl<'a, R> Verifier<'a, Accumulate<R>> {
         if self.cursor != self.adjust.len() {
             return Err(Error::tape_unconsumed(self.cursor, self.adjust.len()));
         }
-        let w = self.state.xy.reduce() + self.delta * self.state.z.reduce();
+        let w = self.xy.reduce() + self.delta * self.z.reduce();
         Ok(VerifierOutput {
             w,
-            poly: self.state.poly,
-            assertions: *self.state.assertions.finalize().as_bytes(),
+            poly: self.poly,
+            assertions: *self.assertions.finalize().as_bytes(),
         })
     }
 }
 
-impl<R: RngCore> Context for Verifier<'_, Accumulate<R>> {
+impl<R: RngCore> Context for Verifier<'_, R> {
     type Error = Error;
     type Wire = Gf2_128;
     type Field = Gf2;
@@ -209,10 +165,10 @@ impl<R: RngCore> Context for Verifier<'_, Accumulate<R>> {
         set_lsb(&mut key, false);
         self.cursor = i + 1;
 
-        let chi = draw_chi(&mut self.state.rng);
+        let chi = draw_chi(&mut self.rng);
 
-        self.state.xy.add_product(a * b, chi);
-        self.state.z.add_product(key, chi);
+        self.xy.add_product(a * b, chi);
+        self.z.add_product(key, chi);
 
         key
     }
@@ -223,13 +179,13 @@ impl<R: RngCore> Context for Verifier<'_, Accumulate<R>> {
 
     fn assert_const(&mut self, v: Gf2_128, expected: Gf2) -> Result<()> {
         let mac = if expected.0 { v + self.delta } else { v };
-        self.state.assertions.update(&mac.to_inner().to_le_bytes());
+        self.assertions.update(&mac.to_inner().to_le_bytes());
 
         Ok(())
     }
 }
 
-impl<R: RngCore> PolyContext for Verifier<'_, Accumulate<R>> {
+impl<R: RngCore> PolyContext for Verifier<'_, R> {
     type Coeffs = VerifierCoeffs;
 
     fn lift(&self, wire: Gf2_128) -> Expr<VerifierCoeffs, U1> {
@@ -248,15 +204,14 @@ impl<R: RngCore> PolyContext for Verifier<'_, Accumulate<R>> {
         let wire = self.input();
         // Pin the fresh wire to the expression: `expr - wire == 0`.
         let constraint = expr - self.lift(wire);
-        let chi = draw_chi(&mut self.state.rng);
-        self.state
-            .poly
+        let chi = draw_chi(&mut self.rng);
+        self.poly
             .fold_expr(&constraint, Maximum::<N, U1>::USIZE, chi);
         wire
     }
 
     fn assert_zero<N: Degree>(&mut self, expr: Expr<VerifierCoeffs, N>) -> Result<()> {
-        let Self { state, .. } = self;
-        state.poly.assert_expr(&expr, || draw_chi(&mut state.rng))
+        let Self { poly, rng, .. } = self;
+        poly.assert_expr(&expr, || draw_chi(&mut *rng))
     }
 }

--- a/crates/zk-core/tests/gf64.rs
+++ b/crates/zk-core/tests/gf64.rs
@@ -1,14 +1,14 @@
 //! End-to-end tests for the `GF(2^64)` circuit path: build a small arithmetic
-//! circuit over `Gf2_64`, drive it through the [`Commit`]/[`Prover`]/[`Verifier`]
-//! triple against a simulated subfield sVOLE tape, and check that the
-//! QuickSilver consistency check accepts a correct execution and rejects a
-//! corrupted one.
+//! circuit over `Gf2_64`, drive it through the
+//! [`Witness`]/[`Accumulate`]/[`Verifier`] triple against a simulated subfield
+//! sVOLE tape, and check that the QuickSilver consistency check accepts a
+//! correct execution and rejects a corrupted one.
 
 use mpz_circuits::Context;
 use mpz_fields::{ExtensionField, gf2_64::Gf2_64, gf2_128::Gf2_128};
 use mpz_zk_core::{
     DeltaPowers, PolyContext, ProverOutput, VerifierOutput,
-    gf64::{Auth64, Commit, Prover, Verifier},
+    gf64::{Accumulate, Auth64, Verifier, Witness},
     vope_receiver, vope_sender,
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -52,7 +52,7 @@ struct Setup {
     input_auth: Vec<Auth64>,
     /// Verifier input wires (adjusted keys).
     input_keys: Vec<Gf2_128>,
-    /// Cleartext input values (for the commit pass).
+    /// Cleartext input values (for the witness pass).
     input_values: [Gf2_64; N_IN],
     gate_masks: Vec<Gf2_64>,
     gate_macs: Vec<Gf2_128>,
@@ -96,7 +96,7 @@ fn setup(seed: u64) -> Setup {
         })
         .collect();
 
-    // Gate tape: masks start at the sVOLE choices; the commit pass overwrites
+    // Gate tape: masks start at the sVOLE choices; the witness pass overwrites
     // them with adjustments.
     let gate_masks: Vec<Gf2_64> = choices[N_IN..].to_vec();
     let gate_macs: Vec<Gf2_128> = macs[N_IN..].to_vec();
@@ -136,13 +136,15 @@ fn setup(seed: u64) -> Setup {
 /// and the gate adjust tape for the verifier.
 fn prove(s: &Setup) -> (Gf2_128, Gf2_128, [u8; 32], Vec<Gf2_64>) {
     let mut gate_adjust = s.gate_masks.clone();
-    let mut commit = Commit::new(&mut gate_adjust);
+    let mut commit = Witness::new(&mut gate_adjust);
     circuit(&mut commit, &s.input_values, s.expected).unwrap();
     commit.finish().unwrap();
 
-    let mut prover = Prover::committed(&s.gate_macs).accumulate(ChaCha12Rng::from_seed(s.chi));
+    let mut prover = Accumulate::new(&s.gate_macs, ChaCha12Rng::from_seed(s.chi));
     circuit(&mut prover, &s.input_auth, s.expected).unwrap();
-    let ProverOutput { u, v, assertions, .. } = prover.finish().unwrap();
+    let ProverOutput {
+        u, v, assertions, ..
+    } = prover.finish().unwrap();
 
     let (a_0, a_1) = vope_receiver(&s.vope_choices, &s.vope_ev);
     (u + a_0, v + a_1, assertions, gate_adjust)
@@ -150,8 +152,13 @@ fn prove(s: &Setup) -> (Gf2_128, Gf2_128, [u8; 32], Vec<Gf2_64>) {
 
 /// Runs the verifier's accumulate pass and returns `(w + b, assertions)`.
 fn verify(s: &Setup, gate_adjust: &[Gf2_64]) -> (Gf2_128, [u8; 32]) {
-    let verifier = Verifier::new(s.delta, &s.gate_keys, gate_adjust).unwrap();
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(s.chi));
+    let mut verifier = Verifier::new(
+        s.delta,
+        &s.gate_keys,
+        gate_adjust,
+        ChaCha12Rng::from_seed(s.chi),
+    )
+    .unwrap();
     circuit(&mut verifier, &s.input_keys, s.expected).unwrap();
     let VerifierOutput { w, assertions, .. } = verifier.finish().unwrap();
     (w + vope_sender(&s.vope_keys), assertions)
@@ -187,11 +194,19 @@ fn wrong_expected_breaks_assertion() {
     let s = setup(3);
     let (_u, _v, p_assertions, gate_adjust) = prove(&s);
 
-    let verifier = Verifier::new(s.delta, &s.gate_keys, &gate_adjust).unwrap();
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(s.chi));
+    let mut verifier = Verifier::new(
+        s.delta,
+        &s.gate_keys,
+        &gate_adjust,
+        ChaCha12Rng::from_seed(s.chi),
+    )
+    .unwrap();
     let wrong = s.expected + Gf2_64(1);
     circuit(&mut verifier, &s.input_keys, wrong).unwrap();
-    let VerifierOutput { assertions: v_assertions, .. } = verifier.finish().unwrap();
+    let VerifierOutput {
+        assertions: v_assertions,
+        ..
+    } = verifier.finish().unwrap();
 
     assert_ne!(
         p_assertions, v_assertions,
@@ -201,11 +216,11 @@ fn wrong_expected_breaks_assertion() {
 
 #[test]
 fn unsatisfying_witness_fails_commit() {
-    // The commit pass evaluates in cleartext and catches a witness that does
+    // The witness pass evaluates in cleartext and catches a witness that does
     // not satisfy the asserted output early.
     let s = setup(5);
     let mut masks = s.gate_masks.clone();
-    let mut commit = Commit::new(&mut masks);
+    let mut commit = Witness::new(&mut masks);
     let wrong = s.expected + Gf2_64(1);
     assert!(circuit(&mut commit, &s.input_values, wrong).is_err());
 }
@@ -214,7 +229,15 @@ fn unsatisfying_witness_fails_commit() {
 fn tape_length_mismatch_rejected() {
     let s = setup(4);
     let bad_adjust = vec![Gf2_64(0); s.gate_keys.len() + 1];
-    assert!(Verifier::new(s.delta, &s.gate_keys, &bad_adjust).is_err());
+    assert!(
+        Verifier::new(
+            s.delta,
+            &s.gate_keys,
+            &bad_adjust,
+            ChaCha12Rng::from_seed(s.chi)
+        )
+        .is_err()
+    );
 }
 
 // --- polynomial-constraint path --------------------------------------------
@@ -257,7 +280,9 @@ fn poly_round_trip() {
     // Subfield sVOLE for the five input wires.
     let choices: Vec<Gf2_64> = (0..n).map(|_| Gf2_64(rng.random())).collect();
     let keys: Vec<Gf2_128> = (0..n).map(|_| Gf2_128::new(rng.random())).collect();
-    let macs: Vec<Gf2_128> = (0..n).map(|i| keys[i] + embed(choices[i]) * delta).collect();
+    let macs: Vec<Gf2_128> = (0..n)
+        .map(|i| keys[i] + embed(choices[i]) * delta)
+        .collect();
     let input_auth: Vec<Auth64> = (0..n)
         .map(|i| Auth64 {
             value: values[i],
@@ -277,13 +302,13 @@ fn poly_round_trip() {
         pw = pw * delta;
     }
 
-    // Commit pass validates the witness in cleartext.
-    let mut commit = Commit::new(&mut []);
+    // Witness pass validates the witness in cleartext.
+    let mut commit = Witness::new(&mut []);
     poly_gadget(&mut commit, &values).unwrap();
     commit.finish().unwrap();
 
     // Prover accumulate.
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(chi));
     poly_gadget(&mut prover, &input_auth).unwrap();
     let ProverOutput { poly, .. } = prover.finish().unwrap();
     let coefficients: Vec<Gf2_128> = poly
@@ -295,8 +320,7 @@ fn poly_round_trip() {
         .collect();
 
     // Verifier accumulate + check.
-    let verifier = Verifier::new(delta, &[], &[]).unwrap();
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+    let mut verifier = Verifier::new(delta, &[], &[], ChaCha12Rng::from_seed(chi)).unwrap();
     poly_gadget(&mut verifier, &input_keys).unwrap();
     let VerifierOutput { poly: vpoly, .. } = verifier.finish().unwrap();
 
@@ -324,7 +348,9 @@ fn poly_unsatisfied_rejected() {
     let n = values.len();
     let choices: Vec<Gf2_64> = (0..n).map(|_| Gf2_64(rng.random())).collect();
     let keys: Vec<Gf2_128> = (0..n).map(|_| Gf2_128::new(rng.random())).collect();
-    let macs: Vec<Gf2_128> = (0..n).map(|i| keys[i] + embed(choices[i]) * delta).collect();
+    let macs: Vec<Gf2_128> = (0..n)
+        .map(|i| keys[i] + embed(choices[i]) * delta)
+        .collect();
     let input_auth: Vec<Auth64> = (0..n)
         .map(|i| Auth64 {
             value: values[i],
@@ -332,6 +358,6 @@ fn poly_unsatisfied_rejected() {
         })
         .collect();
 
-    let mut prover = Prover::committed(&[]).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&[], ChaCha12Rng::from_seed(chi));
     assert!(poly_gadget(&mut prover, &input_auth).is_err());
 }

--- a/crates/zk-core/tests/sha256.rs
+++ b/crates/zk-core/tests/sha256.rs
@@ -1,7 +1,7 @@
 //! End-to-end integration: build the SHA-256 compression function as
 //! a boolean circuit written against `zk_core::circuit::Context`,
 //! then drive it through the witness-mode evaluator (sanity vs the
-//! `sha2` crate) and through the [`Prover`] / [`Verifier`] pair
+//! `sha2` crate) and through the [`Accumulate`] / [`Verifier`] pair
 //! against a simulated sVOLE tape, verifying that the batch
 //! consistency check accepts.
 
@@ -16,7 +16,9 @@ use mpz_ot_core::ideal::rcot::IdealRCOT;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rand_chacha::ChaCha12Rng;
 
-use mpz_zk_core::{Commit, Proof, Prover, ProverOutput, Verifier, VerifierOutput, vope_receiver, vope_sender};
+use mpz_zk_core::{
+    Accumulate, Proof, ProverOutput, Verifier, VerifierOutput, Witness, vope_receiver, vope_sender,
+};
 
 const VOPE_COST: usize = 128;
 
@@ -134,7 +136,7 @@ fn sha256_quicksilver_batch_check_accepts() {
         .collect();
 
     // Gate tape slices (caller-owned). `gate_masks` is mutated in
-    // place by the prover's commit pass: after `finish` it holds the
+    // place by the prover's witness pass: after `finish` it holds the
     // masked witness adjust bits.
     let mut gate_masks: Vec<bool> = choices[input_count..main_cost].to_vec();
     let gate_macs: Vec<Gf2_128> = macs[input_count..main_cost].to_vec();
@@ -143,15 +145,20 @@ fn sha256_quicksilver_batch_check_accepts() {
     let msg_p: [Gf2_128; 512] = core::array::from_fn(|i| input_mac_wires[i]);
     let state_p: [Gf2_128; 256] = core::array::from_fn(|i| input_mac_wires[512 + i]);
 
-    // Commit pass: adjusts `gate_masks` in place, touching no MACs.
-    let mut commit = Commit::new(&mut gate_masks);
-    let _ = sha256_compress(&mut commit, msg_p, state_p);
+    // Witness pass: cleartext bit wires; adjusts `gate_masks` in place,
+    // touching no MACs.
+    let msg_b: [Gf2; 512] = core::array::from_fn(|i| Gf2(input_bits[i]));
+    let state_b: [Gf2; 256] = core::array::from_fn(|i| Gf2(input_bits[512 + i]));
+    let mut commit = Witness::new(&mut gate_masks);
+    let _ = sha256_compress(&mut commit, msg_b, state_b);
     commit.finish().expect("commit finish");
 
     // Accumulate pass: re-evaluates the circuit, folding the proof.
-    let mut prover = Prover::committed(&gate_macs).accumulate(ChaCha12Rng::from_seed(chi));
+    let mut prover = Accumulate::new(&gate_macs, ChaCha12Rng::from_seed(chi));
     let prover_out = sha256_compress(&mut prover, msg_p, state_p);
-    let ProverOutput { u, v, assertions, .. } = prover.finish().expect("accumulate finish");
+    let ProverOutput {
+        u, v, assertions, ..
+    } = prover.finish().expect("accumulate finish");
 
     let (a_0, a_1) = vope_receiver(&vope_choices, &vope_ev);
     let proof = Proof {
@@ -173,12 +180,16 @@ fn sha256_quicksilver_batch_check_accepts() {
 
     let gate_keys: Vec<Gf2_128> = raw_keys[input_count..main_cost].to_vec();
 
-    let verifier = Verifier::new(delta, &gate_keys, &gate_masks).expect("new");
-    let mut verifier = verifier.accumulate(ChaCha12Rng::from_seed(chi));
+    let mut verifier =
+        Verifier::new(delta, &gate_keys, &gate_masks, ChaCha12Rng::from_seed(chi)).expect("new");
     let msg_v: [Gf2_128; 512] = core::array::from_fn(|i| input_key_wires[i]);
     let state_v: [Gf2_128; 256] = core::array::from_fn(|i| input_key_wires[512 + i]);
     let verifier_out = sha256_compress(&mut verifier, msg_v, state_v);
-    let VerifierOutput { w, assertions: v_assertions, .. } = verifier.finish().expect("finish");
+    let VerifierOutput {
+        w,
+        assertions: v_assertions,
+        ..
+    } = verifier.finish().expect("finish");
 
     // Output IT-MAC sanity: MAC == key + b·delta for each output bit.
     let expected_bits = sha2_compress_out_bits(msg, H0);


### PR DESCRIPTION
## Summary
- zk-core: collapse the two-pass protocol into Witness (mask-only) and Accumulate (challenge-folded), replacing the old Commit/Prover split
- vm-zk: rework capture/commit/segment/prover/verifier/replay around this pipeline; add DESIGN.md; drop config.rs/cost.rs
- vm-core/vm-memory: add an access_log for memory accesses and expand register/memory auth to support it
- vm-circuits: update divrem/shift/compare/count instruction circuits
- ot-core/ot: small softspoken/ferret fixups