### PR TITLE
perf(fields): use extmul for WASM clmul32, drop bit-reversal trick

### DIFF
--- a/crates/fields/src/bmul_simd.rs
+++ b/crates/fields/src/bmul_simd.rs
@@ -1,13 +1,16 @@
 //! WASM `simd128` carry-less multiplication primitives.
 //!
-//! Uses the BearSSL bit-interleaving algorithm (the same one as scalar
-//! `bmul`) but runs the forward and bit-reversed halves of
-//! `bmul64_full` in parallel across the two `u64` lanes of a `v128`,
-//! collapsing 32 scalar 64×64 multiplications into 16 `i64x2_mul`s.
-//!
-//! Since WASM has no carry-less-multiply instruction in `simd128`
-//! (neither stable nor relaxed-SIMD), the lane-parallel BearSSL trick
-//! is the best acceleration available.
+//! WASM has no carry-less-multiply instruction in `simd128` (neither
+//! stable nor relaxed-SIMD), so multiplication is built from the BearSSL
+//! bit-interleaving algorithm over 32×32→64 integer products
+//! ([`clmul32_x4`]). The `i64x2.extmul_*_u32x4` instructions each compute
+//! two such products and lower to a single widening multiply on common
+//! hosts — much cheaper than `i64x2.mul`, which engines emulate with a
+//! multi-instruction sequence. Working from 32-bit pieces also yields the
+//! full product with no truncation, so no bit-reversal trick is needed;
+//! wider multiplies recombine the 64-bit pieces with Karatsuba, and since
+//! the recombination is linear over GF(2) it can be deferred across
+//! XOR-accumulation loops.
 
 use std::arch::wasm32::*;
 
@@ -39,109 +42,71 @@ pub(crate) fn bit_spread_v128(mut v: v128) -> v128 {
     v
 }
 
-/// Returns a `v128` whose lane `i` holds the low-64 carry-less product of
-/// `x`'s and `y`'s lane `i`. Both lanes run the BearSSL bit-interleaving
-/// algorithm simultaneously via `i64x2_mul`.
-#[inline(always)]
-pub(crate) fn bmul64_lo_v128(x: v128, y: v128) -> v128 {
-    let m0 = u64x2_splat(0x1111_1111_1111_1111);
-    let m1 = u64x2_splat(0x2222_2222_2222_2222);
-    let m2 = u64x2_splat(0x4444_4444_4444_4444);
-    let m3 = u64x2_splat(0x8888_8888_8888_8888);
-
-    let a0 = v128_and(x, m0);
-    let a1 = v128_and(x, m1);
-    let a2 = v128_and(x, m2);
-    let a3 = v128_and(x, m3);
-    let b0 = v128_and(y, m0);
-    let b1 = v128_and(y, m1);
-    let b2 = v128_and(y, m2);
-    let b3 = v128_and(y, m3);
-
-    let z0 = v128_xor(
-        v128_xor(i64x2_mul(a0, b0), i64x2_mul(a1, b3)),
-        v128_xor(i64x2_mul(a2, b2), i64x2_mul(a3, b1)),
-    );
-    let z1 = v128_xor(
-        v128_xor(i64x2_mul(a0, b1), i64x2_mul(a1, b0)),
-        v128_xor(i64x2_mul(a2, b3), i64x2_mul(a3, b2)),
-    );
-    let z2 = v128_xor(
-        v128_xor(i64x2_mul(a0, b2), i64x2_mul(a1, b1)),
-        v128_xor(i64x2_mul(a2, b0), i64x2_mul(a3, b3)),
-    );
-    let z3 = v128_xor(
-        v128_xor(i64x2_mul(a0, b3), i64x2_mul(a1, b2)),
-        v128_xor(i64x2_mul(a2, b1), i64x2_mul(a3, b0)),
-    );
-
-    v128_xor(
-        v128_xor(v128_and(z0, m0), v128_and(z1, m1)),
-        v128_xor(v128_and(z2, m2), v128_and(z3, m3)),
-    )
-}
-
-/// Bit-reverses a `u64` (scalar — WASM has no bit-reverse instruction).
-#[inline(always)]
-pub(crate) fn rev64(mut x: u64) -> u64 {
-    x = ((x & 0x5555_5555_5555_5555) << 1) | ((x >> 1) & 0x5555_5555_5555_5555);
-    x = ((x & 0x3333_3333_3333_3333) << 2) | ((x >> 2) & 0x3333_3333_3333_3333);
-    x = ((x & 0x0f0f_0f0f_0f0f_0f0f) << 4) | ((x >> 4) & 0x0f0f_0f0f_0f0f_0f0f);
-    x.swap_bytes()
-}
-
-/// Full 64×64 carry-less product, left in *raw* v128 form. Lane 0 is
-/// the low 64 bits of the product; lane 1 is the BearSSL bit-reversed
-/// product form (which still needs `rev64(lane1) >> 1` to recover the
-/// high 64 bits — see [`recover_raw`]).
+/// BearSSL 4-mask clmul32 over all four u32 lane pairs of `a` × `b`,
+/// XORed into `acc = (low lane products, high lane products)`: result
+/// u64 lane `l` of the pair is the full 32×32 carry-less product of
+/// `a`'s and `b`'s u32 lane `l`, one `extmul` per two products.
 ///
-/// Prefer this over [`bmul64_full`] whenever many partials are going to
-/// be XOR-accumulated: since `rev64` and `>> 1` are linear over GF(2),
-/// they commute with XOR and can be deferred to the end of the
-/// accumulation.
+/// Carry safety: 4-bit mask spacing leaves each product column with at
+/// most 8 addends, so integer carries never reach the next lattice
+/// position and are cleared by the per-`k` masking.
 #[inline(always)]
-pub(crate) fn bmul64_raw(x: u64, y: u64) -> v128 {
-    bmul64_lo_v128(u64x2(x, rev64(x)), u64x2(y, rev64(y)))
+pub(crate) fn clmul32_x4(a: v128, b: v128, acc: (v128, v128)) -> (v128, v128) {
+    let mut t_lo = [u64x2_splat(0); 4];
+    let mut t_hi = [u64x2_splat(0); 4];
+
+    let am = mask4(a);
+    let bm = mask4(b);
+
+    for i in 0..4 {
+        for j in 0..4 {
+            let k = (i + j) & 3;
+            t_lo[k] = v128_xor(t_lo[k], i64x2_extmul_low_u32x4(am[i], bm[j]));
+            t_hi[k] = v128_xor(t_hi[k], i64x2_extmul_high_u32x4(am[i], bm[j]));
+        }
+    }
+
+    let mut r_lo = acc.0;
+    let mut r_hi = acc.1;
+    for k in 0..4 {
+        let mk = u64x2_splat(0x1111_1111_1111_1111 << k);
+        r_lo = v128_xor(r_lo, v128_and(t_lo[k], mk));
+        r_hi = v128_xor(r_hi, v128_and(t_hi[k], mk));
+    }
+    (r_lo, r_hi)
 }
 
-/// Recover scalar `(lo, hi)` from an accumulated raw v128 bmul partial.
+/// Low-lanes-only variant of [`clmul32_x4`], for packs with only the
+/// two low u32 lane pairs populated.
 #[inline(always)]
-pub(crate) fn recover_raw(v: v128) -> (u64, u64) {
-    let lo = u64x2_extract_lane::<0>(v);
-    let hi = rev64(u64x2_extract_lane::<1>(v)) >> 1;
-    (lo, hi)
+pub(crate) fn clmul32_x2(a: v128, b: v128, acc: v128) -> v128 {
+    let mut t = [u64x2_splat(0); 4];
+
+    let am = mask4(a);
+    let bm = mask4(b);
+
+    for i in 0..4 {
+        for j in 0..4 {
+            let k = (i + j) & 3;
+            t[k] = v128_xor(t[k], i64x2_extmul_low_u32x4(am[i], bm[j]));
+        }
+    }
+
+    let mut r = acc;
+    for k in 0..4 {
+        let mk = u64x2_splat(0x1111_1111_1111_1111 << k);
+        r = v128_xor(r, v128_and(t[k], mk));
+    }
+    r
 }
 
-/// Full 64×64 → 128 bit carry-less product. Returns `(lo, hi)` such that
-/// the 128-bit product is `hi·2⁶⁴ + lo`.
+/// The four BearSSL lattice maskings of `v`.
 #[inline(always)]
-pub(crate) fn bmul64_full(x: u64, y: u64) -> (u64, u64) {
-    recover_raw(bmul64_raw(x, y))
-}
-
-/// Full 128×128 → 256 bit carry-less product. Returns `(lo, hi)` such
-/// that the 256-bit product is `hi·2¹²⁸ + lo`.
-#[inline(always)]
-pub(crate) fn bmul128_full(a: u128, b: u128) -> (u128, u128) {
-    let a_lo = a as u64;
-    let a_hi = (a >> 64) as u64;
-    let b_lo = b as u64;
-    let b_hi = (b >> 64) as u64;
-
-    // Karatsuba: the middle partial p01^p10 = p_mid ^ p00 ^ p11, where
-    // p_mid = (a_lo+a_hi)(b_lo+b_hi) — three bmul64_full instead of four.
-    let (p00_lo, p00_hi) = bmul64_full(a_lo, b_lo);
-    let (p11_lo, p11_hi) = bmul64_full(a_hi, b_hi);
-    let (pm_lo, pm_hi) = bmul64_full(a_lo ^ a_hi, b_lo ^ b_hi);
-
-    let mid_lo = pm_lo ^ p00_lo ^ p11_lo;
-    let mid_hi = pm_hi ^ p00_hi ^ p11_hi;
-
-    let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
-    let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);
-
-    let lo = p00 ^ ((mid_lo as u128) << 64);
-    let hi = p11 ^ (mid_hi as u128);
-
-    (lo, hi)
+fn mask4(v: v128) -> [v128; 4] {
+    [
+        v128_and(v, u32x4_splat(0x1111_1111)),
+        v128_and(v, u32x4_splat(0x2222_2222)),
+        v128_and(v, u32x4_splat(0x4444_4444)),
+        v128_and(v, u32x4_splat(0x8888_8888)),
+    ]
 }

--- a/crates/fields/src/gf2_128/wasm.rs
+++ b/crates/fields/src/gf2_128/wasm.rs
@@ -1,19 +1,72 @@
 //! WASM `simd128` backend for GF(2¹²⁸).
 //!
-//! Uses `bmul_simd::bmul128_full` (Karatsuba: three `bmul64_full`s, each
-//! of which runs its forward and reversed halves in v128 parallel), then
-//! reduces mod p(x) = x¹²⁸+x⁷+x²+x+1 with the same shift/XOR chain as the
-//! soft backend.
+//! Multiplication runs on `bmul_simd::clmul32_x4` (32×32→64 carry-less
+//! pieces via single-multiply `extmul`s), recombined with two-level
+//! Karatsuba: 64→32 splits each 64×64 product into three clmul32
+//! streams, 128→64 splits the full product into three 64×64 products —
+//! nine streams total, packed across `extmul` lanes. All recombination
+//! is linear over GF(2), so the accumulating kernels defer it (and the
+//! final reduction mod p(x) = x¹²⁸+x⁷+x²+x+1) out of their loops.
 
 use std::arch::wasm32::*;
 
-use crate::bmul_simd::{bit_spread_v128, bmul128_full, bmul64_raw, recover_raw};
+use crate::bmul_simd::{bit_spread_v128, clmul32_x2, clmul32_x4};
 
 use super::Gf2_128;
 
+/// Splits an element into the two operand packs and the lone scalar:
+/// pack1 = `[w0, w1, w2, w3]` (streams P00.q00, P00.q11 | P11.q00,
+/// P11.q11), pack2 = `[w0^w1, w2^w3, w0^w2, w1^w3]` (P00.qm, P11.qm |
+/// PM.q00, PM.q11) and scalar `(w0^w2)^(w1^w3)` (PM.qm), where P00/P11/PM
+/// are the outer (64-bit) Karatsuba streams and q00/q11/qm the inner
+/// (32-bit) ones.
+#[inline(always)]
+fn packs(v: u128) -> (v128, v128, u32) {
+    let w0 = v as u32;
+    let w1 = (v >> 32) as u32;
+    let w2 = (v >> 64) as u32;
+    let w3 = (v >> 96) as u32;
+    let m0 = w0 ^ w2;
+    let m1 = w1 ^ w3;
+    (u32x4(w0, w1, w2, w3), u32x4(w0 ^ w1, w2 ^ w3, m0, m1), m0 ^ m1)
+}
+
+/// Recombines one 64×64 Karatsuba-32 stream triple into a 128-bit product.
+#[inline(always)]
+fn comb64(q00: u64, q11: u64, qm: u64) -> u128 {
+    let mid = qm ^ q00 ^ q11;
+    (q00 as u128) ^ ((q11 as u128) << 64) ^ ((mid as u128) << 32)
+}
+
+/// Recovers the unreduced 256-bit product `(lo, hi)` from the accumulated
+/// stream pairs of [`packs`]-shaped operands: `acc_p` holds P00/P11's
+/// q00 and q11 streams, `acc_q` holds their qm streams plus PM's q00 and
+/// q11, and `pm_qm` is PM's accumulated qm stream.
+#[inline(always)]
+fn recover(acc_p: (v128, v128), acc_q: (v128, v128), pm_qm: u64) -> (u128, u128) {
+    let p00 = comb64(
+        u64x2_extract_lane::<0>(acc_p.0),
+        u64x2_extract_lane::<1>(acc_p.0),
+        u64x2_extract_lane::<0>(acc_q.0),
+    );
+    let p11 = comb64(
+        u64x2_extract_lane::<0>(acc_p.1),
+        u64x2_extract_lane::<1>(acc_p.1),
+        u64x2_extract_lane::<1>(acc_q.0),
+    );
+    let pm = comb64(
+        u64x2_extract_lane::<0>(acc_q.1),
+        u64x2_extract_lane::<1>(acc_q.1),
+        pm_qm,
+    );
+
+    let mid = pm ^ p00 ^ p11;
+    (p00 ^ (mid << 64), p11 ^ (mid >> 64))
+}
+
 #[inline]
 pub(super) fn mul(a: u128, b: u128) -> u128 {
-    let (lo, hi) = bmul128_full(a, b);
+    let (lo, hi) = mul_full(a, b);
     reduce128(lo, hi)
 }
 
@@ -21,7 +74,15 @@ pub(super) fn mul(a: u128, b: u128) -> u128 {
 /// accumulator XORs these and reduces once with [`reduce`].
 #[inline]
 pub(super) fn mul_full(a: u128, b: u128) -> (u128, u128) {
-    bmul128_full(a, b)
+    let zero = u64x2_splat(0);
+    let (ap1, ap2, am) = packs(a);
+    let (bp1, bp2, bm) = packs(b);
+
+    let acc_p = clmul32_x4(ap1, bp1, (zero, zero));
+    let acc_q = clmul32_x4(ap2, bp2, (zero, zero));
+    let r = clmul32_x2(u32x4(am, 0, 0, 0), u32x4(bm, 0, 0, 0), zero);
+
+    recover(acc_p, acc_q, u64x2_extract_lane::<0>(r))
 }
 
 /// Reduces an accumulated 256-bit polynomial `hi·x¹²⁸ + lo` to a field element.
@@ -54,89 +115,72 @@ pub(super) fn square(a: u128) -> u128 {
 
 #[inline]
 pub(super) fn inner_product(a: &[Gf2_128], b: &[Gf2_128]) -> u128 {
-    // Accumulate the three Karatsuba partials (p00, p11, p01^p10) in v128
-    // "raw" form — lane 0 = lo, lane 1 = BearSSL-reversed hi-form. Both
-    // parts are linear in GF(2) under XOR, so the per-iteration Karatsuba
-    // merge and the rev64+shift recovery can be deferred to the end.
-    let mut acc00 = u64x2_splat(0);
-    let mut acc11 = u64x2_splat(0);
-    let mut acc_mid = u64x2_splat(0);
+    let zero = u64x2_splat(0);
+    let mut acc_p = (zero, zero);
+    let mut acc_q = (zero, zero);
+    let mut acc_r = (zero, zero);
 
-    for (x, y) in a.iter().zip(b.iter()) {
-        let a_lo = x.0 as u64;
-        let a_hi = (x.0 >> 64) as u64;
-        let b_lo = y.0 as u64;
-        let b_hi = (y.0 >> 64) as u64;
-
-        // Karatsuba: three products instead of four. The middle partial
-        // p01^p10 = p_mid ^ p00 ^ p11 is recovered after the loop — both the
-        // recovery and the XOR merge are linear over GF(2), so they defer.
-        let p00 = bmul64_raw(a_lo, b_lo);
-        let p11 = bmul64_raw(a_hi, b_hi);
-        let p_mid = bmul64_raw(a_lo ^ a_hi, b_lo ^ b_hi);
-
-        acc00 = v128_xor(acc00, p00);
-        acc11 = v128_xor(acc11, p11);
-        acc_mid = v128_xor(acc_mid, p_mid);
+    // The lone PM.qm stream of four consecutive elements shares one
+    // full-width clmul32 pack; every recombination the streams need is
+    // linear, so it happens once in `recover`.
+    let ca = a.chunks_exact(4);
+    let cb = b.chunks_exact(4);
+    let (ra, rb) = (ca.remainder(), cb.remainder());
+    for (xs4, ys4) in ca.zip(cb) {
+        let mut xs = [0u32; 4];
+        let mut ys = [0u32; 4];
+        for e in 0..4 {
+            let (xp1, xp2, xsc) = packs(xs4[e].0);
+            let (yp1, yp2, ysc) = packs(ys4[e].0);
+            acc_p = clmul32_x4(xp1, yp1, acc_p);
+            acc_q = clmul32_x4(xp2, yp2, acc_q);
+            xs[e] = xsc;
+            ys[e] = ysc;
+        }
+        acc_r = clmul32_x4(
+            u32x4(xs[0], xs[1], xs[2], xs[3]),
+            u32x4(ys[0], ys[1], ys[2], ys[3]),
+            acc_r,
+        );
     }
 
-    // One-time recovery, then the Karatsuba merge mid = p_mid ^ p00 ^ p11.
-    let (p00_lo, p00_hi) = recover_raw(acc00);
-    let (p11_lo, p11_hi) = recover_raw(acc11);
-    let (mid_lo, mid_hi) = recover_raw(acc_mid);
-    let mid_lo = mid_lo ^ p00_lo ^ p11_lo;
-    let mid_hi = mid_hi ^ p00_hi ^ p11_hi;
+    for (x, y) in ra.iter().zip(rb.iter()) {
+        let (xp1, xp2, xs) = packs(x.0);
+        let (yp1, yp2, ys) = packs(y.0);
+        acc_p = clmul32_x4(xp1, yp1, acc_p);
+        acc_q = clmul32_x4(xp2, yp2, acc_q);
+        acc_r.0 = clmul32_x2(u32x4(xs, 0, 0, 0), u32x4(ys, 0, 0, 0), acc_r.0);
+    }
 
-    let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
-    let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);
-
-    let lo = p00 ^ ((mid_lo as u128) << 64);
-    let hi = p11 ^ (mid_hi as u128);
-
+    let r = v128_xor(acc_r.0, acc_r.1);
+    let pm_qm = u64x2_extract_lane::<0>(r) ^ u64x2_extract_lane::<1>(r);
+    let (lo, hi) = recover(acc_p, acc_q, pm_qm);
     reduce128(lo, hi)
 }
 
-/// `Σ aᵢ · bᵢ · cᵢ`. Per iteration: one full `mul(aᵢ, bᵢ)` (bmul128_full +
-/// reduce) to get the 128-bit `xy` intermediate, then accumulate the three
-/// `(xy · cᵢ)` Karatsuba partials in raw v128 form — deferring the
-/// rev64+shift recovery and the final reduction to one post-loop pass.
+/// `Σ aᵢ · bᵢ · cᵢ`. Per iteration: one full `mul(aᵢ, bᵢ)` to get the
+/// 128-bit `xy` intermediate, then accumulate the `(xy · cᵢ)` streams,
+/// deferring their recombination and the final reduction to one
+/// post-loop pass.
 #[inline]
 pub(super) fn double_inner_product(a: &[Gf2_128], b: &[Gf2_128], c: &[Gf2_128]) -> u128 {
-    let mut acc00 = u64x2_splat(0);
-    let mut acc11 = u64x2_splat(0);
-    let mut acc_mid = u64x2_splat(0);
+    let zero = u64x2_splat(0);
+    let mut acc_p = (zero, zero);
+    let mut acc_q = (zero, zero);
+    let mut acc_r = zero;
 
     for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
-        let (xy_lo, xy_hi) = bmul128_full(x.0, y.0);
-        let xy = reduce128(xy_lo, xy_hi);
+        let xy = mul(x.0, y.0);
 
-        let a_lo = xy as u64;
-        let a_hi = (xy >> 64) as u64;
-        let b_lo = z.0 as u64;
-        let b_hi = (z.0 >> 64) as u64;
-
-        // Karatsuba: three products; middle recovered after the loop.
-        let p00 = bmul64_raw(a_lo, b_lo);
-        let p11 = bmul64_raw(a_hi, b_hi);
-        let p_mid = bmul64_raw(a_lo ^ a_hi, b_lo ^ b_hi);
-
-        acc00 = v128_xor(acc00, p00);
-        acc11 = v128_xor(acc11, p11);
-        acc_mid = v128_xor(acc_mid, p_mid);
+        let (xp1, xp2, xs) = packs(xy);
+        let (zp1, zp2, zs) = packs(z.0);
+        acc_p = clmul32_x4(xp1, zp1, acc_p);
+        acc_q = clmul32_x4(xp2, zp2, acc_q);
+        acc_r = clmul32_x2(u32x4(xs, 0, 0, 0), u32x4(zs, 0, 0, 0), acc_r);
     }
 
-    let (p00_lo, p00_hi) = recover_raw(acc00);
-    let (p11_lo, p11_hi) = recover_raw(acc11);
-    let (mid_lo, mid_hi) = recover_raw(acc_mid);
-    let mid_lo = mid_lo ^ p00_lo ^ p11_lo;
-    let mid_hi = mid_hi ^ p00_hi ^ p11_hi;
-
-    let p00 = ((p00_hi as u128) << 64) | (p00_lo as u128);
-    let p11 = ((p11_hi as u128) << 64) | (p11_lo as u128);
-
-    let lo = p00 ^ ((mid_lo as u128) << 64);
-    let hi = p11 ^ (mid_hi as u128);
-
+    let pm_qm = u64x2_extract_lane::<0>(acc_r);
+    let (lo, hi) = recover(acc_p, acc_q, pm_qm);
     reduce128(lo, hi)
 }
 

--- a/crates/fields/src/gf2_64/wasm.rs
+++ b/crates/fields/src/gf2_64/wasm.rs
@@ -1,29 +1,50 @@
 //! WASM `simd128` backend for GF(2⁶⁴).
 //!
-//! Uses `bmul_simd::bmul64_full` (v128-parallelised BearSSL) for the
-//! 64×64 carry-less product, then reduces mod p(x) = x⁶⁴+x⁴+x³+x+1
-//! with the same shift/XOR chain as the soft backend. `inner_product`
-//! keeps its accumulator in a v128 across the whole loop, amortising
-//! both the reduction *and* the final bit-reverse+shift.
+//! Multiplication runs on `bmul_simd::clmul32_x4` (32×32→64 carry-less
+//! pieces via single-multiply `extmul`s): Karatsuba splits the 64×64
+//! product into three clmul32 streams — q00, q11 and the middle — which
+//! fit one pack. The recombination is linear over GF(2), so the
+//! accumulating kernels defer it (and the final reduction mod
+//! p(x) = x⁶⁴+x⁴+x³+x+1) out of their loops.
 
 use std::arch::wasm32::*;
 
-use crate::bmul_simd::{bit_spread_v128, bmul64_full, bmul64_lo_v128, rev64};
+use crate::bmul_simd::{bit_spread_v128, clmul32_x4};
 
 use super::Gf2_64;
 
+/// Splits an element into its clmul32 stream operands
+/// `[w0, w1, w0^w1, 0]` (streams q00, q11, qm).
+#[inline(always)]
+fn pack(v: u64) -> v128 {
+    let w0 = v as u32;
+    let w1 = (v >> 32) as u32;
+    u32x4(w0, w1, w0 ^ w1, 0)
+}
+
+/// Recovers the unreduced 128-bit product from an accumulated stream
+/// pack of [`pack`]-shaped operands.
+#[inline(always)]
+fn recover(acc: (v128, v128)) -> u128 {
+    let q00 = u64x2_extract_lane::<0>(acc.0);
+    let q11 = u64x2_extract_lane::<1>(acc.0);
+    let qm = u64x2_extract_lane::<0>(acc.1);
+
+    let mid = qm ^ q00 ^ q11;
+    (q00 as u128) ^ ((q11 as u128) << 64) ^ ((mid as u128) << 32)
+}
+
 #[inline]
 pub(super) fn mul(a: u64, b: u64) -> u64 {
-    let (lo, hi) = bmul64_full(a, b);
-    reduce64(lo, hi)
+    reduce(mul_full(a, b))
 }
 
 /// Unreduced carry-less product `a · b` (≤ 127 bits) packed into a `u128`.
 /// The accumulator XORs these and reduces once with [`reduce`].
 #[inline]
 pub(super) fn mul_full(a: u64, b: u64) -> u128 {
-    let (lo, hi) = bmul64_full(a, b);
-    (lo as u128) | ((hi as u128) << 64)
+    let zero = u64x2_splat(0);
+    recover(clmul32_x4(pack(a), pack(b), (zero, zero)))
 }
 
 /// Reduces an accumulated 128-bit polynomial to a field element.
@@ -46,41 +67,27 @@ pub(super) fn square(a: u64) -> u64 {
 
 #[inline]
 pub(super) fn inner_product(a: &[Gf2_64], b: &[Gf2_64]) -> u64 {
-    // Accumulate raw v128 partials (lane 0 = lo, lane 1 = bit-reversed hi-raw).
-    // The lane 1 → hi conversion (rev64 + shift) is linear, so it commutes
-    // with XOR accumulation and can be deferred to the end.
-    let mut acc = u64x2_splat(0);
+    let zero = u64x2_splat(0);
+    let mut acc = (zero, zero);
     for (x, y) in a.iter().zip(b.iter()) {
-        let v = bmul64_lo_v128(
-            u64x2(x.0, rev64(x.0)),
-            u64x2(y.0, rev64(y.0)),
-        );
-        acc = v128_xor(acc, v);
+        acc = clmul32_x4(pack(x.0), pack(y.0), acc);
     }
-    let lo = u64x2_extract_lane::<0>(acc);
-    let hi = rev64(u64x2_extract_lane::<1>(acc)) >> 1;
-    reduce64(lo, hi)
+    reduce(recover(acc))
 }
 
 /// `Σ aᵢ · bᵢ · cᵢ`. Per iteration: one full `mul(aᵢ, bᵢ)` to get the
-/// 64-bit `xy` intermediate, then accumulate the raw v128 partial for
-/// `(xy · cᵢ)` — deferring the rev64+shift recovery and the final
-/// reduction to one post-loop pass.
+/// 64-bit `xy` intermediate, then accumulate the `(xy · cᵢ)` streams,
+/// deferring their recombination and the final reduction to one
+/// post-loop pass.
 #[inline]
 pub(super) fn double_inner_product(a: &[Gf2_64], b: &[Gf2_64], c: &[Gf2_64]) -> u64 {
-    let mut acc = u64x2_splat(0);
+    let zero = u64x2_splat(0);
+    let mut acc = (zero, zero);
     for ((x, y), z) in a.iter().zip(b.iter()).zip(c.iter()) {
-        let (xy_lo, xy_hi) = bmul64_full(x.0, y.0);
-        let xy = reduce64(xy_lo, xy_hi);
-        let v = bmul64_lo_v128(
-            u64x2(xy, rev64(xy)),
-            u64x2(z.0, rev64(z.0)),
-        );
-        acc = v128_xor(acc, v);
+        let xy = mul(x.0, y.0);
+        acc = clmul32_x4(pack(xy), pack(z.0), acc);
     }
-    let lo = u64x2_extract_lane::<0>(acc);
-    let hi = rev64(u64x2_extract_lane::<1>(acc)) >> 1;
-    reduce64(lo, hi)
+    reduce(recover(acc))
 }
 
 #[inline]


### PR DESCRIPTION
## Summary
- Replace the `i64x2_mul`-based BearSSL bit-interleaving kernel in `bmul_simd` with 32x32->64 `clmul32` pieces built on `i64x2.extmul_*_u32x4`, which lowers to a single widening multiply on common hosts instead of the multi-instruction sequence engines use to emulate `i64x2.mul`.
- Producing the full 64-bit product directly removes the `rev64` bit-reversal recombination step the old lo/hi-half trick needed.
- GF(2^64) recombines three `clmul32` streams via one level of Karatsuba; GF(2^128) recombines nine streams via two levels. All recombination is linear over GF(2), so it's deferred out of the accumulating loops (`inner_product`, `double_inner_product`) as before.

## Test plan
- [x] `cargo test` (native) in `crates/fields` — 42 passed
- [x] `cargo test --target wasm32-wasip1` in `crates/fields` (simd128 path exercised) — 35 passed
- [x] `cargo build --target wasm32-wasip1` clean